### PR TITLE
Add engineOptions setting to Docker configuration.

### DIFF
--- a/src/main/groovy/nextflow/util/DockerBuilder.groovy
+++ b/src/main/groovy/nextflow/util/DockerBuilder.groovy
@@ -43,6 +43,8 @@ class DockerBuilder {
 
     private List<String> options = []
 
+    private List<String> engineOptions = []
+
     private boolean remove = true
 
     private String temp
@@ -97,6 +99,9 @@ class DockerBuilder {
 
         if( params.containsKey('temp') )
             this.temp = params.temp
+
+        if( params.containsKey('engineOptions') )
+            addEngineOptions(params.engineOptions.toString())
 
         if( params.containsKey('runOptions') )
             addRunOptions(params.runOptions.toString())
@@ -155,13 +160,23 @@ class DockerBuilder {
         return this
     }
 
+    DockerBuilder addEngineOptions(String str) {
+        engineOptions.add(str)
+        return this
+    }
+
     String build(StringBuilder result = new StringBuilder()) {
         assert image
 
         if( sudo )
             result << 'sudo '
 
-        result << 'docker run -i '
+        result << 'docker '
+
+        if( engineOptions )
+            result << engineOptions.join(' ') << ' '
+
+        result << 'run -i '
 
         if( cpus )
             result << "--cpuset ${cpus} "

--- a/src/test/groovy/nextflow/util/DockerBuilderTest.groovy
+++ b/src/test/groovy/nextflow/util/DockerBuilderTest.groovy
@@ -66,6 +66,7 @@ class DockerBuilderTest extends Specification {
         new DockerBuilder('busybox').params(runOptions: '-x --zeta').build() == 'docker run -i -v $PWD:$PWD -w $PWD -x --zeta busybox'
         new DockerBuilder('busybox').params(userEmulation:true).build() == 'docker run -i -u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME -v $PWD:$PWD -w $PWD busybox'
         new DockerBuilder('busybox').setName('hola').build() == 'docker run -i -v $PWD:$PWD -w $PWD --name hola busybox'
+        new DockerBuilder('busybox').params(engineOptions: '--tlsverify --tlscert="/path/to/my/cert"').build() == 'docker --tlsverify --tlscert="/path/to/my/cert" run -i -v $PWD:$PWD -w $PWD busybox'
 
         new DockerBuilder('fedora')
                 .addEnv(envFile)


### PR DESCRIPTION
Sample usage:
```
docker {
    enabled = true
    engineOptions = "--tlsverify --tlscacert=\"/Users/mas2182/.docker/machine/machines/dev/ca.pem\" --tlscert=\"/Users/mas2182/.docker/machine/machines/dev/cert.pem\" --tlskey=\"/Users/mas2182/.docker/machine/machines/dev/key.pem\" -H=tcp://192.168.99.100:2376"   
    runOptions = " -v /Users/mas2182/temp/ARTIFACT_REPOSITORY:/scratchLocal/gobyweb/ARTIFACT_REPOSITORY"       
}
```