### PR TITLE
First shot at Cytoscape.js DAG rendering

### DIFF
--- a/src/main/groovy/nextflow/dag/CytoscapeHtmlRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/CytoscapeHtmlRenderer.groovy
@@ -1,0 +1,33 @@
+package nextflow.dag
+
+import groovy.transform.CompileStatic
+import java.nio.file.Path
+
+/**
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+class CytoscapeHtmlRenderer implements DagRenderer {
+
+    /**
+     * Render the DAG in HTML using Cytoscape.js
+     * to the specified file.
+     * See http://js.cytoscape.org for more info.
+     */
+    @Override
+    void renderDocument(DAG dag, Path file) {
+        String tmplPage = readTemplate()
+        String network = CytoscapeJsRenderer.renderNetwork(dag)
+        file.text = tmplPage.replaceAll(~/\/\* REPLACE_WITH_NETWORK_DATA \*\//, network)
+    }
+
+    private String readTemplate() {
+        StringWriter writer = new StringWriter();
+        def res = CytoscapeJsRenderer.class.getResourceAsStream('cytoscape.js.dag.template.html')
+        int ch
+        while( (ch=res.read()) != -1 ) {
+            writer.append(ch as char);
+        }
+        writer.toString();
+    }
+}

--- a/src/main/groovy/nextflow/dag/CytoscapeJsRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/CytoscapeJsRenderer.groovy
@@ -1,41 +1,25 @@
 package nextflow.dag
 
-import groovy.transform.PackageScope
-import groovy.transform.ToString
-import nextflow.Session
-
+import groovy.transform.CompileStatic
+import java.nio.file.Path
 
 /**
- *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Mike Smoot <mes@aescon.com>
  */
-class CytoscapeJsRenderer {
+class CytoscapeJsRenderer implements DagRenderer {
 
     /**
-     * Render the DAG in HTML using Cytoscape.js
-     * See http://js.cytoscape.org
-     *
-     * @return A string representing the DAG in
-     *         HTML rendered using Cytoscape.js.
+     * Render the DAG in Cytoscape.js compatibile
+     * JSON to the specified file.
+     * See http://js.cytoscape.org for more info.
      */
-    static String render(DAG dag) {
-        String tmplPage = readTemplate()
-        String network = renderNetwork(dag)
-        return tmplPage.replaceAll(~/\/\* REPLACE_WITH_NETWORK_DATA \*\//, network)
+    @Override
+    void renderDocument(DAG dag, Path file) {
+        file.text = renderNetwork(dag)
     }
 
-    private static String readTemplate() {
-        StringWriter writer = new StringWriter();
-        def res = CytoscapeJsRenderer.class.getResourceAsStream('cytoscape.js.dag.template.html')
-        int ch
-        while( (ch=res.read()) != -1 ) {
-            writer.append(ch as char);
-        }
-        writer.toString();
-    }
-
-    private static String renderNetwork(DAG dag) {
+    static String renderNetwork(DAG dag) {
         def result = []
         result << "elements: {"
 

--- a/src/main/groovy/nextflow/dag/CytoscapeJsRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/CytoscapeJsRenderer.groovy
@@ -1,0 +1,77 @@
+package nextflow.dag
+
+import groovy.transform.PackageScope
+import groovy.transform.ToString
+import nextflow.Session
+
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+class CytoscapeJsRenderer {
+
+    /**
+     * Render the DAG in HTML using Cytoscape.js
+     * See http://js.cytoscape.org
+     *
+     * @return A string representing the DAG in
+     *         HTML rendered using Cytoscape.js.
+     */
+    static String render(DAG dag) {
+        String tmplPage = readTemplate()
+        String network = renderNetwork(dag)
+        return tmplPage.replaceAll(~/\/\* REPLACE_WITH_NETWORK_DATA \*\//, network)
+    }
+
+    private static String readTemplate() {
+        StringWriter writer = new StringWriter();
+        def res = CytoscapeJsRenderer.class.getResourceAsStream('cytoscape.js.dag.template.html')
+        int ch
+        while( (ch=res.read()) != -1 ) {
+            writer.append(ch as char);
+        }
+        writer.toString();
+    }
+
+    private static String renderNetwork(DAG dag) {
+        def result = []
+        result << "elements: {"
+
+        result << "nodes: ["
+        dag.vertices.each { vertex -> result << renderVertex( vertex ) }
+        result << "],"
+
+        result << "edges: ["
+        dag.edges.each { edge -> result << renderEdge( edge ) }
+        result << "],"
+
+        result << "},"
+
+        return result.join('\n')
+    }
+
+    private static String renderVertex(vertex) {
+        String pre = "{ data: { id: '${vertex.getName()}'"
+        String post = "}, classes: '${vertex.type.name()}' },"
+        if (vertex.label) {
+            return pre + ", label: '${vertex.label}'" + post
+        } else {
+            return pre + post
+        }
+    }
+
+
+    private static String renderEdge(edge) {
+        assert edge.from != null && edge.to != null
+        String dat = "{ data: { source: '${edge.from.name}', target: '${edge.to.name}'"
+        if ( edge.label ) {
+            return dat + ", label: '${edge.label}' } },"
+        }
+        else {
+            return dat + "} },"
+        }
+    }
+
+}

--- a/src/main/groovy/nextflow/dag/DAG.groovy
+++ b/src/main/groovy/nextflow/dag/DAG.groovy
@@ -243,18 +243,12 @@ class DAG {
         result ?: (session ? resolveChannelName( session.getBinding().getVariables(), handler.instance ) : null )
     }
 
-    String render() {
+    void normalize() {
         normalizeMissingVertices()
         if( session )
             resolveEdgeNames(session.getBinding().getVariables())
         else
             log.debug "Missing session object -- Cannot normalize edge names"
-
-        def result = []
-        result << "digraph graphname {"
-        edges.each { edge -> result << edge.render()  }
-        result << "}"
-        return result.join('\n')
     }
 
 
@@ -301,60 +295,6 @@ class DAG {
          */
         String getName() { "p${getOrder()}" }
 
-        /**
-         * Render the DAG using the Graphviz DOT format
-         * See http://www.graphviz.org/content/dot-language
-         *
-         * @return A string representing the DAG in the DOT notation
-         */
-        String render() {
-
-            List attrs = []
-
-            switch (type) {
-                case Type.NODE:
-                    attrs << "shape=point"
-                    if (label) {
-                        attrs << "label=\"\""
-                        attrs << "xlabel=\"$label\""
-                    }
-                    break
-
-                case Type.ORIGIN:
-                    attrs << "shape=point"
-                    attrs << "label=\"\""
-                    attrs << "fixedsize=true"
-                    attrs << "width=0.1"
-                    if( label ) {
-                        attrs << "xlabel=\"$label\""
-                    }
-                    break
-
-                case Type.OPERATOR:
-                    attrs << "shape=circle"
-                    attrs << "label=\"\""
-                    attrs << "fixedsize=true"
-                    attrs << "width=0.1"
-                    if( label ) {
-                        attrs << "xlabel=\"$label\""
-                    }
-                    break
-
-                case Type.PROCESS:
-                    if( label )
-                        attrs << "label=\"$label\""
-                    break
-
-                default:
-                    attrs << "shape=none"
-                    if( label )
-                        attrs << "label=\"$label\""
-            }
-
-
-            return attrs ? "${getName()} [${attrs.join(',')}];" : nul
-        }
-
     }
 
     /**
@@ -384,23 +324,6 @@ class DAG {
          * A descriptive label
          */
         String label
-
-
-        String render() {
-            assert from != null || to != null
-
-            String A = from.render()
-            String B = to.render()
-
-            def result = new StringBuilder()
-            if( A ) result << A << '\n'
-            if( B ) result << B << '\n'
-            result << "${from.name} -> ${to.name}"
-            if( label ) {
-                result << " [label=\"${label}\"]"
-            }
-            result << ";\n"
-        }
 
     }
 

--- a/src/main/groovy/nextflow/dag/DagRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/DagRenderer.groovy
@@ -1,0 +1,16 @@
+
+
+package nextflow.dag
+import java.nio.file.Path
+
+/**
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+interface DagRenderer {
+
+    /**
+     * Render the dag to the specified file.
+     */
+    void renderDocument(DAG dag, Path file);
+}

--- a/src/main/groovy/nextflow/dag/DagreD3HtmlRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/DagreD3HtmlRenderer.groovy
@@ -1,0 +1,64 @@
+package nextflow.dag
+
+import groovy.transform.CompileStatic
+import java.nio.file.Path
+
+/**
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+class DagreD3Renderer implements DagRenderer {
+
+    /**
+     * Render the DAG in HTML using Cytoscape.js
+     * to the specified file.
+     * See http://js.cytoscape.org for more info.
+     */
+    @Override
+    void renderDocument(DAG dag, Path file) {
+        String tmplPage = readTemplate()
+        String network = renderNetwork(dag)
+        file.text = tmplPage.replaceAll(~/\/\* REPLACE_WITH_NETWORK_DATA \*\//, network)
+    }
+
+    private String readTemplate() {
+        StringWriter writer = new StringWriter();
+        def res = DagreD3Renderer.class.getResourceAsStream('dagre.d3.dag.template.html')
+        int ch
+        while( (ch=res.read()) != -1 ) {
+            writer.append(ch as char);
+        }
+        writer.toString();
+    }
+
+    static String renderNetwork(DAG dag) {
+        def result = []
+
+        dag.vertices.each { vertex -> result << renderVertex( vertex ) }
+        dag.edges.each { edge -> result << renderEdge( edge ) }
+
+        return result.join('\n')
+    }
+
+    private static String renderVertex(vertex) {
+        String dat = "g.setNode('${vertex.getName()}'"
+        if (vertex.label) {
+            return dat + ", { label: '${vertex.label}' });"
+        } else {
+            return dat + ", { label: '' });"
+        }
+    }
+
+
+    private static String renderEdge(edge) {
+        assert edge.from != null && edge.to != null
+        String dat = "g.setEdge('${edge.from.name}', '${edge.to.name}'"
+        if ( edge.label ) {
+            return dat + ", { label: '${edge.label}' });"
+        }
+        else {
+            return dat + ", { label: '' });"
+        }
+    }
+
+}

--- a/src/main/groovy/nextflow/dag/DotRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/DotRenderer.groovy
@@ -1,30 +1,32 @@
 package nextflow.dag
 
-import groovy.transform.PackageScope
-import groovy.transform.ToString
-import nextflow.Session
+import groovy.transform.CompileStatic
+import java.nio.file.Path
 
 /**
- *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Mike Smoot <mes@aescon.com>
  */
-class DotRenderer {
+class DotRenderer implements DagRenderer {
 
     /**
      * Render the DAG using the Graphviz DOT format
+     * to the specified file.
      * See http://www.graphviz.org/content/dot-language
-     *
-     * @return A string representing the DAG in the DOT notation
+     * for more info.
      */
-    static String render(DAG dag) {
+    @Override
+    void renderDocument(DAG dag, Path file) {
+        file.text = renderNetwork(dag)
+    }
+
+    static String renderNetwork(DAG dag) {
         def result = []
         result << "digraph graphname {"
         dag.edges.each { edge -> result << renderEdge( edge ) }
         result << "}"
         return result.join('\n')
     }
-
 
     private static String renderVertex(vertex) {
 

--- a/src/main/groovy/nextflow/dag/DotRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/DotRenderer.groovy
@@ -1,0 +1,93 @@
+package nextflow.dag
+
+import groovy.transform.PackageScope
+import groovy.transform.ToString
+import nextflow.Session
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+class DotRenderer {
+
+    /**
+     * Render the DAG using the Graphviz DOT format
+     * See http://www.graphviz.org/content/dot-language
+     *
+     * @return A string representing the DAG in the DOT notation
+     */
+    static String render(DAG dag) {
+        def result = []
+        result << "digraph graphname {"
+        dag.edges.each { edge -> result << renderEdge( edge ) }
+        result << "}"
+        return result.join('\n')
+    }
+
+
+    private static String renderVertex(vertex) {
+
+        List attrs = []
+
+        switch (vertex.type) {
+            case DAG.Type.NODE:
+                attrs << "shape=point"
+                if (vertex.label) {
+                    attrs << "label=\"\""
+                    attrs << "xlabel=\"$vertex.label\""
+                }
+                break
+
+            case DAG.Type.ORIGIN:
+                attrs << "shape=point"
+                attrs << "label=\"\""
+                attrs << "fixedsize=true"
+                attrs << "width=0.1"
+                if( vertex.label ) {
+                    attrs << "xlabel=\"$vertex.label\""
+                }
+                break
+
+            case DAG.Type.OPERATOR:
+                attrs << "shape=circle"
+                attrs << "label=\"\""
+                attrs << "fixedsize=true"
+                attrs << "width=0.1"
+                if( vertex.label ) {
+                    attrs << "xlabel=\"$vertex.label\""
+                }
+                break
+
+            case DAG.Type.PROCESS:
+                if( vertex.label )
+                    attrs << "label=\"$vertex.label\""
+                break
+
+            default:
+                attrs << "shape=none"
+                if( vertex.label )
+                    attrs << "label=\"$vertex.label\""
+        }
+
+
+        return attrs ? "${vertex.getName()} [${attrs.join(',')}];" : null
+    }
+
+    private static String renderEdge(edge) {
+        assert edge.from != null && edge.to != null
+
+        String A = renderVertex( edge.from )
+        String B = renderVertex( edge.to )
+
+        def result = new StringBuilder()
+        if( A ) result << A << '\n'
+        if( B ) result << B << '\n'
+        result << "${edge.from.name} -> ${edge.to.name}"
+        if( edge.label ) {
+            result << " [label=\"${edge.label}\"]"
+        }
+        result << ";\n"
+    }
+
+}

--- a/src/main/groovy/nextflow/dag/ErrorRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/ErrorRenderer.groovy
@@ -1,0 +1,19 @@
+
+
+package nextflow.dag
+
+import groovy.util.logging.Slf4j
+import java.nio.file.Path
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+@Slf4j
+class ErrorRenderer {
+
+    void renderDocument(DAG dag, Path file) {
+        log.error "Failed to render DAG file: $file. Unrecognized file format."
+    }
+}

--- a/src/main/groovy/nextflow/dag/GraphRender.groovy
+++ b/src/main/groovy/nextflow/dag/GraphRender.groovy
@@ -15,7 +15,7 @@ import nextflow.trace.TraceObserver
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
-@CompileStatic
+//@CompileStatic
 class GraphRender implements TraceObserver {
 
     static final String DEF_FILE_NAME = 'dag.dot'
@@ -23,6 +23,14 @@ class GraphRender implements TraceObserver {
     private Path file
 
     private DAG dag
+
+    private Map<String, DagRenderer> renderers = [ 'png' : new GraphVizRenderer('png'),
+                                                   'pdf' : new GraphVizRenderer('pdf'),
+                                                   'svg' : new GraphVizRenderer('svg'),
+                                                   'dot' : new DotRenderer(),
+                                                   'html': new CytoscapeHtmlRenderer(),
+                                                   'json': new CytoscapeJsRenderer() ]
+
 
     GraphRender( Path file ) {
         this.file = file
@@ -36,36 +44,8 @@ class GraphRender implements TraceObserver {
     @Override
     void onFlowComplete() {
         dag.normalize()
-
-        final format = file.getExtension() ?: 'dot'
-
-        if( format == 'html' ) {
-
-           file.text = CytoscapeJsRenderer.render(dag)
-
-        } else {
-
-            def temp = Files.createTempFile('nxf-','.dot')
-            // save the DAG as `dot` to a temp file
-            temp.text = DotRenderer.render(dag)
-
-            if( format == 'dot' ) {
-                temp.moveTo(file)
-            }
-            else {
-                final cmd = "command -v dot &>/dev/null || exit 128 && dot -T${format} ${temp} > ${file}"
-                final exitStatus = ["bash","-c", cmd].execute().waitFor()
-                if( exitStatus == 128 ) {
-                    file = file.resolveSibling( "${file.baseName}.dot" )
-                    temp.moveTo(file)
-                    log.warn "To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org for more info."
-                }
-                else if( exitStatus>0 ) {
-                    log.debug("Graphviz error -- command `$cmd` -- exist status: $exitStatus")
-                    log.warn "Failed to render DAG file: $file"
-                }
-            }
-        }
+        final format = (file.getExtension() ?: 'dot').toLowerCase()
+        renderers.get(format, new ErrorRenderer()).renderDocument(dag, file)
     }
 
 

--- a/src/main/groovy/nextflow/dag/GraphRender.groovy
+++ b/src/main/groovy/nextflow/dag/GraphRender.groovy
@@ -28,6 +28,7 @@ class GraphRender implements TraceObserver {
                                                    'pdf' : new GraphVizRenderer('pdf'),
                                                    'svg' : new GraphVizRenderer('svg'),
                                                    'dot' : new DotRenderer(),
+                                                   'htm' : new DagreD3Renderer(),
                                                    'html': new CytoscapeHtmlRenderer(),
                                                    'json': new CytoscapeJsRenderer() ]
 

--- a/src/main/groovy/nextflow/dag/GraphRender.groovy
+++ b/src/main/groovy/nextflow/dag/GraphRender.groovy
@@ -35,28 +35,37 @@ class GraphRender implements TraceObserver {
 
     @Override
     void onFlowComplete() {
+        dag.normalize()
+
         final format = file.getExtension() ?: 'dot'
-        def temp = Files.createTempFile('nxf-','.dot')
-        // save the DAG as `dot` to a temp file
-        temp.text = dag.render()
 
-        if( format == 'dot' ) {
-            temp.moveTo(file)
-        }
-        else {
-            final cmd = "command -v dot &>/dev/null || exit 128 && dot -T${format} ${temp} > ${file}"
-            final exitStatus = ["bash","-c", cmd].execute().waitFor()
-            if( exitStatus == 128 ) {
-                file = file.resolveSibling( "${file.baseName}.dot" )
+        if( format == 'html' ) {
+
+           file.text = CytoscapeJsRenderer.render(dag)
+
+        } else {
+
+            def temp = Files.createTempFile('nxf-','.dot')
+            // save the DAG as `dot` to a temp file
+            temp.text = DotRenderer.render(dag)
+
+            if( format == 'dot' ) {
                 temp.moveTo(file)
-                log.warn "To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org for more info."
             }
-            else if( exitStatus>0 ) {
-                log.debug("Graphviz error -- command `$cmd` -- exist status: $exitStatus")
-                log.warn "Failed to render DAG file: $file"
+            else {
+                final cmd = "command -v dot &>/dev/null || exit 128 && dot -T${format} ${temp} > ${file}"
+                final exitStatus = ["bash","-c", cmd].execute().waitFor()
+                if( exitStatus == 128 ) {
+                    file = file.resolveSibling( "${file.baseName}.dot" )
+                    temp.moveTo(file)
+                    log.warn "To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org for more info."
+                }
+                else if( exitStatus>0 ) {
+                    log.debug("Graphviz error -- command `$cmd` -- exist status: $exitStatus")
+                    log.warn "Failed to render DAG file: $file"
+                }
             }
         }
-
     }
 
 

--- a/src/main/groovy/nextflow/dag/GraphVizRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/GraphVizRenderer.groovy
@@ -1,0 +1,45 @@
+
+package nextflow.dag
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import java.nio.file.Path
+import java.nio.file.Files
+
+/**
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+@Slf4j
+class GraphVizRenderer implements DagRenderer {
+
+    private final String format
+
+    GraphVizRenderer(String format) {
+        this.format = format
+    }
+
+    /**
+     * Render the DAG using Graphviz to the specified
+     * file in a format specified in the constructor.
+     * See http://www.graphviz.org for more info.
+     */
+    @Override
+    void renderDocument(DAG dag, Path file) {
+        def temp = Files.createTempFile('nxf-','.dot')
+        // save the DAG as `dot` to a temp file
+        temp.text = DotRenderer.renderNetwork(dag)
+
+        final cmd = "command -v dot &>/dev/null || exit 128 && dot -T${format} ${temp} > ${file}"
+        final exitStatus = ["bash","-c", cmd].execute().waitFor()
+        if( exitStatus == 128 ) {
+            file = file.resolveSibling( "${file.baseName}.dot" )
+            temp.moveTo(file)
+            log.warn "To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org for more info."
+        }
+        else if( exitStatus>0 ) {
+            log.debug("Graphviz error -- command `$cmd` -- exist status: $exitStatus")
+            log.warn "Failed to render DAG file: $file"
+        }
+    }
+}

--- a/src/main/resources/nextflow/dag/cytoscape.js.dag.template.html
+++ b/src/main/resources/nextflow/dag/cytoscape.js.dag.template.html
@@ -1,0 +1,125 @@
+<!DOCTYPE>
+
+<html>
+
+    <head>
+        <title>Nextflow Cytoscape.js with Dagre</title>
+
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+        <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+        <script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min.js"></script>
+        <script src="https://cdn.rawgit.com/cpettitt/dagre/v0.7.4/dist/dagre.min.js"></script>
+        <script src="https://cdn.rawgit.com/cytoscape/cytoscape.js-dagre/1.1.2/cytoscape-dagre.js"></script>
+
+        <style>
+            body {
+                font-family: helvetica;
+                font-size: 14px;
+            }
+
+            #cy {
+                width: 100%;
+                height: 100%;
+                position: absolute;
+                left: 0;
+                top: 0;
+                z-index: 999;
+            }
+
+            h1 {
+                opacity: 0.5;
+                font-size: 1em;
+            }
+        </style>
+
+        <script>
+            $(function(){
+                var cy = window.cy = cytoscape({
+                    container: document.getElementById('cy'),
+                    boxSelectionEnabled: false,
+                    autounselectify: true,
+
+                    layout: {
+                        name: 'dagre'
+                    },
+
+                    style: cytoscape.stylesheet()
+                        .selector( 'node')
+                            .css({
+                                'width': 10,
+                                'height': 10,
+                                'content': 'data(label)',
+                                'text-valign': 'center',
+                                'text-halign': 'center',
+                                'text-opacity': 0.5,
+                            })
+                        .selector('node.PROCESS')
+                            .css({
+                                'width': 100,
+                                'height': 50,
+                                'text-opacity': 0.9,
+                                'background-color': '#009911'
+                            })
+                        .selector('node.OPERATOR')
+                            .css({
+                                'background-color': '#11479e',
+                                'text-halign': 'right',
+                            })
+                        .selector('node.ORIGIN')
+                            .css({
+                                'background-color': '#999999',
+                                'text-halign': 'right',
+                            })
+                        .selector('node.TERMINATION')
+                            .css({
+                                'background-color': '#999999',
+                                'text-halign': 'right',
+                            })
+                        .selector('edge')
+                            .css({
+                                'content': 'data(label)',
+                                'text-opacity': 0.5,
+                                'width': 4,
+                                'target-arrow-shape': 'triangle',
+                                'line-color': '#9dbaea',
+                                'target-arrow-color': '#9dbaea'
+                            }),
+
+/* REPLACE_WITH_NETWORK_DATA */
+
+/* this is example data that documents what the network data should look like
+                    elements: {
+                        nodes: [
+                            { data: { id: 'p0', },                    classes: 'ORIGIN' },
+                            { data: { id: 'p1', label: 'txt_to_csv'}, classes: 'PROCESS' },
+                            { data: { id: 'p2', label: 'csv_to_tsv'}, classes: 'PROCESS' },
+                            { data: { id: 'p3', label: 'filter'},     classes: 'OPERATOR'  },
+                            { data: { id: 'p4', label: 'tsv_to_psv'}, classes: 'PROCESS' },
+                            { data: { id: 'p5', label: 'toList'},     classes: 'OPERATOR'  },
+                            { data: { id: 'p6', label: 'merge'},      classes: 'PROCESS' },
+                            { data: { id: 'p7', },                    classes: 'TERMINATION' }
+                        ],
+                        edges: [
+                            { data: { source: 'p1', target: 'p2', label: 'csv_files'} },
+                            { data: { source: 'p0', target: 'p1', label: 'text_files'} },
+                            { data: { source: 'p2', target: 'p3', label: 'tsv_files'} },
+                            { data: { source: 'p3', target: 'p4'} },
+                            { data: { source: 'p4', target: 'p5', label: 'psv_files'} },
+                            { data: { source: 'p5', target: 'p6'} },
+                            { data: { source: 'p6', target: 'p7', label: 'result'} }
+                        ]
+                    },
+*/
+                });
+
+            });
+        </script>
+    </head>
+
+    <body>
+        <h1>Nextflow Cytoscape.js with Dagre</h1>
+        <div id="cy"></div>
+    </body>
+
+</html>

--- a/src/main/resources/nextflow/dag/dagre.d3.dag.template.html
+++ b/src/main/resources/nextflow/dag/dagre.d3.dag.template.html
@@ -1,0 +1,55 @@
+<html>
+<meta charset="utf-8">
+<style>
+
+body {
+  font: 300 14px 'Helvetica Neue', Helvetica;
+}
+
+.node rect {
+  stroke: #333;
+  fill: #fff;
+}
+
+.edgePath path {
+  stroke: #333;
+  fill: #333;
+  stroke-width: 1.5px;
+}
+
+</style>
+<body>
+<svg width=960 height=600><g/></svg>
+<script src="https://d3js.org/d3.v3.js"></script>
+<script src="http://cpettitt.github.io/project/dagre-d3/latest/dagre-d3.min.js"></script>
+<script>
+// Create a new directed graph
+var g = new dagreD3.graphlib.Graph().setGraph({});
+
+/* REPLACE_WITH_NETWORK_DATA */
+
+var svg = d3.select("svg"), inner = svg.select("g");
+
+// Set up zoom support
+var zoom = d3.behavior.zoom().on("zoom", function() {
+      inner.attr("transform", "translate(" + d3.event.translate + ")" +
+                                  "scale(" + d3.event.scale + ")");
+    });
+svg.call(zoom);
+
+// Create the renderer
+var render = new dagreD3.render();
+
+// Run the renderer. This is what draws the final graph.
+render(inner, g);
+
+// Center the graph
+var initialScale = 0.75;
+zoom.translate([(svg.attr("width") - g.graph().width * initialScale) / 2, 20])
+    .scale(initialScale)
+    .event(svg);
+svg.attr('height', g.graph().height * initialScale + 40);
+</script>
+
+</body>
+</html>

--- a/src/test/groovy/nextflow/dag/GraphRenderTest.groovy
+++ b/src/test/groovy/nextflow/dag/GraphRenderTest.groovy
@@ -131,6 +131,30 @@ class GraphRenderTest extends Specification {
         result.contains("label: 'Process 2'")
     }
 
+    def 'should write an htm file' () {
+        given:
+        def htm = Files.createTempFile('nxf-','.htm')
+        def gr = new GraphRender(htm)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        def result = htm.text
+
+        // is htm
+        result.contains('<html>')
+        result.contains('</html>')
+        result.contains('<svg')
+
+        // contains some of the expected javascript
+        result.contains("label: 'Source'")
+        result.contains("label: 'Process 1'")
+        result.contains("label: 'Filter'")
+        result.contains("label: 'Process 2'")
+    }
+
     def 'should write an svg file' () {
         given:
         def svg = Files.createTempFile('nxf-','.svg')

--- a/src/test/groovy/nextflow/dag/GraphRenderTest.groovy
+++ b/src/test/groovy/nextflow/dag/GraphRenderTest.groovy
@@ -1,0 +1,192 @@
+package nextflow.dag
+
+import groovyx.gpars.dataflow.DataflowChannel
+import spock.lang.Specification
+import java.nio.file.Files
+import nextflow.Session
+import nextflow.script.InputsList
+import nextflow.script.OutputsList
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+class GraphRenderTest extends Specification {
+
+    def DAG test_dag
+
+    def setup() {
+
+        def src = Mock(DataflowChannel)
+        def ch1 = Mock(DataflowChannel)
+        def ch2 = Mock(DataflowChannel)
+        def ch3 = Mock(DataflowChannel)
+
+        test_dag = new DAG()
+
+        test_dag.addVertex(
+                DAG.Type.ORIGIN,
+                'Source',
+                null,
+                [ new DAG.ChannelHandler(instance: src, label: 'src') ] )
+
+        test_dag.addVertex(
+                DAG.Type.PROCESS,
+                'Process 1',
+                [ new DAG.ChannelHandler(instance: src, label: 'Source') ],
+                [ new DAG.ChannelHandler(instance: ch1, label: 'Channel 1') ] )
+
+        test_dag.addVertex(
+                DAG.Type.OPERATOR,
+                'Filter',
+                [ new DAG.ChannelHandler(instance: ch1, label: 'Channel 1') ],
+                [ new DAG.ChannelHandler(instance: ch2, label: 'Channel 2') ] )
+
+
+        test_dag.addVertex(
+                DAG.Type.PROCESS,
+                'Process 2',
+                [ new DAG.ChannelHandler(instance: ch2, label: 'Channel 2') ],
+                [ new DAG.ChannelHandler(instance: ch3, label: 'Channel 3') ] )
+
+    }
+
+    def 'should write a dot file' () {
+        given:
+        def dot = Files.createTempFile('nxf-','.dot')
+        def gr = new GraphRender(dot)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        def result = dot.text
+        // is dot
+        result.contains('digraph graphname {')
+
+        // contains expected nodes
+        result.contains('label="Source"')
+        result.contains('label="Process 1"')
+        result.contains('label="Filter"')
+        result.contains('label="Process 2"')
+
+        // contains at least one edge
+        result.contains('->')
+    }
+
+    def 'should write a json file' () {
+        given:
+        def json = Files.createTempFile('nxf-','.json')
+        def gr = new GraphRender(json)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        def result = json.text
+
+        // is json
+        result.contains('elements: {')
+        result.contains('nodes: [')
+        result.contains('edges: [')
+
+        // contains expected nodes
+        result.contains("label: 'Source'")
+        result.contains("label: 'Process 1'")
+        result.contains("label: 'Filter'")
+        result.contains("label: 'Process 2'")
+
+        result.contains("classes: 'ORIGIN'")
+        result.contains("classes: 'PROCESS'")
+        result.contains("classes: 'OPERATOR'")
+
+        // contains at least one edge
+        result.contains('source:')
+        result.contains('target:')
+    }
+
+    def 'should write an html file' () {
+        given:
+        def html = Files.createTempFile('nxf-','.html')
+        def gr = new GraphRender(html)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        def result = html.text
+
+        // is html
+        result.contains('<html>')
+        result.contains('</html>')
+
+        // contains some of the expected json
+        result.contains("label: 'Source'")
+        result.contains("label: 'Process 1'")
+        result.contains("label: 'Filter'")
+        result.contains("label: 'Process 2'")
+    }
+
+    def 'should write an svg file' () {
+        given:
+        def svg = Files.createTempFile('nxf-','.svg')
+        def gr = new GraphRender(svg)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        // just assert that _something_ has been written
+        svg.size() > 0
+    }
+
+    def 'should write a png file' () {
+        given:
+        def png = Files.createTempFile('nxf-','.png')
+        def gr = new GraphRender(png)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        // just assert that _something_ has been written
+        png.size() > 0
+    }
+
+    def 'should write a pdf file' () {
+        given:
+        def pdf = Files.createTempFile('nxf-','.pdf')
+        def gr = new GraphRender(pdf)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        // just assert that _something_ has been written
+        pdf.size() > 0
+    }
+
+    def 'should not write anything with unknown suffix' () {
+        given:
+        def nope = Files.createTempFile('nxf-','.nope')
+        def gr = new GraphRender(nope)
+        gr.dag = test_dag
+
+        when:
+        gr.onFlowComplete()
+
+        then:
+        // nothing should be written!
+        nope.size() == 0
+
+        // Ideally also assert that an error message has been
+        // written to the logs.
+    }
+}


### PR DESCRIPTION
This change adds the ability to export a DAG as an html file where the DAG is rendered using Cytoscape.js and Dagre.  It uses a template html file and simply substitutes in the network data formatted as json that Cytoscape.js will understand.  

The only notable change is that the rendering of Dot and Cytoscape.js are separated into individual classes that are separate from the definition of the DAG, edges, and vertices.  I'd probably argue that the GraphRender class should probably move execution of the dot command to the DotRenderer class to tidy things up, but I haven't made that change. 