### PR TITLE
Allow sbatch to only output the jobid by itself

### DIFF
--- a/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -96,7 +96,7 @@ class SlurmExecutor extends AbstractGridExecutor {
      */
     @Override
     def parseJobId(String text) {
-        def pattern = ~ /Submitted batch job (\d+)/
+        def pattern = ~ /Submitted batch job (\d+)|^(\d+)$/
         for( String line : text.readLines() ) {
             def m = pattern.matcher(line)
             if( m.matches() ) {


### PR DESCRIPTION
see issue #190 - our sbatch wrapper outputs just the jobid for convenience. This pull request accepts just a naked jobid in addition to the default sbatch output.