### PR TITLE
Allows splitFasta to both write files and split by one sequence.

### DIFF
--- a/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
+++ b/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
@@ -149,6 +149,10 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
 
     private long itemsCount
 
+    protected boolean isCollectorEnabled() {
+        return (count > 1 || fileMode)
+    }
+
     /**
      * Process the object to split
      *
@@ -199,10 +203,8 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
     protected processChunk( record ) {
 
         def result = null
-        if( count == 1 && !fileMode ) {
-            result = invokeEachClosure(closure, record)
-        }
-        else {
+
+        if ( isCollectorEnabled() ) {
             // -- append to the list buffer
             collector.add(record)
 
@@ -212,6 +214,9 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
                 collector.next()
                 blockCount = 0
             }
+        }
+        else {
+            result = invokeEachClosure(closure, record)
         }
 
         return result
@@ -223,7 +228,7 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
      */
     protected CollectorStrategy createCollector() {
 
-        if( count<1 )
+        if( !isCollectorEnabled() )
             return null
 
         if( recordMode )

--- a/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
+++ b/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
@@ -73,9 +73,6 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
         if( fileMode && recordMode )
             throw new AbortOperationException("Parameters `file` and `record` conflict on operator: $operatorName")
 
-        if( fileMode && count == 1 )
-            throw new AbortOperationException("Parameter `file` requires a split size grater than 1 for operator: $operatorName")
-
         return this
     }
 
@@ -202,7 +199,7 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
     protected processChunk( record ) {
 
         def result = null
-        if( count == 1 ) {
+        if( count == 1 && !fileMode ) {
             result = invokeEachClosure(closure, record)
         }
         else {
@@ -226,7 +223,7 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
      */
     protected CollectorStrategy createCollector() {
 
-        if( count<=1 )
+        if( count<1 )
             return null
 
         if( recordMode )

--- a/src/main/groovy/nextflow/splitter/StringSplitter.groovy
+++ b/src/main/groovy/nextflow/splitter/StringSplitter.groovy
@@ -52,7 +52,7 @@ class StringSplitter extends AbstractTextSplitter {
     }
 
     protected CollectorStrategy createCollector() {
-        count > 1 ? new CharSequenceCollector() : null
+        isCollectorEnabled() ? new CharSequenceCollector() : null
     }
 
     @Override

--- a/src/test/groovy/nextflow/splitter/AbstractTextSplitterTest.groovy
+++ b/src/test/groovy/nextflow/splitter/AbstractTextSplitterTest.groovy
@@ -105,6 +105,13 @@ class AbstractTextSplitterTest extends Specification {
         result.name == 'file.fa'
         result.toString().startsWith( folder.toString() )
 
+        when:
+        splitter = [:] as AbstractTextSplitter
+        splitter.sourceFile = Paths.get('/some/file.fasta.gz')
+        splitter.options(file: true)
+        result = splitter.createCollector()
+        then:
+        result != null
     }
 
 }

--- a/src/test/groovy/nextflow/splitter/FastaSplitterTest.groovy
+++ b/src/test/groovy/nextflow/splitter/FastaSplitterTest.groovy
@@ -257,6 +257,50 @@ class FastaSplitterTest extends Specification {
                         .stripIndent().leftTrim()
     }
 
+    def testSplitToFileByOne() {
+
+        given:
+        def folder = TestHelper.createInMemTempDir()
+        def fasta = '''
+            >1aboA
+            NLFVALYDFVASGDNTLSITKGEKLRVLGYNHNGEWCEAQTKNGQGWVPS
+            NYITPVN
+            >1ycsB
+            KGVIYALWDYEPQNDDELPMKEGDCMTIIHREDEDEIEWWWARLNDKEGY
+            VPRNLLGLYP
+            >1pht
+            GYQYRALYDYKKEREEDIDLHLGDILTVNKGSLVALGFSDGQEARPEEIG
+            WLNGYNETTGERGDFPGTYVEYIGRKKISP
+            '''
+                .stripIndent().leftTrim()
+
+        when:
+        def result = new FastaSplitter().options(file: folder).target(fasta).list()
+        then:
+        result.size() == 3
+        result[0].text ==
+            '''
+            >1aboA
+            NLFVALYDFVASGDNTLSITKGEKLRVLGYNHNGEWCEAQTKNGQGWVPS
+            NYITPVN
+            '''
+                    .stripIndent().leftTrim()
+
+        result[1].text == '''
+            >1ycsB
+            KGVIYALWDYEPQNDDELPMKEGDCMTIIHREDEDEIEWWWARLNDKEGY
+            VPRNLLGLYP
+            '''
+                .stripIndent().leftTrim()
+
+        result[2].text == '''
+            >1pht
+            GYQYRALYDYKKEREEDIDLHLGDILTVNKGSLVALGFSDGQEARPEEIG
+            WLNGYNETTGERGDFPGTYVEYIGRKKISP
+            '''
+                        .stripIndent().leftTrim()
+    }
+
 
     def testSplitRecordBy2() {
 

--- a/src/test/groovy/nextflow/splitter/StringSplitterTest.groovy
+++ b/src/test/groovy/nextflow/splitter/StringSplitterTest.groovy
@@ -66,5 +66,11 @@ class StringSplitterTest extends Specification {
 
     }
 
+    def testSplitStringByOne () {
+
+        expect:
+        new StringSplitter().options(by: 1).target('ABC') .list() == ['A','B','C']
+
+    }
 
 }


### PR DESCRIPTION
This patch addresses issue https://github.com/nextflow-io/nextflow/issues/181.

This works, but I wish I had the time to cleanly refactor and separate the concepts of "count" and "collecting."  

One question: I'm not sure what to do about StringSplitter.groovy, which check if count>1.  Not sure if that should be changed or not too.

Let me know what you think and I'll updated as needed!