### PR TITLE
Allow launcher to be set up outside NXF_HOME

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -73,7 +73,7 @@ function get() {
 }
 
 function make_temp() {
-    TEMPDIR=${NXF_TEMP:-PWD}
+    TEMPDIR=${NXF_TEMP:-$PWD}
     if [ "$(uname)" = 'Darwin' ]; then mktemp $TEMPDIR/nxf-tmp.XXXXX || exit $?
     else mktemp -t nxf-tmp.XXXXX -p $TEMPDIR || exit $?
     fi
@@ -81,7 +81,8 @@ function make_temp() {
 
 function install() {
     local tmpfile=$(make_temp)
-    get "http://www.nextflow.io/releases/latest/nextflow" "$tmpfile" "$1" || exit $?
+    #get "http://www.nextflow.io/releases/latest/nextflow" "$tmpfile" "$1" || exit $?
+    get "https://raw.githubusercontent.com/douglasgscofield/nextflow/master/nextflow" "$tmpfile" "$1" || exit $?
     mv "$tmpfile" "$1" || exit $?
     chmod +x "$1" || exit $?
     bash "$1" -download || exit $?
@@ -124,6 +125,18 @@ function launch_nextflow() {
     exec bash -c "exec $cmdline"
     exit 1
 }
+
+# check if NXF_NXF_LAUNCHDIR is writable
+if [[ -w "$NXF_HOME" ]] ; then
+    NXF_LAUNCHBASE=${NXF_HOME}
+elif [[ -w "$PWD" ]] ; then
+    NXF_LAUNCHBASE=${PWD}
+elif [[ "$NXF_TEMP" && -w "$NXF_TEMP" ]] ; then
+    NXF_LAUNCHBASE=${NXF_TEMP}
+else
+    echo "Cannot write to both NXF_HOME and current directory, set NXF_TEMP to a writable directory"
+    exit 1
+fi
 
 # check self-install
 if [ "$0" = "bash" ] || [ "$0" = "/bin/bash" ]; then
@@ -218,7 +231,8 @@ NXF_GRAB=${NXF_GRAB:-''}
 NXF_CLASSPATH=${NXF_CLASSPATH:-''}
 NXF_MPIRUN=${NXF_MPIRUN:=''}
 NXF_HOST=${HOSTNAME:-localhost}
-[[ $NXF_LAUNCHER ]] || NXF_LAUNCHER=${NXF_HOME}/tmp/launcher/nextflow-${NXF_PACK}_${NXF_VER}/${NXF_HOST}
+#[[ $NXF_LAUNCHER ]] || NXF_LAUNCHER=${NXF_HOME}/tmp/launcher/nextflow-${NXF_PACK}_${NXF_VER}/${NXF_HOST}
+[[ $NXF_LAUNCHER ]] || NXF_LAUNCHER=${NXF_LAUNCHBASE}/tmp/launcher/nextflow-${NXF_PACK}_${NXF_VER}/${NXF_HOST}
 
 if [[ $NXF_MODE == ignite ]]; then
     # Fix JDK bug when there's a limit on the OS virtual memory

--- a/nextflow
+++ b/nextflow
@@ -239,7 +239,6 @@ NXF_GRAB=${NXF_GRAB:-''}
 NXF_CLASSPATH=${NXF_CLASSPATH:-''}
 NXF_MPIRUN=${NXF_MPIRUN:=''}
 NXF_HOST=${HOSTNAME:-localhost}
-#[[ $NXF_LAUNCHER ]] || NXF_LAUNCHER=${NXF_HOME}/tmp/launcher/nextflow-${NXF_PACK}_${NXF_VER}/${NXF_HOST}
 [[ $NXF_LAUNCHER ]] || NXF_LAUNCHER=${NXF_LAUNCHBASE}/tmp/launcher/nextflow-${NXF_PACK}_${NXF_VER}/${NXF_HOST}
 
 if [[ $NXF_MODE == ignite ]]; then
@@ -374,7 +373,7 @@ else
         done
         printf "$STR">"$LAUNCH_FILE"
     else
-        echo_yellow "Warning: Couldn't create cached classpath folder: $NXF_LAUNCHER -- Maybe NXF_HOME is not writable?"
+        echo_yellow "Warning: Couldn't create cached classpath folder: $NXF_LAUNCHER -- Maybe NXF_HOME is not writable or NXF_LAUNCHBASE should be used?"
     fi
 
 fi

--- a/nextflow
+++ b/nextflow
@@ -126,15 +126,23 @@ function launch_nextflow() {
     exit 1
 }
 
-# check if NXF_NXF_LAUNCHDIR is writable
-if [ -w "$NXF_HOME" ] ; then
+# find base directory to use for launchers: NXF_LAUNCHBASE > NXF_HOME > NXF_TEMP > error
+if [ ! -z "$NXF_LAUNCHBASE" ] ; then
+    if [ ! -d "$NXF_LAUNCHBASE" ] || [ ! -w "$NXF_LAUNCHBASE" ] ; then
+        echo 'Please note:'
+        echo "- If NXF_LAUNCHBASE is set, it must be a writable directory"
+        echo ''
+        exit 1
+    fi
+elif [ -w "$NXF_HOME" ] ; then
     NXF_LAUNCHBASE=${NXF_HOME}
-#elif [ -w "$PWD" ] ; then
-#    NXF_LAUNCHBASE=${PWD}
-elif [[ "$NXF_TEMP" ]] && [ -w "$NXF_TEMP" ] ; then
+elif [ ! -z "$NXF_TEMP"  ] && [ -d "$NXF_TEMP" ] && [ -w "$NXF_TEMP" ] ; then
     NXF_LAUNCHBASE=${NXF_TEMP}
 else
-    echo "Cannot write to NXF_HOME, set NXF_TEMP to a writable directory"
+    echo 'Please note:'
+    echo "- NXF_LAUNCHBASE could not be set to a writable directory. Please set NXF_LAUNCHBASE,"
+    echo "- or ensure that NXF_HOME is writable, or set NXF_TEMP to a writable directory."
+    echo ''
     exit 1
 fi
 

--- a/nextflow
+++ b/nextflow
@@ -129,12 +129,12 @@ function launch_nextflow() {
 # check if NXF_NXF_LAUNCHDIR is writable
 if [[ -w "$NXF_HOME" ]] ; then
     NXF_LAUNCHBASE=${NXF_HOME}
-elif [[ -w "$PWD" ]] ; then
-    NXF_LAUNCHBASE=${PWD}
+#elif [[ -w "$PWD" ]] ; then
+#    NXF_LAUNCHBASE=${PWD}
 elif [[ "$NXF_TEMP" && -w "$NXF_TEMP" ]] ; then
     NXF_LAUNCHBASE=${NXF_TEMP}
 else
-    echo "Cannot write to both NXF_HOME and current directory, set NXF_TEMP to a writable directory"
+    echo "Cannot write to NXF_HOME, set NXF_TEMP to a writable directory"
     exit 1
 fi
 

--- a/nextflow
+++ b/nextflow
@@ -73,8 +73,9 @@ function get() {
 }
 
 function make_temp() {
-    if [ "$(uname)" = 'Darwin' ]; then mktemp $PWD/nxf-tmp.XXXXX || exit $?
-    else mktemp -t nxf-tmp.XXXXX -p $PWD || exit $?
+    TEMPDIR=${NXF_TEMP:-PWD}
+    if [ "$(uname)" = 'Darwin' ]; then mktemp $TEMPDIR/nxf-tmp.XXXXX || exit $?
+    else mktemp -t nxf-tmp.XXXXX -p $TEMPDIR || exit $?
     fi
 }
 

--- a/nextflow
+++ b/nextflow
@@ -127,11 +127,11 @@ function launch_nextflow() {
 }
 
 # check if NXF_NXF_LAUNCHDIR is writable
-if [[ -w "$NXF_HOME" ]] ; then
+if [ -w "$NXF_HOME" ] ; then
     NXF_LAUNCHBASE=${NXF_HOME}
-#elif [[ -w "$PWD" ]] ; then
+#elif [ -w "$PWD" ] ; then
 #    NXF_LAUNCHBASE=${PWD}
-elif [[ "$NXF_TEMP" && -w "$NXF_TEMP" ]] ; then
+elif [[ "$NXF_TEMP" ]] && [ -w "$NXF_TEMP" ] ; then
     NXF_LAUNCHBASE=${NXF_TEMP}
 else
     echo "Cannot write to NXF_HOME, set NXF_TEMP to a writable directory"


### PR DESCRIPTION
We have Nextflow installed in our compute cluster's module system with NXF_HOME set to an installation subdirectory. Users were getting errors running nextflow because for each novel NXF_HOST the launcher could not be installed under NXF_HOME because it is not user-writable.  This pull request is one possible way to address this, by using NXF_LAUNCHBASE as the base of the launcher directory.  If NXF_LAUNCHBASE is set by the user, it is used; if not, then if NXF_HOME is writable, NXF_LAUNCHBASE is set to that; if not, then if NXF_TEMP is set then NXF_LAUNCHBASE is set to that; else fail.