### PR TITLE
Add support for SGI MPT

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -105,25 +105,25 @@ function launch_nextflow() {
     if [[ $NXF_MPIRUN ]]; then
         if [[ -n "$OMPI_COMM_WORLD_RANK" ]]; then 
             if [[ $OMPI_COMM_WORLD_RANK == 0 ]]; then
-		        # sleep a few seconds in order to wait worker daemons to bootstrap
-			  sleep ${NXF_SLEEP:-10}
-			  export NXF_EXECUTOR='ignite'
-			  export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
-			else
-			    cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${OMPI_COMM_WORLD_RANK}.log node ignite"
-			fi
-		elif [[ -n "$SLURM_PROCID"]]; then
+                # sleep a few seconds in order to wait worker daemons to bootstrap
+              sleep ${NXF_SLEEP:-10}
+              export NXF_EXECUTOR='ignite'
+              export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
+            else
+                cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${OMPI_COMM_WORLD_RANK}.log node ignite"
+            fi
+        elif [[ -n "$SLURM_PROCID"]]; then
             if [[ $SLURM_PROCID == 0 ]]; then
-			    # sleep a few seconds in order to wait worker daemons to bootstrap
-			    sleep ${NXF_SLEEP:-10}
-				export NXF_EXECUTOR='ignite'
-				export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
-			else
-			    cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${SLURM_PROCID}.log node ignite"
-			fi
-		else
+                # sleep a few seconds in order to wait worker daemons to bootstrap
+                sleep ${NXF_SLEEP:-10}
+                export NXF_EXECUTOR='ignite'
+                export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
+            else
+                cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${SLURM_PROCID}.log node ignite"
+            fi
+        else
             echo_red 'Missing `$OMPI_COMM_WORLD_RANK` or `$SLURM_PROCID` variable -- it looks you are not running in a MPI environment'; exit 1; 
-		fi
+        fi
     # start in daemon mode
     elif [[ "$bg" ]]; then
       local pid_file="${NXF_PID_FILE:-.nextflow.pid}"

--- a/nextflow
+++ b/nextflow
@@ -124,7 +124,7 @@ function launch_nextflow() {
 		else
             echo_red 'Missing `$OMPI_COMM_WORLD_RANK` or `$SLURM_PROCID` variable -- it looks you are not running in a MPI environment'; exit 1; 
 		fi
-	# start in daemon mode
+    # start in daemon mode
     elif [[ "$bg" ]]; then
       local pid_file="${NXF_PID_FILE:-.nextflow.pid}"
       bash -c "exec $cmdline" &

--- a/nextflow
+++ b/nextflow
@@ -103,16 +103,28 @@ function launch_nextflow() {
     done
 
     if [[ $NXF_MPIRUN ]]; then
-        if [[ -z $OMPI_COMM_WORLD_RANK ]]; then echo_red 'Missing `$OMPI_COMM_WORLD_RANK` variable -- it looks you are not running in a MPI environment'; exit 1; fi
-        if [[ $OMPI_COMM_WORLD_RANK == 0 ]]; then
-            # sleep a few seconds in order to wait worker daemons to bootstrap
-            sleep ${NXF_SLEEP:-10}
-            export NXF_EXECUTOR='ignite'
-            export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
-        else
-            cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${OMPI_COMM_WORLD_RANK}.log node ignite"
-        fi
-    # start in daemon mode
+        if [[ -n "$OMPI_COMM_WORLD_RANK" ]]; then 
+            if [[ $OMPI_COMM_WORLD_RANK == 0 ]]; then
+		        # sleep a few seconds in order to wait worker daemons to bootstrap
+			  sleep ${NXF_SLEEP:-10}
+			  export NXF_EXECUTOR='ignite'
+			  export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
+			else
+			    cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${OMPI_COMM_WORLD_RANK}.log node ignite"
+			fi
+		elif [[ -n "$SLURM_PROCID"]]; then
+            if [[ $SLURM_PROCID == 0 ]]; then
+			    # sleep a few seconds in order to wait worker daemons to bootstrap
+			    sleep ${NXF_SLEEP:-10}
+				export NXF_EXECUTOR='ignite'
+				export NXF_CLUSTER_SHUTDOWNONCOMPLETE='true'
+			else
+			    cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${SLURM_PROCID}.log node ignite"
+			fi
+		else
+            echo_red 'Missing `$OMPI_COMM_WORLD_RANK` or `$SLURM_PROCID` variable -- it looks you are not running in a MPI environment'; exit 1; 
+		fi
+		# start in daemon mode
     elif [[ "$bg" ]]; then
       local pid_file="${NXF_PID_FILE:-.nextflow.pid}"
       bash -c "exec $cmdline" &

--- a/nextflow
+++ b/nextflow
@@ -124,7 +124,7 @@ function launch_nextflow() {
 		else
             echo_red 'Missing `$OMPI_COMM_WORLD_RANK` or `$SLURM_PROCID` variable -- it looks you are not running in a MPI environment'; exit 1; 
 		fi
-		# start in daemon mode
+	# start in daemon mode
     elif [[ "$bg" ]]; then
       local pid_file="${NXF_PID_FILE:-.nextflow.pid}"
       bash -c "exec $cmdline" &

--- a/nextflow
+++ b/nextflow
@@ -112,7 +112,7 @@ function launch_nextflow() {
             else
                 cmdline="${launcher[@]} -log .nextflow_node_${HOSTNAME}_${OMPI_COMM_WORLD_RANK}.log node ignite"
             fi
-        elif [[ -n "$SLURM_PROCID"]]; then
+        elif [[ -n "$SLURM_PROCID" ]]; then
             if [[ $SLURM_PROCID == 0 ]]; then
                 # sleep a few seconds in order to wait worker daemons to bootstrap
                 sleep ${NXF_SLEEP:-10}


### PR DESCRIPTION
The SLURM schedules running the SGI Message Passing Toolkit (MPT) instead of OpenMPI do not set the OMPI_COMM_WORLD_RANK environment variable. Fortunately, they do set SLURM_PROCID in the same way. This commit adds a test for this variable. If OMPI_COMM_WORLD_RANK is set, the SLURM_PROCID test is never run.
