### PR TITLE
pass NXF_OPTS to JVM during the java version check…

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -256,7 +256,7 @@ fi
 
 # Verify installed Java version
 if [ ! -d "$NXF_LAUNCHER" ]; then # <-- only the first time
-    $JAVA_CMD -version 2>&1 | awk '/version/ {print $3}' | grep '"1\.[7|8]\..*"' > /dev/null
+    $JAVA_CMD $NXF_OPTS -version 2>&1 | awk '/version/ {print $3}' | grep '"1\.[7|8]\..*"' > /dev/null
     if [ $? -ne 0 ]; then
          echo_red "Error: cannot find Java or it's a wrong version -- please make sure that Java 7 or higher it's installed"
          echo_red "Note: Nextflow is trying to use the Java VM defined by the following environment variables:\n JAVA_CMD: $JAVA_CMD\n JAVA_HOME: $JAVA_HOME\n"


### PR DESCRIPTION
…to allow memory definition on memory-restricted environments.

I am trying to run nextflow on our farm cluster (Wellcome Trust Sanger Institute) where the amount of memory available for JVM is limited and has to be passed to java via e.g. `-Xmx` parameter. This prevents nextflow from running because it causes an error during the initial version check (the memory parameter is not added to the java call):
```
$JAVA_CMD -version 2>&1 | awk '/version/ {print $3}' | grep '"1\.[7|8]\..*"' > /dev/null
```

From the nextflow forums it seems that an environment variable `NXF_OPTS` can be used to pass arguments to the JVM. However, these options have not been consistently applied to every call to "java" in the `nextflow` file, therefore they are not passed when the script does its initial version check, which does not allow nextflow to start.

We managed to hack it so that we were able to start the nextflow by adding `NXF_OPTS` to the initial version check:
```
$JAVA_CMD $NXF_OPTS -version 2>&1 | awk '/version/ {print $3}' | grep '"1\.[7|8]\..*"' > /dev/null
```

`NXF_OPTS` together with `JAVA_HOME` can be defined in the .bashrc file:
```
export JAVA_HOME=/software/jdk1.8.0_74
export NXF_OPTS="-Xmx128m -XX:+UseSerialGC"
```

However, we think that a proper fix requires a global insertion of `NXF_OPTS` after every java call in the `nextflow` file.

Many thanks to Helen Brimmer for investigating this problem for me.