### PR TITLE
Encryption and S3 storage class options for AWS Batch executor 

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -395,6 +395,7 @@ proxyPassword               The password to use when connecting through a proxy.
 socketSendBufferSizeHint    The Size hint (in bytes) for the low level TCP send buffer.
 socketRecvBufferSizeHint    The Size hint (in bytes) for the low level TCP receive buffer.
 socketTimeout               The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out.
+storageEncryption           The S3 server side encryption to be used when saving objects on S3 (currently only AES256 is supported)
 userAgent                   The HTTP user agent header passed with all HTTP requests.
 uploadMaxThreads            The maximum number of threads used for multipart upload.
 uploadChunkSize             The size of a single part in a multipart upload (default: `10 MB`).
@@ -409,6 +410,8 @@ For example::
         client {
             maxConnections = 20
             connectionTimeout = 10000
+            uploadStorageClass = 'REDUCED_REDUNDANCY'
+            storageEncryption = 'AES256'
         }
     }
 

--- a/src/main/groovy/nextflow/executor/AwsBatchExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AwsBatchExecutor.groovy
@@ -300,12 +300,20 @@ class AwsBatchFileCopyStrategy extends SimpleFileCopyStrategy {
         }
     }
 
+
     /**
      * @return A script snippet that download from S3 the task scripts:
      * {@code .command.env}, {@code .command.sh}, {@code .command.in},
      * etc.
      */
     String getBeforeStartScript() {
+	
+		def S3StorageClass = Global.AwsGetStorageClass()
+		def S3Encryption = Global.AwsGetStorageEncryption()
+		def S3EncryptionCommand = ""
+		if(S3Encryption == "AES256") {
+			S3EncryptionCommand += "--sse "+S3Encryption
+		}
 
         """
         # aws helper
@@ -314,9 +322,9 @@ class AwsBatchFileCopyStrategy extends SimpleFileCopyStrategy {
           local s3path=\$2
 
           if [[ -d \$name ]]; then
-            aws s3 cp --quiet --storage-class REDUCED_REDUNDANCY --recursive \$name \$s3path
+            aws s3 cp \$name \$s3path --quiet --storage-class """+S3StorageClass+""" --recursive """+S3EncryptionCommand+"""
           else
-            aws s3 cp --quiet --storage-class REDUCED_REDUNDANCY \$name \$s3path
+            aws s3 cp \$name \$s3path --quiet --storage-class """+S3StorageClass+""" """+S3EncryptionCommand+"""
           fi
         }
 

--- a/src/main/groovy/nextflow/executor/AwsBatchExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AwsBatchExecutor.groovy
@@ -320,11 +320,10 @@ class AwsBatchFileCopyStrategy extends SimpleFileCopyStrategy {
         nxf_s3_upload() {
           local name=\$1
           local s3path=\$2
-
           if [[ -d \$name ]]; then
-            aws s3 cp \$name \$s3path --quiet --storage-class """+S3StorageClass+""" --recursive """+S3EncryptionCommand+"""
+            aws s3 cp \$name \$s3path --quiet --storage-class $S3StorageClass --recursive $S3EncryptionCommand
           else
-            aws s3 cp \$name \$s3path --quiet --storage-class """+S3StorageClass+""" """+S3EncryptionCommand+"""
+            aws s3 cp \$name \$s3path --quiet --storage-class $S3StorageClass $S3EncryptionCommand
           fi
         }
 

--- a/subprojects/nxf-commons/src/main/nextflow/Global.groovy
+++ b/subprojects/nxf-commons/src/main/nextflow/Global.groovy
@@ -157,7 +157,7 @@ class Global {
         if( config==null ) config = this.config
 		if(config && config.aws instanceof Map) {
 			def client = getAwsClientConfig()
-			def storageClass = ((Map)client).storage_class
+			def storageClass = ((Map)client).upload_storage_class
 			if (storageClass == "REDUCED_REDUNDANCY") {
 				return storageClass
 			}
@@ -171,7 +171,6 @@ class Global {
 	static String AwsGetStorageEncryption(Map env=null, Map config=null) {
         if( env==null ) env = System.getenv()
         if( config==null ) config = this.config
-
 		if(config && config.aws instanceof Map) {
 			def client = getAwsClientConfig()
 			def storageEncryption = ((Map)client).storage_encryption

--- a/subprojects/nxf-commons/src/main/nextflow/Global.groovy
+++ b/subprojects/nxf-commons/src/main/nextflow/Global.groovy
@@ -157,9 +157,11 @@ class Global {
         if( config==null ) config = this.config
 		if(config && config.aws instanceof Map) {
 			def client = getAwsClientConfig()
-			def storageClass = ((Map)client).upload_storage_class
-			if (storageClass == "REDUCED_REDUNDANCY") {
-				return storageClass
+			if(client) {
+				def storageClass = ((Map)client).upload_storage_class
+				if (storageClass == "REDUCED_REDUNDANCY") {
+					return storageClass
+				}
 			}
 		}
 		return "STANDARD"
@@ -173,9 +175,11 @@ class Global {
         if( config==null ) config = this.config
 		if(config && config.aws instanceof Map) {
 			def client = getAwsClientConfig()
-			def storageEncryption = ((Map)client).storage_encryption
-			if (storageEncryption == "AES256") {
-				return storageEncryption
+			if(client) {
+				def storageEncryption = ((Map)client).storage_encryption
+				if (storageEncryption == "AES256") {
+					return storageEncryption
+				}
 			}
 		}
 		return null

--- a/subprojects/nxf-commons/src/main/nextflow/Global.groovy
+++ b/subprojects/nxf-commons/src/main/nextflow/Global.groovy
@@ -114,6 +114,9 @@ class Global {
         return null
     }
 
+
+
+
     static List<String> getAwsCredentials(Map env, Map config) {
 
         def home = Paths.get(System.properties.get('user.home') as String)
@@ -146,6 +149,41 @@ class Global {
         def ini = new IniFile(file)
         return ini.section('default').region
     }
+
+
+
+	static String AwsGetStorageClass(Map env=null, Map config=null) {
+        if( env==null ) env = System.getenv()
+        if( config==null ) config = this.config
+		if(config && config.aws instanceof Map) {
+			def client = getAwsClientConfig()
+			def storageClass = ((Map)client).storage_class
+			if (storageClass == "REDUCED_REDUNDANCY") {
+				return storageClass
+			}
+		}
+		return "STANDARD"
+
+
+	}
+
+
+	static String AwsGetStorageEncryption(Map env=null, Map config=null) {
+        if( env==null ) env = System.getenv()
+        if( config==null ) config = this.config
+
+		if(config && config.aws instanceof Map) {
+			def client = getAwsClientConfig()
+			def storageEncryption = ((Map)client).storage_encryption
+			if (storageEncryption == "AES256") {
+				return storageEncryption
+			}
+		}
+		return null
+
+
+	}
+
 
     static List<String> getAwsCredentials(Map env) {
         getAwsCredentials(env, config)

--- a/subprojects/nxf-commons/src/test/nextflow/GlobalTest.groovy
+++ b/subprojects/nxf-commons/src/test/nextflow/GlobalTest.groovy
@@ -146,4 +146,14 @@ class GlobalTest extends Specification {
 	}
 
 
+   	def testAwsStorageOptionsWithNoAwsClientConfig() {
+			
+        Global.config = [process: [
+			queue:"test"
+		]]
+
+		expect:
+		Global.AwsGetStorageEncryption() == null
+		Global.AwsGetStorageClass() == "STANDARD"
+	}
 }

--- a/subprojects/nxf-commons/src/test/nextflow/GlobalTest.groovy
+++ b/subprojects/nxf-commons/src/test/nextflow/GlobalTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class GlobalTest extends Specification {
-
+ 
 
     def testAwsCredentials() {
 
@@ -100,6 +100,50 @@ class GlobalTest extends Specification {
         then:
         Global.normalizeAwsClientConfig(config).upload_retry_sleep == '5000'
     }
+
+
+   	def testAwsStorageClassRR() {
+			
+        Global.config = [aws: [
+            region: 'eu-west-1',
+			client: [
+				storageEncryption: 'AES256',
+				uploadStorageClass: 'REDUCED_REDUNDANCY'
+			]
+        ]]
+
+		expect:
+		Global.AwsGetStorageClass() == "REDUCED_REDUNDANCY"
+	}
+
+
+
+   	def testAwsStorageClassStandard() {
+			
+        Global.config = [aws: [
+            region: 'eu-west-1',
+			client: [
+				storageEncryption: 'AES256',
+			]
+        ]]
+
+		expect:
+		Global.AwsGetStorageClass() == "STANDARD"
+	}
+
+
+   	def testAwsStorageClassStandard() {
+			
+        Global.config = [aws: [
+            region: 'eu-west-1',
+			client: [
+				storageEncryption: 'AES256',
+			]
+        ]]
+
+		expect:
+		Global.AwsGetStorageEncryption() == "AES256"
+	}
 
 
 }


### PR DESCRIPTION
I have added into the nextflow.config file the option to specify S3 server side encryption (currently just AES256). Also the existing storage class option, already available for the S3FileSystem client, is now retrieved in the AWS Batch Executor and used during file upload. Tests are provided for the functions that were added.