### PR TITLE
Added broadcast trace observer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ dependencies {
         exclude group: 'org.apache.tika', module: 'tika-core'
         exclude group: 'com.amazonaws', module: 'aws-java-sdk-s3'
     }
+    compile('com.corundumstudio.socketio:netty-socketio:1.7.12')
     compile ('com.amazonaws:aws-java-sdk-s3:1.11.25')
     compile ('com.amazonaws:aws-java-sdk-ec2:1.11.25')
     compile ('javax.mail:mail:1.4.7')

--- a/src/main/groovy/nextflow/Session.groovy
+++ b/src/main/groovy/nextflow/Session.groovy
@@ -49,6 +49,7 @@ import nextflow.script.ScriptBinding
 import nextflow.trace.ExtraeTraceObserver
 import nextflow.trace.GraphObserver
 import nextflow.trace.TimelineObserver
+import nextflow.trace.BroadcastObserver
 import nextflow.trace.TraceFileObserver
 import nextflow.trace.TraceObserver
 import nextflow.util.Barrier
@@ -307,6 +308,7 @@ class Session implements ISession {
         createTimelineObserver(result)
         createExtraeObserver(result)
         createDagObserver(result)
+        createBroadcastObserver(result)
 
         return result
     }
@@ -336,6 +338,18 @@ class Session implements ISession {
             if( !fileName ) fileName = TimelineObserver.DEF_FILE_NAME
             def traceFile = (fileName as Path).complete()
             def observer = new TimelineObserver(traceFile)
+            result << observer
+        }
+    }
+
+    /**
+     * Create broadcast observer
+     */
+    protected void createBroadcastObserver(Collection<TraceObserver> result) {
+        Boolean isEnabled = config.navigate('broadcast.enabled') as Boolean
+        Integer port = config.navigate('broadcast.port') as Integer
+        if( isEnabled ) {
+            def observer = new BroadcastObserver(port)
             result << observer
         }
     }

--- a/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -144,6 +144,9 @@ class CmdRun extends CmdBase implements HubOptions {
     @Parameter(names = ['-with-timeline'], description = 'Create processes execution timeline file')
     String withTimeline
 
+    @Parameter(names = ['-with-broadcast'], description = 'Create a trace event broadcast server')
+    String withBroadcast
+
     @Parameter(names = '-with-singularity', description = 'Enable process execution in a Singularity container')
     def withSingularity
 

--- a/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -215,6 +215,11 @@ class Launcher {
                 normalized << TimelineObserver.DEF_FILE_NAME
             }
 
+            else if( current == '-with-broadcast' && (i==args.size() || args[i].startsWith('-'))) {
+                log.info "with broadcast found"
+                normalized << '-'
+            }
+
             else if( current == '-with-dag' && (i==args.size() || args[i].startsWith('-'))) {
                 normalized << GraphObserver.DEF_FILE_NAME
             }

--- a/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -43,6 +43,7 @@ import nextflow.util.HistoryFile
 class ConfigBuilder {
 
     static final public DEFAULT_PROFILE = 'standard'
+    static final public DEFAULT_BROADCAST_PORT = 9092
 
     CliOptions options
 
@@ -394,6 +395,19 @@ class ConfigBuilder {
             config.timeline.enabled = true
             if( !config.timeline.file )
                 config.timeline.file = cmdRun.withTimeline
+        }
+
+        // -- sets broadcast server options
+        if( cmdRun.withBroadcast ) {
+            if( !(config.broadcast instanceof Map) )
+                config.broadcast = [:]
+            config.broadcast.enabled = true
+            try {
+                int port = Integer.parseInt(cmdRun.withBroadcast)
+                config.broadcast.port = port
+            } catch (NumberFormatException ex) {
+                config.broadcast.port = DEFAULT_BROADCAST_PORT
+            }
         }
 
         // -- sets DAG report options

--- a/src/main/groovy/nextflow/trace/BroadcastObserver.groovy
+++ b/src/main/groovy/nextflow/trace/BroadcastObserver.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2013-2016, Centre for Genomic Regulation (CRG).
+ * Copyright (c) 2013-2016, Paolo Di Tommaso and the respective authors.
+ *
+ *   This file is part of 'Nextflow'.
+ *
+ *   Nextflow is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Nextflow is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Nextflow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nextflow.trace
+import java.nio.file.Path
+
+import groovy.transform.PackageScope
+import groovy.util.logging.Slf4j
+import nextflow.Session
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskProcessor
+
+import com.corundumstudio.socketio.Configuration
+import com.corundumstudio.socketio.SocketIOServer
+import com.corundumstudio.socketio.BroadcastOperations
+
+/**
+ * SocketIO trace event broadcast server.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Mike Smoot <mes@aescon.com>
+ */
+@Slf4j
+class BroadcastObserver implements TraceObserver {
+
+    private final SocketIOServer server;
+    private final BroadcastOperations broadcast;
+
+    BroadcastObserver( int port ) {
+        log.info 'Constructing Broadcast observer'
+        Configuration config = new Configuration();
+        config.setHostname('localhost');
+        config.setPort(port);
+
+        server = new SocketIOServer(config);
+        broadcast = server.getBroadcastOperations();
+    }
+
+    private void send(msg) {
+        broadcast.sendEvent( "message", msg.replaceAll("'",'"'));
+    }
+
+    @Override
+    void onFlowStart(Session session) {
+        server.start();
+        send("{'type': 'flow_start', 'name': 'pipeline'}")
+    }
+
+    @Override
+    void onFlowComplete() {
+        send("{'type': 'flow_stop', 'name': 'pipeline'}")
+        server.stop();
+    }
+
+    @Override
+    void onProcessCreate(TaskProcessor process) {
+        send("{'type': 'process_create', 'name': '${process.getName()}'}")
+    }
+
+
+    @Override
+    void onProcessSubmit(TaskHandler handler) {
+        send("{'type': 'process_submit', 'name': '${handler.task.name}' }")
+    }
+
+    @Override
+    void onProcessStart(TaskHandler handler) {
+        send("{'type': 'process_start', 'name': '${handler.task.name}'}")
+    }
+
+    @Override
+    void onProcessComplete(TaskHandler handler) {
+        send("{'type': 'process_complete', 'name': '${handler.task.name}'}")
+    }
+
+    @Override
+    void onProcessCached(TaskHandler handler) {
+        send("{'type': 'process_cached', 'name': '${handler.task.name}'}")
+    }
+
+}


### PR DESCRIPTION
This is a very basic socketio server that broadcasts trace events as they occur.  This is enabled with a `-with-broadcast` command line flag.  The flag takes an optional port number argument on which the server will broadcast.  If the port number doesn't parse as an integer it will default to port 9092

This probably isn't ready for release.  First and foremost, I think the messages should include more information from the various objects available to TraceObserver.   Maybe just turn this into a branch in the nextflow repo?  I just want to share so that others can hack on this code too!