### PR TITLE
fixes bug 389

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     compile "com.beust:jcommander:1.35"
     compile("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
     compile('org.iq80.leveldb:leveldb:0.7')
-    compile('org.eclipse.jgit:org.eclipse.jgit:4.3.1.201605051710-r')
+    compile('org.eclipse.jgit:org.eclipse.jgit:4.8.0.201706111038-r')
     compile('io.nextflow:nxf-s3fs:1.0.0') {
         exclude group: 'org.apache.tika', module: 'tika-core'
         exclude group: 'com.amazonaws', module: 'aws-java-sdk-s3'

--- a/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -153,10 +153,6 @@ class AssetManagerTest extends Specification {
     }
 
 
-    // Downloading the first time with a tag (not branch) should work fine.
-    // But the second time with the same tag (which would just be a pull)
-    // will cause a detached HEAD exception with jgit.
-    // So we don't pull the repo is tagged and instead return Already Up To Date.
     @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})
     def testPullTagTwice() {
 
@@ -171,13 +167,12 @@ class AssetManagerTest extends Specification {
         folder.resolve('nextflow-io/hello/.git').isDirectory()
 
         when:
-        def result = manager.download("v1.2")
+        manager.download("v1.2")
         then:
         noExceptionThrown()
-        result == "Already-up-to-date"
     }
 
-    // Hashes should behave the same as tags.
+    // The hashes used here are NOT associated with tags.
     @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})
     def testPullHashTwice() {
 
@@ -187,12 +182,12 @@ class AssetManagerTest extends Specification {
         def manager = new AssetManager().build('nextflow-io/hello', [github: [auth: token]])
 
         when:
-        manager.download("0ec2ecd0ac13bc7e32594c0258ebce55e383d241")
+        manager.download("6b9515aba6c7efc6a9b3f273ce116fc0c224bf68")
         then:
         folder.resolve('nextflow-io/hello/.git').isDirectory()
 
         when:
-        def result = manager.download("0ec2ecd0ac13bc7e32594c0258ebce55e383d241")
+        def result = manager.download("6b9515aba6c7efc6a9b3f273ce116fc0c224bf68")
         then:
         noExceptionThrown()
         result == "Already-up-to-date"
@@ -222,6 +217,8 @@ class AssetManagerTest extends Specification {
 
     // First clone a repo with a tag, then forget to include the -r argument
     // when you execute nextflow.
+    // Note that while the download will work, execution will fail subsequently
+    // at a separate check - this just tests that we don't fail because of a detached head.
     @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})
     def testPullTagThenBranch() {
 
@@ -236,10 +233,9 @@ class AssetManagerTest extends Specification {
         folder.resolve('nextflow-io/hello/.git').isDirectory()
 
         when:
-        def result = manager.download()
+        manager.download()
         then:
         noExceptionThrown()
-        result == "Already-up-to-date"
     }
 
 


### PR DESCRIPTION
So, the approach I've arrived at is to NOT run `git pull` if the repo in question is checked out to a tag or commit hash.  My original idea of running the equivalent of `git pull origin tagname` does not appear to work with JGit.  Creating a pull command with `git.pull().setRemoteBranchName(tagname)` doesn't help.  Adding a `.setRemote('origin')` doesn't help either (and is the default in the JGit code anyway).

Instead I simply check the repo to see if it's checked out to a tag and if so, don't run `git pull`.  This won't cause any problems for a commit hash and could only cause a problem with a tag if you happen to re-write the tag with a new hash.  In that case, however, I feel like you get what you deserve for violating the integrity of the tags!  :)

Anyway, let me know what you think.  I've added several tests and run this locally a bunch, but please give this a close look.