### PR TITLE
Fixes for FreeBSD

### DIFF
--- a/buildtools/make-guava-cache.sh
+++ b/buildtools/make-guava-cache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VER='16.0.1'
 FILE="guava-$VER.jar"

--- a/cloud/launch.sh
+++ b/cloud/launch.sh
@@ -124,7 +124,7 @@ fi
 #
 local scriptschell=$(mktemp)
 cat <<EndOfString >> $scriptschell
-#!/bin/bash
+#!/usr/bin/env bash
 su - ec2-user << 'EndOfScript'
 export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ./gradlew -q compile exportClasspath

--- a/docs/ignite.rst
+++ b/docs/ignite.rst
@@ -160,7 +160,7 @@ Platform LSF launcher
 
 The following example shows a launcher script for the `Platform LSF <https://en.wikipedia.org/wiki/Platform_LSF/>`_ resource manager::
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     #BSUB -oo output_%J.out
     #BSUB -eo output_%J.err
     #BSUB -J <job name>
@@ -184,7 +184,7 @@ Univa Grid Engine launcher
 
 The following example shows a launcher script for the `Univa Grid Engine <https://en.wikipedia.org/wiki/Univa_Grid_Engine>`_ (aka SGE)::
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     #$ -cwd
     #$ -j y
     #$ -o <output file name>
@@ -204,7 +204,7 @@ Linux SLURM launcher
 
 When using Linux SLURM you will need to use ``srun`` instead ``mpirun`` in your launcher script. For example::
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     #SBATCH --job-name=<job name>
     #SBATCH --output=<log file %j>
     #SBATCH --ntasks=5

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -237,7 +237,7 @@ where the Nextflow script file is located (any other location can be provided by
 
 The template script can contain any piece of code that can be executed by the underlying system. For example::
 
-  #!/bin/bash
+  #!/usr/bin/env bash
   echo "process started at `date`"
   echo $STR
   :

--- a/docs/sync-doc.sh
+++ b/docs/sync-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TARGET=../../nextflow-website/assets
 LATEST=$TARGET/docs/latest/
 

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export NXF_CMD=$PWD/nextflow; 
 (

--- a/launch.sh
+++ b/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2013-2016, Centre for Genomic Regulation (CRG).
 # Copyright (c) 2013-2016, Paolo Di Tommaso and the respective authors.

--- a/nextflow
+++ b/nextflow
@@ -88,7 +88,7 @@ function get() {
 
 function make_temp() {
     local base=${NXF_TEMP:=$PWD}
-    if [ "$(uname)" = 'Darwin' ]; then mktemp "${base}/nxf-tmp.XXXXX" || exit $?
+    if [ "$(uname)" = 'Darwin' ] || [ "$(uname)" = 'FreeBSD' ]; then mktemp "${base}/nxf-tmp.XXXXX" || exit $?
     else mktemp -t nxf-tmp.XXXXX -p "${base}" || exit $?
     fi
 }

--- a/nextflow
+++ b/nextflow
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright (c) 2013-2017, Centre for Genomic Regulation (CRG).
 #  Copyright (c) 2013-2017, Paolo Di Tommaso and the respective authors.

--- a/pub-tests.sh
+++ b/pub-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Make test results available through

--- a/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
+++ b/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
@@ -323,7 +323,7 @@ class AmazonCloudDriver implements CloudDriver {
         }
 
         if( builder ) {
-            builder.add(0, '#!/bin/bash')
+            builder.add(0, '#!/usr/bin/env bash')
         }
 
         builder.join('\n')

--- a/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -642,7 +642,7 @@ class BashWrapperBuilder {
 
         // override the docker entry point the image is NOT defined as executable
         if( !executable )
-            builder.params(entry: '/usr/bin/env bash')
+            builder.params(entry: '/bin/bash')
 
         builder.build()
         return builder

--- a/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -99,7 +99,7 @@ class BashWrapperBuilder {
 
         nxf_mktemp() {
             local base=${1:-/tmp}
-            if [[ $(uname) = Darwin ]]; then mktemp -d $base/nxf.XXXXXXXXXX
+            if [[ $(uname) = Darwin ]] || [[ $(uname) = FreeBSD ]]; then mktemp -d $base/nxf.XXXXXXXXXX
             else TMPDIR="$base" mktemp -d -t nxf.XXXXXXXXXX
             fi
         }

--- a/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -65,7 +65,7 @@ class BashWrapperBuilder {
         catch( Exception e ) {
             log.warn "Invalid value for `NXF_DEBUG` variable: $str -- See http://www.nextflow.io/docs/latest/config.html#environment-variables"
         }
-        BASH = Collections.unmodifiableList(  level > 0 ? ['/bin/bash','-uex'] : ['/bin/bash','-ue'] )
+        BASH = Collections.unmodifiableList(  level > 0 ? ['/usr/bin/env bash','-uex'] : ['/usr/bin/env bash','-ue'] )
 
     }
 
@@ -372,7 +372,7 @@ class BashWrapperBuilder {
          */
 
         def wrapper = new StringBuilder()
-        wrapper << '#!/bin/bash' << ENDL
+        wrapper << '#!/usr/bin/env bash' << ENDL
         if( headerScript )
             wrapper << headerScript << ENDL
 
@@ -449,7 +449,7 @@ class BashWrapperBuilder {
          */
         if( statsEnabled || fixOwnership() ) {
             final stub = new StringBuilder()
-            stub << '#!/bin/bash' << ENDL
+            stub << '#!/usr/bin/env bash' << ENDL
             stub << 'set -e' << ENDL
             stub << 'set -u' << ENDL
             stub << 'NXF_DEBUG=${NXF_DEBUG:=0}; [[ $NXF_DEBUG > 2 ]] && set -x' << ENDL << ENDL
@@ -478,7 +478,7 @@ class BashWrapperBuilder {
             stubFile.text = stub.toString()
 
             // invoke it from the main script
-            wrapper << "/bin/bash " << fileStr(stubFile)
+            wrapper << "/usr/bin/env bash " << fileStr(stubFile)
             if( containerBuilder && !executable ) wrapper << "\""
         }
         else {
@@ -642,7 +642,7 @@ class BashWrapperBuilder {
 
         // override the docker entry point the image is NOT defined as executable
         if( !executable )
-            builder.params(entry: '/bin/bash')
+            builder.params(entry: '/usr/bin/env bash')
 
         builder.build()
         return builder

--- a/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -318,7 +318,7 @@ class TaskProcessor {
      *          <pre>
      *              {
      *                 """
-     *                 #!/bin/bash
+     *                 #!/usr/bin/env bash
      *                 do this ${x}
      *                 do that ${y}
      *                 :

--- a/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
+++ b/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 su - !{userName} << 'EndOfScript'
 (
 set -e

--- a/src/test/groovy/nextflow/cloud/aws/AmazonCloudDriverTest.groovy
+++ b/src/test/groovy/nextflow/cloud/aws/AmazonCloudDriverTest.groovy
@@ -243,7 +243,7 @@ class AmazonCloudDriverTest extends Specification {
         def script = driver.cloudInitScript(cloud)
         then:
         script ==   '''
-                    #!/bin/bash
+                    #!/usr/bin/env bash
                     su - ec2-user << 'EndOfScript'
                     (
                     set -e

--- a/src/test/groovy/nextflow/container/ContainerScriptTokensTest.groovy
+++ b/src/test/groovy/nextflow/container/ContainerScriptTokensTest.groovy
@@ -65,18 +65,18 @@ class ContainerScriptTokensTest extends Specification {
 
         when:
         script = '''
-            #!/bin/bash
+            #!/usr/bin/env bash
             container/name --foo --bar
             '''
         then:
         ContainerScriptTokens.parse( script ).image == 'container/name'
         ContainerScriptTokens.parse( script ).index == 1
         ContainerScriptTokens.parse( script ).variables == [:]
-        ContainerScriptTokens.parse( script ).lines == ['#!/bin/bash', 'container/name --foo --bar']
+        ContainerScriptTokens.parse( script ).lines == ['#!/usr/bin/env bash', 'container/name --foo --bar']
 
         when:
         script = '''
-            #!/bin/bash
+            #!/usr/bin/env bash
             THIS='one'
             THAT="two"
 
@@ -89,7 +89,7 @@ class ContainerScriptTokensTest extends Specification {
         ContainerScriptTokens.parse( script ).image ==  'hello/world'
         ContainerScriptTokens.parse( script ).index == 4
         ContainerScriptTokens.parse( script ).variables == [THIS:'one', THAT:'two']
-        ContainerScriptTokens.parse( script ).lines == ['#!/bin/bash', "THIS='one'", 'THAT="two"', '', 'hello/world --foo --bar', 'some','other', 'stuff']
+        ContainerScriptTokens.parse( script ).lines == ['#!/usr/bin/env bash', "THIS='one'", 'THAT="two"', '', 'hello/world --foo --bar', 'some','other', 'stuff']
 
     }
 

--- a/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
+++ b/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
@@ -86,9 +86,9 @@ class DockerBuilderTest extends Specification {
                 .runCommand == 'sudo docker run -i -v "$PWD":"$PWD" -w "$PWD" busybox'
 
         new DockerBuilder('busybox')
-                .params(entry: '/usr/bin/env bash')
+                .params(entry: '/bin/bash')
                 .build()
-                .runCommand == 'docker run -i -v "$PWD":"$PWD" -w "$PWD" --entrypoint /usr/bin/env bash busybox'
+                .runCommand == 'docker run -i -v "$PWD":"$PWD" -w "$PWD" --entrypoint /bin/bash busybox'
 
         new DockerBuilder('busybox')
                 .params(runOptions: '-x --zeta')

--- a/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
+++ b/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
@@ -86,9 +86,9 @@ class DockerBuilderTest extends Specification {
                 .runCommand == 'sudo docker run -i -v "$PWD":"$PWD" -w "$PWD" busybox'
 
         new DockerBuilder('busybox')
-                .params(entry: '/bin/bash')
+                .params(entry: '/usr/bin/env bash')
                 .build()
-                .runCommand == 'docker run -i -v "$PWD":"$PWD" -w "$PWD" --entrypoint /bin/bash busybox'
+                .runCommand == 'docker run -i -v "$PWD":"$PWD" -w "$PWD" --entrypoint /usr/bin/env bash busybox'
 
         new DockerBuilder('busybox')
                 .params(runOptions: '-x --zeta')
@@ -244,7 +244,7 @@ class DockerBuilderTest extends Specification {
 
         when:
         def script = '''
-            #!/bin/bash
+            #!/usr/bin/env bash
             FOO=bar
             busybox --foo --bar
             do_this
@@ -256,7 +256,7 @@ class DockerBuilderTest extends Specification {
 
         then:
         docker.addContainerRunCommand(tokens) == '''
-            #!/bin/bash
+            #!/usr/bin/env bash
             FOO=bar
             docker run -i -e "FOO=bar" -v "$PWD":"$PWD" -w "$PWD" busybox --foo --bar
             do_this
@@ -265,12 +265,12 @@ class DockerBuilderTest extends Specification {
                 .stripIndent().leftTrim()
 
         when:
-        tokens = ContainerScriptTokens.parse('#!/bin/bash\nbusybox')
+        tokens = ContainerScriptTokens.parse('#!/usr/bin/env bash\nbusybox')
         docker = new DockerBuilder('busybox')
         docker.build()
         then:
         docker.addContainerRunCommand(tokens) == '''
-            #!/bin/bash
+            #!/usr/bin/env bash
             docker run -i -v "$PWD":"$PWD" -w "$PWD" busybox
             '''
                 .stripIndent().leftTrim()

--- a/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -73,22 +73,22 @@ class ShifterBuilderTest extends Specification {
                 .runCommand == 'shifter --verbose --image busybox'
 
         new ShifterBuilder('ubuntu:latest')
-                .params(entry: '/bin/bash')
+                .params(entry: '/usr/bin/env bash')
                 .build()
-                .runCommand == 'shifter --image ubuntu:latest /bin/bash'
+                .runCommand == 'shifter --image ubuntu:latest /usr/bin/env bash'
 
         new ShifterBuilder('ubuntu')
-                .params(entry: '/bin/bash')
+                .params(entry: '/usr/bin/env bash')
                 .addEnv(Paths.get("/data/env_file"))
                 .build()
-                .runCommand == 'BASH_ENV="/data/env_file" shifter --image ubuntu /bin/bash'
+                .runCommand == 'BASH_ENV="/data/env_file" shifter --image ubuntu /usr/bin/env bash'
 
         new ShifterBuilder('fedora')
-                .params(entry: '/bin/bash')
+                .params(entry: '/usr/bin/env bash')
                 .addEnv([VAR_X:1, VAR_Y:2])
                 .addEnv("VAR_Z=3")
                 .build()
-                .runCommand == 'VAR_X=1 VAR_Y=2 VAR_Z=3 shifter --image fedora /bin/bash'
+                .runCommand == 'VAR_X=1 VAR_Y=2 VAR_Z=3 shifter --image fedora /usr/bin/env bash'
 
     }
 

--- a/src/test/groovy/nextflow/executor/AwsBatchScriptLauncherTest.groovy
+++ b/src/test/groovy/nextflow/executor/AwsBatchScriptLauncherTest.groovy
@@ -39,7 +39,7 @@ class AwsBatchScriptLauncherTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -47,7 +47,7 @@ class AwsBatchScriptLauncherTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 1
                 set -e
                 set -u
@@ -132,7 +132,7 @@ class AwsBatchScriptLauncherTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash -ue .command.sh <(aws s3 cp --quiet s3:/${folder}/.command.in -)
+                /usr/bin/env bash -ue .command.sh <(aws s3 cp --quiet s3:/${folder}/.command.in -)
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?

--- a/src/test/groovy/nextflow/executor/AwsBatchScriptLauncherTest.groovy
+++ b/src/test/groovy/nextflow/executor/AwsBatchScriptLauncherTest.groovy
@@ -75,7 +75,7 @@ class AwsBatchScriptLauncherTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }

--- a/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -158,7 +158,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -267,7 +267,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -481,7 +481,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -607,7 +607,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -826,7 +826,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -937,7 +937,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -1051,7 +1051,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -1161,7 +1161,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -1275,7 +1275,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -1387,7 +1387,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -1530,7 +1530,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -1637,7 +1637,7 @@ class BashWrapperBuilderTest extends Specification {
 
                     nxf_mktemp() {
                         local base=\${1:-/tmp}
-                        if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                        if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                         else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                         fi
                     }
@@ -1693,7 +1693,7 @@ class BashWrapperBuilderTest extends Specification {
 
                     nxf_mktemp() {
                         local base=\${1:-/tmp}
-                        if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                        if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                         else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                         fi
                     }
@@ -1749,7 +1749,7 @@ class BashWrapperBuilderTest extends Specification {
 
                     nxf_mktemp() {
                         local base=\${1:-/tmp}
-                        if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                        if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                         else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                         fi
                     }
@@ -1911,7 +1911,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }
@@ -2049,7 +2049,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 nxf_mktemp() {
                     local base=\${1:-/tmp}
-                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    if [[ \$(uname) = Darwin ]] || [[ \$(uname) = FreeBSD ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
                     else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
                     fi
                 }

--- a/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -863,7 +863,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -974,7 +974,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1087,7 +1087,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID ubuntu -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID ubuntu -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1197,7 +1197,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID ubuntu -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID ubuntu -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1312,7 +1312,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v /folder\\ with\\ blanks:/folder\\ with\\ blanks -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                docker run -i -v /folder\\ with\\ blanks:/folder\\ with\\ blanks -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1425,7 +1425,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -2086,7 +2086,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee2=\$!
                 (
                 shifter_pull docker:ubuntu:latest
-                NXF_DEBUG=\${NXF_DEBUG:=0} BASH_ENV=\"${folder}/.command.env\" shifter --image docker:ubuntu:latest /usr/bin/env bash -c "/usr/bin/env bash -ue ${folder}/.command.sh"
+                NXF_DEBUG=\${NXF_DEBUG:=0} BASH_ENV=\"${folder}/.command.env\" shifter --image docker:ubuntu:latest /bin/bash -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?

--- a/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -79,7 +79,7 @@ class BashWrapperBuilderTest extends Specification {
                 containerImage: 'docker_x',
                 environment: [a:1, b:2],
                 script: 'echo ciao',
-                shell: ['bash','-e']
+                shell: ['/usr/bin/env bash','-e']
         )
 
         when:
@@ -93,7 +93,7 @@ class BashWrapperBuilderTest extends Specification {
         wrapper.containerImage == 'docker_x'
         wrapper.environment ==  [a:1, b:2]
         wrapper.script ==  'echo ciao'
-        wrapper.shell == ['bash','-e']
+        wrapper.shell == ['/usr/bin/env bash','-e']
     }
 
 
@@ -120,7 +120,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                 .stripIndent().leftTrim()
@@ -128,7 +128,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 #BSUB -x 1
                 #BSUB -y 2
                 # NEXTFLOW TASK: Hello 1
@@ -194,7 +194,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash -ue ${folder}/.command.sh
+                /usr/bin/env bash -ue ${folder}/.command.sh
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -231,7 +231,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -239,7 +239,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 1
                 set -e
                 set -u
@@ -303,7 +303,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash ${folder}/.command.run.1
+                /usr/bin/env bash ${folder}/.command.run.1
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -313,7 +313,7 @@ class BashWrapperBuilderTest extends Specification {
 
                 folder.resolve('.command.run.1').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 set -e
                 set -u
                 NXF_DEBUG=\${NXF_DEBUG:=0}; [[ \$NXF_DEBUG > 2 ]] && set -x
@@ -402,7 +402,7 @@ class BashWrapperBuilderTest extends Specification {
                 touch .command.trace
                 start_millis=\$(nxf_date)
                 (
-                /bin/bash -ue ${folder}/.command.sh
+                /usr/bin/env bash -ue ${folder}/.command.sh
                 ) &
                 pid=\$!
                 nxf_trace "\$pid" .command.trace &
@@ -445,7 +445,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -453,7 +453,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 1
                 set -e
                 set -u
@@ -518,7 +518,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash -ue ${folder}/.command.sh < ${folder}/.command.in
+                /usr/bin/env bash -ue ${folder}/.command.sh < ${folder}/.command.in
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -568,7 +568,7 @@ class BashWrapperBuilderTest extends Specification {
          */
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -579,7 +579,7 @@ class BashWrapperBuilderTest extends Specification {
          */
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 2
                 set -e
                 set -u
@@ -644,7 +644,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash ${folder}/.command.run.1
+                /usr/bin/env bash ${folder}/.command.run.1
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -657,7 +657,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run.1').text ==
             """
-            #!/bin/bash
+            #!/usr/bin/env bash
             set -e
             set -u
             NXF_DEBUG=\${NXF_DEBUG:=0}; [[ \$NXF_DEBUG > 2 ]] && set -x
@@ -746,7 +746,7 @@ class BashWrapperBuilderTest extends Specification {
             touch .command.trace
             start_millis=\$(nxf_date)
             (
-            /bin/bash -ue ${folder}/.command.sh < ${folder}/.command.in
+            /usr/bin/env bash -ue ${folder}/.command.sh < ${folder}/.command.in
             ) &
             pid=\$!
             nxf_trace "\$pid" .command.trace &
@@ -790,7 +790,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -798,7 +798,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 3
                 set -e
                 set -u
@@ -863,7 +863,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/bin/bash -ue ${folder}/.command.sh"
+                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -901,7 +901,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -909,7 +909,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 4
                 set -e
                 set -u
@@ -974,7 +974,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/bin/bash -ue ${folder}/.command.sh"
+                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1015,7 +1015,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -1023,7 +1023,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 5
                 set -e
                 set -u
@@ -1087,7 +1087,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID ubuntu -c "/bin/bash -ue ${folder}/.command.sh"
+                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID ubuntu -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1125,7 +1125,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -1133,7 +1133,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 6
                 set -e
                 set -u
@@ -1197,7 +1197,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID ubuntu -c "/bin/bash -ue ${folder}/.command.sh"
+                docker run -i -v \$(nxf_mktemp):/tmp -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID ubuntu -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1239,7 +1239,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -1247,7 +1247,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 7
                 set -e
                 set -u
@@ -1312,7 +1312,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                docker run -i -v /folder\\ with\\ blanks:/folder\\ with\\ blanks -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/bin/bash -ue ${folder}/.command.sh"
+                docker run -i -v /folder\\ with\\ blanks:/folder\\ with\\ blanks -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1351,7 +1351,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -1359,7 +1359,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 3
                 set -e
                 set -u
@@ -1425,7 +1425,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /bin/bash --name \$NXF_BOXID busybox -c "/bin/bash -ue ${folder}/.command.sh"
+                sudo docker run -i -v ${folder}:${folder} -v "\$PWD":"\$PWD" -w "\$PWD" --entrypoint /usr/bin/env bash --name \$NXF_BOXID busybox -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1494,7 +1494,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 """
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 FOO=bar
                 docker run -i -e "NXF_DEBUG=\${NXF_DEBUG:=0}" -e "FOO=bar" -v $folder:$folder -v "\$PWD":"\$PWD" -w "\$PWD" --name \$NXF_BOXID docker-io/busybox --fox --baz
                 """
@@ -1502,7 +1502,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello
                 set -e
                 set -u
@@ -1567,7 +1567,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash -ue ${folder}/.command.sh
+                /usr/bin/env bash -ue ${folder}/.command.sh
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1600,7 +1600,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 """
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 docker run -i -v $folder:$folder -v "\$PWD":"\$PWD" -w "\$PWD" --name \$NXF_BOXID my.registry.com/docker-io/busybox --fox --baz
                 """
                         .stripIndent().leftTrim()
@@ -1875,7 +1875,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -1883,7 +1883,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 9
                 set -e
                 set -u
@@ -1949,7 +1949,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee .command.err < "\$CERR" >&2 &
                 tee2=\$!
                 (
-                /bin/bash -ue ${folder}/.command.sh
+                /usr/bin/env bash -ue ${folder}/.command.sh
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?
@@ -1992,7 +1992,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()
@@ -2000,7 +2000,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.run').text ==
                 """
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: Hello 1
                 set -e
                 set -u
@@ -2086,7 +2086,7 @@ class BashWrapperBuilderTest extends Specification {
                 tee2=\$!
                 (
                 shifter_pull docker:ubuntu:latest
-                NXF_DEBUG=\${NXF_DEBUG:=0} BASH_ENV=\"${folder}/.command.env\" shifter --image docker:ubuntu:latest /bin/bash -c "/bin/bash -ue ${folder}/.command.sh"
+                NXF_DEBUG=\${NXF_DEBUG:=0} BASH_ENV=\"${folder}/.command.env\" shifter --image docker:ubuntu:latest /usr/bin/env bash -c "/usr/bin/env bash -ue ${folder}/.command.sh"
                 ) >"\$COUT" 2>"\$CERR" &
                 pid=\$!
                 wait \$pid || ret=\$?

--- a/src/test/groovy/nextflow/executor/CondorExecutorTest.groovy
+++ b/src/test/groovy/nextflow/executor/CondorExecutorTest.groovy
@@ -252,7 +252,7 @@ class CondorExecutorTest extends Specification {
         folder.resolve('.command.run').canExecute()
 
         folder.resolve('.command.sh').text == '''
-                #!/bin/bash -ue
+                #!/usr/bin/env bash -ue
                 echo Hello world!
                 '''
                 .stripIndent()

--- a/src/test/groovy/nextflow/processor/ProcessConfigTest.groovy
+++ b/src/test/groovy/nextflow/processor/ProcessConfigTest.groovy
@@ -45,7 +45,7 @@ class ProcessConfigTest extends Specification {
         def config = new ProcessConfig(script)
 
         expect:
-        config.shell ==  ['/bin/bash','-ue']
+        config.shell ==  ['/usr/bin/env bash','-ue']
         config.cacheable
         config.validExitStatus == [0]
     }

--- a/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -45,9 +45,9 @@ class TaskConfigTest extends Specification {
 
         where:
         expected             | value
-        ['/bin/bash', '-ue'] | null
-        ['/bin/bash', '-ue'] | []
-        ['/bin/bash', '-ue'] | ''
+        ['/usr/bin/env bash', '-ue'] | null
+        ['/usr/bin/env bash', '-ue'] | []
+        ['/usr/bin/env bash', '-ue'] | ''
         ['bash']             | 'bash'
         ['bash']             | ['bash']
         ['bash', '-e']       | ['bash', '-e']

--- a/trigger_circleci_build.sh
+++ b/trigger_circleci_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # See 
 # https://circleci.com/docs/nightly-builds/

--- a/validation/test.sh
+++ b/validation/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 set -e 
 trap "exit" INT
 


### PR DESCRIPTION
This PR allow Nextflow to run on FreeBSD. Two changes have been integrated

- Call _/usr/bin/env bash_ instead of _/bin/bash_
- mktemp needs the same parameters as under Darwin

Note that the test suite under FreeBSD needs to be called using `gmake test`