### PR TITLE
adding AWS_DEFAULT_REGION variable. Addressing #512

### DIFF
--- a/src/main/groovy/nextflow/executor/AwsBatchExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AwsBatchExecutor.groovy
@@ -198,7 +198,8 @@ class AwsBatchTaskHandler extends TaskHandler {
                 cliPath: executor.session.getExecConfigProp(name,'awscli',null) as String,
                 storageClass: executor.session.config.navigate('aws.client.uploadStorageClass') as String,
                 storageEncryption: executor.session.config.navigate('aws.client.storageEncryption') as String,
-                remoteBinDir: executor.remoteBinDir as String
+                remoteBinDir: executor.remoteBinDir as String,
+                region: executor.session.config.navigate('aws.region') as String
             )
 
     }
@@ -605,6 +606,9 @@ class AwsBatchFileCopyStrategy extends SimpleFileCopyStrategy {
             result << "chmod +x \$PWD/nextflow-bin/*\n"
             result << "export PATH=\$PWD/nextflow-bin:\$PATH\n"
         }
+        if (opts.region) {
+            result << "export AWS_DEFAULT_REGION=${opts.region}"
+        }
         result << TaskProcessor.bashEnvironmentScript(copy)
 
         return result.size() ? "# process environment\n" + result.toString() + '\n' : null
@@ -704,6 +708,8 @@ class AwsOptions {
     String storageEncryption
 
     String remoteBinDir
+
+    String region
 
     void setStorageClass(String value) {
         if( value in [null, 'STANDARD', 'REDUCED_REDUNDANCY'])


### PR DESCRIPTION
This should address #512, it has been already tested and the export variable string is correctly added into the ```.command.run``` bash wrapper script.