### PR TITLE
-C (uppercase C) option doesn't exist

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -21,7 +21,7 @@ option ``-c <config file>``.
   ignored and they are merged as explained above.
 
 .. tip:: If you want to ignore any default configuration files and use only the custom one use the command line option
-  ``-C <config file>``.
+  ``-c <config file>``.
 
 Config syntax
 --------------


### PR DESCRIPTION
As far as I can tell, the config file can be specified with `-c` or `--config` but `-C` just tells me "beep boop, stupid user!"

```
Unknown option: -C -- Check the available commands and options and syntax with 'help'
```