### PR TITLE
install script: mktemp fails on busybox as template string contains one too few 'X's

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -89,8 +89,8 @@ function get() {
 
 function make_temp() {
     local base=${NXF_TEMP:=$PWD}
-    if [ "$(uname)" = 'Darwin' ]; then mktemp "${base}/nxf-tmp.XXXXX" || exit $?
-    else mktemp -t nxf-tmp.XXXXX -p "${base}" || exit $?
+    if [ "$(uname)" = 'Darwin' ]; then mktemp "${base}/nxf-tmp.XXXXXX" || exit $?
+    else mktemp -t nxf-tmp.XXXXXX -p "${base}" || exit $?
     fi
 }
 


### PR DESCRIPTION
The `mktemp` that ships with the latest Alpine Linux Docker image (which uses BusyBox v1.27.2) requires a template string longer than the one specified in the NextFlow 0.28.1 install script.

In the install script we have `nxf-tmp.XXXXX` but BusyBox's `mktemp` requires `nxf-tmp.XXXXXX`.  

I've also updated the template string for OS X; someone with access to OS X will need to check that I haven't broken things for them.