### PR TITLE
Introduce HTTP POST feature and broadcast workflow process runtime information

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -655,13 +655,29 @@ eventually provided by the underlying system (eg. ``sendmail`` or ``mail``).
 Scope `report`
 --------------
 
-The ``report`` scope scope allows you to define configuration setting of the workflow :ref:`execution-report`.
+The ``report`` scope allows you to define configuration setting of the workflow :ref:`execution-report`.
 
 ================== ================
 Name                Description
 ================== ================
 enabled             If ``true`` it create the workflow execution report.
 file                The path of the created execution report file (default: ``report.html``).
+================== ================
+
+.. _config-weblog:
+
+Scope `weblog`
+--------------
+
+The ``weblog`` scope allows to send detailed :ref:`trace scope<trace-fields>` information as HTTP POST request to a webserver, shipped as a JSON object.
+
+Detailed information about the JSON fields can be found in the :ref:`weblog description<weblog-service>`.
+
+================== ================
+Name                Description
+================== ================
+enabled             If ``true`` it will send HTTP POST requests to a given url.
+url                The url where to send HTTP POST requests (default: ``http:localhost``).
 ================== ================
 
 

--- a/docs/tracing.rst
+++ b/docs/tracing.rst
@@ -220,3 +220,50 @@ The DAG produced by Nextflow for the `Shootstrap <https://github.com/cbcrg/shoot
 
 .. image:: images/dag.png
 
+.. _weblog-service:
+
+Weblog via HTTP
+===============
+
+In order to enable Nextflow to send detailed trace reports via HTTP POST requests, add the following command line option::
+
+  nextflow run <pipeline name> -with-weblog [url]
+
+Nextflow will then take trace information and send it as JSON object to the given URL. An example JSON message can look like this::
+
+   {
+        "runName": "mighty_jones",
+        "runId": "f6b21633-af1e-4fe2-8328-39e70b110c83",
+        "runStatus": "process_started",
+        "utcTime": "2018-05-14T08:28:48Z",
+        "trace": {
+            "task_id": 2,
+            "status": "RUNNING",
+            "hash": "e9/9efab9",
+            "name": "printHello (3)",
+            "exit": 2147483647,
+            "submit": 1526313056637,
+            "start": 1526313056715,
+            "process": "printHello",
+            "tag": null,
+            "module": [
+
+            ],
+            "container": "nextflow/examples",
+            ...
+   }
+
+The JSON object contains the following attributes:
+
+================== ================
+Attribute          Description
+================== ================
+runName            The worklow run name. Nextflow creates an own, if you do not provide one explicitly.
+runId              The unique workflow id Nextflow creates for every workflow.
+runStatus          The current status of the workflow. One of ``["started", "process_submitted", "process_started", "process_completed", "error", "completed"]``.
+utcTime            The UTC timestamp in ISO 8601 format.
+(trace)            Provided only on process submission, process start, process complete and workflow error.
+================== ================
+
+The ``trace`` attribute contains a list of trace information fields, which you can look up in the :ref:`trace fields<trace-fields>` description.
+

--- a/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
  * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
  * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
  *
@@ -129,6 +130,9 @@ class CmdRun extends CmdBase implements HubOptions {
 
     @Parameter(names='-stdin', hidden = true)
     boolean stdin
+
+    @Parameter(names = ['-with-weblog'], description = 'Send workflow status messages via HTTP to target URL')
+    String withWebLog
 
     @Parameter(names = ['-with-trace'], description = 'Create processes execution tracing file')
     String withTrace

--- a/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
  * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
  * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
  *
@@ -226,6 +227,10 @@ class Launcher {
             }
 
             else if( current == '-with-singularity' && (i==args.size() || args[i].startsWith('-'))) {
+                normalized << '-'
+            }
+
+            else if( current == '-with-weblog' && (i==args.size() || args[i].startsWith('-'))) {
                 normalized << '-'
             }
 

--- a/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
  * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
  * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
  *
@@ -496,6 +497,15 @@ class ConfigBuilder {
                 config.notification.enabled = true
                 config.notification.to = cmdRun.withNotification
             }
+        }
+
+        // -- sets the messages options
+        if( cmdRun.withWebLog ) {
+            if( !(config.weblog instanceof Map) )
+                config.weblog = [:]
+            config.weblog.enabled = true
+            if ( !config.weblog.url )
+                config.weblog.url = cmdRun.withWebLog
         }
 
 

--- a/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
  * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
  * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
  *
@@ -502,7 +503,7 @@ class TaskPollingMonitor implements TaskMonitor {
         finally {
             // abort the session if a task task was returned
             if (fault instanceof TaskFault) {
-                session.fault(fault)
+                session.fault(fault, handler)
             }
         }
     }
@@ -539,7 +540,7 @@ class TaskPollingMonitor implements TaskMonitor {
 
             // abort the execution in case of task failure
             if (fault instanceof TaskFault) {
-                session.fault(fault)
+                session.fault(fault, handler)
             }
         }
 

--- a/src/main/groovy/nextflow/trace/TraceObserver.groovy
+++ b/src/main/groovy/nextflow/trace/TraceObserver.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
  * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
  * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
  *
@@ -30,49 +31,56 @@ import nextflow.processor.TaskProcessor
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @CompileStatic
-interface TraceObserver {
+trait TraceObserver {
 
     /**
      * The is method is invoked when the flow is going to start
      */
-    void onFlowStart(Session session)
+    void onFlowStart(Session session){}
 
     /**
      * This method is invoked when the flow is going to complete
      */
-    void onFlowComplete()
+    void onFlowComplete(){}
 
     /*
      * Invoked when the process is created.
      */
-    void onProcessCreate( TaskProcessor process )
+    void onProcessCreate( TaskProcessor process ){}
 
     /**
      * This method is invoked before a process run is going to be submitted
      * @param handler
      */
-    void onProcessSubmit(TaskHandler handler, TraceRecord trace)
+    void onProcessSubmit(TaskHandler handler, TraceRecord trace){}
 
     /**
      * This method is invoked when a process run is going to start
      * @param handler
      */
-    void onProcessStart(TaskHandler handler, TraceRecord trace)
+    void onProcessStart(TaskHandler handler, TraceRecord trace){}
 
     /**
      * This method is invoked when a process run completes
      * @param handler
      */
-    void onProcessComplete(TaskHandler handler, TraceRecord trace)
+    void onProcessComplete(TaskHandler handler, TraceRecord trace){}
 
     /**
      * method invoked when a task execution is skipped because a cached result is found
      * @param handler
      */
-    void onProcessCached(TaskHandler handler, TraceRecord trace)
+    void onProcessCached(TaskHandler handler, TraceRecord trace){}
 
     /**
      * @return {@code true} whenever this observer requires to collect task execution metrics
      */
-    boolean enableMetrics()
+    boolean enableMetrics(){}
+
+    /**
+     * Method that is invoked, when a workflow fails.
+     * @param handler
+     * @param trace
+     */
+    void onFlowError(TaskHandler handler, TraceRecord trace){}
 }

--- a/src/main/groovy/nextflow/trace/WebLogObserver.groovy
+++ b/src/main/groovy/nextflow/trace/WebLogObserver.groovy
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
+ * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
+ * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
+ *
+ *   This file is part of 'Nextflow'.
+ *
+ *   Nextflow is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Nextflow is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Nextflow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nextflow.trace
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
+import groovyx.gpars.agent.Agent
+
+import nextflow.Session
+import nextflow.script.WorkflowMetadata
+import nextflow.util.SimpleHttpClient
+import nextflow.processor.TaskHandler
+
+/**
+ * Send out messages via HTTP to a configured URL on different workflow
+ * execution events.
+ *
+ * @author Sven Fillinger <sven.fillinger@qbic.uni-tuebingen.de>
+ */
+@Slf4j
+class WebLogObserver implements TraceObserver{
+
+    /**
+     * Workflow identifier, will be taken from the Session() object later
+     */
+    private String runName
+
+    /**
+     * Store the sessions unique ID for downstream reference purposes
+     */
+    private String runId
+
+    /**
+     * Not a HTTP header, but a message header with some general workflow info
+     */
+    private static JsonSlurper JSLURPER = new JsonSlurper()
+
+    /**
+     * The default url is localhost
+     */
+    static String DEF_URL = 'http://localhost'
+
+    /**
+     * Contains server request response
+     */
+    String response = ""
+
+    /**
+     * Simple http client object that will send out messages
+     */
+    private SimpleHttpClient httpClient = new SimpleHttpClient()
+
+    /**
+     * Holds information of workflow metadata
+     */
+    private WorkflowMetadata workflowMetadata
+
+    /**
+     * An agent for the http request in an own thread
+     */
+    private Agent<WebLogObserver> webLogAgent
+
+    /**
+     * Constructor that consumes a URL and creates
+     * a basic HTTP client.
+     * @param url The target address for sending messages to
+     */
+    WebLogObserver(String url) {
+        this.httpClient.setUrl(checkUrl(url))
+        this.runName = ""
+        this.runId = ""
+        this.webLogAgent = new Agent<>(this)
+    }
+
+    /**
+     * Check the URL and create an HttpPost() object. If a invalid i.e. protocol is used,
+     * the constructor will raise an exception.
+     *
+     * The RegEx was taken and adapted from http://urlregex.com
+     *
+     * @param url String with target URL
+     * @return The requested url or the default url, if invalid
+     */
+    static String checkUrl(String url){
+        try {
+            assert url=~ "^(https|http)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]"
+        } catch (AssertionError e){
+            throw new IllegalArgumentException("Only http or https are supported protocols. The given URL was ${url}.")
+        }
+        return url
+    }
+
+    /**
+     * On workflow start, submit a message with some basic
+     * information, like Id, activity and an ISO 8601 formatted
+     * timestamp.
+     * @param session The current Nextflow session object
+     */
+    @Override
+    void onFlowStart(Session session) {
+        // This is either set by the user or via Nexflows name generator
+        runName = session.getRunName()
+        runId = session.getUniqueId()
+        asyncHttpMessage("started")
+    }
+
+    /**
+     * Send an HTTP message when the workflow is completed.
+     */
+    @Override
+    void onFlowComplete() {
+        asyncHttpMessage("completed")
+    }
+
+    /**
+     * Send an HTTP message when a process has been submitted
+     * @param handler
+     * @param trace
+     */
+    @Override
+    void onProcessSubmit(TaskHandler handler, TraceRecord trace) {
+        asyncHttpMessage("process_submitted", trace)
+    }
+
+    /**
+     * Send an HTTP message, when a process has started
+     * @param handler
+     * @param trace
+     */
+    @Override
+    void onProcessStart(TaskHandler handler, TraceRecord trace) {
+        asyncHttpMessage("process_started", trace)
+    }
+
+    /**
+     * Send an HTTP message, when a process completed
+     * @param handler
+     * @param trace
+     */
+    @Override
+    void onProcessComplete(TaskHandler handler, TraceRecord trace) {
+        asyncHttpMessage("process_completed", trace)
+    }
+
+    /**
+     * Send an HTTP message, when a workflow has failed
+     * @param handler
+     * @param trace
+     */
+    @Override
+    void onFlowError(TaskHandler handler, TraceRecord trace) {
+        asyncHttpMessage("error", trace)
+    }
+
+    /**
+     * Little helper method that sends a HTTP POST message as JSON with
+     * the current run status, ISO 8601 UTC timestamp, run name and the TraceRecord
+     * object, if present.
+     * @param runStatus The current run status. One of {'started', 'process_submit', 'process_start',
+     * 'process_complete', 'error', 'completed'}
+     * @param trace A TraceRecord object that contains current process information
+     */
+    protected void sendHttpMessage(String runStatus, TraceRecord trace = null){
+
+        if (!this.httpClient.getUrl()){
+            this.response = "No message send, url was not specified or formatted wrong."
+            log.error(this.response)
+            return
+        }
+
+        // Set the message info
+        def time = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
+        def messageJson = JSLURPER.parseText(
+                """{ "runName": "$runName", "runId": "$runId", "runStatus":"$runStatus", "utcTime":"$time" }""")
+
+        // Append the trace object if present
+        if (trace)
+            messageJson["trace"] = JSLURPER.parseText(JsonOutput.toJson(trace.store))
+
+        // The actual HTTP request
+        httpClient.sendHttpMessage(JsonOutput.toJson(messageJson))
+        logHttpResponse()
+
+        this.response = httpClient.getResponse()
+    }
+
+    /**
+     * Asynchronous HTTP POST request wrapper.
+     * @param runStatus The workflow run status
+     * @param trace A TraceRecord object with workflow information
+     * @return A Java string, that contains the HTTP request response
+     */
+    protected void asyncHttpMessage(String runStatus, TraceRecord trace = null){
+        webLogAgent.send{sendHttpMessage(runStatus, trace)}
+    }
+
+    /**
+     * Little helper function that can be called for logging upon an incoming HTTP response
+     */
+    private void logHttpResponse(){
+        def statusCode = httpClient.getResponseCode()
+        if (statusCode == 200)
+            log.debug "Successfully send message to ${httpClient.getUrl()}, received status code 200."
+        else {
+            log.debug "Failed to send message to ${httpClient.getUrl()}, received status code $statusCode"
+            log.debug httpClient.getResponse()
+        }
+    }
+
+}

--- a/src/main/groovy/nextflow/util/SimpleHttpClient.groovy
+++ b/src/main/groovy/nextflow/util/SimpleHttpClient.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
+ * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
+ * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
+ *
+ *   This file is part of 'Nextflow'.
+ *
+ *   Nextflow is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Nextflow is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Nextflow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nextflow.util
+
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
+
+/**
+ * Small and simple http client that sends POST requests
+ * to a given URL. Currently used by the MessageObserver class
+ * only.
+ *
+ * @author Sven Fillinger <sven.fillinger@qbic.uni-tuebingen.de>
+ */
+@Slf4j
+class SimpleHttpClient {
+
+    /**
+     * Default user agent
+     */
+    private static String USER_AGENT = "Nextflow weblog"
+
+    /**
+     * Contains the HTTP POST target url
+     */
+    private String url = ""
+
+    /**
+     * Contains the response code of a request
+     */
+    private int responseCode = -1
+
+    /**
+     * Contains the response string of a request
+     */
+    private String response = ""
+
+    /**
+     * Setter for the target url
+     * @param url
+     */
+    void setUrl(String url) {
+        this.url = url
+    }
+
+    /**
+     * Send a json formatted string as HTTP POST request
+     * @param json Message content as JSON
+     */
+    void sendHttpMessage(String json) throws IllegalStateException, IllegalArgumentException{
+
+        if (!this.url)
+            throw new IllegalStateException("URL needs to be set!")
+
+        if (!isJson(json)){
+            throw new IllegalArgumentException("Message String needs to be a valid JSON object!")
+        }
+
+        // Open a connection to the target url
+        def con = setUpConnection(this.url)
+        // Make header settings
+        con.setRequestMethod("POST")
+        con.setRequestProperty("Content-Type", "application/json")
+        con.setRequestProperty("User-Agent", USER_AGENT)
+        con.setRequestProperty("Accept-Language", "en-US,en;q=0.5")
+        con.setDoOutput(true)
+
+        // Send POST request
+        DataOutputStream output = new DataOutputStream(con.getOutputStream())
+        output.writeBytes(json)
+        output.flush()
+        output.close()
+
+        // Retrieve response code
+        this.responseCode = con.getResponseCode()
+
+        // Retrieve response message
+        BufferedReader reader = new BufferedReader(new InputStreamReader(con.getInputStream()))
+        String lineContent
+        StringBuffer tmpResponse = new StringBuffer()
+
+        while ((lineContent = reader.readLine()) != null){
+            tmpResponse.append(lineContent)
+        }
+
+        reader.close()
+
+        this.response = tmpResponse.toString()
+
+    }
+
+    /**
+     * Validate JSON string
+     * @param s Putative JSON object
+     * @return true if JSON, false else
+     */
+    protected boolean isJson(String s){
+        try{
+            new JsonSlurper().parseText(s)
+        } catch (Exception e){
+            log.error(e.message, e)
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Sets up the header for the request properly and creates
+     * a connection to a target url
+     * @param url The target url
+     * @return A http connection
+     */
+    protected HttpURLConnection setUpConnection(String url){
+        new URL(url).openConnection() as HttpURLConnection
+    }
+
+    /**
+     * Getter for url
+     * @return The current set url
+     */
+    String getUrl(){
+        return this.url
+    }
+
+    /**
+     * Getter for the response code
+     * @return The HTTP response code
+     */
+    int getResponseCode(){
+        return this.responseCode
+    }
+
+    /**
+     * Getter for the response message
+     * @return The HTTP response message
+     */
+    String getResponse(){
+        return this.response
+    }
+
+    /**
+     * Getter for the current user agent
+     * @return The HTTP header user agent
+     */
+    String getUserAgent(){
+        return this.userAgent
+    }
+
+    /**
+     * Setter for the header user agent
+     * @param agent A user agent for the HTTP request
+     */
+    void setUserAgent(String agent){
+        this.userAgent = agent
+    }
+
+
+
+}

--- a/src/test/groovy/nextflow/trace/WebLogObserverTest.groovy
+++ b/src/test/groovy/nextflow/trace/WebLogObserverTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
+ * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
+ * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
+ *
+ *   This file is part of 'Nextflow'.
+ *
+ *   Nextflow is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Nextflow is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Nextflow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nextflow.trace
+
+import nextflow.Session
+import nextflow.processor.TaskHandler
+import spock.lang.Specification
+
+class WebLogObserverTest extends Specification{
+
+    def 'do not send messages on wrong formatted url' () {
+
+        when:
+        new WebLogObserver("localhost")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'send message on different workflow events' () {
+
+        given:
+        def httpPostObserver0 = Spy(WebLogObserver, constructorArgs: ["http://localhost"])
+        def sessionStub = Mock(Session){
+            getRunName() >> "testRun"
+            getUniqueId() >> UUID.randomUUID()
+        }
+        def traceStub = Mock(TraceRecord)
+        def handlerStub = Mock(TaskHandler)
+
+        when:
+        httpPostObserver0.onFlowStart(sessionStub)
+        httpPostObserver0.onFlowComplete()
+        httpPostObserver0.onProcessSubmit(handlerStub, traceStub)
+        httpPostObserver0.onProcessStart(handlerStub, traceStub)
+        httpPostObserver0.onProcessComplete(handlerStub, traceStub)
+        httpPostObserver0.onFlowError(handlerStub, traceStub)
+
+        then:
+        noExceptionThrown()
+        2 * httpPostObserver0.asyncHttpMessage(_)
+        4 * httpPostObserver0.asyncHttpMessage(!null, !null)
+
+    }
+
+}

--- a/src/test/groovy/nextflow/util/SimpleHttpClientTest.groovy
+++ b/src/test/groovy/nextflow/util/SimpleHttpClientTest.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2018, University of Tübingen, Quantitative Biology Center (QBiC).
+ * Copyright (c) 2013-2018, Centre for Genomic Regulation (CRG).
+ * Copyright (c) 2013-2018, Paolo Di Tommaso and the respective authors.
+ *
+ *   This file is part of 'Nextflow'.
+ *
+ *   Nextflow is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Nextflow is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Nextflow.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package nextflow.util
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class SimpleHttpClientTest extends Specification{
+
+    @Shared SimpleHttpClient httpClient
+
+    @Shared String dummyUrl
+
+    def setupSpec(){
+
+        httpClient = new SimpleHttpClient()
+
+        dummyUrl = "http://foo.bar"
+
+    }
+
+    def 'should set a http url successfully' () {
+
+        given:
+        def url = "http://localhost"
+
+        when:
+        httpClient.setUrl(url)
+
+        then:
+        noExceptionThrown()
+        assert httpClient.getUrl() == url
+
+    }
+
+    def 'should raise a ConnectException' () {
+
+        given:
+        def url = "http://localhost"
+
+        when:
+        httpClient.setUrl(url)
+        httpClient.sendHttpMessage('{"test_id": 2}')
+
+        then:
+        thrown(ConnectException)
+        assert httpClient.getResponse() == ''
+        assert httpClient.getResponseCode() == -1
+
+    }
+
+    def 'should return a HTTP 404 error' () {
+
+        given:
+        def con = Mock(HttpURLConnection)
+        def httpClient0 = Spy(SimpleHttpClient)
+        httpClient0.setUpConnection(dummyUrl) >> con
+        httpClient0.setUrl(dummyUrl)
+        con.getOutputStream() >> new OutputStream() {
+            @Override
+            void write(int i) throws IOException {
+
+            }
+        }
+        con.getInputStream() >> new InputStream() {
+            @Override
+            int read() throws IOException {
+                return -1
+            }
+        }
+        con.getResponseCode() >> 404
+
+        when:
+        httpClient0.sendHttpMessage('{"test_id": 2}')
+
+        then:
+        noExceptionThrown()
+        assert httpClient0.getResponseCode() == 404 : "Response code was ${httpClient.getResponseCode()}"
+
+    }
+
+    def 'should not send message when not a JSON-like string' (){
+
+        given:
+        def httpClient0 = Spy(SimpleHttpClient)
+        httpClient0.setUrl(dummyUrl)
+
+        when:
+        httpClient0.sendHttpMessage("Foobar")
+
+        then:
+        thrown(IllegalArgumentException)
+        assert httpClient0.getResponseCode() == -1
+        1 * httpClient0.isJson("Foobar")
+        0 * httpClient0.setUpConnection(dummyUrl)
+
+    }
+
+    def 'raise exception when host not available'() {
+
+        given:
+        httpClient.setUrl(dummyUrl)
+
+        when:
+        httpClient.sendHttpMessage('{"test_id": 2}')
+
+        then:
+        thrown(UnknownHostException)
+    }
+
+    def 'check isJson() method'() {
+
+        when:
+        def noJson = httpClient.isJson("noJson")
+        def json = httpClient.isJson('{"test": 2}')
+
+        then:
+        noExceptionThrown()
+        assert !noJson
+        assert json
+
+    }
+
+    def 'ckeck for missing URL'() {
+
+        when:
+        httpClient.setUrl("")
+        httpClient.sendHttpMessage()
+
+
+        then:
+        thrown(IllegalStateException)
+
+
+    }
+
+
+}


### PR DESCRIPTION
**Motivation**
I thought it would be super cool to have a mechanism to let Nextflow send **trace reports** from the workflow processes **during workflow execution**, so one can **monitor** the workflow status and process on remote target sites (Webportals, API webservice with database logging, etc.).

This idea was already mentioned here https://github.com/nextflow-io/nextflow/pull/454 by @mes5k, but using websockets instead. Websockets are a lot more complex as they are stateful and one would need to be very careful with the implementation not to brake workflow execution. So I desided to go for simple HTTP POST requests, and it is the task of the user to provide a webserver, that consumes the information (JSON).

**Mechanism**
I introduced a `-with-messages` option, that will trigger this functionality.  You can specify the url in a `messages`-scope:

```
messages {
   // example URL
   url = "http://api.myserver.com/workflow/monitor"
}
```

The logic is contained in the `MessageObserver` class analogous to the other observers, implementing the interface `TraceObserver`.  HTTP POST requests will send a JSON object with information during the following Nextflow execution steps:

- onFlowStart() - when the workflow starts
- onFlowComplete() - when the workflow is completed
- onProcessSubmit() - when a process is submitted
- onProcessStart() - when a process starts
- onProcessComplete() - when a process is completed

and **new**:

- onFlowError() - which is invoked now in all observers when the Nextflow session catches an error.

For the latter, I observed, that the `TaskHandler` object was always `null`, even when I changed the error strategy to 'finish', which should call `Session.cancel(handler)` and not `Session.abort(task.error)`. For that I had to change two lines of code https://github.com/nextflow-io/nextflow/commit/8104f6d5ccde600396dfa260eeda0e73a9e69b87, hope that is OK. 

**Information send via HTTP**
A JSON object with the following structure:

```
{
   "runName": "<Nextflow run name>",
   "runID": "<Nextflow run ID>",
   "runStatus": "<started|running|error|completed>",
   "trace": "<Nextflows trace record>"
}

```

**Note**:  The `"trace": "<Nextflows trace record>"` entry is NOT present when `onFlowStart()` and `onFlowComplete()` are invoked. When present, `"trace"` contains all information showed in the [Nextflow documentation](https://www.nextflow.io/docs/latest/tracing.html).

As this is my first PR here, critically remark my code and I am happy for feedback!

Sven









