### PR TITLE
Issue/296 relative staging and publishdir symlinks

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1945,7 +1945,8 @@ Value   Description
 ======= ==================
 copy    Input files are staged in the process work directory by creating a copy.
 link    Input files are staged in the process work directory by creating an (hard) link for each of them.
-symlink Input files are staged in the process work directory by creating an symlink for each of them (default).
+symlink Input files are staged in the process work directory by creating a symbolic link with an absolute path for each of them (default).
+rellink Input files are staged in the process work directory by creating a symbolic link with a relative path for each of them.
 ======= ==================
 
 

--- a/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -263,7 +263,8 @@ class PublishDir {
         log.trace "publishing file: $source -[$mode]-> $destination"
 
         if( !mode || mode == Mode.SYMLINK ) {
-            Files.createSymbolicLink(destination, source)
+            def sourceRelative = destination.getParent().relativize(source)
+            Files.createSymbolicLink(destination, sourceRelative)
         }
         else if( mode == Mode.LINK ) {
             FilesEx.mklink(source, [hard:true], destination)

--- a/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -45,7 +45,8 @@ class SimpleFileCopyStrategyTest extends Specification {
         files['sub/dir/seq_4.fa']  = Paths.get("/home'data/file4")
 
         when:
-        def strategy = new SimpleFileCopyStrategy()
+        def task = new TaskBean(workDir: Paths.get("/my/work/dir"))
+        def strategy = new SimpleFileCopyStrategy(task)
         def script = strategy.getStageInputFilesScript(files)
         def lines = script.readLines()
 
@@ -67,7 +68,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         files = [:]
         files['file.txt'] = Paths.get('/data/file')
         files['seq_1.fa'] = Paths.get('/data/seq')
-        strategy = new SimpleFileCopyStrategy(separatorChar: '; ')
+        strategy = new SimpleFileCopyStrategy(workDir: Paths.get("/my/work/dir"), separatorChar: '; ')
         script = strategy.getStageInputFilesScript(files)
         lines = script.readLines()
 
@@ -103,22 +104,84 @@ class SimpleFileCopyStrategyTest extends Specification {
         strategy.normalizeGlobStarPaths(['file1.txt','path/file2.txt','path/**/file3.txt', 'path/**/file4.txt','**/fa']) == ['file1.txt','path/file2.txt','path','*']
     }
 
-
     @Unroll
     def 'should return a valid stage-in command' () {
 
         given:
-        def strategy = [:] as SimpleFileCopyStrategy
+        def task = new TaskBean(workDir: Paths.get("/my/work/dir"))
+        def strategy = new SimpleFileCopyStrategy(task)
+
         expect:
         strategy.stageInCommand(source, target, mode) == result
 
         where:
-        source                      | target            | mode      | result
-        'some/path/to/file.txt'     | 'file.txt'        | null      | 'ln -s some/path/to/file.txt file.txt'
-        "some/path/to/file'3.txt"   | 'file\'3.txt'     | null      | "ln -s some/path/to/file\\'3.txt file\\'3.txt"
-        'some/path/to/file.txt'     | 'file.txt'        | 'link'    | 'ln some/path/to/file.txt file.txt'
-        '/some/path/to/file.txt'    | 'file.txt'        | 'copy'    | 'cp -fRL /some/path/to/file.txt file.txt'
-        '/some/path/to/file.txt'    | 'here/to/abc.txt' | 'copy'    | 'cp -fRL /some/path/to/file.txt here/to/abc.txt'
+        source                      | target               | mode              | result
+        'some/path/to/file.txt'     | 'file.txt'           | null              | 'ln -s some/path/to/file.txt file.txt'
+        "some/path/to/file'3.txt"   | 'file\'3.txt'        | null              | "ln -s some/path/to/file\\'3.txt file\\'3.txt"
+        'some/path/to/file.txt'     | 'file.txt'           | 'link'            | 'ln some/path/to/file.txt file.txt'
+        '/some/path/to/file.txt'    | 'file.txt'           | 'copy'            | 'cp -fRL /some/path/to/file.txt file.txt'
+        '/some/path/to/file.txt'    | 'here/to/abc.txt'    | 'copy'            | 'cp -fRL /some/path/to/file.txt here/to/abc.txt'
+
+        // Check the various combinations of relative/absolute inputs to 
+        // rellink when workDir is defined:
+        '/some/path/to/file.txt'    | 'abc.txt'            | 'rellink' | 'ln -s ../../../some/path/to/file.txt abc.txt'
+        '/some/path/to/file.txt'    | 'xyz/abc.txt'        | 'rellink' | 'ln -s ../../../../some/path/to/file.txt xyz/abc.txt'
+        'some/path/to/file.txt'     | 'abc.txt'            | 'rellink' | 'ln -s some/path/to/file.txt abc.txt'
+        '/my/other/file.txt'        | 'abc.txt'            | 'rellink' | 'ln -s ../../other/file.txt abc.txt'
+        '/my/work/dir/file.txt'     | 'abc.txt'            | 'rellink' | 'ln -s file.txt abc.txt'
+
+        // Check that the 'symlink' mode is default and uses absolute paths
+        '/some/path/to/file.txt'    | 'abc.txt'            | null              | 'ln -s /some/path/to/file.txt abc.txt'
+        '/some/path/to/file.txt'    | 'abc.txt'            | 'symlink'         | 'ln -s /some/path/to/file.txt abc.txt'
+
+    }
+
+    @Unroll
+    def 'stage-in command should throw an exception with no work dir' () {
+
+        given:
+        def strategy = new SimpleFileCopyStrategy()
+
+        when:
+        strategy.stageInCommand(source, target, mode)
+
+        then:
+        java.lang.AssertionError e = thrown()
+        e.message.startsWith("Task work dir path must be defined")
+
+        where:
+        source                      | target               | mode
+        'some/path/to/file.txt'     | 'file.txt'           | null
+        'some/path/to/file.txt'     | 'file.txt'           | 'link'
+        '/some/path/to/file.txt'    | 'file.txt'           | 'copy'
+        '/some/path/to/file.txt'    | 'file.txt'           | 'symlink'
+        '/my/work/dir/file.txt'     | 'file.txt'           | 'rellink'
+
+    }
+
+    @Unroll
+    def 'stage-in command should throw an exception absolute target path' () {
+
+        given:
+        def task = new TaskBean(workDir: Paths.get("/my/work/dir"))
+        def strategy = new SimpleFileCopyStrategy(task)
+
+        when:
+        strategy.stageInCommand(source, target, mode)
+
+        then:
+        java.lang.AssertionError e = thrown()
+        e.message.startsWith("Target path must be relative")
+
+        where:
+        source                   | target                | mode
+        '/some/path/to/file.txt' | '/abc.txt'            | null
+        'some/path/to/file.txt'  | '/abc.txt'            | null
+        '/some/path/to/file.txt' | '/some/other/abc.txt' | 'symlink'
+        'some/path/to/file.txt'  | '/some/other/abc.txt' | 'symlink'
+        '/some/path/to/file.txt' | '/some/other/abc.txt' | 'rellink'
+        'some/path/to/file.txt'  | '/some/other/abc.txt' | 'rellink'
+
     }
 
     @Unroll
@@ -184,7 +247,7 @@ class SimpleFileCopyStrategyTest extends Specification {
 
         given:
         def inputs = ['hello.txt': Paths.get('/some/file.txt'), 'dir/to/file.txt': Paths.get('/other/file.txt')]
-        def task = new TaskBean()
+        def task = new TaskBean(workDir: Paths.get("/my/work/dir"))
 
         when:
         def strategy = new SimpleFileCopyStrategy(task)
@@ -204,7 +267,7 @@ class SimpleFileCopyStrategyTest extends Specification {
 
         given:
         def inputs = ['hello.txt': Paths.get('/some/file.txt'), 'dir/to/file.txt': Paths.get('/other/file.txt')]
-        def task = new TaskBean( stageInMode: 'copy' )
+        def task = new TaskBean( stageInMode: 'copy', workDir: Paths.get("/my/work/dir") )
 
         when:
         def strategy = new SimpleFileCopyStrategy(task)


### PR DESCRIPTION
As mentioned in nextflow-io/nextflow#296, it would be very useful for symlinks to be relative paths so that -- when working directories are moved or accessed via different mount points -- the links still work.

I've modified SimpleFileCopyStrategy.groovy so that staged files are symlinked with relative paths, and the publishDir directive for symlinks also use relative paths.