### PR TITLE
When using storeDir, files are moved instead of copied + tests

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1898,7 +1898,7 @@ In more detail, it affects the process execution in two main ways:
    the ``storeDir`` directive. When the files exist the process execution is skipped and these files are used as
    the actual process result.
 
-#. Whenever a process is successfully completed the files listed in the `output` declaration block are copied into the directory
+#. Whenever a process is successfully completed the files listed in the `output` declaration block are moved into the directory
    specified by the ``storeDir`` directive.
 
 The following example shows how to use the ``storeDir`` directive to create a directory containing a BLAST database

--- a/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -156,9 +156,10 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
             def prefix = getUnstagePrefix(targetDir)
             if( prefix )
                 result << prefix
+            def useStageoutMode = (workDir != targetDir && stageoutMode == null) ? 'move' : stageoutMode
             for( int i=0; i<normalized.size(); i++ ) {
                 final path = normalized[i]
-                final cmd = stageOutCommand(path, targetDir, stageoutMode) + ' || true' // <-- add true to avoid it stops on errors
+                final cmd = stageOutCommand(path, targetDir, useStageoutMode) + ' || true' // <-- add true to avoid it stops on errors
                 result << cmd
             }
         }

--- a/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -328,6 +328,126 @@ class BashWrapperBuilderTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'test bash wrapper with inputs and outputs and storeDir' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def storeDirFolder = Files.createTempDirectory('testStoreDir')
+
+        /*
+         * simple bash run
+         */
+        when:
+        def bash = new BashWrapperBuilder([
+                name: 'Hello 1',
+                workDir: folder,
+                targetDir: storeDirFolder,
+                scratch: true,
+                inputFiles: ['sample_1.fq':Paths.get('/some/data/sample_1.fq'), 'sample_2.fq':Paths.get('/some/data/sample_2.fq'), ],
+                outputFiles: ['test.bam','test.bai'],
+                script: 'echo Hello world!',
+                headerScript: '#BSUB -x 1\n#BSUB -y 2'
+        ] as TaskBean )
+        bash.build()
+
+        then:
+        folder.resolve('.command.run').text ==
+                """
+                #!/bin/bash
+                #BSUB -x 1
+                #BSUB -y 2
+                # NEXTFLOW TASK: Hello 1
+                set -e
+                set -u
+                NXF_DEBUG=\${NXF_DEBUG:=0}; [[ \$NXF_DEBUG > 1 ]] && set -x
+
+                nxf_env() {
+                    echo '============= task environment ============='
+                    env | sort | sed "s/\\(.*\\)AWS\\(.*\\)=\\(.\\{6\\}\\).*/\\1AWS\\2=\\3xxxxxxxxxxxxx/"
+                    echo '============= task output =================='
+                }
+
+                nxf_kill() {
+                    declare -a ALL_CHILD
+                    while read P PP;do
+                        ALL_CHILD[\$PP]+=" \$P"
+                    done < <(ps -e -o pid= -o ppid=)
+
+                    walk() {
+                        [[ \$1 != \$\$ ]] && kill \$1 2>/dev/null || true
+                        for i in \${ALL_CHILD[\$1]:=}; do walk \$i; done
+                    }
+
+                    walk \$1
+                }
+
+                nxf_mktemp() {
+                    local base=\${1:-/tmp}
+                    if [[ \$(uname) = Darwin ]]; then mktemp -d \$base/nxf.XXXXXXXXXX
+                    else TMPDIR="\$base" mktemp -d -t nxf.XXXXXXXXXX
+                    fi
+                }
+
+                on_exit() {
+                  exit_status=\${ret:=\$?}
+                  printf \$exit_status > ${folder}/.exitcode
+                  set +u
+                  [[ "\$tee1" ]] && kill \$tee1 2>/dev/null
+                  [[ "\$tee2" ]] && kill \$tee2 2>/dev/null
+                  [[ "\$ctmp" ]] && rm -rf \$ctmp || true
+                  rm -rf \$NXF_SCRATCH || true
+                  exit \$exit_status
+                }
+
+                on_term() {
+                    set +e
+                    [[ "\$pid" ]] && nxf_kill \$pid
+                }
+
+                trap on_exit EXIT
+                trap on_term TERM INT USR1 USR2
+
+                NXF_SCRATCH="\$(set +u; nxf_mktemp \$TMPDIR)"
+                [[ \$NXF_DEBUG > 0 ]] && nxf_env
+                touch ${folder}/.command.begin
+                [[ \$NXF_SCRATCH ]] && echo "nxf-scratch-dir \$HOSTNAME:\$NXF_SCRATCH" && cd \$NXF_SCRATCH
+                # stage input files
+                rm -f sample_1.fq
+                rm -f sample_2.fq
+                ln -s /some/data/sample_1.fq sample_1.fq
+                ln -s /some/data/sample_2.fq sample_2.fq
+
+                set +e
+                ctmp=\$(set +u; nxf_mktemp /dev/shm 2>/dev/null || nxf_mktemp \$TMPDIR)
+                cout=\$ctmp/.command.out; mkfifo \$cout
+                cerr=\$ctmp/.command.err; mkfifo \$cerr
+                tee .command.out < \$cout &
+                tee1=\$!
+                tee .command.err < \$cerr >&2 &
+                tee2=\$!
+                (
+                /bin/bash -ue ${folder}/.command.sh
+                ) >\$cout 2>\$cerr &
+                pid=\$!
+                wait \$pid || ret=\$?
+                wait \$tee1 \$tee2
+                cp .command.out ${folder}/.command.out || true
+                cp .command.err ${folder}/.command.err || true
+                # copies output files to target
+                if [[ \${ret:=0} == 0 ]]; then
+                  mkdir -p ${storeDirFolder}
+                  mv -f test.bam ${storeDirFolder} || true
+                  mv -f test.bai ${storeDirFolder} || true
+                fi
+                """
+                        .stripIndent().leftTrim()
+
+
+        cleanup:
+        folder?.deleteDir()
+        storeDirFolder?.deleteDir()
+    }
+
 
     def 'test bash wrapper with inputs and outputs with s3 target' () {
 


### PR DESCRIPTION
This PR addresses issue #745. Based on @pditommaso's comment, this change makes the default behaviour for `storeDir` to move files to the specified directory instead of copying them.

In the process of making this change, I realised that the `storeDir` behaviour is modified by the `stageOutMode` directive, which I had assumed applied only to `publishDir`.

When `targetDir` and `workDir` differ, this is considered an indication that the `storeDir` directive was used as [`storeDir` takes precedence over `workDir`](https://github.com/nextflow-io/nextflow/blob/f8dae9c89155bd1cd0cced92df71bd0ba27e7176/src/main/groovy/nextflow/processor/TaskRun.groovy#L495) and the 'move' `stageOutMode` is used by default, unless `stageOutMode` has been specifically set to some other value.