### PR TITLE
Fix for #783 bug in dot rendering 

### DIFF
--- a/src/main/groovy/nextflow/Const.groovy
+++ b/src/main/groovy/nextflow/Const.groovy
@@ -59,12 +59,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1531207368095
+    static public final long APP_TIMESTAMP = 1529171346935
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 4873
+    static public final int APP_BUILDNUM = 4867
 
 
     /**

--- a/src/main/groovy/nextflow/Const.groovy
+++ b/src/main/groovy/nextflow/Const.groovy
@@ -59,12 +59,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1529171346935
+    static public final long APP_TIMESTAMP = 1531207368095
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 4867
+    static public final int APP_BUILDNUM = 4873
 
 
     /**

--- a/src/main/groovy/nextflow/dag/DotRenderer.groovy
+++ b/src/main/groovy/nextflow/dag/DotRenderer.groovy
@@ -55,7 +55,7 @@ class DotRenderer implements DagRenderer {
 
     String renderNetwork(DAG dag) {
         def result = []
-        result << "digraph $name {"
+        result << "digraph \"$name\" {"
         dag.edges.each { edge -> result << renderEdge( edge ) }
         result << "}\n"
         return result.join('\n')

--- a/src/test/groovy/nextflow/dag/DotRendererTest.groovy
+++ b/src/test/groovy/nextflow/dag/DotRendererTest.groovy
@@ -55,7 +55,7 @@ class DotRendererTest extends Specification {
         then:
         file.text ==
             '''
-            digraph TheGraph {
+            digraph "TheGraph" {
             p0 [shape=point,label="",fixedsize=true,width=0.1];
             p1 [shape=circle,label="",fixedsize=true,width=0.1,xlabel="Op1"];
             p0 -> p1;

--- a/src/test/groovy/nextflow/trace/GraphObserverTest.groovy
+++ b/src/test/groovy/nextflow/trace/GraphObserverTest.groovy
@@ -87,7 +87,7 @@ class GraphObserverTest extends Specification {
         then:
         def result = file.text
         // is dot
-        result.contains("digraph ${file.baseName} {")
+        result.contains("digraph \"${file.baseName}\" {")
         // contains expected nodes
         result.contains('label="Source"')
         result.contains('label="Process 1"')
@@ -194,7 +194,7 @@ class GraphObserverTest extends Specification {
         then:
         def result = file.text
         // is dot
-        result.contains("digraph ${file.baseName} {")
+        result.contains("digraph \"${file.baseName}\" {")
         // contains expected nodes
         result.contains('label="Source"')
         result.contains('label="Process 1"')


### PR DESCRIPTION
Fix for #783 bug in dot rendering. Caused by use of DOT language keyword as graph name.  

Graph name in dot is optional, so if it is not needed for anything downstream this should suffice:

```
digraph {
}
```

Otherwise, note that graph name is an instance of `ID` in [DOT language](http://www.graphviz.org/doc/info/lang.html) and:   

> An `ID` is one of the following:
> Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores ('_') or digits ([0-9]), not beginning with a digit;
> a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? );
> any double-quoted string ("...") possibly containing escaped quotes (\")1;
> an HTML string (<...>).

> An `ID` is just a string; the lack of quote characters in the first two forms is just for simplicity. There is no semantic difference between abc_2 and "abc_2", or between 2.34 and "2.34". **Obviously, to use a keyword as an `ID`, it must be quoted.** 

so this works as well:

```
digraph "graph" {
}
```