### PR TITLE
Adding additional mount points for AWS Batch containers

### DIFF
--- a/src/main/groovy/nextflow/processor/ProcessConfig.groovy
+++ b/src/main/groovy/nextflow/processor/ProcessConfig.groovy
@@ -67,6 +67,7 @@ class ProcessConfig implements Map<String,Object> {
             'cpus',
             'container',
             'containerOptions',
+            'batchContainerMounts',
             'cleanup',
             'clusterOptions',
             'disk',


### PR DESCRIPTION
Hi Paolo,

This patch allows users to add additional mount points to AWS Batch job definitions without having to create entirely new job definitions.  The motivation for our group is that we use lots of containers per pipeline and the overhead of creating job definitions for each container and then keeping those job definitions up-to-date as versions change would be way too much.  However, we really want to be able to share flat-file databases between containers using EFS.  We can't afford to have a container running blast sync a 100GB blast database from S3 to the container for each of many 1000's of jobs. Given that mounting EFS with AWS Batch is pretty straightforward, this seems like a reasonable way to go.

So, the code has cleaned up relatively nicely, I've run it successfully, and I've added unit tests, but I haven't spent a ton of time polishing this code because I'm not sure it's something you'll want to accept.  If you like this patch and think it's a reasonable addition to AWS Batch, then we can iterate on any changes you'd like (and add documentation).  Otherwise, we'll need to think internally about how to deal with this limitation.

To use this code, you'd just add the following to your `nextflow.config`

```
process.batchContainerMounts = [[name:'efs', containerPath:'/mnt/efs', hostPath:'/mnt/efs']]
```

I haven't tried it, but I assume that you could also add

```
    batchContainerMounts = [[name:'efs', containerPath:'/mnt/efs', hostPath:'/mnt/efs']]
```

to an individual process with special needs.

Let me know what you think! 


thanks,
Mike

