### PR TITLE
Easy mounts for AWS Batch

### DIFF
--- a/src/main/groovy/nextflow/cloud/aws/batch/AwsOptions.groovy
+++ b/src/main/groovy/nextflow/cloud/aws/batch/AwsOptions.groovy
@@ -46,12 +46,15 @@ class AwsOptions {
 
     String region
 
+    List batchContainerMounts
+
     AwsOptions() { }
 
     AwsOptions(Session session) {
         storageClass = session.config.navigate('aws.client.uploadStorageClass') as String
         storageEncryption = session.config.navigate('aws.client.storageEncryption') as String
         region = session.config.navigate('aws.region') as String
+        batchContainerMounts = session.config.navigate('aws.batchContainerMounts') as List
     }
 
     void setStorageClass(String value) {


### PR DESCRIPTION
Hi Paolo,

This is similar to the patch I sent you last week which allows users to specify additional mount points for AWS Batch. Whereas last time I added a `batchContainerMounts` to the `process` config scope, this time I'm adding it to the `aws` config scope.  Given that `aws` already has AWS specific things and [k8s](https://www.nextflow.io/docs/latest/config.html#scope-k8s) has several Kubernetes specific settings related to storage, I figure this additional option shouldn't be objectionable.  The code is even simpler this time.

To reiterate, this approach is much preferred for our team because it keeps pipeline specific configuration concerns encapsulated with the pipeline.  Trying to create individual job definitions for every docker image used across all of our pipelines would be a huge headache.  To do this in a reliable, maintainable, and reproducible way is very much _not_ just a matter of writing a script.

I also understand that you're already working on enhancing the batch configuration to dynamically create queues, compute environments, and other things that may address this need.  If I'm following, what you're proposing is similar to `nextflow cloud`, but for AWS Batch instead of Ignite.  I think that's a reasonable approach for running one-off pipelines, but for our production environment where we're working hard to control costs, my preference is to separate the infrastructure definition from the pipeline definition.  If I've misunderstood what you're planning and I'll be able to add mounts in a way similar to what I've described above without needing to specify the entire batch environment, then I'm happy to be patient and wait.

Like last time, if you're willing to accept this patch I'll write documentation and do whatever cleanup you'd like.


thanks,
Mike