### PR TITLE
Fix up grammar in -resume warning on new project

### DIFF
--- a/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -438,7 +438,7 @@ class ConfigBuilder {
             uniqueId = HistoryFile.DEFAULT.getLast()?.sessionId
 
             if( !uniqueId ) {
-                log.warn "It seems you never run this project before -- Option `-resume` is ignored"
+                log.warn "It appears you have never run this project before -- Option `-resume` is ignored"
             }
         }
 


### PR DESCRIPTION
- Changed present tense to present perfect. 
- Replaced "seems" with "appears" because "appears" seems more appropriate in this context. To this developer, "appears" indicates that the warning is tied more closely to data.