### PR TITLE
PbsProExecutor fix

### DIFF
--- a/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -250,14 +250,14 @@ abstract class AbstractGridExecutor extends Executor {
     /**
      * @return The status for all the scheduled and running jobs
      */
-    protected abstract Map<String,QueueStatus> getQueueStatus(queue)
-    
+    protected Map<String,QueueStatus> getQueueStatus(queue) {
+
         List cmd = queueStatusCommand(queue)
         if( !cmd ) return null
 
         try {
             log.trace "[${name.toUpperCase()}] getting queue ${queue?"($queue) ":''}status > cmd: ${cmd.join(' ')}"
-
+            
             final buf = new StringBuilder()
             final process = new ProcessBuilder(cmd).redirectErrorStream(true).start()
             process.consumeProcessOutputStream(buf)

--- a/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -250,8 +250,8 @@ abstract class AbstractGridExecutor extends Executor {
     /**
      * @return The status for all the scheduled and running jobs
      */
-    Map<String,QueueStatus> getQueueStatus(queue) {
-
+    protected abstract Map<String,QueueStatus> getQueueStatus(queue)
+    
         List cmd = queueStatusCommand(queue)
         if( !cmd ) return null
 

--- a/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -161,4 +161,38 @@ class PbsExecutor extends AbstractGridExecutor {
         return p!=-1 ? line.substring(p+prefix.size()).trim() : null
     }
 
+    /**
+     * @return The status for all the scheduled and running jobs
+     */
+    Map<String,QueueStatus> getQueueStatus(queue) {
+
+        List cmd = queueStatusCommand(queue)
+        if( !cmd ) return null
+
+        try {
+            log.trace "[${name.toUpperCase()}] getting queue ${queue?"($queue) ":''}status > cmd: ${cmd.join(' ')}"
+
+            def process = new ProcessBuilder(cmd).start()
+            def result = process.text
+            process.waitForOrKill( 10 * 1000 )
+            def exit = process.exitValue()
+
+
+            if( exit == 0 ) {
+                log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status > cmd exit: $exit\n$result"
+                return parseQueueStatus(result)
+            }
+            else {
+                log.warn "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status cannot be fetched > exit status: $exit\n$result"
+                return null
+            }
+
+        }
+        catch( Exception e ) {
+            log.warn "[${name.toUpperCase()}] failed to retrieve queue ${queue?"($queue) ":''}status -- See the log file for details", e
+            return null
+        }
+
+    }
+
 }

--- a/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -164,6 +164,7 @@ class PbsExecutor extends AbstractGridExecutor {
     /**
      * @return The status for all the scheduled and running jobs
      */
+    @Override
     Map<String,QueueStatus> getQueueStatus(queue) {
 
         List cmd = queueStatusCommand(queue)

--- a/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -93,4 +93,29 @@ class PbsProExecutor extends PbsExecutor {
             'S': QueueStatus.HOLD
     ]
 
+    @Override
+    protected Map<String, QueueStatus> parseQueueStatus(String text) {
+
+        final JOB_ID = 'Job Id:'
+        final JOB_STATUS = 'job_state '
+        final result = [:]
+
+        String id = null
+        String status = null
+        text.eachLine { line ->
+            if( line.startsWith(JOB_ID) ) {
+                id = fetchValue(JOB_ID, line)
+            }
+            else if( id ) {
+                status = fetchValue(JOB_STATUS, line)
+            }
+            result.put( id, DECODE_STATUS[status] ?: AbstractGridExecutor.QueueStatus.UNKNOWN )
+        }
+
+        return result
+    }
+
+
+
+
 }

--- a/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -85,4 +85,12 @@ class PbsProExecutor extends PbsExecutor {
         return ['/bin/bash','-c', "set -o pipefail; $cmd | { egrep '(Job Id:|job_state =)' || true; }".toString()]
     }
 
+    static private Map DECODE_STATUS = [
+            'F': QueueStatus.DONE,
+            'R': QueueStatus.RUNNING,
+            'Q': QueueStatus.PENDING,
+            'H': QueueStatus.HOLD,
+            'S': QueueStatus.HOLD
+    ]
+
 }

--- a/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -82,7 +82,7 @@ class PbsProExecutor extends PbsExecutor {
     protected List<String> queueStatusCommand(Object queue) {
         String cmd = 'qstat -f'
         if( queue ) cmd += ' ' + queue
-        return ['bash','-c', "set -o pipefail; $cmd | { egrep '(Job Id:|job_state =)' || true; }".toString()]
+        return ['/bin/bash','-c', "set -o pipefail; $cmd | { egrep '(Job Id:|job_state =)' || true; }".toString()]
     }
 
 }


### PR DESCRIPTION
## Proposition to solve #908 

### Queue Status `Done`: `F`(inished) is the new `C`(ompleted)
- Added separate DECODE_STATUS map for `PbsProExecutor` class

### Removing `=` from string match `job status =` -> `job status `
- As a consequence `parseQueueStatus` had to be implemented both in `PbsExecutor` and `PbsProExecutor` (because `PbsProExecutor` being a sub class of `PbsExecutor`).
- A lot of duplicate code regarding this issue could be avoided if somebody can confirm that all subclasses of AbstractGridExecutor still work correctly with `jobstatus ` instead of `job status =`