### PR TITLE
Fix for issue #927

### DIFF
--- a/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -345,10 +345,9 @@ abstract class AbstractGridExecutor extends Executor {
             return true
         }
 
-        if( !status.containsKey(jobId) ) { // in case the status of the job was not found, we should assume it is still running 
-                                           // (see https://github.com/nextflow-io/nextflow/issues/927)
+        if( !status.containsKey(jobId) ) {
             log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status > map does not contain jobId: `$jobId`"
-            return true
+            return false
         }
 
         final result = status[jobId.toString()] == QueueStatus.RUNNING || status[jobId.toString()] == QueueStatus.HOLD

--- a/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -345,9 +345,10 @@ abstract class AbstractGridExecutor extends Executor {
             return true
         }
 
-        if( !status.containsKey(jobId) ) {
+        if( !status.containsKey(jobId) ) { // in case the status of the job was not found, we should assume it is still running 
+                                           // (see https://github.com/nextflow-io/nextflow/issues/927)
             log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status > map does not contain jobId: `$jobId`"
-            return false
+            return true
         }
 
         final result = status[jobId.toString()] == QueueStatus.RUNNING || status[jobId.toString()] == QueueStatus.HOLD

--- a/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -41,7 +41,7 @@ abstract class AbstractGridExecutor extends Executor {
 
     private final static List<String> INVALID_NAME_CHARS = [ " ", "/", ":", "@", "*", "?", "\\n", "\\t", "\\r" ]
 
-    private Map lastQueueStatus
+    protected Map lastQueueStatus
 
     /**
      * Initialize the executor class

--- a/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Path
 import groovy.util.logging.Slf4j
 import nextflow.processor.TaskRun
 import nextflow.util.MemoryUnit
+import nextflow.util.Throttle
 /**
  * Processor for LSF resource manager
  *

--- a/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -142,7 +142,8 @@ class LsfExecutor extends AbstractGridExecutor {
     protected List<String> queueStatusCommand( queue ) {
         // note: use the `-w` option to avoid that the printed jobid maybe truncated when exceed 7 digits
         // see https://www.ibm.com/support/knowledgecenter/en/SSETD4_9.1.3/lsf_config_ref/lsf.conf.lsb_jobid_disp_length.5.html
-        final result = ['bjobs', '-w']
+        // use the `-a` option to include recently finished jobs
+        final result = ['bjobs', '-w', '-a']
 
         if( queue )
             result << '-q' << queue.toString()

--- a/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -423,8 +423,8 @@ class LsfExecutorTest extends Specification {
         def executor = [:] as LsfExecutor
 
         expect:
-        executor.queueStatusCommand(null) == ['bjobs', '-w']
-        executor.queueStatusCommand('long') == ['bjobs', '-w', '-q', 'long']
+        executor.queueStatusCommand(null) == ['bjobs', '-w', '-a']
+        executor.queueStatusCommand('long') == ['bjobs', '-w', '-a', '-q', 'long']
 
     }
 


### PR DESCRIPTION
Fixes issue #927. The most important change is that when the executor fails to retrieve a status of the job, it will assume the job is still running. I think it is a more meaningful approach than the current one.

Signed-off-by: Tomas Pluskal <plusik@gmail.com>
