### PR TITLE
Google Cloud docs: APIs & Service Account roles

### DIFF
--- a/docs/googlecloud.rst
+++ b/docs/googlecloud.rst
@@ -34,10 +34,13 @@ Download the Google Cloud CLI and initialise using the following command::
 
     gcloud init
 
+`Enable the Cloud Genomics, Compute Engine, and Cloud Storage APIs <https://console.cloud.google.com/flows/enableapi?apiid=genomics,compute,storage_api>`_
+
 Create and download credentials for google cloud in the console using the following procedure:
 
 * Go to APIs & Services → Credentials →  Create Credentials
 * Select Service account key.
+* Choose the following Roles: Genomics > Genomics Admin, Storage > Storage Object Admin, & Service Account > Service Account User
 * Download the json file and save as "creds.json".
 
 Export as env variable::
@@ -173,12 +176,13 @@ Download Google Cloud CLI and initialize using the following command::
 
     gcloud init
 
-You must also enable the Google Genomics API from your cloud console. See: `Enabling Google Genomics API <https://cloud.google.com/apis/docs/enable-disable-apis>`
+`Enable the Cloud Genomics, Compute Engine, and Cloud Storage APIs <https://console.cloud.google.com/flows/enableapi?apiid=genomics,compute,storage_api>`_
 
 Create and download credentials for google cloud in the console:
 
 * Go to APIs & Services → Credentials → Create Credentials
 * Select Service account key.
+* Choose the following Roles: Genomics > Genomics Admin, Storage > Storage Object Admin, & Service Account > Service Account User
 * Download the json file and save as "creds.json".
 
 Export as env variable::


### PR DESCRIPTION
1) Add link to enable required Google Cloud APIs
2) Include Service Account roles that are required