### PR TITLE
Launcher.cliString shoudn't be null

### DIFF
--- a/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -120,7 +120,8 @@ class Launcher {
      */
     @PackageScope
     Launcher parseMainArgs(String... args) {
-        this.cliString = System.getenv('NXF_CLI')
+        // when using a fat jar "*-all.jar" NXF_CLI is null
+        this.cliString = System.getenv('NXF_CLI') ?: "nextflow"
         this.colsString = System.getenv('COLUMNS')
 
         def cols = getColumns()


### PR DESCRIPTION
when running nextflow from a **fat jar** `nextflow/build/libs/nextflow-18.12.0-SNAPSHOT-all.jar` the variable `Launcher.cliString` is `null`.

In consequence, the history is never saved because of this line in ScriptRunner: https://github.com/nextflow-io/nextflow/blob/master/src/main/groovy/nextflow/script/ScriptRunner.groovy#L403

