### PR TITLE
Add missing = to beforeScript documentation

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1202,7 +1202,7 @@ For example::
 
     process foo {
 
-      beforeScript 'source /cluster/bin/setup'
+      beforeScript = 'source /cluster/bin/setup'
 
       """
       echo bar


### PR DESCRIPTION
There was a missing = in the documentation that caused us some headaches ;-) 
