### PR TITLE
Update FilePorter to cache foreign files into a common directory

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -47,10 +47,10 @@ import nextflow.processor.TaskFault
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskProcessor
 import nextflow.script.ScriptBinding
+import nextflow.trace.AnsiLogObserver
 import nextflow.trace.GraphObserver
 import nextflow.trace.ReportObserver
 import nextflow.trace.StatsObserver
-import nextflow.trace.AnsiLogObserver
 import nextflow.trace.TimelineObserver
 import nextflow.trace.TraceFileObserver
 import nextflow.trace.TraceObserver
@@ -65,6 +65,7 @@ import nextflow.util.NameGenerator
 import sun.misc.Signal
 import sun.misc.SignalHandler
 import static nextflow.Const.S3_UPLOADER_CLASS
+
 /**
  * Holds the information on the current execution
  *
@@ -308,15 +309,16 @@ class Session implements ISession {
 
         // -- DGA object
         this.dag = new DAG(session:this)
+
+        // -- init work dir
+        this.workDir = ((config.workDir ?: 'work') as Path).complete()
+        this.setLibDir( config.libDir as String )
     }
 
     /**
      * Initialize the session workDir, libDir, baseDir and scriptName variables
      */
     void init( Path scriptPath ) {
-
-        this.workDir = ((config.workDir ?: 'work') as Path).complete()
-        this.setLibDir( config.libDir as String )
 
         if(!workDir.mkdirs()) throw new AbortOperationException("Cannot create work-dir: $workDir -- Make sure you have write permissions or specify a different directory by using the `-w` command line option")
         log.debug "Work-dir: ${workDir.toUriString()} [${FileHelper.getPathFsType(workDir)}]"

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -86,7 +86,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
     @Memoized
     private Map<String,Path> resolveForeignFiles0(Map<String,Path> files) {
         if( !porter )
-            porter = new FilePorter(workDir)
+            porter = new FilePorter()
         porter.stageForeignFiles(files)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
@@ -18,9 +18,11 @@ package nextflow.file
 
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.Callable
+import java.util.concurrent.CompletionService
 import java.util.concurrent.ExecutionException
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.ExecutorCompletionService
 import java.util.concurrent.Future
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadFactory
@@ -37,6 +39,9 @@ import groovy.util.logging.Slf4j
 import nextflow.Global
 import nextflow.Session
 import nextflow.exception.ProcessStageException
+import nextflow.extension.FilesEx
+import nextflow.util.CacheHelper
+
 /**
  * Move foreign (ie. remote) files to the staging work area
  *
@@ -49,6 +54,14 @@ class FilePorter {
     static Random rnd = Random.newInstance()
 
     private Path stagingDir
+
+    // Timeout for displaying the download message
+    private long pollTimeout = 5L
+    private TimeUnit pollTimeoutUnit = TimeUnit.SECONDS
+
+    FilePorter() {
+        getStagingDir()
+    }
 
     FilePorter( Path stagingDir) {
         assert stagingDir, "Argument stagingDir cannot be null"
@@ -84,7 +97,8 @@ class FilePorter {
         log.trace "Stage foreign files: $paths"
         def result = new HashMap(filesMap)
 
-        def futures = getExecutor().invokeAll(actions)
+        def stageExecutor = getExecutor()
+        def futures = submitStagingActions(stageExecutor, actions, paths)
         log.trace "Stage foreign files completed: $paths"
 
         try {
@@ -99,6 +113,24 @@ class FilePorter {
         return result
     }
 
+    protected ArrayList<Future> submitStagingActions(CompletionService executor, List<Callable> actions, List<Path> paths) {
+        // submit actions
+        for ( def action : actions ) {
+            executor.submit(action)
+        }
+        def futures = new ArrayList<Future>(actions.size())
+        // display a message if staging takes more than the defined timeout
+        while ( futures.size() < actions.size() ) {
+            def future = executor.poll(pollTimeout, pollTimeoutUnit)
+            if ( !future ) {
+                log.info1(getDownloadMessage(paths))
+                continue
+            }
+            futures << future
+        }
+        return futures
+    }
+
     /**
      * Download a foreign file (ie. remote) storing it the current pipeline execution directory
      *
@@ -108,9 +140,20 @@ class FilePorter {
     protected Path stageForeignFile(Path filePath) {
         int max = getMaxRetries()
         int count = 0
+
+        // create cache directory
+        def hash = CacheHelper.hasher(filePath).hash().toString()
+        final target = getCacheDir(stagingDir, hash).resolve(filePath.getName())
+
+        // Synchronize download for multiple Nextflow instances running at the same time
+        final lockFile = FileHelper.getLocalTempLockPath().resolve("${hash}.lock").toFile()
+        final wait = "Another Nextflow instance is downloading the foreign file $filePath -- please wait the download completes"
+        final err =  "Unable to acquire exclusive lock on file: $lockFile"
+        final mutex = new FileMutex(target: lockFile, waitMessage: wait, errorMessage: err)
+
         while( true ) {
             try {
-                return stageForeignFile0(filePath)
+                mutex .lock { stageForeignFile0(filePath, target) }
             }
             catch( IOException e ) {
                 if( count++ < max && !(e instanceof NoSuchFileException )) {
@@ -123,7 +166,22 @@ class FilePorter {
 
                 throw new ProcessStageException(fmtError(filePath,e), e)
             }
+            finally {
+                lockFile.delete()
+            }
+
+            return target
         }
+    }
+
+    protected String getDownloadMessage(List<Path> filePaths) {
+        def msg = 'Staging foreign file'
+        if (filePaths.size() > 1)
+            msg += 's:\n'
+        else
+            msg += ' '
+        msg += filePaths.collect() { it.toUriString() }.join('\n')
+        return msg
     }
 
     private String fmtError(Path filePath, Exception e) {
@@ -135,12 +193,23 @@ class FilePorter {
         return message
     }
 
-    private Path stageForeignFile0(Path source) {
-        // create temp directory
-        final tempDir = FileHelper.createTempFolder(stagingDir)
-        final target = tempDir.resolve(source.getName())
+    private Path stageForeignFile0(Path source, Path target) {
+        if( target.exists() ) {
+            log.debug "Local cache found for foreign file ${source.toUriString()} at ${target.toUriString()}"
+            return target
+        }
         log.debug "Copying foreign file ${source.toUriString()} to work dir: ${target.toUriString()}"
         return FileHelper.copyPath(source, target)
+    }
+
+    private Path getCacheDir(Path workDir, String hash) {
+        def bucket = hash.substring(0,2)
+        def result = workDir.resolve( "$bucket/${hash.substring(2)}")
+
+        if( !FilesEx.mkdirs(result) ) {
+            throw new IOException("Unable to create cache directory: $result -- Verify file system access permissions or if a file having the same name exists")
+        }
+        return result.toAbsolutePath()
     }
 
     @ToString
@@ -157,14 +226,29 @@ class FilePorter {
 
     /**
      * @return
+     *      The number of core threads used for parallel files copy.
+     *      This value can be defined by using the {@code filePorter.coreThreads} configuration setting
+     *      (default: <number of avail CPU cores>)
+     */
+    static protected int getCoreThreads() {
+        Integer result = Global.session.config.navigate('filePorter.coreThreads') as Integer
+        if( !result )
+            result = Runtime.runtime.availableProcessors()
+        log.debug "filePorter.coreThreads=$result"
+        return result
+    }
+
+
+    /**
+     * @return
      *      The maximum number of threads used for parallel files copy.
      *      This value can be defined by using the {@code filePorter.maxThreads} configuration setting
-     *      (default: <number of avail CPU cores>)
+     *      (default: <2 * number of avail CPU cores>)
      */
     static protected int getMaxThreads() {
         Integer result = Global.session.config.navigate('filePorter.maxThreads') as Integer
         if( !result )
-            result = Runtime.runtime.availableProcessors()
+            result = 2 * Runtime.runtime.availableProcessors()
         log.debug "filePorter.maxThreads=$result"
         return result
     }
@@ -178,35 +262,59 @@ class FilePorter {
         Integer result = Global.session.config.navigate('filePorter.maxRetries') as Integer
         if( !result )
             result = 3
-        log.debug "filePorter.maxThreads=$result"
+        log.debug "filePorter.maxRetries=$result"
         return result
+    }
+
+    /**
+     * Lazy getter for the stagingDir property
+     * @return
+     *      The path the foreign files are copied to.
+     *      This value can be defined by using the {@code filePorter.stagingDir} configuration setting (default: <session_workDir/download>).
+     */
+     Path getStagingDir() {
+         if (!stagingDir) {
+             String result = Global.session.config.navigate('filePorter.stagingDir') as String
+             if (!result)
+                 result = System.getenv().get('NXF_DOWNLOAD_PATH')
+             if (!result)
+                 result = Global.session.workDir.resolve("download").toString()
+             log.debug "filePorter.stagingDir=$result"
+             stagingDir = Paths.get(result).toAbsolutePath()
+         }
+         return stagingDir
     }
 
     /**
      * @return Creates lazily the executor service used to stage remote files
      */
-    static private ExecutorService getExecutor() {
+    static private CompletionService getExecutor() {
         createExecutor(Global.session as Session)
     }
 
     // note: memoized guarantees to use the same executor during the same session
     @Memoized
-    static synchronized private ExecutorService createExecutor(Session session) {
+    static synchronized private CompletionService createExecutor(Session session) {
+        def coreThreads = getCoreThreads()
+        def maxThreads = getMaxThreads()
+
         final result = new ThreadPoolExecutor(
-                0,
-                getMaxThreads(),
+                coreThreads,
+                maxThreads,
                 60L,
                 TimeUnit.SECONDS,
                 new LinkedBlockingQueue<Runnable>(),
                 new DownloaderThreadFactory() )
 
+        result.allowCoreThreadTimeOut(true);
+
         // register the shutdown on termination
         session?.onShutdown {
-            executor.shutdown()
-            executor.awaitTermination(1,TimeUnit.MINUTES)
+            result.shutdown()
+            result.awaitTermination(1, TimeUnit.MINUTES)
         }
 
-        return result
+        return new ExecutorCompletionService<>(result)
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/file/FilePorterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/file/FilePorterTest.groovy
@@ -16,25 +16,45 @@
 
 package nextflow.file
 
+import spock.lang.Specification
+
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorCompletionService
+import java.util.concurrent.Executors
 
+import nextflow.Global
 import nextflow.Session
-import spock.lang.Specification
 import test.TestHelper
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class FilePorterTest extends Specification {
 
+    def 'should get the core threads value' () {
+
+        when:
+        new Session()
+        then:
+        FilePorter.getCoreThreads() == Runtime.getRuntime().availableProcessors()
+
+        when:
+        new Session([filePorter: [coreThreads: 10]])
+        then:
+        FilePorter.getCoreThreads() == 10
+
+    }
+
     def 'should get the max threads value' () {
 
         when:
         new Session()
         then:
-        FilePorter.getMaxThreads() == Runtime.getRuntime().availableProcessors()
+        FilePorter.getMaxThreads() == 2 * Runtime.getRuntime().availableProcessors()
 
         when:
         new Session([filePorter: [maxThreads: 99]])
@@ -54,6 +74,25 @@ class FilePorterTest extends Specification {
         new Session([filePorter: [maxRetries: 88]])
         then:
         FilePorter.getMaxRetries() == 88
+
+    }
+
+    def 'should get the download path' () {
+
+        given:
+        new Session()
+        def fp = Spy(FilePorter)
+
+        when:
+        fp.stagingDir
+        then:
+        1 * fp.getStagingDir() >> Global.session.workDir.resolve('download')
+
+        when:
+        Global.session.config = [filePorter: [downloadPath: '/foo/bar']]
+        fp.stagingDir
+        then:
+        1 * fp.getStagingDir() >> Paths.get('/foo/bar')
 
     }
 
@@ -83,5 +122,32 @@ class FilePorterTest extends Specification {
 
         cleanup:
         folder?.deleteDir()
+    }
+
+    def 'should submit actions' () {
+
+        given:
+        new Session()
+        def executor = new ExecutorCompletionService(Executors.newFixedThreadPool(2))
+        def actions = [
+                { sleep(500) } as Callable,
+                { sleep(2000) } as Callable
+        ]
+        def paths = [Paths.get('/foo/bar')]
+        def fp = Spy(FilePorter)
+
+        when:
+        def futures = fp.submitStagingActions(executor, actions, paths)
+        then:
+        futures.size() == 2
+        0 * fp.getDownloadMessage(paths)
+
+        when:
+        fp.pollTimeout = 1L
+        futures = fp.submitStagingActions(executor, actions, paths)
+        then:
+        futures.size() == 2
+        1 * fp.getDownloadMessage(paths)
+        fp.getDownloadMessage(paths) == 'Staging foreign file /foo/bar'
     }
 }

--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -227,6 +227,15 @@ class FileHelper {
         return localTempBasePath
     }
 
+    final static Path getLocalTempLockPath() {
+        def prefix = 'nxf-locks'
+        def lockPath = localTempBasePath.resolve(prefix)
+        if (!FilesEx.mkdirs(lockPath)) {
+            throw new IOException("Unable to create locks directory: $lockPath -- Verify file system access permissions or if a folder having the same name exists")
+        }
+        return lockPath
+    }
+
     static boolean isGlobAllowed( Path path ) {
         return !(path.getFileSystem().provider().scheme in UNSUPPORTED_GLOB_WILDCARDS)
     }


### PR DESCRIPTION
The download directory can be changed using en environment variable or a Nextflow configuration option.
This also updates FilePorter for multithreaded file staging within the same Nextflow process.