### PR TITLE
metrics was missing in the index of the documentation (#1012)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,11 +28,9 @@ Contents:
    ignite
    kubernetes
    tracing
+   metrics
    sharing
    metadata
    mail
    example
    faq
-
-
-


### PR DESCRIPTION
It seems that the metrics section was missing from the documentation index after pull request (#1012).

I have added metrics in the index.