### PR TITLE
Use base 2 to report memory values in the table-humanreadable similar…

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/trace/assets/ReportTemplate.js
+++ b/modules/nextflow/src/main/resources/nextflow/trace/assets/ReportTemplate.js
@@ -166,6 +166,7 @@ $(function() {
     if (bytes == '-' || bytes == 0){
       return bytes;
     }
+    bytes = norm_mem([bytes]);
     // https://stackoverflow.com/a/14919494
     var thresh = 1000;
     if(Math.abs(bytes) < thresh) {

--- a/modules/nextflow/src/main/resources/nextflow/trace/assets/ReportTemplate.js
+++ b/modules/nextflow/src/main/resources/nextflow/trace/assets/ReportTemplate.js
@@ -166,9 +166,8 @@ $(function() {
     if (bytes == '-' || bytes == 0){
       return bytes;
     }
-    bytes = norm_mem([bytes]);
     // https://stackoverflow.com/a/14919494
-    var thresh = 1000;
+    var thresh = 1024;
     if(Math.abs(bytes) < thresh) {
       return bytes + ' B';
     }


### PR DESCRIPTION
In the memplot form the report, memory usage are plotted using a base 2 unit.

In the table-humanreadable from the report, the task table displays the memory using a base 10 unit.

The pull request harmonizes the memory unit such that base 2 unit is used in both cases.