### PR TITLE
Use peak_vmem and peak_rss as default output in the trace file instead of rss and vmem

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
@@ -54,8 +54,8 @@ class TraceFileObserver implements TraceObserver {
             'duration',
             'realtime',
             '%cpu',
-            'rss',
-            'vmem',
+            'peak_rss',
+            'peak_vmem',
             'rchar',
             'wchar'
     ]

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
@@ -201,8 +201,8 @@ class TraceFileObserverTest extends Specification {
         result[9] == '17.5%'                    // cpu
         result[10] == '9.8 MB'                  // peak_rss
         result[11] == '29.3 MB'                 // peak_vmem
-        result[12] == '19.5 MB'                 // rchar
-        result[13] == '29.3 MB'                 // wchar
+        result[12] == '29.3 MB'                 // rchar
+        result[13] == '9.8 MB'                  // wchar
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
@@ -180,8 +180,8 @@ class TraceFileObserverTest extends Specification {
         record.duration = 1408714912000 - 1408714874000
         record.realtime = 1408714912000 - 1408714875000
         record.'%cpu' = 17.50f
-        record.rss = 10_000 * 1024
-        record.vmem = 20_000 * 1024
+        record.peak_rss = 10_000 * 1024
+        record.peak_vmem = 30_000 * 1024
         record.rchar = 30_000 * 1024
         record.wchar = 10_000 * 1024
 
@@ -197,11 +197,12 @@ class TraceFileObserverTest extends Specification {
         result[5] == '99'                       // exit status
         result[6] == '2014-08-22 13:41:14.000'  // submit
         result[7] == '38s'                      // wall-time
-        result[8] == '37s'                     // run-time
-        result[9] == '17.5%'                   // cpu
-        result[10] == '9.8 MB'                  // vmem
-        result[11] == '19.5 MB'                 // rchar
-        result[12] == '29.3 MB'                 // wchar
+        result[8] == '37s'                      // run-time
+        result[9] == '17.5%'                    // cpu
+        result[10] == '9.8 MB'                  // peak_rss
+        result[11] == '29.3 MB'                 // peak_vmem
+        result[12] == '19.5 MB'                 // rchar
+        result[13] == '29.3 MB'                 // wchar
 
     }
 


### PR DESCRIPTION
As the memory plot in the Resource Usage of the report now displays both peak_vmem and peak_rss, I suggest to report these peak memory values as default into the trace file. Indeed, only peak memory values really matters for process profiling.