### PR TITLE
removed the aws batch experimental

### DIFF
--- a/docs/awscloud.rst
+++ b/docs/awscloud.rst
@@ -265,8 +265,7 @@ Read :ref:`Cloud configuration<config-cloud>` section to learn more about advanc
 AWS Batch
 =========
 
-.. warning:: This is an experimental feature and it may change in a future release. It requires Nextflow
-  version `0.26.0` or later.
+.. warning:: Requires Nextflow version `0.26.0` or later.
 
 `AWS Batch <https://aws.amazon.com/batch/>`_ is a managed computing service that allows the execution of containerised
 workloads in the Amazon cloud infrastructure.


### PR DESCRIPTION
removed the warning that AWS Batch was experimental. 

Signed-off-by: KevinSayers <sayerskt@gmail.com>