### PR TITLE
Add Travis CI image badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Nextflow
 ========
 
+[![Build Status](https://travis-ci.org/nextflow-io/nextflow.svg?branch=master)](https://travis-ci.org/nextflow-io/nextflow)
+
 *"Dataflow variables are spectacularly expressive in concurrent programming"*
 <br>[Henri E. Bal , Jennifer G. Steiner , Andrew S. Tanenbaum](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.145.7873)
 


### PR DESCRIPTION
Hello,
Shall we start to use Travis CI build status image badge to README to see the result easily?

Like this.
https://github.com/junaruga/nextflow/blob/feature/ci-badge/README.md

