### PR TITLE
Use installed jdks to save the running time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
+dist: xenial
 sudo: required
 language: groovy
 jdk:
   - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+matrix:
+  allow_failures:
+    jdk: openjdk11
+  fast_finish: true
 services:
   - docker
 before_install:
@@ -13,13 +21,9 @@ install:
 git:
   submodules: true
 env:
-  matrix:
-  - TEST_JDK=
-  - TEST_JDK=9
-  - TEST_JDK=10
-  - TEST_JDK=11
   global:
-  - GRADLE_OPTS='-Dorg.gradle.daemon=false'
+    - GRADLE_OPTS='-Dorg.gradle.daemon=false'
+    - TEST_JDK=
 before_script:
   - rm $HOME/.gitconfig
   - mkdir -p "$HOME/.nextflow" && echo "providers.github.auth='$NXF_GITHUB_ACCESS_TOKEN'" > "$HOME/.nextflow/scm"


### PR DESCRIPTION
https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
Travis distrubition `xenial` that was recently provided by Travis CI has pre-installed JDK 11, 10, 9, and 8 

So, shall we start to run on the installed JDKs instead of installing manually by `TEST_JDK` value?

This is the results on my forked repositories.
https://travis-ci.org/junaruga/nextflow/builds/494505618

For JDK 8, 9, 10, the reason of the error is my repository does not have a permission to access AWS?
For JDK 11, I faced below error.

```
> Task :nf-ga4gh:compileGroovy FAILED
warning: [options] bootstrap class path not set in conjunction with -source 8
/home/travis/build/junaruga/nextflow/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/client/Pair.java:32: error: package javax.annotation does not exist
@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-02-01T15:43:49.638Z")
                 ^
```



