### PR TITLE
Add pullOptions for singularity

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -355,6 +355,7 @@ enabled             Turn this flag to ``true`` to enable Singularity execution (
 engineOptions       This attribute can be used to provide any option supported by the Singularity engine i.e. ``singularity [OPTIONS]``.
 envWhitelist        Comma separated list of environment variable names to be included in the container environment.
 runOptions          This attribute can be used to provide any extra command line options supported by the ``singularity exec``.
+pullOptions         This attribute can be used to provide any extra command line options supported by the ``singularity pull``.
 autoMounts          When ``true`` Nextflow automatically mounts host paths in the executed contained. It requires the `user bind control` feature enabled in your Singularity installation (default: ``false``).
 cacheDir            The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all computing nodes.
 pullTimeout         The amount of time the Singularity pull can last, exceeding which the process is terminated (default: ``20 min``).

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -355,7 +355,7 @@ enabled             Turn this flag to ``true`` to enable Singularity execution (
 engineOptions       This attribute can be used to provide any option supported by the Singularity engine i.e. ``singularity [OPTIONS]``.
 envWhitelist        Comma separated list of environment variable names to be included in the container environment.
 runOptions          This attribute can be used to provide any extra command line options supported by the ``singularity exec``.
-pullOptions         This attribute can be used to provide any extra command line options supported by the ``singularity pull``.
+noHttps             Turn this flag to ``true`` to pull the Singularity image with http protocol (default: ``false``).
 autoMounts          When ``true`` Nextflow automatically mounts host paths in the executed contained. It requires the `user bind control` feature enabled in your Singularity installation (default: ``false``).
 cacheDir            The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all computing nodes.
 pullTimeout         The amount of time the Singularity pull can last, exceeding which the process is terminated (default: ``20 min``).

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -199,7 +199,9 @@ class SingularityCache {
 
         log.info "Pulling Singularity image $imageUrl [cache $localPath]"
 
-        String cmd = "singularity pull --name ${Escape.path(localPath.getFileName())} $imageUrl > /dev/null"
+        final pullOptions = (config.pullOptions)? config.pullOptions : ''
+
+        String cmd = "singularity pull ${pullOptions} --name ${Escape.path(localPath.getFileName())} $imageUrl > /dev/null"
         try {
             runCommand( cmd, localPath.parent )
             log.debug "Singularity pull complete image=$imageUrl path=$localPath"

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -199,9 +199,9 @@ class SingularityCache {
 
         log.info "Pulling Singularity image $imageUrl [cache $localPath]"
 
-        final pullOptions = (config.pullOptions)? config.pullOptions : ''
+        final noHttpsOption = (config.noHttps)? '--nohttps' : ''
 
-        String cmd = "singularity pull ${pullOptions} --name ${Escape.path(localPath.getFileName())} $imageUrl > /dev/null"
+        String cmd = "singularity pull ${noHttpsOption} --name ${Escape.path(localPath.getFileName())} $imageUrl > /dev/null"
         try {
             runCommand( cmd, localPath.parent )
             log.debug "Singularity pull complete image=$imageUrl path=$localPath"

--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
@@ -85,14 +85,15 @@ class SingularityCacheTest extends Specification {
         def dir = Files.createTempDirectory('test')
         def IMAGE = 'docker://pditommaso/foo:latest'
         def LOCAL = 'foo-latest.img'
+        ContainerConfig config = [pullOptions: "--nohttps"]
         and:
-        def cache = Spy(SingularityCache)
+        def cache = Spy(SingularityCache, constructorArgs: [ config ])
 
         when:
         cache.downloadSingularityImage(IMAGE)
         then:
         1 * cache.localImagePath(IMAGE) >> dir.resolve(LOCAL)
-        1 * cache.runCommand("singularity pull --name $LOCAL $IMAGE > /dev/null", dir) >> 0
+        1 * cache.runCommand("singularity pull --nohttps --name $LOCAL $IMAGE > /dev/null", dir) >> 0
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
@@ -85,7 +85,7 @@ class SingularityCacheTest extends Specification {
         def dir = Files.createTempDirectory('test')
         def IMAGE = 'docker://pditommaso/foo:latest'
         def LOCAL = 'foo-latest.img'
-        ContainerConfig config = [pullOptions: "--nohttps"]
+        ContainerConfig config = [noHttps: true] 
         and:
         def cache = Spy(SingularityCache, constructorArgs: [ config ])
 


### PR DESCRIPTION
Hi,

Singularity has some pull options:
```
Options:
      --docker-login     interactive prompt for docker authentication
  -F, --force            overwrite an image file if it exists
  -h, --help             help for pull
      --library string   the library to pull from (default
                         "https://library.sylabs.io")
      --nohttps          do NOT use HTTPS, for communicating with local
                         docker registry
```

And I need `--nohttps` option to pull my image because my docker registry is in my private network.
Please consider this. 
Thanks.
