### PR TITLE
Fix bug: ImagePullSecret, ImagePullPolicy and label are ignored when …

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -134,6 +134,11 @@ class PodOptions {
 
     String getImagePullSecret() { imagePullSecret }
 
+    PodOptions setImagePullSecret(String s ) {
+        this.imagePullSecret = s
+        return this
+    }
+
     String getImagePullPolicy() { imagePullPolicy }
 
     PodOptions setImagePullPolicy(String p ) {
@@ -167,6 +172,20 @@ class PodOptions {
 
         // node select
         result.nodeSelector = other.nodeSelector ?: this.nodeSelector
+
+	if (other.imagePullPolicy) {
+	    result.imagePullPolicy = other.imagePullPolicy
+	} else {
+	    result.imagePullPolicy = imagePullPolicy
+	}
+	if (other.imagePullSecret) {
+	    result.imagePullSecret = other.imagePullSecret
+	} else {
+	    result.imagePullSecret = imagePullSecret
+	}
+
+	result.labels.putAll(labels)
+	result.labels.putAll(other.labels)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -280,7 +280,7 @@ class PodSpecBuilder {
             spec.securityContext = securityContext.toSpec()
 
         if( imagePullSecret )
-            spec.imagePullSecrets = ((Map)[name: imagePullSecret])
+            spec.imagePullSecrets = [((Map)[name: imagePullSecret])]
 
         // add labels
         if( labels )

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
@@ -288,6 +288,30 @@ class PodOptionsTest extends Specification {
         opts.nodeSelector.toSpec() == [foo: 'X', bar: "Y"]
     }
 
+    def 'imagePullSecret, imagePullPolicy and label are copied to merged object' (){
+	given:
+	def data = [
+		[imagePullPolicy : 'FOO'],
+		[imagePullSecret : 'BAR'],
+		[label: "LABEL", value: 'VALUE']
+	]
+
+	when:
+	def opts = new PodOptions() + new PodOptions(data)
+	then:
+	opts.labels == ["LABEL": "VALUE"]
+	opts.imagePullPolicy == 'FOO'
+	opts.imagePullSecret == 'BAR'
+
+	when:
+	opts = new PodOptions(data) + new PodOptions()
+	then:
+	opts.labels == ["LABEL": "VALUE"]
+	opts.imagePullPolicy == 'FOO'
+	opts.imagePullSecret == 'BAR'
+
+    }
+
     def 'should create pod labels' () {
 
         given:

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -444,7 +444,7 @@ class PodSpecBuilderTest extends Specification {
                 spec: [
                         restartPolicy:'Never',
                         securityContext: [ runAsUser: 1000 ],
-                        imagePullSecrets: [ name: 'myPullSecret' ],
+                        imagePullSecrets: [[ name: 'myPullSecret' ]],
                         nodeSelector: [gpu: 'true', queue: 'fast'],
                         
                         containers:[


### PR DESCRIPTION
…creating the yaml for a pod

Using the k8s executor these fields were not written to the yaml files for the pods. The reason was that the plus operation on PodOptions ignored these fields. With this patch they won't get lost anymore.