### PR TITLE
Implements the support for GPU resources on K8s

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/res/GpuResource.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/res/GpuResource.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2019, Centre for Genomic Regulation (CRG)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.executor.res
+
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * Models GPU resource request
+ * 
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@EqualsAndHashCode
+class GpuResource {
+
+    final Integer request
+    final Integer limit
+    final String type
+    final String runtime
+
+    GpuResource( Number value ) {
+        this(limit: value)
+    }
+
+    GpuResource( Map res ) {
+        if( res.limit!=null && res.request!=null ) {
+            this.limit = res.limit as int
+            this.request = res.request as int
+        }
+        else if( res.limit!=null ) {
+            this.limit = res.limit as int
+            this.request = res.limit as int
+        }
+        else if( res.request != null ) {
+            this.request = res.request as int
+        }
+
+        if( res.type )
+            this.type = res.type as String
+
+        if( res.runtime )
+            this.runtime = res.runtime as String
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
@@ -175,10 +175,13 @@ class K8sTaskHandler extends TaskHandler {
         // add computing resources
         final cpus = taskCfg.get('cpus') as Integer
         final mem = taskCfg.getMemory()
+        final gpu = taskCfg.getGpu()
         if( cpus )
             builder.withCpus(cpus as int)
         if( mem )
             builder.withMemory(mem)
+        if( gpu )
+            builder.withGpu(gpu)
 
         final List<String> hostMounts = getContainerMounts()
         for( String mount : hostMounts ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/ProcessConfig.groovy
@@ -16,8 +16,6 @@
 
 package nextflow.processor
 
-import static nextflow.util.CacheHelper.*
-
 import java.util.regex.Pattern
 
 import groovy.transform.PackageScope
@@ -44,6 +42,8 @@ import nextflow.script.StdInParam
 import nextflow.script.StdOutParam
 import nextflow.script.ValueInParam
 import nextflow.script.ValueOutParam
+import static nextflow.util.CacheHelper.HashMode
+
 /**
  * Holds the process configuration properties
  *
@@ -70,6 +70,7 @@ class ProcessConfig implements Map<String,Object> {
             'errorStrategy',
             'executor',
             'ext',
+            'gpu',
             'instanceType',
             'queue',
             'label',
@@ -668,8 +669,6 @@ class ProcessConfig implements Map<String,Object> {
         return this
     }
 
-    private static final Map POD_OPTIONS = [secret:String, mountPath:String, envName: String]
-
     /**
      * Allow use to specify K8s `pod` options
      *
@@ -692,5 +691,28 @@ class ProcessConfig implements Map<String,Object> {
         allOptions.add(entry)
         return this
 
+    }
+
+    ProcessConfig gpu( Map params, value )  {
+        if( value instanceof Number ) {
+            if( params.limit==null )
+                params.limit=value
+            else if( params.request==null )
+                params.request=value
+        }
+        else if( value != null )
+            throw new IllegalArgumentException("Not a valid gpu directive value: $value [${value.getClass().getName()}]")
+        gpu(params)
+        return this
+    }
+
+    ProcessConfig gpu( value ) {
+        if( value instanceof Number )
+            configProperties.put('gpu', [limit: value])
+        else if( value instanceof Map )
+            configProperties.put('gpu', value)
+        else if( value != null )
+            throw new IllegalArgumentException("Not a valid gpu directive value: $value [${value.getClass().getName()}]")
+        return this
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.processor
 
+import nextflow.executor.res.GpuResource
 import static nextflow.processor.TaskProcessor.*
 
 import java.nio.file.Path
@@ -347,6 +348,17 @@ class TaskConfig extends LazyMap implements Cloneable {
 
     PodOptions getPodOptions() {
         new PodOptions((List)get('pod'))
+    }
+
+    GpuResource getGpu() {
+        def value = get('gpu')
+        if( value instanceof Number )
+            return new GpuResource(value)
+        if( value instanceof Map )
+            return new GpuResource(value)
+        if( value != null )
+            throw new IllegalArgumentException("Invalid gpu directive value: $value [${value.getClass().getName()}]")
+        return null
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/executor/res/GpuResourceTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/res/GpuResourceTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2019, Centre for Genomic Regulation (CRG)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.executor.res
+
+import spock.lang.Specification
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class GpuResourceTest extends Specification {
+
+    def 'should create a gpu resource' () {
+
+        when:
+        def gpu = new GpuResource(VALUE)
+        then:
+        gpu.type == TYPE
+        gpu.request == REQ
+        gpu.limit == LIM
+        gpu.type == TYPE
+        gpu.runtime == RUNTIME
+
+        where:
+        VALUE                       | REQ   | LIM   | TYPE  | RUNTIME
+        1                           | 1     | 1     | null  | null
+        5                           | 5     | 5     | null  | null
+        [request: 2]                | 2     | null  | null  | null
+        [limit: 4]                  | 4     | 4     | null  | null
+        [request: 2, limit: 4]      | 2     | 4     | null  | null
+        [request: 2, limit: 4]      | 2     | 4     | null  | null
+        [limit: 3, type: 'nvidia']  | 3     | 3     | 'nvidia' | null
+        [limit: 3, runtime: 'foo']  | 3     | 3     | null  | 'foo'
+    }
+}

--- a/modules/nextflow/src/test/groovy/nextflow/processor/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/ProcessConfigTest.groovy
@@ -552,4 +552,35 @@ class ProcessConfigTest extends Specification {
 
     }
 
+    def 'should apply gpu config' () {
+
+        given:
+        def process = new ProcessConfig(Mock(BaseScript))
+
+        when:
+        process.gpu 5
+        then:
+        process.gpu == [limit: 5]
+
+        when:
+        process.gpu request: 1, limit: 5, type: 'nvida'
+        then:
+        process.gpu == [request: 1, limit: 5, type: 'nvida']
+
+        when:
+        process.gpu 5, type: 'nvida'
+        then:
+        process.gpu == [limit: 5, type: 'nvida']
+
+        when:
+        process.gpu 1, limit: 5
+        then:
+        process.gpu == [request: 1, limit:5]
+
+        when:
+        process.gpu 5, request: 1
+        then:
+        process.gpu == [request: 1, limit:5]
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -547,4 +547,27 @@ class TaskConfigTest extends Specification {
 
     }
 
+    def 'should get gpu resources' () {
+
+        given:
+        def script = Mock(BaseScript)
+
+        when:
+        def process = new ProcessConfig(script)
+        process.gpu 5
+        def res = process.createTaskConfig().getGpu()
+        then:
+        res.limit == 5 
+        res.request == 5
+
+        when:
+        process = new ProcessConfig(script)
+        process.gpu 5, limit: 10, type: 'nvidia'
+        res = process.createTaskConfig().getGpu()
+        then:
+        res.request == 5
+        res.limit == 10
+        res.type == 'nvidia'
+    }
+
 }


### PR DESCRIPTION
This commit implements the `gpu` directive that allows the specification of GPU resources as shown below: 

```
gpu request: 5, limit: 10,type: 'nvidia'
```

or 

``` 
gpu 10, type: 'nvidia'
``` 

In the above case `request` == `limit` == 10. When omitted the `type`defaults to `nvidia`. 
  

So far only the K8s executed applies this setting.  