### PR TITLE
Session ensures it awaits on all observers before exiting.

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
@@ -279,6 +279,13 @@ class TraceFileObserver implements TraceObserver {
     }
 
     /**
+     * Await until the observer has emitted all events
+     */
+    @Override
+    void await() {
+        writer.await()
+    }
+/**
      * Render a {@link TraceRecord} object to a string
      *
      * @param trace

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
@@ -104,4 +104,10 @@ trait TraceObserver {
      *      The associated {@link TraceRecord} fot the current task.
      */
     void onFlowError(TaskHandler handler, TraceRecord trace){}
+
+
+    /**
+     * Await until the observer has emitted all events
+     */
+    void await(){}
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/WebLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/WebLogObserver.groovy
@@ -179,6 +179,13 @@ class WebLogObserver implements TraceObserver{
     }
 
     /**
+     * Wait for the agent responsible for sending messages to finish.
+     */
+    @Override
+    void await() {
+        webLogAgent?.await()
+    }
+/**
      * Little helper method that sends a HTTP POST message as JSON with
      * the current run status, ISO 8601 UTC timestamp, run name and the TraceRecord
      * object, if present.

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -16,8 +16,10 @@
 
 package nextflow
 
+import nextflow.trace.TraceObserver
 import spock.lang.Specification
 import spock.lang.Unroll
+import test.MockSession
 
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -493,4 +495,70 @@ class SessionTest extends Specification {
         session.fetchContainers() == 'ngi/rnaseq:1.2'
     }
 
+    def 'should call await on all observers when await is called on itself'() {
+
+        given:
+        def session = new MockSession()
+        def testObserver1 = Mock(TraceObserver)
+        def testObserver2 = Mock(TraceObserver)
+        session.observers = [testObserver1,testObserver2]
+
+        when:
+        session.await()
+
+        then:
+        1 * testObserver1.await()
+        1 * testObserver2.await()
+    }
+
+    def 'should call await on all observers when destroyed'() {
+
+        given:
+        def session = new MockSession()
+        def testObserver1 = Mock(TraceObserver)
+        def testObserver2 = Mock(TraceObserver)
+        session.observers = [testObserver1,testObserver2]
+
+        when:
+        session.start()
+        session.destroy()
+
+        then:
+        1 * testObserver1.await()
+        1 * testObserver2.await()
+    }
+
+    def 'should call await on all observers when cancelled'() {
+
+        given:
+        def session = new MockSession()
+        def testObserver1 = Mock(TraceObserver)
+        def testObserver2 = Mock(TraceObserver)
+        session.observers = [testObserver1,testObserver2]
+
+        when:
+        session.start()
+        session.cancel()
+
+        then:
+        1 * testObserver1.await()
+        1 * testObserver2.await()
+    }
+
+    def 'should call await on all observers when aborted'() {
+
+        given:
+        def session = new MockSession()
+        def testObserver1 = Mock(TraceObserver)
+        def testObserver2 = Mock(TraceObserver)
+        session.observers = [testObserver1,testObserver2]
+
+        when:
+        session.start()
+        session.abort()
+
+        then:
+        1 * testObserver1.await()
+        1 * testObserver2.await()
+    }
 }


### PR DESCRIPTION
Session calls await on all observers before destroy/cancel/abort allowing them to finish emitting messages (https://github.com/nextflow-io/nextflow/issues/1145) . Fix for issue: https://github.com/nextflow-io/nextflow/issues/1010

Signed-off-by: Ólafur Haukur Flygenring <olafurh@wuxinextcode.com>