### PR TITLE
Upgrade fully to 2.0 Bitbucket API

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
@@ -42,15 +42,15 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
 
     @Override
     String getContentUrl( String path ) {
-        "${config.endpoint}/api/1.0/repositories/$project/src/${getMainBranch()}/$path"
+        "${config.endpoint}/api/2.0/repositories/$project/src/${getMainBranch()}/$path"
     }
 
     private String getMainBranchUrl() {
-        "${config.endpoint}/api/1.0/repositories/$project/main-branch/"
+        "${config.endpoint}/api/2.0/repositories/$project"
     }
 
     String getMainBranch() {
-        invokeAndParseResponse(getMainBranchUrl()) ?. name
+        invokeAndParseResponse(getMainBranchUrl()) ?. mainbranch ?. name
     }
 
     @Override
@@ -77,8 +77,6 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
     byte[] readBytes(String path) {
 
         def url = getContentUrl(path)
-        Map response  = invokeAndParseResponse(url)
-        response.get('data')?.toString()?.getBytes()
-
+        invoke(url)?.getBytes()
     }
 }


### PR DESCRIPTION
Bitbucket has stated that they will remove their 1.0 API on the 29th of April 2019. See - https://developer.atlassian.com/cloud/bitbucket/deprecation-notice-v1-apis/

For some reason they are still up, but its just a matter of time until they remove them.

This pull request updates the BitbucketRepositoryProvider to use the 2.0 API for all interaction with Bitbucket.

Fix for issue: https://github.com/nextflow-io/nextflow/issues/1183


Signed-off-by: Ólafur Haukur Flygenring <olafurh@wuxinextcode.com>