### PR TITLE
Added setCredentialsProvider for submodules

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -939,6 +939,8 @@ class AssetManager {
         // call submodule init
         init.call()
         // call submodule update
+        if( provider.hasCredentials() )
+            update.setCredentialsProvider( new UsernamePasswordCredentialsProvider(provider.user, provider.password) )
         def updatedList = update.call()
         log.debug "Update submodules $updatedList"
     }


### PR DESCRIPTION
When I try to run a script directory from gitea, I got error messages as follows:

```
Jun-27 10:42:24.767 [main] DEBUG nextflow.cli.Launcher - $> nextflow run 'https://mydomain.com/gitea/nf-workflows/star-index.git' --input input.yaml
Jun-27 10:42:24.837 [main] INFO  nextflow.cli.CmdRun - N E X T F L O W  ~  version 19.06.0-edge
Jun-27 10:42:25.347 [main] DEBUG nextflow.scm.AssetManager - Repository URL: https://mydomain.com/gitea/nf-workflows/star-index.git; Project: nf-workflows/star-index; Hub provider: gitea
Jun-27 10:42:25.352 [main] INFO  nextflow.cli.CmdRun - Pulling nf-workflows/star-index ...
Jun-27 10:42:25.356 [main] DEBUG nextflow.scm.RepositoryProvider - Request [credentials pachiras:*********] -> https://mydomain.com/gitea/api/v1/repos/nf-workflows/star-index/raw/nextflow.config
Jun-27 10:42:25.739 [main] DEBUG nextflow.scm.RepositoryProvider - Request [credentials pachiras:*********] -> https://mydomain.com/gitea/api/v1/repos/nf-workflows/star-index/raw/main.nf
Jun-27 10:42:25.859 [main] DEBUG nextflow.scm.RepositoryProvider - Request [credentials pachiras:*********] -> https://mydomain.com/gitea/api/v1/repos/nf-workflows/star-index
Jun-27 10:42:25.951 [main] DEBUG nextflow.scm.AssetManager - Pulling nf-workflows/star-index -- Using remote clone url: https://mydomain.com/gitea/nf-workflows/star-index.git
Jun-27 10:42:27.121 [main] INFO  nextflow.cli.CmdRun -  downloaded from https://mydomain.com/gitea/nf-workflows/star-index.git
Jun-27 10:42:27.377 [main] DEBUG nextflow.cli.Launcher - Operation aborted
org.eclipse.jgit.api.errors.TransportException: https://mydomain.com/gitea/nf-workflows/processes.git: Authentication is required but no has been registered
    at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:254)
    at org.eclipse.jgit.api.CloneCommand.fetch(CloneCommand.java:302)
    at org.eclipse.jgit.api.CloneCommand.call(CloneCommand.java:200)
    at org.eclipse.jgit.api.SubmoduleUpdateCommand.getOrCloneSubmodule(SubmoduleUpdateCommand.java:169)
    at org.eclipse.jgit.api.SubmoduleUpdateCommand.call(SubmoduleUpdateCommand.java:210)
    at nextflow.scm.AssetManager.updateModules(AssetManager.groovy:942)
    at nextflow.cli.CmdRun.getScriptFile(CmdRun.groovy:314)
    at nextflow.cli.CmdRun.run(CmdRun.groovy:219)
    at nextflow.cli.Launcher.run(Launcher.groovy:451)
    at nextflow.cli.Launcher.main(Launcher.groovy:633)
Caused by: org.eclipse.jgit.errors.TransportException: https://mydomain.com/gitea/nf-workflows/processes.git: Authentication is required but no CredentialsProvider has been registered
    at org.eclipse.jgit.transport.TransportHttp.connect(TransportHttp.java:537)
    at org.eclipse.jgit.transport.TransportHttp.openFetch(TransportHttp.java:362)
    at org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:138)
    at org.eclipse.jgit.transport.FetchProcess.execute(FetchProcess.java:124)
    at org.eclipse.jgit.transport.Transport.fetch(Transport.java:1271)
    at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:243)
    ... 9 common frames omitted
```

This is the first time to run a script with a git-submodule. The error was caused at the point where nextflow tries to update the submodule. And the log message says the credential info are not provided for submodule access.

So I added. After adding this it worked perfectly. The way gitea requires the credential information may be different from that of Github or Gitlab.

