### PR TITLE
Add megabyte unit to slurm memory config

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -61,7 +61,7 @@ class SlurmExecutor extends AbstractGridExecutor {
             // be stored, just collected). In both cases memory use is based upon the job's
             // Resident Set Size (RSS). A task may exceed the memory limit until the next periodic
             // accounting sample. -- https://slurm.schedmd.com/sbatch.html
-            result << '--mem' << task.config.getMemory().toMega().toString()
+            result << '--mem' << task.config.getMemory().toMega().toString() + 'M'
         }
 
         // the requested partition (a.k.a queue) name

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -130,7 +130,7 @@ class SlurmExecutorTest extends Specification {
                 #SBATCH -o /work/path/.command.log
                 #SBATCH --no-requeue
                 #SBATCH -t 01:00:00
-                #SBATCH --mem 50
+                #SBATCH --mem 50M
                 #SBATCH -a 1
                 '''
                 .stripIndent().leftTrim()
@@ -150,7 +150,7 @@ class SlurmExecutorTest extends Specification {
                 #SBATCH --no-requeue
                 #SBATCH -c 2
                 #SBATCH -t 02:00:00
-                #SBATCH --mem 200
+                #SBATCH --mem 200M
                 #SBATCH -b 2
                 '''
                 .stripIndent().leftTrim()
@@ -170,7 +170,7 @@ class SlurmExecutorTest extends Specification {
                 #SBATCH --no-requeue
                 #SBATCH -c 8
                 #SBATCH -t 51:00:00
-                #SBATCH --mem 3072
+                #SBATCH --mem 3072M
                 #SBATCH -x 3
                 '''
                 .stripIndent().leftTrim()


### PR DESCRIPTION
The admins on my HPC have configured SLURM with the default_gbytes option set. This will mean that the --mem is interpreted as gigabyte instead of the default megabyte. This behavior can be overruled by supyling a unit. To be compatible with both configurations it is best that nextflow supplies a unit (M) when setting memory requirements.

See https://slurm.schedmd.com/sbatch.html under --mem.