### PR TITLE
Tiny docs fixes

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -507,7 +507,7 @@ Advanced Batch configuration options can be set by using the ``batch`` attribute
 =========================== ================
 Name                        Description
 =========================== ================
-cliPath                     The path where the AWS command line tool is installed in the host AMI. 
+cliPath                     The path where the AWS command line tool is installed in the host AMI.
 jobRole                     The AWS Job Role ARN that needs to be used to execute the Batch Job.
 maxParallelTransfers        Max parallel upload/download transfer operations *per job* (default: ``16``).
 volumes                     One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. ``/host/path:/mount/path[:ro|rw]``. Multiple mounts can be specifid separating them with a comma or using a list object.
@@ -776,7 +776,7 @@ when no other profile is specified by the user.
           }
         }
 
-  In the above example the ``process.cpus`` attribute is not correctly applied because the ``process`` scope it's also
+  In the above example the ``process.cpus`` attribute is not correctly applied because the ``process`` scope is also
   used in the ``foo`` and ``bar`` profile contexts.
 
 The above feature requires version 0.28.x or higher.

--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -83,7 +83,7 @@ For example::
           file 'bar.txt'
         script:
           """
-          your_command > bar.txt
+          another_command $x > bar.txt
           """
     }
 
@@ -103,7 +103,7 @@ Processes having matching input-output declaration can be composed so that the o
 of the first process is passed as input to the following process. Take in consideration
 the previous process definition, it's possible to write the following::
 
-    foo(bar())
+    bar(foo())
 
 Process outputs
 ---------------


### PR DESCRIPTION
Before this commit, the example showed the foo() process being passed the output of bar(). I might be mistaken, but the example looks like the output of foo() should be passed to bar(<here>) rather than the other way around - foo() doesn't take any input.

While we're looking at this section, we might as well show the bar() process doing something with the input file.