### PR TITLE
Explicitly check whether module path does not end with .nf

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -123,7 +123,7 @@ class IncludeDef {
         def module = resolveModulePath(include)
 
         // check if exists a file with `.nf` extension
-        if( !module.name.contains('.') ) {
+        if( !module.name.endsWith('.nf') ) {
             def extendedName = module.resolveSibling( "${module.simpleName}.nf" )
             if( extendedName.exists() )
                 return extendedName


### PR DESCRIPTION
Having a module file with multiple dots in its name results in an error. For example:

#### Module file location:
```bash
ls -1 NextflowCommandLineTools/bwa/0.7.5a.nf
NextflowCommandLineTools/bwa/0.7.5a.nf
```
#### Nextflow script
```nextflow
include mem from 'NextflowCommandLineTools/bwa/0.7.5a'
```
#### Running nextflow
```bash
nextflow run test.nf
N E X T F L O W  ~  version 19.07.0
Launching `test.nf` [furious_poincare] - revision: c5443c2765
WARN: DSL 2 IS AN EXPERIMENTAL FEATURE UNDER DEVELOPMENT -- SYNTAX MAY CHANGE IN FUTURE RELEASE
No such file: Can't find a matching module file for include: NextflowCommandLineTools/bwa/0.7.5a
```

I suggest to explicitly check whether module path does not end with '.nf'. 