### PR TITLE
Docs fix: collectFile `size` vs `skip`

### DIFF
--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -1486,7 +1486,7 @@ The following parameters can be used with the ``collectFile`` operator:
 =============== ========================
 Name            Description
 =============== ========================
-keepHeader      Prepend the resulting file with the header fetched in the first collected file. The header size (ie. lines) can be specified by using the ``size`` parameter (default: ``false``).
+keepHeader      Prepend the resulting file with the header fetched in the first collected file. The header size (ie. lines) can be specified by using the ``skip`` parameter (default: ``false``), to determine how many lines to remove from all collected files except for the first (where no lines will be removed).
 name            Name of the file where all received values are stored.
 newLine         Appends a ``newline`` character automatically after each entry (default: ``false``).
 seed            A value or a map of values used to initialise the files content.


### PR DESCRIPTION
The docs previously suggested the `size` parameter would control how many lines were skipped, but that parameter doesn't exist. I think that that `skip` parameter does this job instead.