### PR TITLE
[#1232] Add custom AWS batch job names

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -509,8 +509,9 @@ Name                        Description
 =========================== ================
 cliPath                     The path where the AWS command line tool is installed in the host AMI.
 jobRole                     The AWS Job Role ARN that needs to be used to execute the Batch Job.
+jobNameTemplate             The GString template for building the Batch job name, has access to WorkflowMetadata and TaskRun with "workflow" and "task"
 maxParallelTransfers        Max parallel upload/download transfer operations *per job* (default: ``16``).
-volumes                     One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. ``/host/path:/mount/path[:ro|rw]``. Multiple mounts can be specifid separating them with a comma or using a list object.
+volumes                     One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. ``/host/path:/mount/path[:ro|rw]``. Multiple mounts can be specified separating them with a comma or using a list object.
 maxTransferAttempts         The maximum number of downloads attempts from S3 (default: `1`).
 delayBetweenAttempts        Delay between download attempts from S3 (default `10 sec`).
 =========================== ================

--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
@@ -175,7 +175,7 @@ class AwsBatchExecutor extends Executor {
         assert task
         assert task.workDir
         log.trace "[AWS BATCH] Launching process > ${task.name} -- work folder: ${task.workDirStr}"
-        new AwsBatchTaskHandler(task, this)
+        new AwsBatchTaskHandler(task, this, session.getWorkflowMetadata())
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsOptions.groovy
@@ -38,7 +38,9 @@ class AwsOptions {
     static final public int MAX_TRANSFER_ATTEMPTS = 1
 
     static final public Duration DEFAULT_DELAY_BETWEEN_ATTEMPTS = Duration.of('10sec')
-  
+
+    static final public String DEFAULT_JOB_NAME_TEMPLATE = '${task.name}'
+
     String cliPath
 
     String storageClass
@@ -59,6 +61,11 @@ class AwsOptions {
      * The job role ARN that should be used
      */
     String jobRole
+
+    /**
+     * The job name template, has access to WorkflowMetadata and TaskRun with "workflow" and "task"
+     */
+    String jobNameTemplate = DEFAULT_JOB_NAME_TEMPLATE
 
     /**
      * Volume mounts
@@ -85,6 +92,7 @@ class AwsOptions {
         region = session.config.navigate('aws.region') as String
         volumes = makeVols(session.config.navigate('aws.batch.volumes'))
         jobRole = session.config.navigate('aws.batch.jobRole')
+        jobNameTemplate = session.config.navigate('aws.batch.jobNameTemplate', DEFAULT_JOB_NAME_TEMPLATE)
     }
 
     protected String getCliPath0(Session session) {


### PR DESCRIPTION
I noticed as I was updating the `config.rst` that a similar concept exists for grid schedulers, perhaps it would be better to reuse that concept? Though the original ticket does specifically mention access to `WorkflowMetadata`. For my use case I can generate different `executor.jobName` with different prefixes.