### PR TITLE
AWS temporary session token support

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
@@ -27,6 +27,7 @@ import javax.mail.internet.MimeMessage
 import javax.mail.internet.MimeMultipart
 
 import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.BasicSessionCredentials
 import com.amazonaws.regions.Region
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.batch.AWSBatchClient
@@ -96,6 +97,11 @@ class AmazonCloudDriver implements CloudDriver {
     private String secretKey
 
     /**
+     * The AWS session key credentials (optional)
+     */
+    private String sessionKey
+
+    /**
      * The AWS region eg. {@code eu-west-1}. If it's not specified the current region is retrieved from
      * the EC2 instance metadata
      */
@@ -124,10 +130,16 @@ class AmazonCloudDriver implements CloudDriver {
         if( config.accessKey && config.secretKey ) {
             this.accessKey = config.accessKey
             this.secretKey = config.secretKey
+            if (config.sessionKey){
+                this.sessionKey = config.sessionKey
+            }
         }
         else if( (credentials=Global.getAwsCredentials()) ) {
             this.accessKey = credentials[0]
             this.secretKey = credentials[1]
+            if (credentials.size() == 3){
+                this.sessionKey = credentials[2]
+            }
         }
 
         if( !accessKey && !fetchIamRole() )
@@ -157,6 +169,11 @@ class AmazonCloudDriver implements CloudDriver {
      * @return The current set AWS secret key
      */
     protected String getSecretKey() { secretKey }
+
+    /**
+     * @return The current set AWS session key
+     */
+    protected String getSessionKey() { sessionKey }
 
     /**
      * Retrieve the current IAM role eventually define for a EC2 instance.
@@ -223,9 +240,11 @@ class AmazonCloudDriver implements CloudDriver {
         if( ec2Client )
             return ec2Client
 
-        def result = (accessKey && secretKey
-                ? new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey))
-                : new AmazonEC2Client())
+        def result = (accessKey && secretKey && sessionKey
+                ? new AmazonEC2Client(new BasicSessionCredentials(accessKey, secretKey, sessionKey))
+                : (accessKey && secretKey 
+                    ? new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey))
+                    : new AmazonEC2Client()))
 
         if( region )
             result.setRegion(getRegionObj(region))
@@ -242,9 +261,11 @@ class AmazonCloudDriver implements CloudDriver {
      */
     @Memoized
     AWSBatchClient getBatchClient() {
-        def result = (accessKey && secretKey
-                ? new AWSBatchClient(new BasicAWSCredentials(accessKey, secretKey))
-                : new AWSBatchClient())
+        def result = (accessKey && secretKey && sessionKey
+                ? new AWSBatchClient(new BasicSessionCredentials(accessKey, secretKey, sessionKey))
+                : (accessKey && secretKey 
+                    ? new AWSBatchClient(new BasicAWSCredentials(accessKey, secretKey))
+                    : new AWSBatchClient()))
 
         if( region )
             result.setRegion(getRegionObj(region))
@@ -539,6 +560,9 @@ class AmazonCloudDriver implements CloudDriver {
         if( !cfg.instanceRole && accessKey && secretKey ) {
             profile += "export AWS_ACCESS_KEY_ID='$accessKey'\n"
             profile += "export AWS_SECRET_ACCESS_KEY='$secretKey'\n"
+            if (sessionKey){
+                profile += "export AWS_SESSION_TOKEN='$sessionKey'\n"
+            }
         }
 
         if( region )

--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
@@ -99,7 +99,7 @@ class AmazonCloudDriver implements CloudDriver {
     /**
      * The AWS session key credentials (optional)
      */
-    private String sessionKey
+    private String sessionToken
 
     /**
      * The AWS region eg. {@code eu-west-1}. If it's not specified the current region is retrieved from
@@ -130,15 +130,15 @@ class AmazonCloudDriver implements CloudDriver {
         if( config.accessKey && config.secretKey ) {
             this.accessKey = config.accessKey
             this.secretKey = config.secretKey
-            if (config.sessionKey){
-                this.sessionKey = config.sessionKey
+            if (config.sessionToken){
+                this.sessionToken = config.sessionToken
             }
         }
         else if( (credentials=Global.getAwsCredentials()) ) {
             this.accessKey = credentials[0]
             this.secretKey = credentials[1]
             if (credentials.size() == 3){
-                this.sessionKey = credentials[2]
+                this.sessionToken = credentials[2]
             }
         }
 
@@ -173,7 +173,7 @@ class AmazonCloudDriver implements CloudDriver {
     /**
      * @return The current set AWS session key
      */
-    protected String getSessionKey() { sessionKey }
+    protected String getsessionToken() { sessionToken }
 
     /**
      * Retrieve the current IAM role eventually define for a EC2 instance.
@@ -240,8 +240,8 @@ class AmazonCloudDriver implements CloudDriver {
         if( ec2Client )
             return ec2Client
 
-        def result = (accessKey && secretKey && sessionKey
-                ? new AmazonEC2Client(new BasicSessionCredentials(accessKey, secretKey, sessionKey))
+        def result = (accessKey && secretKey && sessionToken
+                ? new AmazonEC2Client(new BasicSessionCredentials(accessKey, secretKey, sessionToken))
                 : (accessKey && secretKey 
                     ? new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey))
                     : new AmazonEC2Client()))
@@ -261,8 +261,8 @@ class AmazonCloudDriver implements CloudDriver {
      */
     @Memoized
     AWSBatchClient getBatchClient() {
-        def result = (accessKey && secretKey && sessionKey
-                ? new AWSBatchClient(new BasicSessionCredentials(accessKey, secretKey, sessionKey))
+        def result = (accessKey && secretKey && sessionToken
+                ? new AWSBatchClient(new BasicSessionCredentials(accessKey, secretKey, sessionToken))
                 : (accessKey && secretKey 
                     ? new AWSBatchClient(new BasicAWSCredentials(accessKey, secretKey))
                     : new AWSBatchClient()))
@@ -560,8 +560,8 @@ class AmazonCloudDriver implements CloudDriver {
         if( !cfg.instanceRole && accessKey && secretKey ) {
             profile += "export AWS_ACCESS_KEY_ID='$accessKey'\n"
             profile += "export AWS_SECRET_ACCESS_KEY='$secretKey'\n"
-            if (sessionKey){
-                profile += "export AWS_SESSION_TOKEN='$sessionKey'\n"
+            if (sessionToken){
+                profile += "export AWS_SESSION_TOKEN='$sessionToken'\n"
             }
         }
 

--- a/modules/nf-commons/src/main/nextflow/Global.groovy
+++ b/modules/nf-commons/src/main/nextflow/Global.groovy
@@ -102,13 +102,13 @@ class Global {
 
         for( Path it : files ) {
             final conf = new IniFile(it)
-            final profile = env.get('AWS_DEFAULT_PROFILE', 'default')
-            if( (a=conf.section(profile).aws_access_key_id) && (b=conf.section(profile).aws_secret_access_key) && (c=conf.section(profile).aws_session_token) ) {
-                log.debug "Using AWS temporary session credentials defined in `${profile}` section in file: ${conf.file}"
+            if( (a=conf.section('default').aws_access_key_id) && (b=conf.section('default').aws_secret_access_key) 
+                    && (c=conf.section('default').aws_session_token) ) {
+                log.debug "Using AWS temporary session credentials defined in `default` section in file: ${conf.file}"
                 return [a,b,c]
             }
-            if( (a=conf.section(profile).aws_access_key_id) && (b=conf.section(profile).aws_secret_access_key) ) {
-                log.debug "Using AWS credential defined in `${profile}` section in file: ${conf.file}"
+            if( (a=conf.section('default').aws_access_key_id) && (b=conf.section('default').aws_secret_access_key) ) {
+                log.debug "Using AWS credential defined in `default` section in file: ${conf.file}"
                 return [a,b]
             }
         }

--- a/modules/nf-commons/src/main/nextflow/Global.groovy
+++ b/modules/nf-commons/src/main/nextflow/Global.groovy
@@ -75,6 +75,7 @@ class Global {
 
         String a
         String b
+        String c
 
         if( config && config.aws instanceof Map ) {
             a = ((Map)config.aws).accessKey
@@ -101,8 +102,13 @@ class Global {
 
         for( Path it : files ) {
             final conf = new IniFile(it)
-            if( (a=conf.section('default').aws_access_key_id) && (b=conf.section('default').aws_secret_access_key) ) {
-                log.debug "Using AWS credential defined in `default` section in file: ${conf.file}"
+            final profile = env.get('AWS_DEFAULT_PROFILE', 'default')
+            if( (a=conf.section(profile).aws_access_key_id) && (b=conf.section(profile).aws_secret_access_key) && (c=conf.section(profile).aws_session_token) ) {
+                log.debug "Using AWS temporary session credentials defined in `${profile}` section in file: ${conf.file}"
+                return [a,b,c]
+            }
+            if( (a=conf.section(profile).aws_access_key_id) && (b=conf.section(profile).aws_secret_access_key) ) {
+                log.debug "Using AWS credential defined in `${profile}` section in file: ${conf.file}"
                 return [a,b]
             }
         }

--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -454,6 +454,10 @@ class FileHelper {
                 // S3FS expect the access - secret keys pair in lower notation
                 result.access_key = credentials[0]
                 result.secret_key = credentials[1]
+                if (credentials.size() == 3) {
+                    result.session_key = credentials[2]
+                    log.debug "Using AWS temporary session token for S3FS."
+                }
             }
 
             // AWS region
@@ -482,6 +486,9 @@ class FileHelper {
 
         if( config.secret_key && config.secret_key.size()>6 )
             result.secret_key = "${config.secret_key.substring(0,6)}.."
+
+        if( config.session_key && config.session_key.size()>6 )
+            result.session_key = "${config.session_key.substring(0,6)}.."
 
         return result.toString()
     }


### PR DESCRIPTION
This PR address #934 and adds the ability for nextflow to use temporary AWS credentials from the STS service. There are three credential strings involved AWS_ACCESS_KEY, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN, and are read either from the environment or from the `~/.aws/credentials` file.

Note this does depend on a separate PR in the nextflow-s3fs library: https://github.com/nextflow-io/nextflow-s3fs/pull/17. Also, originally this was part of https://github.com/nextflow-io/nextflow/pull/1248, but now is split into two.