### PR TITLE
Use native shifterimg for  shifter engine

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Contents:
    google
    conda
    docker
+   shifter
    singularity
    ignite
    kubernetes

--- a/docs/shifter.rst
+++ b/docs/shifter.rst
@@ -25,6 +25,8 @@ all of the compute nodes and the `shifterimg` command should also be available a
 Image gateway, for more information see the
 `official documentation <https://github.com/NERSC/shifter/tree/master/doc>`__.
 
+.. note:: The engine should work with at least shifter version 18.03.
+
 Images
 ======
 

--- a/docs/shifter.rst
+++ b/docs/shifter.rst
@@ -1,0 +1,66 @@
+.. _shifter-page:
+
+******************
+Shifter Containers
+******************
+
+`Shifter <https://docs.nersc.gov/programming/shifter/overview/>`__ is yet another container engine alternative to
+`Docker <https://www.docker.com>`__. Shifter works by converting Docker images to a common format that can then be
+distributed and launched on HPC systems. The user interface to shifter enables a user to select an image
+from the `dockerhub registry <https://hub.docker.com/>`__ and then submit jobs which run entirely within the container.
+
+Nextflow provides built-in support for Shifter. This allows you to control the execution environment of the processes
+in your pipeline by running them in isolated containers along-side their dependencies.
+
+Moreover the support provided by Nextflow for different container technologies, allows the same pipeline to be
+transparently executed both with :ref:`Docker <_docker-page>`, :ref:`Singularity <_singularity-page>` or
+:ref:`Shifter <_shifter-page>` containers, depending on the available engine in target execution platforms.
+
+Prerequisites
+=============
+
+You need Shifter and Shifter image gateway installed in your execution environment, i.e: your personal computed or the
+entry node of a distributed cluster. In the case of the distributed cluster case, you should have shifter installed on
+all of the compute nodes and the `shifterimg` command should also be available and shifter properly setup to access the
+Image gateway, for more information see the
+`official documentation <https://github.com/NERSC/shifter/tree/master/doc>`__.
+
+Images
+======
+
+Shifter converts a docker image to squashfs layers which are distributed and launched in the cluster. For more info on
+how to Build Shifter images see the
+`official documentation <https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images>`__.
+
+How it works
+============
+
+The integration for Shifter, at this time, requires you to set up the following parameters in your config file::
+
+  process.container = "dockerhub_user/image_name:image_tag"
+  shifter.enabled = true
+
+and it will always try to search the Docker Hub registry for the images.
+
+.. note:: if you do not specify an image tag it will fetch the 'latest' tag by default.
+
+Multiple Containers
+===================
+
+It is possible to specify a different Shifter image for each process definition in your pipeline script. For example,
+let's suppose you have two processes named ``foo`` and ``bar``. You can specify two different Shifter images
+specifying them in the ``nextflow.config`` file as shown below::
+
+    process {
+        withName:foo {
+            container = 'image_name_1'
+        }
+        withName:bar {
+            container = 'image_name_2'
+        }
+    }
+    shifter {
+        enabled = true
+    }
+
+Read the :ref:`Process scope <config-process>` section to learn more about processes configuration.

--- a/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
@@ -24,29 +24,6 @@ package nextflow.container
  */
 class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
 
-    static private String SHIFTER_HELPERS = '''
-        function shifter_img() {
-          local cmd=$1
-          local image=$2
-          shifterimg -v $cmd $image |  awk -F: '$0~/"status":/{gsub("[\\", ]","",$2);print $2}\'
-        }
-
-        function shifter_pull() {
-          local image=$1
-          local STATUS=$(shifter_img lookup $image)
-          if [[ $STATUS != READY && $STATUS != '' ]]; then
-            STATUS=$(shifter_img pull $image)
-            while [[ $STATUS != READY && $STATUS != FAILURE && $STATUS != '' ]]; do
-              sleep 5
-              STATUS=$(shifter_img pull $image)
-            done
-          fi
-
-          [[ $STATUS == FAILURE || $STATUS == '' ]] && echo "Shifter failed to pull image \\`$image\\`" >&2  && exit 1
-        }
-        '''.stripIndent()
-
-
     private boolean verbose
 
     ShifterBuilder( String image ) {
@@ -83,14 +60,9 @@ class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
     }
 
     @Override
-    String getScriptHelpers() {
-        return SHIFTER_HELPERS + '\n'
-    }
-
-    @Override
     String getRunCommand() {
         def run = super.getRunCommand()
-        def result = "shifter_pull $image\n"
+        def result = "shifterimg pull $image\n"
         result += run
         return result
     }

--- a/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -58,7 +58,7 @@ class ShifterBuilderTest extends Specification {
         def cli = new ShifterBuilder('ubuntu:14').build().getRunCommand()
         then:
         cli ==  '''
-                shifter_pull ubuntu:14
+                shifterimg pull ubuntu:14
                 shifter --image ubuntu:14
                 '''
                 .stripIndent().trim()
@@ -67,7 +67,7 @@ class ShifterBuilderTest extends Specification {
         cli = new ShifterBuilder('ubuntu:14').build().getRunCommand('bwa --this --that file.fasta')
         then:
         cli ==  '''
-                shifter_pull ubuntu:14
+                shifterimg pull ubuntu:14
                 shifter --image ubuntu:14 bwa --this --that file.fasta
                 '''
                 .stripIndent().trim()
@@ -76,7 +76,7 @@ class ShifterBuilderTest extends Specification {
         cli = new ShifterBuilder('ubuntu:14').params(entry:'/bin/bash').build().getRunCommand('bwa --this --that file.fasta')
         then:
         cli ==  '''
-                shifter_pull ubuntu:14
+                shifterimg pull ubuntu:14
                 shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"
                 '''
                 .stripIndent().trim()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -715,9 +715,8 @@ class BashWrapperBuilderTest extends Specification {
                 containerConfig: [enabled: true, engine: 'shifter'] as ContainerConfig ).makeBinding()
 
         then:
-        binding.container_helpers.contains('shifter_pull')
         binding.launch_cmd == '''\
-                shifter_pull docker:ubuntu:latest
+                shifterimg pull docker:ubuntu:latest
                 shifter --image docker:ubuntu:latest /bin/bash -c "eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"
                 '''.stripIndent().rightTrim()
         binding.kill_cmd == null


### PR DESCRIPTION
This PR replaces the helper functions `shifter_pull` and `shifter_img` for the `shifterimg` command 
used natively by shifter.

This PR also adds documentation related to using the engine, the structure and some content of the 
documentation was taken from the singularity documentation.