### PR TITLE
Experimental support for ECS.

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/AmazonCloudDriver.groovy
@@ -101,6 +101,11 @@ class AmazonCloudDriver implements CloudDriver {
      */
     private String region
 
+    /** 
+     *  Private copy of system environment (to allow testing) 
+     */
+    private Map env = System.getenv()
+    
     /**
      * Initialise the Amazon cloud driver with default (empty) parameters
      */
@@ -159,7 +164,6 @@ class AmazonCloudDriver implements CloudDriver {
     protected String getSecretKey() { secretKey }
 
     protected boolean inEcs() {
-	def env = System.getenv()
 	return env.containsKey('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI');
     }
     protected String getUrlBase() {
@@ -186,7 +190,6 @@ class AmazonCloudDriver implements CloudDriver {
 	    def url = ""
 	    
 	    if( inEcs() ) {
-		final env = System.getenv()
 		url = urlbase + env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI']
 	    }
 	    else


### PR DESCRIPTION
When you run nextflow from an EC2 machine, it will normally contact the EC2 metadata server to get the IAM role credentials for the machine, which it uses to perform actions
on behalf of the user.

When nextflow runs in ECS, the metadata server URL does not resolve, but it's still possible to fetch the necessary information.

This commit adds minimal support for ECS by checking for the ECS environment variable 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI', and if that variable is defined, using
it to construct the metadata URL.

I have tested this commit in ECS and EC2 and it seems to work for simple cases.  I tried adding a test, but couldn't find a way to drive the codepath, because it requires
an env var to be set, and Java/Groovy do not make it easy to set an env var.

The test would be added to AmazonCloudDriverTest and look something like this:
def 'should fetch aws role on ECS' () {
        given:
        def driver = Spy(AmazonCloudDriver, constructorArgs: [Mock(AmazonEC2Client)])
        // do something to set 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
        when:
        def result = driver.fetchIamRole()
        then:
        // should verify the driver fetches from a URI starting with $AWS_CONTAINER_CREDENTIALS_URI
        1 * driver.getUrl('http://169.254.169.254/latest/meta-data/iam/security-credentials/') >> 'iam-role-here'
        result == 'iam-role-here'
    }