### PR TITLE
Fix #1195

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -22,7 +22,6 @@ import java.nio.file.Path
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
-import groovy.json.JsonSlurper
 import nextflow.container.ContainerBuilder
 import nextflow.container.DockerBuilder
 import nextflow.container.ShifterBuilder
@@ -316,19 +315,7 @@ class BashWrapperBuilder {
     }
 
     private String getCondaActivateSnippet() {
-        if ( condaEnv ) {
-            // Get path to conda installation using `conda info`
-            def sout = new StringBuilder()
-            Process proc = "conda info --json".execute()
-            proc.waitForProcessOutput(sout, System.err)
-            JsonSlurper jsonSlurper = new JsonSlurper()
-            Map condaInfo = (Map) jsonSlurper.parseText(sout.toString())
-            // Build absolute path to activate script
-            def activateScript = "${condaInfo.conda_prefix}/bin/activate"
-            return "# conda environment\nsource ${Escape.path(activateScript)} ${Escape.path(condaEnv)}\n"
-        } else {
-            return null
-        }
+        condaEnv ? "# conda environment\nsource activate ${Escape.path(condaEnv)}\n" : null
     }
 
     protected String getTraceCommand(String interpreter) {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -315,7 +315,9 @@ class BashWrapperBuilder {
     }
 
     private String getCondaActivateSnippet() {
-        condaEnv ? "# conda environment\nsource activate ${Escape.path(condaEnv)}\n" : null
+        // Extract the "conda_prefix" entry from JSON
+        def condaPrefixSubCmd = 'conda info --json | sed  -n \'s/^.*"conda_prefix":\\s*"\\(.\\+\\)".*$/\\1/p\''
+        condaEnv ? "# conda environment\nsource \$($condaPrefixSubCmd)/bin/activate ${Escape.path(condaEnv)}\n" : null
     }
 
     protected String getTraceCommand(String interpreter) {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -586,7 +586,7 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.conda_activate == '''\
                 # conda environment
-                source activate /some/conda/env/foo
+                source $(conda info --json | sed  -n 's/^.*"conda_prefix":\\s*"\\(.\\+\\)".*$/\\1/p')/bin/activate /some/conda/env/foo
                 '''.stripIndent()
 
     }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
@@ -78,7 +78,7 @@ nxf_main() {
     # beforeScript directive
     echo Before
     # conda environment
-    source activate /conda/env/path
+    source $(conda info --json | sed  -n 's/^.*"conda_prefix":\s*"\(.\+\)".*$/\1/p')/bin/activate /conda/env/path
     set -u
     [[ $NXF_SCRATCH ]] && echo "nxf-scratch-dir $HOSTNAME:$NXF_SCRATCH" && cd $NXF_SCRATCH
     nxf_stage


### PR DESCRIPTION
This addresses #1195. Works for me on SGE now. 

It still requires some input & discussion: 

- I apologize if this looks ugly, it is the first piece of Groovy I wrote and I'm afraid it looks too much like Java :/

- I am unsure how to adapt the test for that. In python, one can mock a shell command output, but I didn't find anything similar for Groovy. Probably it's best to delegate the `conda info --json` to a configuration option and stub that from the test. I am, however, too unfamiliar with the code-base to understand where that should go. `CondaConfig.groovy`?

- This approach would not work if the worker nodes and the head node don't share the same path to the conda installation. In that case, running `conda info` would need to be delegated to the worker nodes. I'm afraid that this would make everything more complicated. This would, of course, still require that the conda binary is in the `PATH` there. 