### PR TITLE
shifterimg workaround for ensuring image pulls

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
@@ -67,7 +67,7 @@ class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
         shifterimg lookup ${image}
         while ! shifterimg lookup ${image}; do
             sleep 5
-            STATUS=$(shifterimg -v pull ${image} | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+            STATUS=$(shifterimg -v pull ${image} | awk -F: '$0~/"status":/{gsub("[\\", ]","",$2);print $2}\')
             [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'${image}\'" >&2  && exit 1
         done
         '''

--- a/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
@@ -67,7 +67,7 @@ class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
         shifterimg lookup $image
         while ! shifterimg lookup $image; do
             sleep 5
-            STATUS=\$(shifterimg -v pull $image | awk -F: '\$0~/"status":/{gsub("[\", ]","",\$2);print \$2}\')
+            STATUS=\$(shifterimg -v pull $image | tail -n2 | head -n1 | awk \'{print \$6}\')
             [[ \$STATUS == "FAILURE" || -z \$STATUS ]] && echo "Shifter failed to pull image \'$image\'" >&2  && exit 1
         done
         """

--- a/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
@@ -62,15 +62,15 @@ class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
     @Override
     String getRunCommand() {
         def run = super.getRunCommand()
-        def result = '''
-        shifterimg pull ${image}
-        shifterimg lookup ${image}
-        while ! shifterimg lookup ${image}; do
+        def result = """
+        shifterimg pull $image
+        shifterimg lookup $image
+        while ! shifterimg lookup $image; do
             sleep 5
-            STATUS=$(shifterimg -v pull ${image} | awk -F: '$0~/"status":/{gsub("[\\", ]","",$2);print $2}\')
-            [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'${image}\'" >&2  && exit 1
+            STATUS=\$(shifterimg -v pull $image | awk -F: '\$0~/"status":/{gsub("[\", ]","",\$2);print \$2}\')
+            [[ \$STATUS == "FAILURE" || -z \$STATUS ]] && echo "Shifter failed to pull image \'$image\'" >&2  && exit 1
         done
-        '''
+        """
         result += run
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ShifterBuilder.groovy
@@ -62,7 +62,7 @@ class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
     @Override
     String getRunCommand() {
         def run = super.getRunCommand()
-        def result = """
+        def result = """\
         shifterimg pull $image
         shifterimg lookup $image
         while ! shifterimg lookup $image; do
@@ -70,7 +70,7 @@ class ShifterBuilder extends ContainerBuilder<ShifterBuilder> {
             STATUS=\$(shifterimg -v pull $image | tail -n2 | head -n1 | awk \'{print \$6}\')
             [[ \$STATUS == "FAILURE" || -z \$STATUS ]] && echo "Shifter failed to pull image \'$image\'" >&2  && exit 1
         done
-        """
+        """.stripIndent()
         result += run
         return result
     }

--- a/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -59,6 +59,12 @@ class ShifterBuilderTest extends Specification {
         then:
         cli ==  '''
                 shifterimg pull ubuntu:14
+                shifterimg lookup ubuntu:14
+                while ! shifterimg lookup ubuntu:14; do
+                    sleep 5
+                    STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'ubuntu:14\'" >&2  && exit 1
+                done
                 shifter --image ubuntu:14
                 '''
                 .stripIndent().trim()
@@ -68,6 +74,12 @@ class ShifterBuilderTest extends Specification {
         then:
         cli ==  '''
                 shifterimg pull ubuntu:14
+                shifterimg lookup ubuntu:14
+                while ! shifterimg lookup ubuntu:14; do
+                    sleep 5
+                    STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'ubuntu:14\'" >&2  && exit 1
+                done
                 shifter --image ubuntu:14 bwa --this --that file.fasta
                 '''
                 .stripIndent().trim()
@@ -77,6 +89,12 @@ class ShifterBuilderTest extends Specification {
         then:
         cli ==  '''
                 shifterimg pull ubuntu:14
+                shifterimg lookup ubuntu:14
+                while ! shifterimg lookup ubuntu:14; do
+                    sleep 5
+                    STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'ubuntu:14\'" >&2  && exit 1
+                done
                 shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"
                 '''
                 .stripIndent().trim()

--- a/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -57,12 +57,12 @@ class ShifterBuilderTest extends Specification {
         when:
         def cli = new ShifterBuilder('ubuntu:14').build().getRunCommand()
         then:
-        cli ==  '''
+        cli.stripIndent().trim() ==  '''
                 shifterimg pull ubuntu:14
                 shifterimg lookup ubuntu:14
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull ubuntu:14 | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14
@@ -72,12 +72,12 @@ class ShifterBuilderTest extends Specification {
         when:
         cli = new ShifterBuilder('ubuntu:14').build().getRunCommand('bwa --this --that file.fasta')
         then:
-        cli ==  '''
+        cli.stripIndent().trim() ==  '''
                 shifterimg pull ubuntu:14
                 shifterimg lookup ubuntu:14
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull ubuntu:14 | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14 bwa --this --that file.fasta
@@ -87,12 +87,12 @@ class ShifterBuilderTest extends Specification {
         when:
         cli = new ShifterBuilder('ubuntu:14').params(entry:'/bin/bash').build().getRunCommand('bwa --this --that file.fasta')
         then:
-        cli ==  '''
+        cli.stripIndent().trim() ==  '''
                 shifterimg pull ubuntu:14
                 shifterimg lookup ubuntu:14
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull ubuntu:14 | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"

--- a/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -57,47 +57,47 @@ class ShifterBuilderTest extends Specification {
         when:
         def cli = new ShifterBuilder('ubuntu:14').build().getRunCommand()
         then:
-        cli.stripIndent().trim() ==  '''
-                shifterimg pull ubuntu:14
-                shifterimg lookup ubuntu:14
-                while ! shifterimg lookup ubuntu:14; do
-                    sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
-                done
-                shifter --image ubuntu:14
-                '''
-                .stripIndent().trim()
+        cli ==  '''\
+        shifterimg pull ubuntu:14
+        shifterimg lookup ubuntu:14
+        while ! shifterimg lookup ubuntu:14; do
+            sleep 5
+            STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
+            [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
+        done
+        shifter --image ubuntu:14
+        '''
+        .stripIndent().trim()
 
         when:
         cli = new ShifterBuilder('ubuntu:14').build().getRunCommand('bwa --this --that file.fasta')
         then:
-        cli.stripIndent().trim() ==  '''
-                shifterimg pull ubuntu:14
-                shifterimg lookup ubuntu:14
-                while ! shifterimg lookup ubuntu:14; do
-                    sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
-                done
-                shifter --image ubuntu:14 bwa --this --that file.fasta
-                '''
-                .stripIndent().trim()
+        cli ==  '''\
+        shifterimg pull ubuntu:14
+        shifterimg lookup ubuntu:14
+        while ! shifterimg lookup ubuntu:14; do
+            sleep 5
+            STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
+            [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
+        done
+        shifter --image ubuntu:14 bwa --this --that file.fasta
+        '''
+        .stripIndent().trim()
 
         when:
         cli = new ShifterBuilder('ubuntu:14').params(entry:'/bin/bash').build().getRunCommand('bwa --this --that file.fasta')
         then:
-        cli.stripIndent().trim() ==  '''
-                shifterimg pull ubuntu:14
-                shifterimg lookup ubuntu:14
-                while ! shifterimg lookup ubuntu:14; do
-                    sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
-                done
-                shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"
-                '''
-                .stripIndent().trim()
+        cli ==  '''\
+        shifterimg pull ubuntu:14
+        shifterimg lookup ubuntu:14
+        while ! shifterimg lookup ubuntu:14; do
+            sleep 5
+            STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
+            [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
+        done
+        shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"
+        '''
+        .stripIndent().trim()
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -63,7 +63,7 @@ class ShifterBuilderTest extends Specification {
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
                     STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'ubuntu:14\'" >&2  && exit 1
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14
                 '''
@@ -78,7 +78,7 @@ class ShifterBuilderTest extends Specification {
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
                     STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'ubuntu:14\'" >&2  && exit 1
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14 bwa --this --that file.fasta
                 '''
@@ -93,7 +93,7 @@ class ShifterBuilderTest extends Specification {
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
                     STATUS=$(shifterimg -v pull ubuntu:14| awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'ubuntu:14\'" >&2  && exit 1
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"
                 '''

--- a/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
@@ -62,7 +62,7 @@ class ShifterBuilderTest extends Specification {
                 shifterimg lookup ubuntu:14
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14 | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14
@@ -77,7 +77,7 @@ class ShifterBuilderTest extends Specification {
                 shifterimg lookup ubuntu:14
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14 | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14 bwa --this --that file.fasta
@@ -92,7 +92,7 @@ class ShifterBuilderTest extends Specification {
                 shifterimg lookup ubuntu:14
                 while ! shifterimg lookup ubuntu:14; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ubuntu:14 | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull ubuntu:14 | tail -n2 | head -n1 | awk '{print $6}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image 'ubuntu:14'" >&2  && exit 1
                 done
                 shifter --image ubuntu:14 /bin/bash -c "bwa --this --that file.fasta"

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -715,16 +715,16 @@ class BashWrapperBuilderTest extends Specification {
                 containerConfig: [enabled: true, engine: 'shifter'] as ContainerConfig ).makeBinding()
 
         then:
-        binding.launch_cmd.stripIndent().rightTrim() == '''
-                shifterimg pull docker:ubuntu:latest
-                shifterimg lookup docker:ubuntu:latest
-                while ! shifterimg lookup docker:ubuntu:latest; do
-                    sleep 5
-                    STATUS=$(shifterimg -v pull docker:ubuntu:latest | tail -n2 | head -n1 | awk \'{print $6}\')
-                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'docker:ubuntu:latest\'" >&2  && exit 1
-                done
-                shifter --image docker:ubuntu:latest /bin/bash -c "eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"
-                '''.stripIndent().rightTrim()
+        binding.launch_cmd == '''
+        shifterimg pull docker:ubuntu:latest
+        shifterimg lookup docker:ubuntu:latest
+        while ! shifterimg lookup docker:ubuntu:latest; do
+            sleep 5
+            STATUS=$(shifterimg -v pull docker:ubuntu:latest | tail -n2 | head -n1 | awk \'{print $6}\')
+            [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'docker:ubuntu:latest\'" >&2  && exit 1
+        done
+        shifter --image docker:ubuntu:latest /bin/bash -c "eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"
+        '''.stripIndent().rightTrim()
         binding.kill_cmd == null
         binding.cleanup_cmd == ""
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -720,7 +720,7 @@ class BashWrapperBuilderTest extends Specification {
                 shifterimg lookup docker:ubuntu:latest
                 while ! shifterimg lookup docker:ubuntu:latest; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull docker:ubuntu:latest | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull docker:ubuntu:latest | tail -n2 | head -n1 | awk \'{print $6}\')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'docker:ubuntu:latest\'" >&2  && exit 1
                 done
                 shifter --image docker:ubuntu:latest /bin/bash -c "eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -715,7 +715,7 @@ class BashWrapperBuilderTest extends Specification {
                 containerConfig: [enabled: true, engine: 'shifter'] as ContainerConfig ).makeBinding()
 
         then:
-        binding.launch_cmd == '''
+        binding.launch_cmd == '''\
         shifterimg pull docker:ubuntu:latest
         shifterimg lookup docker:ubuntu:latest
         while ! shifterimg lookup docker:ubuntu:latest; do

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -717,6 +717,12 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.launch_cmd == '''\
                 shifterimg pull docker:ubuntu:latest
+                shifterimg lookup docker:ubuntu:latest
+                while ! shifterimg lookup docker:ubuntu:latest; do
+                    sleep 5
+                    STATUS=$(shifterimg -v pull ${image} | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'docker:ubuntu:latest\'" >&2  && exit 1
+                done
                 shifter --image docker:ubuntu:latest /bin/bash -c "eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"
                 '''.stripIndent().rightTrim()
         binding.kill_cmd == null

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -715,12 +715,12 @@ class BashWrapperBuilderTest extends Specification {
                 containerConfig: [enabled: true, engine: 'shifter'] as ContainerConfig ).makeBinding()
 
         then:
-        binding.launch_cmd == '''\
+        binding.launch_cmd.stripIndent().rightTrim() == '''
                 shifterimg pull docker:ubuntu:latest
                 shifterimg lookup docker:ubuntu:latest
                 while ! shifterimg lookup docker:ubuntu:latest; do
                     sleep 5
-                    STATUS=$(shifterimg -v pull ${image} | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
+                    STATUS=$(shifterimg -v pull docker:ubuntu:latest | awk -F: '$0~/"status":/{gsub("[\", ]","",$2);print $2}')
                     [[ $STATUS == "FAILURE" || -z $STATUS ]] && echo "Shifter failed to pull image \'docker:ubuntu:latest\'" >&2  && exit 1
                 done
                 shifter --image docker:ubuntu:latest /bin/bash -c "eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"


### PR DESCRIPTION
For some unknown reason shifterimg returns before finishing,
it should wait, even from a non-interactive shell.
Added some code from the previous helper function

Signed-off-by: Manuel Torrinha <manuel.torrinha@tecnico.ulisboa.pt>