### PR TITLE
Make Session.cleanup use a delete function that doesn't follow symlinks

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1069,7 +1069,7 @@ class Session implements ISession {
                 def deleted = db.removeTaskEntry(hash)
                 if( deleted ) {
                     // delete folder
-                    FileHelper.asPath(record.workDir).deleteDir()
+                    FileHelper.deletePath(FileHelper.asPath(record.workDir))
                 }
             }
             log.trace "Clean workdir complete"


### PR DESCRIPTION
Fix for issue: https://github.com/nextflow-io/nextflow/issues/1336

Signed-off-by: Ólafur Haukur Flygenring <olafurh@wuxinextcode.com>