### PR TITLE
correct typo in `collect_and_merge.nf` test

### DIFF
--- a/tests/collect_and_merge.nf
+++ b/tests/collect_and_merge.nf
@@ -38,7 +38,7 @@ process algn {
 
 /*
  * aggregation is made by using a 'reduce' operator
- * followed by 'flatMpa'
+ * followed by 'flatMap'
  */
 
 aggregation = algn_files


### PR DESCRIPTION
Nothing major, but I noticed this tiny thing while going through the tests for learning more about `nextflow`.