### PR TITLE
Try building everythng only in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,25 @@
+FROM groovy:jdk8 as build
+
+USER root
+RUN apt-get update \
+    && apt-get install -yq make
+#USER groovy
+
+WORKDIR /src
+COPY . /src
+
+RUN make deps
+RUN make compile
+
+#RUN make test
+#RUN make smoke
+
+RUN make pack
+
+#RUN make install
+
+RUN cd docker && make dist/docker
+
 FROM openjdk:8-jre-alpine
 MAINTAINER Paolo Di Tommaso <paolo.ditommaso@gmail.com>
 
@@ -5,15 +27,15 @@ MAINTAINER Paolo Di Tommaso <paolo.ditommaso@gmail.com>
 # - bash 
 # - gnu coreutils 
 # - curl 
-RUN apk update && apk add bash && apk add coreutils && apk add curl
+RUN apk --no-cache add bash coreutils curl
 
 # see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
 ENV NXF_OPTS='-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap' NXF_HOME=/.nextflow
 
 # copy docker client
-COPY dist/docker /usr/local/bin/docker
-COPY entry.sh /usr/local/bin/entry.sh
-COPY nextflow /usr/local/bin/nextflow
+COPY --from=build /src/docker/dist/docker /usr/local/bin/docker
+COPY docker/entry.sh /usr/local/bin/entry.sh
+COPY --from=build /src/nextflow /usr/local/bin/nextflow
 
 # download runtime
 RUN mkdir /.nextflow \


### PR DESCRIPTION
This uses multi-stage builds to first build, and test, and then uses that build container to assemble the release docker image.

it works right up to calling `nextflow info`, where it fails with:

```
 > [stage-1 6/6] RUN mkdir /.nextflow  && touch /.nextflow/dockerized  && chmod 755 /usr/local/bin/nextflow  && chmod 755 /usr/local/bin/entry.sh  && nextflow info:
#19 0.816 Downloading nextflow dependencies. It may require a few seconds, please wait .. curl: (22) The requested URL returned error: 403 Forbidden
#19 2.394 ERROR: Cannot download nextflow required file -- make sure you can connect to the internet

#19 2.395 Alternatively you can try to download this file:
#19 2.395     https://www.nextflow.io/releases/v19.10.0-edge/nextflow-19.10.0-edge-one.jar
#19 2.395 
#19 2.395 and save it as:
#19 2.395     /.nextflow/framework/19.10.0-edge/nextflow-19.10.0-edge-one.jar
#19 2.395 
```

That URL fails for me too, so I wonder if its incorrect.

on the other hand, using 

```
COPY --from=build /src/build/releases/nextflow-19.10.0-edge-all /usr/local/bin/nextflow
```

(ie, not the script)
I get something alot more like what I want