### PR TITLE
Handle ProviderMismatchException in CacheHelper

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -216,8 +216,11 @@ public class CacheHelper {
         try {
             attrs = Files.readAttributes(path, BasicFileAttributes.class);
         }
-        catch(IOException | ProviderMismatchException e) {
+        catch(IOException e) {
             log.debug("Unable to get file attributes file: {} -- Cause: {}", FilesEx.toUriString(path), e.toString());
+        }
+        catch(ProviderMismatchException e) {
+            log.warn("File system is unable to get file attributes file: {} -- Cause: {}", FilesEx.toUriString(path), e.toString());
         }
 
         if( mode==HashMode.DEEP && attrs!=null && attrs.isRegularFile() )

--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -220,6 +220,7 @@ public class CacheHelper {
             log.debug("Unable to get file attributes file: {} -- Cause: {}", FilesEx.toUriString(path), e.toString());
         }
         catch(ProviderMismatchException e) {
+            // see https://github.com/nextflow-io/nextflow/pull/1382
             log.warn("File system is unable to get file attributes file: {} -- Cause: {}", FilesEx.toUriString(path), e.toString());
         }
 

--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.ProviderMismatchException;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.HashMap;
@@ -215,7 +216,7 @@ public class CacheHelper {
         try {
             attrs = Files.readAttributes(path, BasicFileAttributes.class);
         }
-        catch(IOException e) {
+        catch(IOException | ProviderMismatchException e) {
             log.debug("Unable to get file attributes file: {} -- Cause: {}", FilesEx.toUriString(path), e.toString());
         }
 


### PR DESCRIPTION
I had a java.nio.file.ProviderMismatchException which is not catched in CacheHelper because IOException is not a parent class of ProviderMismatchException


The following PR had a catch so the error will be displayed.

```
Nov-18 14:54:18.058 [Actor Thread 20] ERROR nextflow.processor.TaskProcessor - Error executing process > 'mergeControls (merge contols)'

Caused by:
  java.nio.file.ProviderMismatchException

java.nio.file.ProviderMismatchException: null
	at sun.nio.fs.UnixPath.toUnixPath(UnixPath.java:200)
	at sun.nio.fs.UnixFileSystemProvider.getFileAttributeView(UnixFileSystemProvider.java:115)
	at sun.nio.fs.LinuxFileSystemProvider.getFileAttributeView(LinuxFileSystemProvider.java:68)
	at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
	at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
	at java.nio.file.Files.readAttributes(Files.java:1737)
	at nextflow.util.CacheHelper.hashFile(CacheHelper.java:216)
	at nextflow.util.CacheHelper.hasher(CacheHelper.java:167)
	at nextflow.util.CacheHelper.hasher(CacheHelper.java:159)

```