### PR TITLE
Add missing inputs to the incremental task "test"

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 
 
 test {
+    inputs.files fileTree(dir: 'src/test/groovy', includes: ['**/*.txt', '**/*.conf', '**/*.html'])
     minHeapSize = "512m"
     maxHeapSize = "2048m"
 }


### PR DESCRIPTION
Hello

This pull request fixes the specification of the Gradle task `test`.
Apart from groovy source files, this task depends on some test files that are located in `src/test/groovy` directory.

For example this [test](https://github.com/theosotr/nextflow/blob/master/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy#L256) depends on the [test-bash-wrapper-with-trace.txt](https://github.com/theosotr/nextflow/blob/master/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt) file.

This commit considers those directories as inputs of this task so that tests are triggered whenever there are updates to any of the dependent test files.