### PR TITLE
Execute beforeScript directive after setting the task environment.

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -107,11 +107,11 @@ nxf_main() {
     [[ $NXF_DEBUG > 0 ]] && nxf_env
     {{touch_file}}
     set +u
-    {{before_script}}
     {{module_load}}
     {{conda_activate}}
     set -u
     {{task_env}}
+    {{before_script}}
     [[ $NXF_SCRATCH ]] && echo "nxf-scratch-dir $HOSTNAME:$NXF_SCRATCH" && cd $NXF_SCRATCH
     {{stage_cmd}}
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
@@ -82,11 +82,11 @@ nxf_main() {
     [[ $NXF_DEBUG > 0 ]] && nxf_env
     touch {{folder}}/.command.begin
     set +u
-    # beforeScript directive
-    echo Before
     # conda environment
     source $(conda info --json | awk '/conda_prefix/ { gsub(/"|,/, "", $2); print $2 }')/bin/activate /conda/env/path
     set -u
+    # beforeScript directive
+    echo Before
     [[ $NXF_SCRATCH ]] && echo "nxf-scratch-dir $HOSTNAME:$NXF_SCRATCH" && cd $NXF_SCRATCH
     nxf_stage
 


### PR DESCRIPTION
This PR makes it possible to execute a script inside the bin folder in the beforeScript directive. The change is consistent with the behavior of the afterScript directive that already allows that.