### PR TITLE
Fix bugs in GA4GH TES support

### DIFF
--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -334,9 +334,9 @@ To use this feature define the following variables in the workflow launching env
     export NXF_EXECUTOR_TES_ENDPOINT='http://back.end.com'
     
 
-Then you will be able to run your workflow over TES using the usual Nextflow command line, i.e.::
+Then you will be able to run your workflow over TES using the usual Nextflow command line. Be sure to specify the Docker image to use, i.e.::
 
-    nextflow run rnaseq-nf
+    nextflow run rnaseq-nf -with-docker alpine
 
 .. note:: If the variable ``NXF_EXECUTOR_TES_ENDPOINT`` is omitted the default endpoint is ``http://localhost:8000``.
 

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -334,7 +334,11 @@ To use this feature define the following variables in the workflow launching env
     export NXF_EXECUTOR_TES_ENDPOINT='http://back.end.com'
     
 
-Then you will be able to run your workflow over TES using the usual Nextflow command line. Be sure to specify the Docker image to use, i.e.::
+It is important that the endpoint is specified without the trailing slash; otherwise, the resulting URLs will be not
+normalized and the requests to TES will fail.
+
+Then you will be able to run your workflow over TES using the usual Nextflow command line. Be sure to specify the Docker
+image to use, i.e.::
 
     nextflow run rnaseq-nf -with-docker alpine
 

--- a/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.ga4gh.tes.executor
 
+import nextflow.ga4gh.tes.client.model.TesFileType
+
 import static nextflow.processor.TaskStatus.COMPLETED
 import static nextflow.processor.TaskStatus.RUNNING
 
@@ -214,6 +216,7 @@ class TesTaskHandler extends TaskHandler {
         def result = new TesInput()
         result.url = realPath.toUriString()
         result.path = fileName ? "$WORK_DIR/$fileName" : "$WORK_DIR/${realPath.getName()}"
+        result.type = TesFileType.FILE
         log.trace "[TES] Adding INPUT file: $result"
         return result
     }
@@ -222,6 +225,7 @@ class TesTaskHandler extends TaskHandler {
         def result = new TesOutput()
         result.path = "$WORK_DIR/$fileName"
         result.url = task.workDir.resolve(fileName).toUriString()
+        result.type = TesFileType.FILE
         log.trace "[TES] Adding OUTPUT file: $result"
         return result
     }


### PR DESCRIPTION
As part of the [CINECA](https://www.cineca-project.eu/) project we plan to use Nextflow with [GA4GH TES](https://github.com/ga4gh/task-execution-schemas), a simple standardised execution schema. This pull request fixes three critical problems in Nextflow's current support of TES:

###  1. Specify `type` field explicitly for all standard inputs and outputs
* Nextflow creates several standard inputs and outputs for each submitted task.
* For all of them, the `type` field is always set to `null`.
* TES allows this parameter to be either _FILE_ or _DIRECTORY_, but [does not allow it to be null](https://github.com/ga4gh/task-execution-schemas/blob/9cc12b0c215a7f54fdeb0d0598ebc74fa70eb2a7/openapi/task_execution.swagger.yaml#L261).
* This PR fixes it by explicitly setting the type of all inputs and outputs as `FILE`.

### 2. Update docs to mention that specifying a Docker image name is mandatory when running with TES
* If Docker image is not specified, the `executor.image` field in Nextflow's request will be `null`, hence the request will [fail to comply](https://github.com/ga4gh/task-execution-schemas/blob/9cc12b0c215a7f54fdeb0d0598ebc74fa70eb2a7/openapi/task_execution.swagger.yaml#L217) with TES specification.
* This PR fixes it by mentioning that specifying a Docker image is mandatory when running with TES.

### 3. Clarify that the backend URL must not include a trailing slash
* If the URL is specified with a trailing slash, e. g. `http://back.end.com/`, Nextflow will append `/v1/tasks` to it, and the resulting URL will be `http://back.end.com//v1/tasks` with double slashes.
* Some major implementations of TES, for example [TESK](https://github.com/EMBL-EBI-TSI/TESK), will treat that as a non-normalized URL, and the task submission will fail with a somewhat cryptic error message.
* This PR fixes it by mentinoning this behaviour in the docs.