### PR TITLE
Include GA4GH support into the standalone binary (make pack)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,12 @@ pack:
 	BUILD_PACK=1 ./gradlew packAll
 
 #
+# Create self-contained distribution package, including GA4GH support and associated dependencies
+#
+packGA4GH:
+	BUILD_PACK=1 ./gradlew -PGA4GH packAll
+
+#
 # Upload NF launcher to nextflow.io web site
 #
 deploy:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ The self-contained runnable Nextflow packages can be created by using the follow
 make pack
 ```
 
+To include support of GA4GH and its dependencies in the binary, use `make packGA4GH` instead.
+
 In order to install the compiled packages use the following command:
 
 ```bash

--- a/packing.gradle
+++ b/packing.gradle
@@ -194,7 +194,7 @@ task packAll(type: Jar) {
     archiveName = "nextflow-${version}-all.jar"
 
     from jar // embed our application jar
-    from (configurations.ignite + configurations.amazon + configurations.google + configurations.ga4gh)
+    from (configurations.ignite + configurations.amazon + configurations.google)
     from (configurations.capsule.collect { zipTree(it) })
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     
@@ -208,7 +208,12 @@ task packAll(type: Jar) {
     manifest.attributes('Main-Class': 'CapsuleLoader', 'amazon')
     manifest.attributes('Main-Class': 'CapsuleLoader', 'google')
     manifest.attributes('Main-Class': 'CapsuleLoader', 'ignite')
-    manifest.attributes('Main-Class': 'CapsuleLoader', 'ga4gh')
+
+    if( project.hasProperty('GA4GH') ) {
+        println "The build will include GA4GH dependencies."
+        from(configurations.ga4gh)
+        manifest.attributes('Main-Class': 'CapsuleLoader', 'ga4gh')
+    }
 
     doLast {
         file(releaseDir).mkdir()

--- a/packing.gradle
+++ b/packing.gradle
@@ -194,7 +194,7 @@ task packAll(type: Jar) {
     archiveName = "nextflow-${version}-all.jar"
 
     from jar // embed our application jar
-    from (configurations.ignite + configurations.amazon + configurations.google)
+    from (configurations.ignite + configurations.amazon + configurations.google + configurations.ga4gh)
     from (configurations.capsule.collect { zipTree(it) })
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     
@@ -208,6 +208,7 @@ task packAll(type: Jar) {
     manifest.attributes('Main-Class': 'CapsuleLoader', 'amazon')
     manifest.attributes('Main-Class': 'CapsuleLoader', 'google')
     manifest.attributes('Main-Class': 'CapsuleLoader', 'ignite')
+    manifest.attributes('Main-Class': 'CapsuleLoader', 'ga4gh')
 
     doLast {
         file(releaseDir).mkdir()


### PR DESCRIPTION
When I tried building a modified Nextflow version, I noticed that the standalone binary generated by `make pack` command works fine but does not include support for GA4GH/TES functionality. This PR fixes it.

Signed-off-by: Kirill Tsukanov <tsukanoffkirill@gmail.com>