### PR TITLE
Fixs k8s timeline start

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
@@ -11,7 +11,7 @@ import static nextflow.extension.Bolts.DATETIME_FORMAT
 
 /**
  * Models nextflow script properties and metadata
- * 
+ *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Singleton(strict = false)
@@ -46,6 +46,7 @@ class NextflowMeta {
         volatile float dsl
         boolean strict
     }
+
 
     final VersionNumber version
     final int build
@@ -135,4 +136,5 @@ class NextflowMeta {
         else
             throw new IllegalArgumentException("Unknown nextflow mode=${matcher.group(1)}")
     }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptParserTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptParserTest.groovy
@@ -141,5 +141,4 @@ class ScriptParserTest extends Specification {
         e.message.contains('- cause: unexpected token: foo @ line 2, column 13.')
         e.message.contains('foo.nf\n')
     }
-    
 }


### PR DESCRIPTION
This fix addresses https://github.com/nextflow-io/nextflow/issues/1684.

The patch is pretty simple. It has the K8sTaskHandler check whether the TaskHandler.startTimeMillis is equal to 0 when the task is completing. If it is, then is sets the TaskHandler.startTimeMillis to be the `startedAt` value found in the Pod terminated message payload.