### PR TITLE
Passing exact memory to executors in GiB

### DIFF
--- a/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -214,13 +214,8 @@ class TesTaskHandler extends TaskHandler {
     }
 
     private Double toGiga(MemoryUnit size) {
-        try {
-            // 1073741824 = 1GB
-            return ((double)size.getBytes())/1073741824
-        } catch (NullPointerException npe) {
-            // If no size is provided, return null, so no memory is sent
-            return null
-        }
+        // 1073741824 = 1GB
+        return size != null ? ((double)size.bytes)/1073741824 : null
     }
 
     private TesInput inItem( Path realPath, String fileName = null) {

--- a/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/modules/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -38,6 +38,7 @@ import nextflow.processor.TaskConfig
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskRun
 import nextflow.processor.TaskStatus
+import nextflow.util.MemoryUnit
 /**
  * Handle execution phases for a task executed by a TES executor
  *
@@ -204,7 +205,7 @@ class TesTaskHandler extends TaskHandler {
     private TesResources getResources(TaskConfig cfg) {
         def res = new TesResources()
         res.cpuCores(cfg.getCpus())
-            .ramGb(cfg.getMemory()?.toGiga()) // @TODO only works for >= 1.GB
+            .ramGb(toGiga(cfg.getMemory()))
             .diskGb(cfg.getDisk()?.toGiga())
         log.trace("[TES] Adding resource request: $res")
         // @TODO preemptible
@@ -212,6 +213,15 @@ class TesTaskHandler extends TaskHandler {
         return res
     }
 
+    private Double toGiga(MemoryUnit size) {
+        try {
+            // 1073741824 = 1GB
+            return ((double)size.getBytes())/1073741824
+        } catch (NullPointerException npe) {
+            // If no size is provided, return null, so no memory is sent
+            return null
+        }
+    }
 
     private TesInput inItem( Path realPath, String fileName = null) {
         def result = new TesInput()


### PR DESCRIPTION
This is a new attempt for:
https://github.com/nextflow-io/nextflow/pull/1689

Instead of changing the toGiga function, we are defining a new toGiga function in the `TesTaskHandler` class instead.
