### PR TITLE
Fix fromSRA

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/datasource/SraExplorer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/datasource/SraExplorer.groovy
@@ -37,7 +37,7 @@ import nextflow.util.Duration
 /**
  * Query NCBI SRA database and returns the retrieved FASTQs to the specified
  * target channel. Inspired to SRA-Explorer by Phil Ewels -- https://ewels.github.io/sra-explorer/
- * 
+ *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
@@ -217,7 +217,7 @@ class SraExplorer {
         if( response instanceof Map && response.esearchresult instanceof Map ) {
             def search = (Map)response.esearchresult
             def result = new SearchRecord()
-            result.count = search.count as Integer 
+            result.count = search.count as Integer
             result.retmax = search.retmax as Integer
             result.retstart = search.retstart as Integer
             result.querykey = search.querykey
@@ -275,7 +275,14 @@ class SraExplorer {
             return
 
         def lines = text.trim().readLines()
-        def files = lines[1].split(';')
+        def rows = lines.collect { it.tokenize('\t') }
+        def rowsMapped = rows[1..<rows.size].collect { row ->
+            row.withIndex().collectEntries { value, index ->
+                [rows[0][index], value]
+            }
+        }
+
+        def files = rowsMapped[0]["fastq_ftp"].split(';')
         def result = new ArrayList(files.size())
         for( def str : files ) {
             result.add( FileHelper.asPath("ftp://$str") )
@@ -295,7 +302,7 @@ class SraExplorer {
 
     /**
      * NCBI search https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESummary
-     * 
+     *
      * @param result
      * @return
      */

--- a/modules/nextflow/src/test/groovy/nextflow/datasource/SraExplorerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/datasource/SraExplorerTest.groovy
@@ -117,13 +117,13 @@ class SraExplorerTest extends Specification {
     def 'should return ftp files for accession id' () {
         given:
         def RESP1 = '''
-                fastq_ftp
-                ftp.sra.ebi.ac.uk/vol1/fastq/SRR144/004/SRR1448774/SRR1448774.fastq.gz
+                run_accession\tfastq_ftp
+                SRR1448774\tftp.sra.ebi.ac.uk/vol1/fastq/SRR144/004/SRR1448774/SRR1448774.fastq.gz
                 '''.stripIndent()
 
         def RESP2 = '''
-                fastq_ftp
-                ftp.sra.ebi.ac.uk/vol1/fastq/ERR908/ERR908503/ERR908503_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/ERR908/ERR908503/ERR908503_2.fastq.gz
+                run_accession\tfastq_ftp
+                ERR908503\tftp.sra.ebi.ac.uk/vol1/fastq/ERR908/ERR908503/ERR908503_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/ERR908/ERR908503/ERR908503_2.fastq.gz
                 '''.stripIndent()
 
 
@@ -188,7 +188,7 @@ class SraExplorerTest extends Specification {
         when:
         def target = slurper.apply()
         then:
-        target.count().val == 10
+        target.getVal()[0] == "SRR1448795"
     }
 
     def 'should retrieve NCBI api env' () {


### PR DESCRIPTION
It looks as though the ebi endpoint changed and is now adding an extra
field to the result of the query for the FASTQ file path. EX:

```text
run_accession\tfastq_ftp
SRR1448774\tftp.sra.ebi.ac.uk/vol1/fastq/SRR144/004/SRR1448774/SRR1448774.fastq.gz
```

This causes the SraExplorer.getFastqUrl method to fail. I have added
some flexibility in parsing the returned TSV from ebi to pick the
`fastq_ftp` by header. I have also updated the tests.

Note that the SRA tests only run if you have a token for NCBI. These
tests are skipped normally.

Additionally, the test `should explor sra` was failing due to how the
output was being checked. I think that it was assuming an older version
of a target class. I've updated that with what I think is a sensible
check.

Signed-off-by: Seth Stadick <sstadick@gmail.com>