### PR TITLE
Change check for container in cache to enable read-only use cases ("repository")

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
@@ -18,6 +18,7 @@
 package nextflow.container
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.regex.Pattern
 
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -85,7 +86,7 @@ class SingularityCacheTest extends Specification {
         given:
         def dir = Files.createTempDirectory('test')
         def IMAGE = 'docker://pditommaso/test:latest'
-        def LOCAL = 'test-latest.img'
+        def LOCAL = 'pditommaso-test-latest.img'
         ContainerConfig config = [noHttps: true] 
         and:
         def cache = Spy(SingularityCache, constructorArgs: [ config ])
@@ -94,8 +95,10 @@ class SingularityCacheTest extends Specification {
         cache.downloadSingularityImage(IMAGE)
         then:
         1 * cache.localImagePath(IMAGE) >> dir.resolve(LOCAL)
-        1 * cache.runCommand({(it =~ ~"singularity pull --nohttps -F --name \\.\\S*$LOCAL\\S+ $IMAGE > /dev/null")}, dir) >> 0
+	1 * cache.runCommand( { (it =~ ~"singularity pull --nohttps --name $dir.$LOCAL\\.pulling\\.[0-9]* $IMAGE > /dev/null").find() } , _)
 
+	cleanup:
+	dir.deleteDir()
     }
 
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
@@ -94,7 +94,7 @@ class SingularityCacheTest extends Specification {
         cache.downloadSingularityImage(IMAGE)
         then:
         1 * cache.localImagePath(IMAGE) >> dir.resolve(LOCAL)
-        1 * cache.runCommand("singularity pull --nohttps --name $LOCAL $IMAGE > /dev/null", dir) >> 0
+        1 * cache.runCommand(s =~ ~"singularity pull --nohttps -F --name [^ ]*$LOCAL[^ ]* $IMAGE > /dev/null/", dir) >> 0
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityCacheTest.groovy
@@ -84,8 +84,8 @@ class SingularityCacheTest extends Specification {
 
         given:
         def dir = Files.createTempDirectory('test')
-        def IMAGE = 'docker://pditommaso/foo:latest'
-        def LOCAL = 'foo-latest.img'
+        def IMAGE = 'docker://pditommaso/test:latest'
+        def LOCAL = 'test-latest.img'
         ContainerConfig config = [noHttps: true] 
         and:
         def cache = Spy(SingularityCache, constructorArgs: [ config ])
@@ -94,7 +94,7 @@ class SingularityCacheTest extends Specification {
         cache.downloadSingularityImage(IMAGE)
         then:
         1 * cache.localImagePath(IMAGE) >> dir.resolve(LOCAL)
-        1 * cache.runCommand(s =~ ~"singularity pull --nohttps -F --name [^ ]*$LOCAL[^ ]* $IMAGE > /dev/null/", dir) >> 0
+        1 * cache.runCommand({(it =~ ~"singularity pull --nohttps -F --name \\.\\S*$LOCAL\\S+ $IMAGE > /dev/null")}, dir) >> 0
 
     }
 
@@ -125,8 +125,8 @@ class SingularityCacheTest extends Specification {
     def 'should pull a singularity image' () {
 
         given:
-        def IMAGE = 'docker://pditommaso/foo:latest'
-        def LOCAL = 'foo-latest.img'
+        def IMAGE = 'docker://pditommaso/test:latest'
+        def LOCAL = 'test-latest.img'
         def dir = Paths.get('/test/path')
         def container = dir.resolve(LOCAL)
         and:


### PR DESCRIPTION
This is an approximate implementation of support for #1706.

Roughly follows logic outlined in that suggestion:

* check for file in cache early, if found => return
* if no file in cache, take a mutex and try to download, use a temporary file in the same directory as destination
  * in the downloader, check if someone else has already downloaded the current process waited for the mutex
    * if so, remove tempfile and return
  * try to run `singularity pull` to tempfile and return
* clean up mutex