### PR TITLE
Add example for using named stdout in dsl2.

### DIFF
--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -142,7 +142,28 @@ that can be used to reference the channel in the external scope. For example::
         foo()
         foo.out.samples_bam.view()
     }
+    
+Process named stdout
+--------------------
 
+The process can name stdout using the ``emit`` option:
+
+    process sayHello {
+        input:
+            val cheers
+        output:
+            stdout emit: verbiage
+        script:
+        """
+        echo -n $cheers
+        """
+    }
+
+    workflow {
+        things = channel.of('Hello world!', 'Yo, dude!', 'Duck!')
+        greetings = sayHello(things)
+        greetings.verbiage.subscribe {println "$it" }
+    }
 
 Workflow
 ========


### PR DESCRIPTION
I had to poke around to get this to work, adding it here to save other folks time.

I'm not entirely sure why it doesn't require a comma like the other named output does, but....