### PR TITLE
Add bearer token support - WIP

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/util/SimpleHttpClientTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/SimpleHttpClientTest.groovy
@@ -143,7 +143,7 @@ class SimpleHttpClientTest extends Specification{
 
         when:
         def client = new SimpleHttpClient()
-        client.setAuthToken(TOKEN)
+        client.setBasicToken(TOKEN)
         client.setUserAgent(AGENT)
         client.sendHttpMessage( ENDPOINT, PAYLOAD )
         then:

--- a/modules/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/modules/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -430,12 +430,12 @@ class TowerClient implements TraceObserver {
 
     protected void refreshToken(String refresh) {
         log.debug "+++ Requesting refresh token=$refresh"
-        final url = "$endpoint/trace/oauth/access_token"
+        final url = "$endpoint/oauth/access_token"
         httpClient.sendHttpMessage(
                 url,
                 method: 'POST',
                 contentType: "application/x-www-form-urlencoded",
-                body: "grant_type=refresh_token&refresh_token=${URLEncoder.encode(refreshToken, 'UTF-8')}" )
+                body: "grant_type=refresh_token&refresh_token=${URLEncoder.encode(refresh, 'UTF-8')}" )
 
         final authCookie = httpClient.getCookie('JWT')
         final refreshCookie = httpClient.getCookie('JWT_REFRESH_TOKEN')

--- a/modules/nf-tower/src/main/io/seqera/tower/plugin/TowerFactory.groovy
+++ b/modules/nf-tower/src/main/io/seqera/tower/plugin/TowerFactory.groovy
@@ -50,7 +50,7 @@ class TowerFactory implements TraceObserverFactory {
         tower.maxRetries = config.navigate('tower.maxRetries', 5) as int
         tower.backOffBase = config.navigate('tower.backOffBase', SimpleHttpClient.DEFAULT_BACK_OFF_BASE) as int
         tower.backOffDelay = config.navigate('tower.backOffDelay', SimpleHttpClient.DEFAULT_BACK_OFF_DELAY  ) as int
-
+        tower.tokenMaxAge = config.navigate('tower.tokenMaxAge', TowerClient.DEF_TOKEN_MAX_AGE ) as Duration
         final result = new ArrayList(1)
         result.add(tower)
         return result

--- a/modules/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/modules/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -375,4 +375,28 @@ class TowerClientTest extends Specification {
         tower.getUrlTraceHeartbeat() == 'https://tower.nf/trace/12345/heartbeat'
         tower.getUrlTraceComplete() == 'https://tower.nf/trace/12345/complete'
     }
+
+    def 'should set the auth token' () {
+        given:
+        def http = Mock(SimpleHttpClient)
+        TowerClient client = Spy(TowerClient, constructorArgs: ['https://tower.nf'])
+        and:
+        def SIMPLE = '4ffbf1009ebabea77db3d72efefa836dfbb71271'
+        def BEARER = 'eyJ0aWQiOiA1fS5jZmM1YjVhOThjZjM2MTk1NjBjZWU1YmMwODUxYzA1ZjkzMDdmN2Iz'
+
+        when:
+        client.setAuthToken(http, SIMPLE)
+        then:
+        http.setBasicToken('@token:' + SIMPLE) >> null
+
+        when:
+        client.setAuthToken(http, SIMPLE)
+        then:
+        http.setBasicToken('@token:' + SIMPLE) >> null
+
+        when:
+        client.setAuthToken(http, BEARER)
+        then:
+        http.setBearerToken(BEARER) >> null
+    }
 }


### PR DESCRIPTION
Tentative of implementing a silent refresh for JWT token. The idea is to catch the 401 error code and send a refresh request and then re-submitting the failed request. 

However sill something is failing. @tcrespog Please give a try, to test: 

1) clone and compile this fork: `make compile`
2) create a symlink to the `launch.sh` named `nextflow` and put on your path 
3) change to jwt token ttl to 10 seconds 
4) launch `pditommaso/nf-sleep` adding the params box `timeout: 180` (3 minutes)