### PR TITLE
Google Life Sciences update credential handling.

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -19,26 +19,25 @@ in your system environment::
 Credentials
 -----------
 
-To allow the deployment in the Google Cloud you need to configure the security credentials using
-a *Security account key* JSON file.
+Credentials for submitting requests to the Google Pipelines API are picked up from your
+environment using `Application Default Credentials <https://github.com/googleapis/google-auth-library-java#google-auth-library-oauth2-http>`_.
+Application Default Credentials are designed to use the credentials most natural to the
+environment in which a tool runs.
 
-Nextflow looks for this file using the ``GOOGLE_APPLICATION_CREDENTIALS`` variable that
-has to be defined in the launching environment.
+The most common case will be to pick up your end-user Google credentials from your
+workstation. You can create these by running the command:
 
-If you don't have it, download the credentials file from the Google Cloud Console following these steps:
+    gcloud auth application-default login 
 
-* Open the `Google Cloud Console <https://console.cloud.google.com>`_
-* Go to APIs & Services → Credentials
-* Click on the *Create credentials* (blue) drop-down and choose *Service account key*, in the following page
-* Select an existing *Service account* or create a new one if needed
-* Select JSON as *Key type*
-* Click the *Create* button and download the JSON file giving a name of your choice e.g. ``creds.json``.
+and running through the authentication flow. This will write a credential file to your gcloud
+configuration directory that will be used for any tool you run on your workstation that
+picks up default credentials.
 
-Finally define the following variable replacing the path in the example with the one of your
-credentials file just downloaded::
+The next most common case would be when running on a Compute Engine VM. In this case,
+Application Default Credentials will pick up the Compute Engine Service Account
+credentials for that VM.
 
-    export GOOGLE_APPLICATION_CREDENTIALS=/path/your/file/creds.json
-
+See the `Application Default Credentials <https://github.com/googleapis/google-auth-library-java#google-auth-library-oauth2-http>`_ documentation for how to enable other use cases.
 
 .. _google-lifesciences:
 

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
@@ -181,21 +181,18 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
 
     static String getProjectIdFromCreds(String credsFilePath) {
         if( !credsFilePath )
-          return null;
+            throw new AbortOperationException('Missing Google credentials -- make sure your environment defines the GOOGLE_APPLICATION_CREDENTIALS environment variable')
 
         final file = new File(credsFilePath)
         try {
             final creds = (Map)new JsonSlurper().parse(file)
-
-            // A service accound credentials file likely has a project ID.
-            // An end user credential file (gcloud auth application-default login) will not.
             if( creds.project_id )
                 return creds.project_id
+            else
+                throw new AbortOperationException("Missing `project_id` in Google credentials file: $credsFilePath")
         }
         catch(FileNotFoundException e) {
             throw new AbortOperationException("Missing Google credentials file: $credsFilePath")
         }
-
-        return null;
     }
 }

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
@@ -181,18 +181,21 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
 
     static String getProjectIdFromCreds(String credsFilePath) {
         if( !credsFilePath )
-            throw new AbortOperationException('Missing Google credentials -- make sure your environment defines the GOOGLE_APPLICATION_CREDENTIALS environment variable')
+          return null;
 
         final file = new File(credsFilePath)
         try {
             final creds = (Map)new JsonSlurper().parse(file)
+
+            // A service accound credentials file likely has a project ID.
+            // An end user credential file (gcloud auth application-default login) will not.
             if( creds.project_id )
                 return creds.project_id
-            else
-                throw new AbortOperationException("Missing `project_id` in Google credentials file: $credsFilePath")
         }
         catch(FileNotFoundException e) {
             throw new AbortOperationException("Missing Google credentials file: $credsFilePath")
         }
+
+        return null;
     }
 }

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesExecutor.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesExecutor.groovy
@@ -70,14 +70,17 @@ class GoogleLifeSciencesExecutor extends Executor {
             throw new AbortOperationException("Executor `google-lifesciences` requires a Google Storage bucket to be specified as a working directory -- Add the option `-w gs://<your-bucket/path>` to your run command line or specify a workDir in your config file")
         }
 
+        // Typically a user will set the GCP project ID in the config.
+        // If not, and they have used a service account credentials file, then we get the
+        // service account's project ID and use that as the default.
         def credsFile = env.get('GOOGLE_APPLICATION_CREDENTIALS')
         final projectId = GoogleLifeSciencesConfig.getProjectIdFromCreds(credsFile)
 
         config = GoogleLifeSciencesConfig.fromSession(session)
         if( !config.project )
-            config.project = projectId
-        else if( config.project != projectId )
-            throw new AbortOperationException("Project Id `$config.project` declared in the nextflow config file does not match the one expected by credentials file: $credsFile")
+             config.project = projectId
+        if( !config.project )
+             throw new AbortOperationException("No project ID declared in the nextflow config file")
 
         if( session.binDir && !config.disableBinDir ) {
             final cloudPath = getTempDir()

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesExecutor.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesExecutor.groovy
@@ -70,17 +70,31 @@ class GoogleLifeSciencesExecutor extends Executor {
             throw new AbortOperationException("Executor `google-lifesciences` requires a Google Storage bucket to be specified as a working directory -- Add the option `-w gs://<your-bucket/path>` to your run command line or specify a workDir in your config file")
         }
 
-        // Typically a user will set the GCP project ID in the config.
-        // If not, and they have used a service account credentials file, then we get the
-        // service account's project ID and use that as the default.
-        def credsFile = env.get('GOOGLE_APPLICATION_CREDENTIALS')
-        final projectId = GoogleLifeSciencesConfig.getProjectIdFromCreds(credsFile)
+        // Typically the credentials picked up are the "Application Default Credentials"
+        // as described at:
+        //   https://github.com/googleapis/google-auth-library-java
+        //
+        // In that case, the project ID needs to be set in the nextflow config file.
+
+        // If instead, the GOOGLE_APPLICATION_CREDENTIALS environment variable is set,
+        // then the project ID will be picked up (along with the credentials) from the
+        // JSON file that environment variable points to.
 
         config = GoogleLifeSciencesConfig.fromSession(session)
-        if( !config.project )
-             config.project = projectId
-        if( !config.project )
-             throw new AbortOperationException("No project ID declared in the nextflow config file")
+
+        def credsFile = env.get('GOOGLE_APPLICATION_CREDENTIALS')
+        if( credsFile ) {
+            final projectId = GoogleLifeSciencesConfig.getProjectIdFromCreds(credsFile)
+
+            if( !config.project )
+                config.project = projectId
+            else if( config.project != projectId )
+                throw new AbortOperationException("Project Id `$config.project` declared in the nextflow config file does not match the one expected by credentials file: $credsFile")
+
+        } else {
+            if( !config.project )
+                throw new AbortOperationException("No project ID declared in the nextflow config file")
+        }
 
         if( session.binDir && !config.disableBinDir ) {
             final cloudPath = getTempDir()


### PR DESCRIPTION
This is a suggested implementation for updating credentials handling for the Google Life Sciences executor as discussed in #1709.

Automatically pick up Application Default Credentials removing explicit requirements for the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set.

I assume there are some tests to update. Feel free to take over this PR or point me to where to updates tests.