### PR TITLE
Docs for nextflow installation CAPSULE_LOG variable

### DIFF
--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -36,6 +36,8 @@ It only needs two easy steps:
 .. tip:: In the case you don't have ``wget`` installed you can use the ``curl`` utility instead by entering
    the following command: ``curl -s https://get.nextflow.io | bash``
 
+.. tip:: Set ``export CAPSULE_LOG=none`` to make the installation logs less verbose.
+
 
 .. _getstart-first:
 


### PR DESCRIPTION
Adding documentation about the `CAPSULE_LOG` environment variable for less verbose logs.

See https://github.com/nextflow-io/nextflow/issues/1800#issuecomment-730168723