### PR TITLE
Add instructions for downloading the nextflow-*-all variant.

### DIFF
--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -22,22 +22,28 @@ Windows system is supported through `WSL <https://en.wikipedia.org/wiki/Windows_
 Installation
 ============
 
-`Nextflow` is distributed as a self-contained executable package, which means that it does not require any special installation procedure.
+`Nextflow` is distributed as an executable package, which means that it does not require any special installation procedure.
 
 It only needs two easy steps:
 
-#.  Download the executable package by copying and pasting the following command in your terminal
-    window: ``wget -qO- https://get.nextflow.io | bash``.
-    It will create the ``nextflow`` main executable file in the current directory.
+#.  Download the executable package by copying and pasting either one of the following commands in your terminal
+    window: ``wget -qO- https://get.nextflow.io | bash``
+
+    Or, if you prefer `curl`: ``curl -s https://get.nextflow.io | bash``
+
+    This will create the ``nextflow`` main executable file in the current directory.
+
+#.  Make the binary executable on your system by running ``chmod +x nextflow``.
 
 #.  Optionally, move the ``nextflow`` file to a directory accessible by your ``$PATH`` variable
     (this is only required to avoid remembering and typing the full path to ``nextflow`` each time you need to run it).
 
-.. tip:: In the case you don't have ``wget`` installed you can use the ``curl`` utility instead by entering
-   the following command: ``curl -s https://get.nextflow.io | bash``
+.. tip:: Set ``export CAPSULE_LOG=none`` to make the dependency installation logs less verbose.
 
-.. tip:: Set ``export CAPSULE_LOG=none`` to make the installation logs less verbose.
-
+.. note::
+    To avoid downloading the dependencies, you could also use the ``nextflow-VERSION-all`` variant available from Github for every Nextflow release version.
+   #. Simply go to the Github releases page and unfold the ``Assets`` section for a release.
+   #. Copy the URL of the ``nextflow-VERSION-all`` asset and issue the download command on your terminal. ``wget -qO-  ASSET-URL``. It will create the completely self-contained ``nextflow-VERSION-all`` executable file in the current directory.
 
 .. _getstart-first:
 

--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -42,8 +42,9 @@ It only needs two easy steps:
 
 .. note::
     To avoid downloading the dependencies, you could also use the ``nextflow-VERSION-all`` variant available from Github for every Nextflow release version.
-   #. Simply go to the Github releases page and unfold the ``Assets`` section for a release.
+   #. Simply go to the `Github releases page <https://github.com/nextflow-io/nextflow/releases>`__ and unfold the ``Assets`` section for a release.
    #. Copy the URL of the ``nextflow-VERSION-all`` asset and issue the download command on your terminal. ``wget -qO-  ASSET-URL``. It will create the completely self-contained ``nextflow-VERSION-all`` executable file in the current directory.
+
 
 .. _getstart-first:
 

--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -22,7 +22,7 @@ Windows system is supported through `WSL <https://en.wikipedia.org/wiki/Windows_
 Installation
 ============
 
-`Nextflow` is distributed as an executable package, which means that it does not require any special installation procedure.
+`Nextflow` is distributed as a self-installer package, which means that it does not require any special installation procedure.
 
 It only needs two easy steps:
 
@@ -42,7 +42,7 @@ It only needs two easy steps:
 
 .. note::
     To avoid downloading the dependencies, you could also use the ``nextflow-VERSION-all`` variant available from Github for every Nextflow release version.
-   #. Simply go to the `Github releases page <https://github.com/nextflow-io/nextflow/releases>`__ and unfold the ``Assets`` section for a release.
+   #. Go to the `Github releases page <https://github.com/nextflow-io/nextflow/releases>`__ and unfold the ``Assets`` section for a release.
    #. Copy the URL of the ``nextflow-VERSION-all`` asset and issue the download command on your terminal. ``wget -qO-  ASSET-URL``. It will create the completely self-contained ``nextflow-VERSION-all`` executable file in the current directory.
 
 


### PR DESCRIPTION
This PR adds instructions in the docs to download the `nextflow-*-variant` 
https://github.com/nextflow-io/nextflow/issues/1602


Here's what the change looks like 

<img width="737" alt="image" src="https://user-images.githubusercontent.com/12799326/100223113-0f3d7e00-2f41-11eb-967c-9c05051fa0c6.png">


