### PR TITLE
Add code highlighting to -params-file

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -13,7 +13,7 @@ settings to are applied. All possible configuration sources are reported below, 
 of priority:
 
 1. Parameters specified on the command line (``--something value``)
-2. Parameters provided using the -params-file option
+2. Parameters provided using the ``-params-file`` option
 3. Config file specified using the ``-c my_config`` option
 4. The config file named ``nextflow.config`` in the current directory
 5. The config file named ``nextflow.config`` in the workflow project directory


### PR DESCRIPTION
Minor: add inline code formatting to the `-params-file` item

Following on from https://github.com/nextflow-io/nextflow/pull/855 and https://github.com/nextflow-io/nextflow/commit/1ae3855ca4ff7a7763e2c0d52cf91577853edb82