### PR TITLE
Add support for custom network in Google Cloud Life Sciences executor

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -129,6 +129,7 @@ google.lifeSciences.copyImage                  The container image run to copy i
 google.lifeSciences.debug                      When ``true`` copies the `/google` debug directory in that task bucket directory (default: ``false``)
 google.lifeSciences.preemptible                When ``true`` enables the usage of *preemptible* virtual machines or ``false`` otherwise (default: ``true``)
 google.lifeSciences.usePrivateAddress          When ``true`` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: ``false``). Requires version `20.03.0-edge` or later.
+google.lifeSciences.network                    Set  network name to attach the VM's network interface to. The value will be prefixed with global/networks/ unless it contains a /, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used.
 google.lifeSciences.sshDaemon                  When ``true`` runs SSH daemon in the VM carrying out the job to which it's possible to connect for debugging purposes (default: ``false``).
 google.lifeSciences.sshImage                   The container image used to run the SSH daemon (default: ``gcr.io/cloud-genomics-pipelines/tools``).
 ============================================== =================

--- a/modules/nextflow/src/main/groovy/nextflow/Const.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Const.groovy
@@ -58,12 +58,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1605515037267
+    static public final long APP_TIMESTAMP = 1607101046267
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 5448
+    static public final int APP_BUILDNUM = 5452
 
 
     /**

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
@@ -60,6 +60,7 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
     Integer debugMode
     String copyImage
     boolean usePrivateAddress
+    String network
     boolean enableRequesterPaysBuckets
 
     int maxParallelTransfers = MAX_TRANSFER
@@ -122,6 +123,7 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
         final copyImage = config.navigate('google.lifeSciences.copyImage', DEFAULT_COPY_IMAGE) as String
         final debugMode = config.navigate('google.lifeSciences.debug', System.getenv('NXF_DEBUG'))
         final privateAddr  = config.navigate('google.lifeSciences.usePrivateAddress') as boolean
+        final network = config.navigate('google.lifeSciences.network') as String
         final requesterPays = config.navigate('google.enableRequesterPaysBuckets') as boolean
         //
         final maxParallelTransfers = config.navigate('aws.batch.maxParallelTransfers', MAX_TRANSFER) as int
@@ -146,6 +148,7 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
                 sshDaemon: sshDaemon,
                 sshImage: sshImage,
                 usePrivateAddress: privateAddr,
+                network: network,
                 enableRequesterPaysBuckets: requesterPays,
                 maxParallelTransfers: maxParallelTransfers,
                 maxTransferAttempts: maxTransferAttempts,

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
@@ -183,8 +183,15 @@ class GoogleLifeSciencesHelper {
                 .setServiceAccount(serviceAccount)
                 .setPreemptible(req.preemptible)
 
+        def network = new Network()
         if( req.usePrivateAddress ) {
-            vm.setNetwork( new Network().setUsePrivateAddress(true) )
+            network.setUsePrivateAddress(true)
+        }
+        if( req.network ) {
+            network.setNetwork(req.network)
+        }
+        if(req.network || req.usePrivateAddress ) {
+            vm.setNetwork(network)
         }
 
         if( req.bootDiskSizeGb ) {

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesSubmitRequest.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesSubmitRequest.groovy
@@ -65,4 +65,6 @@ class GoogleLifeSciencesSubmitRequest {
     String entryPoint
 
     boolean usePrivateAddress
+
+    String network
 }

--- a/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy
+++ b/modules/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy
@@ -306,6 +306,7 @@ class GoogleLifeSciencesTaskHandler extends TaskHandler {
         req.cpuPlatform = executor.config.cpuPlatform
         req.bootDiskSizeGb = executor.config.bootDiskSize?.toGiga() as Integer
         req.entryPoint = task.config.getContainerOptionsMap().getOrDefault('entrypoint', GoogleLifeSciencesConfig.DEFAULT_ENTRY_POINT)
+        req.network = executor.config.network
         req.usePrivateAddress = executor.config.usePrivateAddress
         return req
     }

--- a/modules/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfigTest.groovy
+++ b/modules/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfigTest.groovy
@@ -181,6 +181,19 @@ class GoogleLifeSciencesConfigTest extends Specification {
         config.usePrivateAddress
     }
 
+    def 'should config network' () {
+        when:
+        def config = GoogleLifeSciencesConfig.fromSession0([google:[project:'foo', region:'x', lifeSciences: [:]]])
+        then:
+        config.network == null
+
+        when:
+        config = GoogleLifeSciencesConfig.fromSession0([google:[project:'foo', region:'x', lifeSciences: [network:'custom-vpc']]])
+        then:
+        config.network == 'custom-vpc'
+
+    }
+
     def 'should config debug mode' () {
         when:
         def config = GoogleLifeSciencesConfig.fromSession0([google:[project:'foo', region:'x', lifeSciences: [:]]])

--- a/modules/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
+++ b/modules/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
@@ -191,6 +191,7 @@ class GoogleLifeSciencesHelperTest extends GoogleSpecification {
                     accelerator: acc,
                     bootDiskSizeGb: 75,
                     cpuPlatform: 'Intel Skylake',
+                    network: 'custom-vpc',
                     usePrivateAddress: true ))
         then:
         with(resources3) {
@@ -205,6 +206,7 @@ class GoogleLifeSciencesHelperTest extends GoogleSpecification {
             getVirtualMachine().getAccelerators()[0].getType()=='nvidia-tesla-k80'
             getVirtualMachine().getBootDiskSizeGb() == 75
             getVirtualMachine().getCpuPlatform() == 'Intel Skylake'
+            getVirtualMachine().getNetwork() == 'custom-vpc'
             getVirtualMachine().getNetwork().getUsePrivateAddress()
         }
     }

--- a/modules/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandlerTest.groovy
+++ b/modules/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandlerTest.groovy
@@ -182,6 +182,7 @@ class GoogleLifeSciencesTaskHandlerTest extends GoogleSpecification {
         req.cpuPlatform == null
         req.entryPoint == GoogleLifeSciencesConfig.DEFAULT_ENTRY_POINT
         !req.usePrivateAddress
+        req.network == null
 
         when:
         req = handler.createPipelineRequest()
@@ -213,6 +214,7 @@ class GoogleLifeSciencesTaskHandlerTest extends GoogleSpecification {
                     getPreemptible() >> true
                     getBootDiskSize() >> MemoryUnit.of('20 GB')
                     getUsePrivateAddress() >> true
+                    getNetwork() >> 'custom-vpc'
                     getCpuPlatform() >> 'Intel Skylake'
                 }
             }
@@ -250,6 +252,7 @@ class GoogleLifeSciencesTaskHandlerTest extends GoogleSpecification {
         req.cpuPlatform =='Intel Skylake'
         req.entryPoint == GoogleLifeSciencesConfig.DEFAULT_ENTRY_POINT
         req.usePrivateAddress
+        req.network == 'custom-vpc'
 
         when:
         req = handler.createPipelineRequest()


### PR DESCRIPTION
This pull request adds support for specifying a VPC network to be passed to the Life Sciences API described in issue  #1574 