### PR TITLE
Another typo fix for DSL2 docs

### DIFF
--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -523,7 +523,7 @@ DSL2 migration notes
 * DSL2 final version is activated using the declaration ``nextflow.enable.dsl=2`` in place of ``nextflow.preview.dsl=2``.
 * Process inputs of type ``set`` have to be replaced with :ref:`tuple <process-input-tuple>`.
 * Process outputs of type ``set`` have to be replaced with :ref:`tuple <process-out-tuple>`.
-* Process output option ``mode flatten`` is not available any more. Replace it using the :ref:`operator-flatten` to the
+* Process output option ``mode flatten`` is not available any more. Replace it using the :ref:`operator-flatten` operator to the
   corresponding output channel.
 * Anonymous and unwrapped includes are not supported any more. Replace it with a explicit module inclusion. For example::
 

--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -245,7 +245,7 @@ implicitly executed. Therefore it's the entry point of the workflow application.
 
 .. note::
   Implicit workflow definition is ignored when a script is included as module. This
-  allows the writing a workflow script that can be used either as a library module and as
+  allows the writing of a workflow script that can be used either as a library module and as
   application script. 
 
 .. tip::


### PR DESCRIPTION
Original

![image](https://user-images.githubusercontent.com/17950287/102487498-f8370b00-406a-11eb-8a0d-d579b7ad3b87.png)

You could also rephrase to: "Process output option mode flatten is not available any more. Replace it using flatten on the corresponding output channel."

Regardless `:ref:operator-flatten` doesn't pick up the 'operator' part of the section name in the `.rst` file.