### PR TITLE
Added fix for duplicate DataflowBroadcast channels in DAG (1486)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/dag/NodeMarker.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/NodeMarker.groovy
@@ -76,5 +76,16 @@ class NodeMarker {
             session.dag.addSourceNode(name, source)
     }
 
+    /**
+     * Add a mapping from DataflowBroadcast node to ReadChannel node.
+     *
+     * @param readChannelNode
+     * @param dataflowBroadcastNode
+     */
+    static void addDataflowBroadcastPair( readChannelNode, dataflowBroadcastNode )  {
+        if( session && session.dag && !session.aborted )
+            session.dag.addDataflowBroadcastPair(readChannelNode, dataflowBroadcastNode)
+    }
+
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/extension/OpCall.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/OpCall.groovy
@@ -126,14 +126,19 @@ class OpCall implements Callable {
     Object[] getArgs() { args }
 
     private <T> T read0(source){
+        T readChan = (T)source;
         if( source instanceof DataflowBroadcast )
-            return (T)CH.getReadChannel(source)
+            readChan = (T)CH.getReadChannel(source)
 
         if( source instanceof DataflowQueue )
-            return (T)CH.getReadChannel(source)
+            readChan = (T)CH.getReadChannel(source)
 
-        else
-            return (T)source
+        if( !ignoreDagNode )
+            // Keep track of this relationship so we can retrieve the
+            // DataflowBroadcast or DataflowQueue when rendering the DAG.
+            NodeMarker.addDataflowBroadcastPair(readChan, source)
+
+        return readChan
     }
 
     private Object[] read1(Object[] args) {

--- a/modules/nextflow/src/test/groovy/nextflow/dag/DAGTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/dag/DAGTest.groovy
@@ -21,7 +21,12 @@ import spock.lang.Specification
 
 import groovyx.gpars.dataflow.DataflowChannel
 import groovyx.gpars.dataflow.DataflowQueue
+import groovyx.gpars.dataflow.DataflowBroadcast
 import groovyx.gpars.dataflow.DataflowVariable
+import nextflow.script.params.InputsList;
+import nextflow.script.params.InParam;
+import nextflow.script.params.OutputsList;
+import nextflow.script.params.OutParam;
 import nextflow.Session
 /**
  *
@@ -270,6 +275,53 @@ class DAGTest extends Specification {
         dag.edges[0].label == 'channel_1'
         dag.edges[1].label == 'funnel_2'
 
+    }
+
+    def 'should convert dataflow broadcast to dataflow channel' () {
+
+        given:
+        def ch1 = new DataflowBroadcast()
+        def ch2 = new DataflowBroadcast()
+        def ch1r = Mock(DataflowChannel)
+        def ch2r = Mock(DataflowChannel)
+
+        def chC = new DataflowBroadcast()
+        def chE = new DataflowBroadcast()
+        def chV = new DataflowBroadcast()
+
+        def dag = new DAG()
+
+        def pInList = new InputsList()
+        def ip1 = Mock(InParam) { rawChannel >> chC }
+        pInList.add( ip1 )
+
+        def pOutList = new OutputsList()
+        def op1 = Mock(OutParam) { getOutChannels() >> [chE] }
+        pOutList.add( op1 )
+
+        when:
+        dag.addDataflowBroadcastPair(ch1r, ch1)
+        dag.addDataflowBroadcastPair(ch2r, ch2)
+
+        dag.addSourceNode( 'Channel.from', ch1r)
+        dag.addSourceNode( 'Channel.from', ch2r)
+
+        dag.addOperatorNode( 'combine', [ch1r, ch2r], chC )
+
+        dag.addProcessNode( 'example', pInList, pOutList )
+
+        dag.addOperatorNode( 'view', chE, chV )
+
+        then:
+        // Only 5 vertices because DAG.normalize() hasn't been called,
+        // which would add the 6th.
+        dag.vertices.size() == 5
+
+        // 5 edges because of the outging edge from view.
+        dag.edges.size() == 5
+
+        // All channels converted back to DataflowBroadcast.
+        dag.edges.each{ it.channel instanceof DataflowBroadcast }
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Mike Smoot <mes@aescon.com>

This PR fixes https://github.com/nextflow-io/nextflow/issues/1486.  The basic idea is that it keeps track of the DataflowBroadcast to DataflowReadChannel conversion that happens in `OpCall.read0` so that when we create the DAG we're able to lookup the expected DataflowBroadcast from the provided DataflowReadChannel to connect the graph correctly.  I've added a unit test and tested on the example that shows the problem, but haven't tested too extensively otherwise. 