### PR TITLE
Charliecloud improvements

### DIFF
--- a/docs/charliecloud.rst
+++ b/docs/charliecloud.rst
@@ -21,7 +21,7 @@ executed on any platform supporting the Charliecloud engine.
 Prerequisites
 ==============
 
-You will need Charliecloud version ``0.19`` or later installed on your execution environment e.g. your computer or a
+You will need Charliecloud version ``0.21`` or later installed on your execution environment e.g. your computer or a
 distributed cluster, depending on where you want to run your pipeline.
 
 How it works

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -418,6 +418,7 @@ Name                Description
 ================== ================
 enabled             Turn this flag to ``true`` to enable Charliecloud execution (default: ``false``).
 envWhitelist        Comma separated list of environment variable names to be included in the container environment.
+temp                Mounts a path of your choice as the ``/tmp`` directory in the container. Use the special value ``auto`` to create a temporary directory each time a container is created.
 runOptions          This attribute can be used to provide any extra command line options supported by the ``ch-run`` command.
 cacheDir            The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all computing nodes.
 pullTimeout         The amount of time the Charliecloud pull can last, exceeding which the process is terminated (default: ``20 min``).

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -125,7 +125,7 @@ class CharliecloudCache {
         if( str )
             return checkDir(str)
 
-        str = env.get('CH_GROW_STORAGE')
+        str = env.get('CH_IMAGE_STORAGE')
         if( str )
             return checkDir(str)
 
@@ -153,8 +153,8 @@ class CharliecloudCache {
     }
 
     /**
-     * Run ch-grow to pull a remote image and store in the file system.
-     * Requires charliecloud 0.19 or later.
+     * Run ch-image to pull a remote image and store in the file system.
+     * Requires charliecloud 0.21 or later.
      *
      * @param imageUrl The docker image remote URL
      * @return  the container image local {@link Path}
@@ -200,9 +200,7 @@ class CharliecloudCache {
 
         log.info "Pulling Charliecloud image $imageUrl [cache $targetPath]"
 
-        // FIXME: ch-grow will be renamed to ch-image in charliecloud 0.21
-        // charliecloud PR https://github.com/hpc/charliecloud/pull/904
-        String cmd = "ch-grow pull $imageUrl $targetPath > /dev/null"
+        String cmd = "ch-image pull $imageUrl $targetPath > /dev/null"
         try {
             runCommand( cmd, targetPath )
             log.debug "Charliecloud pull complete image=$imageUrl path=$targetPath"
@@ -224,7 +222,7 @@ class CharliecloudCache {
 
         final max = pullTimeout.toMillis()
         final builder = new ProcessBuilder(['bash','-c',cmd])
-        builder.environment().remove('CH_GROW_STORAGE')
+        builder.environment().remove('CH_IMAGE_STORAGE')
         final proc = builder.start()
         final err = new StringBuilder()
         final consumer = proc.consumeProcessErrorStream(err)

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -38,36 +38,41 @@ class CharliecloudBuilderTest extends Specification {
         expect:
         new CharliecloudBuilder('busybox')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
-                .params(runOptions: '-j -w')
+                .params(runOptions: '-j')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -j -w -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -j -b "$PWD":"$PWD" -c "$PWD" busybox --'
+        
+        new CharliecloudBuilder('busybox')
+                .params(temp: '/foo')
+                .build()
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo:/tmp -b "$PWD":"$PWD" -c "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .addEnv('X=1')
                 .addEnv(ALPHA:'aaa', BETA: 'bbb')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" --set-env=<( echo "X=1" ) --set-env=<( echo "ALPHA="aaa"" ) --set-env=<( echo "BETA="bbb"" ) -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=<( echo "X=1" ) --set-env=<( echo "ALPHA="aaa"" ) --set-env=<( echo "BETA="bbb"" ) -b "$PWD":"$PWD" -c "$PWD" busybox --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 "$PWD"";ch-run --no-home --unset-env="*" -b /foo/data/file1:/foo/data/file1 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo/data/file1:/foo/data/file1 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .addMount(path2)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .addMount(path2)
                 .params(readOnlyInputs: true)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
     }
 
     def 'should get run command' () {
@@ -75,17 +80,17 @@ class CharliecloudBuilderTest extends Specification {
         when:
         def cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand()
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -b "$PWD":"$PWD" -c "$PWD" ubuntu -- bwa --this --that file.fastq'
+        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" ubuntu -- bwa --this --that file.fastq'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -b "$PWD":"$PWD" -c "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }
 
     @Unroll

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
@@ -78,7 +78,7 @@ class CharliecloudCacheTest extends Specification {
     }
 
 
-    def 'should run ch-grow pull command'() {
+    def 'should run ch-image pull command'() {
 
         given:
         def dir = Files.createTempDirectory('test')
@@ -93,7 +93,7 @@ class CharliecloudCacheTest extends Specification {
         then:
         1 * cache.localImagePath(IMAGE) >> TARGET_PATH
         and:
-        1 * cache.runCommand("ch-grow pull $IMAGE $TARGET_PATH > /dev/null", TARGET_PATH) >> 0
+        1 * cache.runCommand("ch-image pull $IMAGE $TARGET_PATH > /dev/null", TARGET_PATH) >> 0
         and:
         TARGET_PATH.parent.exists()
         and:


### PR DESCRIPTION
Hi @pditommaso,

I have encountered some rough edges when running nextflow with charliecloud, which occur when running from the user $HOME directory.

I think the problem is that Charliecloud does not support passing mountflags with bind-mounted directories as opposed to Singularity for example (I believe that is what the `readOnlyInputs` flag is there for, please correct me if I'm wrong).

So in order to make sure the work directory is writeable, this removes the `readOnlyInputs` logic for Charliecloud entirely and ensures that mounted directories are always writeable in the container.

Further changes:

* addresses a breaking change that will land in Charliecloud 0.23 (`ch-grow pull` is now `ch-image pull`)
* adds the functionality to specify a directory that is mounted to /tmp within the container