### PR TITLE
Decrease s3 cp sleep

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
@@ -52,7 +52,7 @@ class BashFunLib {
                 pid=("\${copy[@]}")
                 
                 if ((\${#pid[@]}>=\$max)); then
-                  sleep 1
+                  sleep 0.3
                 else
                   eval "\${cmd[\$i]}" &
                   pid+=(\$!)


### PR DESCRIPTION
Hi!

tbh, I'm not sure what this will impact. We noticed a process sleeping for an hour+ due to s3 import of 4000+ files. I'm sure aws can handle >1rps. I'm not sure how much. I also see this used in the google life sciences handler.

From `man sleep` on my ubuntu focal machine:
```
 Unlike most implementations that require NUMBER be an integer, here NUMBER may
       be an arbitrary floating point number.
```

Again, I'm not sure what this'll impact. But less wait would be :ok_hand: 