### PR TITLE
Reverts the singularity CPU/memory options 

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityBuilder.groovy
@@ -85,14 +85,6 @@ class SingularityBuilder extends ContainerBuilder<SingularityBuilder> {
         if( runOptions )
             result << runOptions.join(' ') << ' '
 
-        if( cpus ) {
-            result << "--vm-cpu ${String.format("%.1f", cpus)} "
-        }
-
-        if( memory ) {
-            result << "--vm-ram ${memory} "
-        }
-
         result << image
 
         runCommand = result.toString()

--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityBuilderTest.groovy
@@ -123,31 +123,6 @@ class SingularityBuilderTest extends Specification {
         cmd == 'set +u; env - PATH="$PATH" SINGULARITYENV_TMP="$TMP" SINGULARITYENV_TMPDIR="$TMPDIR" singularity exec ubuntu.img /bin/sh -c "cd $PWD; bwa --this --that file.fastq"'
     }
 
-
-    def 'test memory and cpus'() {
-
-        expect:
-        new SingularityBuilder('busybox')
-                .setCpus(2)
-                .build()
-                .runCommand == 'set +u; env - PATH="$PATH" SINGULARITYENV_TMP="$TMP" SINGULARITYENV_TMPDIR="$TMPDIR" singularity exec --vm-cpu 2.0 busybox'
-
-
-        new SingularityBuilder('busybox')
-                .setMemory('100')
-                .build()
-                .runCommand == 'set +u; env - PATH="$PATH" SINGULARITYENV_TMP="$TMP" SINGULARITYENV_TMPDIR="$TMPDIR" singularity exec --vm-ram 100 busybox'
-
-
-        new SingularityBuilder('busybox')
-                .setCpus(2.5)
-                .setMemory('100')
-                .build()
-                .runCommand == 'set +u; env - PATH="$PATH" SINGULARITYENV_TMP="$TMP" SINGULARITYENV_TMPDIR="$TMPDIR" singularity exec --vm-cpu 2.5 --vm-ram 100 busybox'
-
-
-    }
-
     @Unroll
     def 'test singularity env'() {
 


### PR DESCRIPTION
This PR reverts the changes introduced in #1833  to singularity CPU/memory options as they are not directly related to resource limiting and operate at the vm level.

This issue was raised in #1869 


