### PR TITLE
Add the pool start task to setup azcopy

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -319,10 +319,6 @@ class AzBatchService implements Closeable {
         final resFiles = new ArrayList(10)
 
         resFiles << new ResourceFile()
-                .withHttpUrl('https://nf-xpack.s3-eu-west-1.amazonaws.com/azcopy/linux_amd64_10.8.0/azcopy')
-                .withFilePath('.nextflow-bin/azcopy')
-
-        resFiles << new ResourceFile()
                 .withHttpUrl(AzHelper.toHttpUrl(cmdRun, sas))
                 .withFilePath(TaskRun.CMD_RUN)
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -514,7 +514,7 @@ class AzBatchService implements Closeable {
                 .withFilePath('azcopy')
 
         def poolStartTask = new StartTask()
-                .withCommandLine('bash -c "chmod +x azcopy && cp azcopy \$AZ_BATCH_NODE_SHARED_DIR/" ')
+                .withCommandLine('bash -c "chmod +x azcopy && mkdir \$AZ_BATCH_NODE_SHARED_DIR/bin/ && cp azcopy \$AZ_BATCH_NODE_SHARED_DIR/bin/" ')
                 .withResourceFiles(resourceFiles)
 
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
@@ -62,7 +62,7 @@ class AzFileCopyStrategy extends SimpleFileCopyStrategy {
         final result = new StringBuilder()
         final copy = environment ? new LinkedHashMap<String,String>(environment) : new LinkedHashMap<String,String>()
         copy.remove('PATH')
-        copy.put('PATH', '$PWD/.nextflow-bin:$PATH')
+        copy.put('PATH', '$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR:$PATH')
         copy.put('AZCOPY_LOG_LOCATION', '$PWD/.azcopy_log')
         copy.put('AZ_SAS', sasToken)
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
@@ -62,7 +62,7 @@ class AzFileCopyStrategy extends SimpleFileCopyStrategy {
         final result = new StringBuilder()
         final copy = environment ? new LinkedHashMap<String,String>(environment) : new LinkedHashMap<String,String>()
         copy.remove('PATH')
-        copy.put('PATH', '$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR:$PATH')
+        copy.put('PATH', '$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH')
         copy.put('AZCOPY_LOG_LOCATION', '$PWD/.azcopy_log')
         copy.put('AZ_SAS', sasToken)
 


### PR DESCRIPTION
This PR adds a small snippet and the` pool level StartTask`  is now being reflected in the `pool properties`.

![image](https://user-images.githubusercontent.com/12799326/106623495-6c623b00-6553-11eb-9eaa-47a795b3ef40.png)


And the `azcopy` executable binary is now visible on every node's `shared` directory

![image](https://user-images.githubusercontent.com/12799326/106623558-813ece80-6553-11eb-9e36-cbbb91fbc840.png)
