### PR TITLE
[Docs] Add instructions for custom VM type, depending on default regional quota

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -101,6 +101,11 @@ A minimal configuration looks like the following snippet::
         accountName = '<YOUR BATCH ACCOUNT NAME>'
         accountKey = '<YOUR BATCH ACCOUNT KEY>'
         autoPoolMode = true
+        pools {
+          auto {
+            vmType = 'STANDARD_D2_V3' // Default VM type is STANDARD_A1
+         }
+        }
       }
     }
 

--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -104,6 +104,7 @@ A minimal configuration looks like the following snippet::
         pools {
           auto {
             vmType = 'STANDARD_D2_V3' // Default VM type is STANDARD_A1
+            autoScale = true // Scale up/down the number of nodes based on pending tasks
          }
         }
       }


### PR DESCRIPTION
This PR tweaks the default `azure.config` shared in WIP the docs.