### PR TITLE
[Enhancement] Update the default auto-scale formula for Azure Batch Pool resources

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -554,19 +554,18 @@ class AzBatchService implements Closeable {
 
     protected String scaleFormula(AzPoolOpts opts) {
         // https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling
-        def DEFAULT_FORMULA = """
-            cappedPoolSize = ${opts.vmCount};
-            \$samples = \$PendingTasks.GetSamplePercent(TimeInterval_Minute * 15);
-            \$tasks = \$samples < 70 ? max(0, \$PendingTasks.GetSample(1)) : max( \$PendingTasks.GetSample(1), avg(\$PendingTasks.GetSample(TimeInterval_Minute * 15)));
-            \$targetVMs = \$tasks > 0? \$tasks:max(0, \$TargetDedicatedNodes/2);
-            \$TargetDedicatedNodes = max(0, min(\$targetVMs, cappedPoolSize));
-            \$NodeDeallocationOption = taskcompletion;
-                """.stripIndent()
+        def DEFAULT_FORMULA = '''
+            cappedPoolSize = {{vmCount}};
+            $samples = $PendingTasks.GetSamplePercent(TimeInterval_Minute * 15);
+            $tasks = $samples < 70 ? max(0, $PendingTasks.GetSample(1)) : max( $PendingTasks.GetSample(1), avg($PendingTasks.GetSample(TimeInterval_Minute * 15)));
+            $targetVMs = $tasks > 0? $tasks:max(0, $TargetDedicatedNodes/2);
+            $TargetDedicatedNodes = max(0, min($targetVMs, cappedPoolSize));
+            $NodeDeallocationOption = taskcompletion;
+                '''.stripIndent()
 
         final scaleFormula = opts.scaleFormula ?: DEFAULT_FORMULA
         final vars = new HashMap<String,String>()
         vars.vmCount = opts.vmCount
-        vars.now = Instant.now().toString()
         return new MustacheTemplateEngine().render(scaleFormula, vars)
     }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -216,8 +216,8 @@ class AzBatchServiceTest extends Specification {
         when:
         def ret = svc.scaleFormula( new AzPoolOpts(vmCount: 4) )
         then:
-        ret.contains('$TargetDedicatedNodes = 4;')
-        ret.contains('$TargetDedicatedNodes = (lifespan > startup ? (max($RunningTasks.GetSample(span, ratio), $ActiveTasks.GetSample(span, ratio)) == 0 ? 0 : $TargetDedicatedNodes) : 4);')
+        ret.contains('cappedPoolSize = 4;')
+        ret.contains('$NodeDeallocationOption = taskcompletion;')
     }
 
     def 'should guess vm' () {


### PR DESCRIPTION
This PR adds support for scaling down for Azure Batch Pool resources to 0 when there are no tasks.

- The pool was created with auto-scale formula (initially 0 nodes)
- Nodes were added after tasks were added to a linked job
- Tasks were executed
- After around 15 minutes nodes will be removed and the count will be set to 0.