### PR TITLE
catch failing commands in nxf_parallel

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
@@ -59,7 +59,10 @@ class BashFunLib {
                   ((i+=1))
                 fi
             done
-            ((\${#pid[@]}>0)) && wait \${pid[@]}
+            for p in "\${pid[@]}"
+            do
+                wait \$p
+            done
             )
             unset IFS
         }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
@@ -1,0 +1,79 @@
+package nextflow.executor
+
+import java.util.concurrent.TimeUnit
+import java.nio.file.Files
+
+import nextflow.util.Duration
+import spock.lang.Specification
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class BashFunLibTest extends Specification {
+
+    def 'should fail on errors in nxf_parallel' () {
+
+        given:
+        def scriptFile = Files.createTempFile("test", "sh")
+        def script = """
+        #!/bin/bash
+
+        set -e
+        """.stripIndent() +
+
+        BashFunLib.body(5, 5, Duration.of('1 sec')) +
+
+        """
+        cmds=()
+        cmds+=("true")
+        cmds+=("false")
+        nxf_parallel "\${cmds[@]}"
+        """.stripIndent()
+
+        scriptFile.text = script
+
+        def process = "bash ${scriptFile}".execute()
+        process.waitFor(1, TimeUnit.SECONDS)
+
+        expect:
+        process.exitValue() == 1
+
+        cleanup:
+        if( scriptFile ) Files.delete(scriptFile)
+
+    }
+
+    def 'should succeed with nxf_parallel' () {
+
+        given:
+        def scriptFile = Files.createTempFile("test", "sh")
+        def script = """
+        #!/bin/bash
+
+        set -e
+        """.stripIndent() +
+
+        BashFunLib.body(5, 5, Duration.of('1 sec')) +
+
+        """
+        cmds=()
+        cmds+=("true")
+        cmds+=("true")
+        nxf_parallel "\${cmds[@]}"
+        """.stripIndent()
+
+        scriptFile.text = script
+
+        def process = "bash ${scriptFile}".execute()
+        process.waitFor(1, TimeUnit.SECONDS)
+
+        expect:
+        process.exitValue() == 0
+
+        cleanup:
+        if( scriptFile ) Files.delete(scriptFile)
+
+    }
+
+}

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
@@ -177,7 +177,10 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                               ((i+=1))
                             fi
                         done
-                        ((${#pid[@]}>0)) && wait ${pid[@]}
+                        for p in "${pid[@]}"
+                        do
+                            wait $p
+                        done
                         )
                         unset IFS
                     }
@@ -262,7 +265,10 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                           ((i+=1))
                         fi
                     done
-                    ((${#pid[@]}>0)) && wait ${pid[@]}
+                    for p in "${pid[@]}"
+                    do
+                        wait $p
+                    done
                     )
                     unset IFS
                 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -108,7 +108,10 @@ class AwsBatchScriptLauncherTest extends Specification {
                           ((i+=1))
                         fi
                     done
-                    ((${#pid[@]}>0)) && wait ${pid[@]}
+                    for p in "${pid[@]}"
+                    do
+                        wait $p
+                    done
                     )
                     unset IFS
                 }
@@ -281,7 +284,10 @@ class AwsBatchScriptLauncherTest extends Specification {
                               ((i+=1))
                             fi
                         done
-                        ((${#pid[@]}>0)) && wait ${pid[@]}
+                        for p in "${pid[@]}"
+                        do
+                            wait $p
+                        done
                         )
                         unset IFS
                     }
@@ -420,7 +426,10 @@ class AwsBatchScriptLauncherTest extends Specification {
                               ((i+=1))
                             fi
                         done
-                        ((${#pid[@]}>0)) && wait ${pid[@]}
+                        for p in "${pid[@]}"
+                        do
+                            wait $p
+                        done
                         )
                         unset IFS
                     }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/S3HelperTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/S3HelperTest.groovy
@@ -86,7 +86,10 @@ class S3HelperTest extends Specification {
                               ((i+=1))
                             fi
                         done
-                        ((${#pid[@]}>0)) && wait ${pid[@]}
+                        for p in "${pid[@]}"
+                        do
+                            wait $p
+                        done
                         )
                         unset IFS
                     }
@@ -179,7 +182,10 @@ class S3HelperTest extends Specification {
                               ((i+=1))
                             fi
                         done
-                        ((${#pid[@]}>0)) && wait ${pid[@]}
+                        for p in "${pid[@]}"
+                        do
+                            wait $p
+                        done
                         )
                         unset IFS
                     }

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderS3Test.groovy
@@ -111,7 +111,10 @@ class BashWrapperBuilderS3Test extends Specification {
                       ((i+=1))
                     fi
                 done
-                ((${#pid[@]}>0)) && wait ${pid[@]}
+                for p in "${pid[@]}"
+                do
+                    wait $p
+                done
                 )
                 unset IFS
             }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -144,7 +144,10 @@ class AzFileCopyStrategyTest extends Specification {
                           ((i+=1))
                         fi
                     done
-                    ((${#pid[@]}>0)) && wait ${pid[@]}
+                    for p in "${pid[@]}"
+                    do
+                        wait $p
+                    done
                     )
                     unset IFS
                 }
@@ -267,7 +270,10 @@ class AzFileCopyStrategyTest extends Specification {
                           ((i+=1))
                         fi
                     done
-                    ((${#pid[@]}>0)) && wait ${pid[@]}
+                    for p in "${pid[@]}"
+                    do
+                        wait $p
+                    done
                     )
                     unset IFS
                 }
@@ -414,7 +420,10 @@ class AzFileCopyStrategyTest extends Specification {
                               ((i+=1))
                             fi
                         done
-                        ((${#pid[@]}>0)) && wait ${pid[@]}
+                        for p in "${pid[@]}"
+                        do
+                            wait $p
+                        done
                         )
                         unset IFS
                     }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -53,7 +53,10 @@ nxf_parallel() {
           ((i+=1))
         fi
     done
-    ((${#pid[@]}>0)) && wait ${pid[@]}
+    for p in "${pid[@]}"
+    do
+        wait $p
+    done
     )
     unset IFS
 }


### PR DESCRIPTION
Greetings!

We hit a brutal edge case - got ratelimited by the metadata endpoint while running thousands of containers through an ec2 instance. Unfortunately `nxf_parallel` is not catching errors, so nextflow failed to stage files and yet the process chugged along. This was no bueno!

Anyway, here's a fix with some tests.