### PR TITLE
Allowing pod spec labels to start with numbers in addition to alphas.

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -487,7 +487,7 @@ class PodSpecBuilder {
             str = str.substring(0,63)
         }
         str = str.replaceAll(/[^a-zA-Z0-9\.\_\-]+/, '_')
-        str = str.replaceAll(/^[^a-zA-Z]+/, '')
+        str = str.replaceAll(/^[^a-zA-Z0-9]+/, '')
         str = str.replaceAll(/[^a-zA-Z0-9]+$/, '')
         return str
     }

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -71,6 +71,7 @@ class PodSpecBuilderTest extends Specification {
                 .withNamespace('xyz')
                 .withLabel('app','myApp')
                 .withLabel('runName','something')
+                .withLabel('version','3.6.1')
                 .withAnnotation("anno1", "value1")
                 .withAnnotations([anno2: "value2", anno3: "value3"])
                 .build()
@@ -83,7 +84,8 @@ class PodSpecBuilderTest extends Specification {
                            namespace:'xyz',
                            labels: [
                                    app: 'myApp',
-                                   runName: 'something'
+                                   runName: 'something',
+                                   version: '3.6.1'
                            ],
                            annotations: [
                                    anno1: "value1",
@@ -664,7 +666,7 @@ class PodSpecBuilderTest extends Specification {
         'hello_world.'  | 'hello_world'
         'hello_123'     | 'hello_123'
         'HELLO 123'     | 'HELLO_123'
-        '123hello'      | 'hello'
+        '123hello'      | '123hello'
         'x2345678901234567890123456789012345678901234567890123456789012345' | 'x23456789012345678901234567890123456789012345678901234567890123'
     }
 }


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/nextflow-io/nextflow/issues/1905).  One of the regexes used to sanitize the labels just omitted numbers.  Per [the spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) (and manually created examples), labels should be allowed to start with numbers.