### PR TITLE
Fixed typos and grammar issues in tutorial

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -149,7 +149,7 @@ Named pools
 -------------
 
 If you want to have a more precise control on the computing nodes pools used in your pipeline using a different pool
-depending the task in your pipeline, you can use the Nextflow :ref:`process-queue` directive the specify the *name* of a
+depending on the task in your pipeline, you can use the Nextflow :ref:`process-queue` directive the specify the *name* of a
 Azure Batch compute pool that has to be used to run that process' tasks.
 
 The pool is expected to be already available in the Batch environment, unless the setting ``allowPoolCreation=true`` is
@@ -240,7 +240,7 @@ azure.batch.accountName                         The batch service account name.
 azure.batch.accountKey                          The batch service account key.
 azure.batch.endpoint                            The batch service endpoint e.g. ``https://nfbatch1.westeurope.batch.azure.com``.
 azure.batch.location                            The batch service location e.g. ``westeurope``. This is not needed when the endpoint is specified.
-azure.batch.autoPoolMode                        Enable the automatic creation of batch pools depending the pipeline resources demand (default: ``true``)
+azure.batch.autoPoolMode                        Enable the automatic creation of batch pools depending on the pipeline resources demand (default: ``true``)
 azure.batch.allowPoolCreation                   Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: ``false``)
 azure.batch.deleteJobsOnCompletion              Enable the automatic deletion of jobs created by the pipeline execution (default: ``true``).
 azure.batch.deletePoolsOnCompletion             Enable the automatic deletion of compute node pools upon pipeline completion (default: ``false``).

--- a/docs/channel.rst
+++ b/docs/channel.rst
@@ -33,9 +33,9 @@ or chaining it with a channel operator such as :ref:`operator-map`, :ref:`operat
 Queue channels are also created by process output declarations using the ``into`` clause.
 
 .. note:: The definition implies that the same queue channel cannot be used more than one time as process
- output and more then one time as process input.
+ output and more than one time as process input.
 
-In you need to connect a process output channel to more then one process or operator use the
+In you need to connect a process output channel to more than one process or operator use the
 :ref:`operator-into` operator to create two (or more) copies of the same channel and use each
 of them to connect a separate process.
 
@@ -72,7 +72,7 @@ For example::
       """
     }
 
-The process in the above snippet declare a single input which implicitly is a value channel.
+The process in the above snippet declares a single input which implicitly is a value channel.
 Therefore also the ``result`` output is a value channel that can be read by more than one process.
 
 See also: :ref:`process-understand-how-multiple-input-channels-work`.
@@ -538,7 +538,7 @@ Observing events
 subscribe
 ---------
 
-The ``subscribe`` method permits to execute a user define function each time a new value is emitted by the source channel.
+The ``subscribe`` method allows you to execute a user defined function each time a new value is emitted by the source channel.
 
 The emitted value is passed implicitly to the specified function. For example::
 
@@ -556,10 +556,10 @@ The emitted value is passed implicitly to the specified function. For example::
 
 
 .. note:: Formally the user defined function is a ``Closure`` as defined by the Groovy programming language on which
-  the `Nextflow` scripts are based on.
+  the `Nextflow` scripts are based.
 
 If needed the closure parameter can be defined explicitly, using a name other than ``it`` and, optionally,
-specifying the expected value type, as showed in the following example::
+specifying the expected value type, as shown in the following example::
 
     Channel
         .from( 'alpha', 'beta', 'lambda' )

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -776,7 +776,7 @@ brackets, as shown below::
 Scope `weblog`
 --------------
 
-The ``weblog`` scope allows to send detailed :ref:`trace scope<trace-fields>` information as HTTP POST request to a webserver, shipped as a JSON object.
+The ``weblog`` scope allows you to send detailed :ref:`trace scope<trace-fields>` information as HTTP POST request to a webserver, shipped as a JSON object.
 
 Detailed information about the JSON fields can be found in the :ref:`weblog description<weblog-service>`.
 

--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -523,8 +523,8 @@ DSL2 migration notes
 * DSL2 final version is activated using the declaration ``nextflow.enable.dsl=2`` in place of ``nextflow.preview.dsl=2``.
 * Process inputs of type ``set`` have to be replaced with :ref:`tuple <process-input-tuple>`.
 * Process outputs of type ``set`` have to be replaced with :ref:`tuple <process-out-tuple>`.
-* Process output option ``mode flatten`` is not available any more. Replace it using the :ref:`operator-flatten` operator on the corresponding output channel.
-* Anonymous and unwrapped includes are not supported any more. Replace it with a explicit module inclusion. For example::
+* Process output option ``mode flatten`` is not available anymore. Replace it using the :ref:`operator-flatten` operator on the corresponding output channel.
+* Anonymous and unwrapped includes are not supported anymore. Replace it with a explicit module inclusion. For example::
 
         include './some/library'
         include bar from './other/library'

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -48,7 +48,7 @@ In more detail:
 
 * line 13: Opens the `output` declaration block. Lines following this clause are interpreted as output definitions.
 
-* line 14: Defines that the process outputs files whose names match the pattern ``seq_*``. These files are sent over the
+* line 14: Defines that the process output files whose names match the pattern ``seq_*``. These files are sent over the
   channel ``records``.
 
 * lines 16-18: The actual script executed by the process to split the provided file.

--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -106,7 +106,7 @@ The amount of resources requested by each job submission is defined by the follo
 * :ref:`process-memory`
 * :ref:`process-clusterOptions`
 
-.. note:: SLURM `partitions` can be considered jobs queues. Nextflow allows to set partitions by using the above ``queue``
+.. note:: SLURM `partitions` can be considered jobs queues. Nextflow allows you to set partitions by using the above ``queue``
     directive.
 
 .. tip:: Nextflow does not provide a direct support for SLURM multi-clusters feature. If you need to

--- a/docs/google.rst
+++ b/docs/google.rst
@@ -242,7 +242,7 @@ Limitation
 ----------
 
 * Currently it's not possible to specify a disk type different from the default one assigned
-  by the service depending the chosen instance type.
+  by the service depending on the chosen instance type.
 
 
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -121,8 +121,8 @@ For example::
 
 .. note:: Both the ``onError`` and ``onComplete`` handlers are invoked when an error condition is encountered.
     However the first is called as soon as the error is raised, while the second just before the pipeline execution
-    is going terminate. When using the ``finish`` :ref:`process-page-error-strategy`, between the two there could be
-    a significant time gap depending by the time required to complete any pending job.
+    is going to terminate. When using the ``finish`` :ref:`process-page-error-strategy`, between the two there could be
+    a significant time gap depending on the time required to complete any pending job.
 
 
 Decoupling metadata

--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -44,8 +44,8 @@ The ``filter`` operator allows you to get only the items emitted by a channel th
 all the others. The filtering condition can be specified by using either a :ref:`regular expression <script-regexp>`,
 a literal value, a type `qualifier` (i.e. a Java class) or any boolean `predicate`.
 
-The following example shows how to filter a channel by using a regular expression that returns only string that
-begins with ``a``::
+The following example shows how to filter a channel by using a regular expression that returns only strings that
+begin with ``a``::
 
     Channel
         .from( 'a', 'b', 'aa', 'bc', 3, 4.5 )
@@ -222,7 +222,7 @@ from the channel to which is applied. For example::
 
 The above snippet will print 10 numbers in the range from 1 to 100.
 
-The operator supports a second parameter that allows to set the initial `seed` for the random number generator.
+The operator supports a second parameter that allows you to set the initial `seed` for the random number generator.
 By setting it, the ``randomSample`` operator will always return the same pseudo-random sequence. For example::
 
   Channel
@@ -340,7 +340,7 @@ flatMap
 ----------
 
 The ``flatMap`` operator applies a function of your choosing to every item emitted by a channel, and
-returns the items so obtained as a new channel. Whenever the `mapping` function returns a list of items,
+returns the items so obtained as a new channel. Whereas the `mapping` function returns a list of items,
 this list is flattened so that each single item is emitted on its own.  
 
 For example::
@@ -522,7 +522,7 @@ deep            Similar to the previous, but the hash number is created on actua
 
 .. tip:: You should always specify the number of expected element in each tuple using the ``size`` attribute
   to allow the ``groupTuple`` operator to stream the collected values as soon as possible. However there
-  are use cases in which each tuple has a different size depending grouping key. In this cases use the
+  are use cases in which each tuple has a different size depending on grouping key. In this case use the
   built-in function ``groupKey`` that allows you to create a special grouping key object to which it's possible
   to associate the group size for a given key.
 
@@ -634,7 +634,7 @@ The ``collate`` operator transforms a channel in such a way that the emitted val
         [1, 2, 3]
         [1]
 
-As shown in the above example the last tuple may be incomplete e.g. contain less elements than the specified size.
+As shown in the above example the last tuple may be incomplete e.g. contain fewer elements than the specified size.
 If you want to avoid this, specify ``false`` as the second parameter. For example::
 
     Channel
@@ -846,7 +846,7 @@ text entries. For example::
 The above example shows hows CSV text is parsed and is split into single rows. Values can be accessed
 by its column index in the row object.
 
-When the CSV begins with a header line defining the columns names, you can specify the parameter ``header: true`` which
+When the CSV begins with a header line defining the column names, you can specify the parameter ``header: true`` which
 allows you to reference each value by its name, as shown in the following example::
 
     Channel
@@ -1444,8 +1444,8 @@ The following example shows how use a `closure` to collect and sort all sequence
          .view { it.text }
 
 
-.. warning:: The ``collectFile`` operator to carry out its function need to store in a temporary folder that is
- automatically deleted on job completion. For performance reason this folder is allocated in the machine local storage,
+.. warning:: The ``collectFile`` operator needs to store files in a temporary folder that is automatically deleted on 
+  job completion. For performance reasons this folder is located in the machine's local storage,
  and it will require as much free space as are the data you are collecting. Optionally, an alternative temporary data
  folder can be specified by using the ``tempDir`` parameter.
 
@@ -1635,7 +1635,7 @@ just after the condition expression. For example::
   implicitly returned.
 
 .. warning:: The branch evaluation closure must be specified inline, ie. it *cannot* be assigned to a
-  variable and passed as argument to the operator, how it can be done with other operators.
+  variable and passed as argument to the operator, the way it can be done with other operators.
 
 To create a branch criteria as variable that can be passed as an argument to more than one
 ``branch`` operator use the ``branchCriteria`` built-in method as shown below::
@@ -1717,8 +1717,8 @@ It prints::
 
 
 .. tip:: The statement expression can be omitted when the value to be emitted is the same as
-  the following one. If you need just need to forward the same value to multiple channel
-  you can use the following the shorthand notation showed below.
+  the following one. If you need just need to forward the same value to multiple channels
+  you can use the following the shorthand notation shown below.
 
 ::
 
@@ -1727,12 +1727,12 @@ It prints::
         .multiMap { it -> foo: bar: it }
         .set { result }
 
-As before creates two channels, however both of them receive the same source items.
+As before this creates two channels but now both of them receive the same source items.
 
 
 .. warning::
   The multi-map evaluation closure must be specified inline, ie. it *cannot* be assigned to a
-  variable and passed as argument to the operator, how it can be done with other operators.
+  variable and passed as argument to the operator, the way it can be done with other operators.
 
 To create a multi-map criteria as variable that can be passed as an argument to more than one
 ``multiMap`` operator use the ``multiMapCriteria`` built-in method as shown below::
@@ -2252,7 +2252,7 @@ print
 ------
 
 .. warning::
-  The ``print`` operator is deprecated and not supported any more when using DSL2 syntax. Use
+  The ``print`` operator is deprecated and not supported anymore when using DSL2 syntax. Use
   `view`_ instead.
 
 The ``print`` operator prints the items emitted by a channel to the standard output.
@@ -2275,7 +2275,7 @@ println
 --------
 
 .. warning::
-  The ``println`` operator is deprecated and not supported any more when using DSL2 syntax. Use
+  The ``println`` operator is deprecated and not supported anymore when using DSL2 syntax. Use
   `view`_ instead.
 
 The ``println`` operator prints the items emitted by a channel to the console standard output appending
@@ -2324,8 +2324,8 @@ The ``view`` operator prints the items emitted by a channel to the console stand
 
 Each item is printed on a separate line unless otherwise specified by using the ``newLine: false`` optional parameter.
 
-How the channel items are printed can be controlled by using an optional closure parameter. The closure it must return
-the actual value of the item being to be printed::
+How the channel items are printed can be controlled by using an optional closure parameter. The closure must return
+the actual value of the item to be printed::
 
     Channel.from(1,2,3)
             .map { it -> [it, it*it] }
@@ -2338,9 +2338,9 @@ It prints::
     Square of: 3 is 9
 
 
-.. note:: Both the *view* and `print`_ (or `println`_) operators consume them items emitted by the source channel to which they
-    are applied. However, the main difference between them is that the former returns a newly create channel whose content
-    is identical to the source one. This allows the *view* operator to be chained like other operators.
+.. note:: Both the *view* and `print`_ (or `println`_) operators consume the items emitted by the source channel to which they
+    are applied. The main difference between them is that the former returns a newly created channel whose content
+    is identical to the source channel while the latter does not. This allows the *view* operator to be chained like other operators.
 
 .. _operator-close:
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -369,8 +369,8 @@ Inputs
 
 Nextflow processes are isolated from each other but can communicate between themselves sending values through channels.
 
-The `input` block defines which channels the process is expecting to receive inputs data from. You can only define one
-input block at a time and it must contain one or more inputs declarations.
+The `input` block defines from which channels the process expects to receive data. You can only define one
+input block at a time and it must contain one or more input declarations.
 
 The input block follows the syntax shown below::
 
@@ -923,11 +923,10 @@ See also: :ref:`channel-types`.
 Outputs
 =======
 
-The `output` declaration block allows to define the channels used by the process to send out the results produced.
+The `output` declaration block allows you to define the channels used by the process to send out the results produced.
+You can only define one output block at a time and it must contain one or more output declarations.
 
-It can be defined at most one output block and it can contain one or more outputs declarations.
 The output block follows the syntax shown below::
-
     output:
       <output qualifier> <output name> [into <target channel>[,channel,..]] [attribute [,..]]
 
@@ -937,26 +936,26 @@ one or more channels over which outputs are sent. Finally some optional attribut
 .. note:: When the output name is the same as the channel name, the ``into`` part of the declaration can be omitted.
 
 
-.. TODO the channel is implicitly create if does not exist
+.. TODO the channel is implicitly created if does not exist
 
 The qualifiers that can be used in the output declaration block are the ones listed in the following table:
 
 =========== =============
 Qualifier   Semantic
 =========== =============
-val         Sends variable's with the name specified over the output channel.
+val         Sends variables with the name specified over the output channel.
 file        Sends a file produced by the process with the name specified over the output channel.
 path        Sends a file produced by the process with the name specified over the output channel (replaces ``file``).
 env         Sends the variable defined in the process environment with the name specified over the output channel.
 stdout      Sends the executed process `stdout` over the output channel.
-tuple       Lets to send multiple values over the same output channel.
+tuple       Sends multiple values over the same output channel.
 =========== =============
 
 
 Output values
 -------------
 
-The ``val`` qualifier allows to output a `value` defined in the script context. In a common usage scenario,
+The ``val`` qualifier allows you to output a `value` defined in the script context. In a common usage scenario,
 this is a value which has been defined in the `input` declaration block, as shown in the following example::
 
    methods = ['prot','dna', 'rna']
@@ -977,7 +976,7 @@ this is a value which has been defined in the `input` declaration block, as show
    receiver.view { "Received: $it" }
 
 
-Valid output values are value literals, input values identifiers, variables accessible in the process scope and
+Valid output values are value literals, input value identifiers, variables accessible in the process scope and
 value expressions. For example::
 
     process foo {
@@ -1002,7 +1001,7 @@ value expressions. For example::
 Output files
 ------------
 
-The ``file`` qualifier allows to output one or more files, produced by the process, over the specified channel.
+The ``file`` qualifier allows you to output one or more files, produced by the process, over the specified channel.
 For example::
 
 
@@ -1026,7 +1025,7 @@ file is sent over the ``numbers`` channel. A downstream `process` declaring the 
 be able to receive it.
 
 .. note:: If the channel specified as output has not been previously declared in the pipeline script, it
-  will implicitly created by the output declaration itself.
+  will implicitly be created by the output declaration itself.
 
 
 .. TODO explain Path object
@@ -1035,7 +1034,7 @@ Multiple output files
 ---------------------
 
 When an output file name contains a ``*`` or ``?`` wildcard character it is interpreted as a `glob`_ path matcher.
-This allows to *capture* multiple files into a list object and output them as a sole emission. For example::
+This allows you to *capture* multiple files into a list object and output them as a sole emission. For example::
 
     process splitLetters {
 
@@ -1064,7 +1063,7 @@ It prints::
 Some caveats on glob pattern behavior:
 
 * Input files are not included in the list of possible matches.
-* Glob pattern matches against both files and directories path.
+* Glob pattern matches against both files and directory paths.
 * When a two stars pattern ``**`` is used to recourse across directories, only file paths are matched
   i.e. directories are not included in the result list.
 
@@ -1079,7 +1078,7 @@ By default all the files matching the specified glob pattern are emitted by the 
 It is also possible to emit each file as a sole item by adding the ``mode flatten`` attribute in the output file
 declaration.
 
-By using the ``mode`` attribute the previous example can be re-written as show below::
+By using the ``mode`` attribute the previous example can be re-written as shown below::
 
     process splitLetters {
 
@@ -1130,7 +1129,7 @@ In the above example, each time the process is executed an alignment file is pro
 on the actual value of the ``x`` input.
 
 .. tip:: The management of output files is a very common misunderstanding when using Nextflow.
-  With other tools, it is generally necessary to organize the outputs files into some kind of directory 
+  With other tools it is generally necessary to organize the output files into some kind of directory 
   structure or to guarantee a unique file name scheme, so that result files won't overwrite each other 
   and that they can be referenced univocally by downstream tasks.
 
@@ -1152,7 +1151,7 @@ for the ``file`` output qualifier, therefore it's backward compatible with the s
 and the semantic for the input ``file`` described above.
 
 The main advantage of ``path`` over the ``file`` qualifier is that it allows the specification
-of a number of output to fine-control the output files.
+of a number of outputs to fine-control the output files.
 
 ============== =====================
 Name            Description
@@ -1168,7 +1167,7 @@ includeInputs   When ``true`` any input files matching an output file glob patte
 
 .. warning::
     Breaking change: the ``file`` qualifier interprets ``:`` as path separator, therefore ``file 'foo:bar'``
-    captures both files ``foo`` and ``bar``. The ``path`` qualifier interprets it just a plain file name character,
+    captures both files ``foo`` and ``bar``. The ``path`` qualifier interprets it as just a plain file name character,
     and therefore the output definition ``path 'foo:bar'`` captures the output file with name ``foo:bar``.
 
 
@@ -1230,7 +1229,7 @@ Output 'set' of values
 Output 'tuple' of values
 ------------------------
 
-The ``tuple`` qualifier allows to send multiple values into a single channel. This feature is useful
+The ``tuple`` qualifier allows you to send multiple values into a single channel. This feature is useful
 when you need to `group together` the results of multiple executions of the same process, as shown in the following
 example::
 
@@ -1290,7 +1289,7 @@ When
 The ``when`` declaration allows you to define a condition that must be verified in order to execute the process.
 This can be any expression that evaluates a boolean value.
 
-It is useful to enable/disable the process execution depending the state of various inputs and parameters. For example::
+It is useful to enable/disable the process execution depending on the state of various inputs and parameters. For example::
 
 
     process find {
@@ -1422,7 +1421,7 @@ along with the same inputs, will cause the process execution to be skipped, prod
 the actual results.
 
 The caching feature generates a unique `key` by indexing the process script and inputs. This key is used
-identify univocally the outputs produced by the process execution.
+to identify univocally the outputs produced by the process execution.
 
 
 The cache is enabled by default, you can disable it for a specific process by setting the ``cache``
@@ -1502,7 +1501,7 @@ Simply replace in the above script ``dockerbox:tag`` with the Docker image name 
 
 .. tip:: This can be very useful to execute your scripts into a replicable self-contained environment or to deploy your pipeline in the cloud.
 
-.. note:: This directive is ignore for processes :ref:`executed natively <process-native>`.
+.. note:: This directive is ignored for processes :ref:`executed natively <process-native>`.
 
 
 .. _process-containerOptions:
@@ -2038,7 +2037,7 @@ saveAs          A closure which, given the name of the file being published, ret
                 a custom strategy.
                 Return the value ``null`` from the closure to *not* publish a file.
                 This is useful when the process has multiple output files, but you want to publish only some of them.
-enabled         Allow to enable or disable the publish rule depending the boolean value specified (default: ``true``).
+enabled         Enable or disable the publish rule depending on the boolean value specified (default: ``true``).
 =============== =================
 
 Table of publish modes:
@@ -2150,7 +2149,7 @@ scratch
 
 The ``scratch`` directive allows you to execute the process in a temporary folder that is local to the execution node.
 
-This is useful when your pipeline is launched by using a `grid` executor, because it permits to decrease the NFS
+This is useful when your pipeline is launched by using a `grid` executor, because it allows you to decrease the NFS
 overhead by running the pipeline processes in a temporary directory in the local disk of the actual execution node.
 Only the files declared as output in the process definition will be copied in the pipeline working area.
 
@@ -2290,7 +2289,7 @@ See also: `scratch`_.
 tag
 ---
 
-The ``tag`` directive allows you to associate each process executions with a custom label, so that it will be easier
+The ``tag`` directive allows you to associate each process execution with a custom label, so that it will be easier
 to identify them in the log file or in the trace execution report. For example::
 
     process foo {

--- a/docs/script.rst
+++ b/docs/script.rst
@@ -265,7 +265,7 @@ the current task configuration directives. For examples::
 
 
 In the above snippet the ``task.cpus`` report the value for the :ref:`cpus directive<process-cpus>` and
-the ``task.memory`` the current value for :ref:`memory directive<process-memory>` depending the actual
+the ``task.memory`` the current value for :ref:`memory directive<process-memory>` depending on the actual
 setting given in the workflow configuration file.
 
 See :ref:`Process directives <process-directives>` for details.

--- a/docs/singularity.rst
+++ b/docs/singularity.rst
@@ -14,7 +14,7 @@ Nextflow provides built-in support for Singularity. This allows you to precisely
 of the processes in your pipeline by running them in isolated containers along all their dependencies.
 
 Moreover the support provided by Nextflow for different container technologies, allows the same pipeline to be
-transparently executed both with Docker or Singularity containers, depending the available engine in the target
+transparently executed both with Docker or Singularity containers, depending on the available engine in the target
 execution platforms.
 
 
@@ -139,7 +139,7 @@ Nextflow version 18.10 introduced support for the `Singularity Library <https://
    
    process.container = 'library://library/default/alpine:3.8'
 
-The pseudo-protocol allow to import Singularity using a local Docker installation instead of downloading
+The pseudo-protocol allows you to import Singularity using a local Docker installation instead of downloading
 the container image from the Docker registry. It requires Nextflow 19.04.0 or later and Singularity 3.0.3 or later.
 
 .. note:: This feature requires the availability of the ``singularity`` tool in the computer


### PR DESCRIPTION
Changes are mostly in Processes, Channels, and Operators because that's how far I've read the tutorial so far.