### PR TITLE
charliecloud: get container environment from file

### DIFF
--- a/docs/charliecloud.rst
+++ b/docs/charliecloud.rst
@@ -21,7 +21,7 @@ executed on any platform supporting the Charliecloud engine.
 Prerequisites
 ==============
 
-You will need Charliecloud version ``0.21`` or later installed on your execution environment e.g. your computer or a
+You will need Charliecloud version ``0.22`` or later installed on your execution environment e.g. your computer or a
 distributed cluster, depending on where you want to run your pipeline.
 
 How it works
@@ -81,18 +81,6 @@ Whereas this would pull from Docker Hub::
     process.container = 'nextflow/examples:latest'
     charliecloud.enabled = true
 
-Container environment
-=====================
-
-A current limitation is that Charliecloud does not inherit environment variables specified in Docker ENV layers.
-This means that if a container has software dependencies installed at a location that is not in the host system's
-``$PATH``, it needs to be added explicitly using the :ref:`env scope <config-env>`.
-
-For example::
-
-    process.container = 'https://quay.io/biocontainers/multiqc:1.3--py35_2'
-    charliecloud.enabled = true
-    env.PATH = '/opt/conda/bin:$PATH'
 
 Multiple containers
 ===================

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -63,7 +63,7 @@ class CharliecloudBuilder extends ContainerBuilder<CharliecloudBuilder> {
     CharliecloudBuilder build(StringBuilder result) {
         assert image
 
-        result << 'ch-run --no-home --unset-env="*" -w '
+        result << 'ch-run --no-home --unset-env="*" -w --set-env=' + image + '/ch/environment '
 
         appendEnv(result)
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -38,41 +38,41 @@ class CharliecloudBuilderTest extends Specification {
         expect:
         new CharliecloudBuilder('busybox')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment -b "$PWD":"$PWD" -c "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .params(runOptions: '-j')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -j -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment -j -b "$PWD":"$PWD" -c "$PWD" busybox --'
         
         new CharliecloudBuilder('busybox')
                 .params(temp: '/foo')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo:/tmp -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment -b /foo:/tmp -b "$PWD":"$PWD" -c "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .addEnv('X=1')
                 .addEnv(ALPHA:'aaa', BETA: 'bbb')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=<( echo "X=1" ) --set-env=<( echo "ALPHA="aaa"" ) --set-env=<( echo "BETA="bbb"" ) -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment --set-env=<( echo "X=1" ) --set-env=<( echo "ALPHA="aaa"" ) --set-env=<( echo "BETA="bbb"" ) -b "$PWD":"$PWD" -c "$PWD" busybox --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo/data/file1:/foo/data/file1 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b /foo/data/file1:/foo/data/file1 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .addMount(path2)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .addMount(path2)
                 .params(readOnlyInputs: true)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
     }
 
     def 'should get run command' () {
@@ -80,17 +80,17 @@ class CharliecloudBuilderTest extends Specification {
         when:
         def cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand()
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" ubuntu -- bwa --this --that file.fastq'
+        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b "$PWD":"$PWD" -c "$PWD" ubuntu -- bwa --this --that file.fastq'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w -b "$PWD":"$PWD" -c "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b "$PWD":"$PWD" -c "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }
 
     @Unroll


### PR DESCRIPTION
Hi,

With charliecloud v[0.22](https://github.com/hpc/charliecloud/releases/tag/v0.22), ENV layers of docker containers are saved to
a file located in `$IMAGE/ch/environment` when the container is pulled.

Hence it is no longer necessary to pass for example PATH variables explicitly via the env scope, because we can just read it from `/ch/environment`