### PR TITLE
docs: add undocumented features

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -614,6 +614,7 @@ The following settings are available:
 Name                Description
 ================== ================
 cacheDir            Defines the path where Conda environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all computing nodes.
+createOptions          This attribute can be used to provide any extra command line options supported by the ``conda create`` command. For details see: https://docs.conda.io/projects/conda/en/latest/commands/create.html.
 createTimeout       Defines the amount of time the Conda environment creation can last. The creation process is terminated when the timeout is exceeded (default: ``20 min``).
 ================== ================
 

--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -1389,6 +1389,7 @@ The following parameters can be used with the ``collectFile`` operator:
 =============== ========================
 Name            Description
 =============== ========================
+``cache``       Caches the resulting file(s), so that pipelines can be resumed without recreating the file in each execution (default: ``false``)
 ``keepHeader``  Prepend the resulting file with the header fetched in the first collected file. The header size (ie. lines) can be specified by using the ``skip`` parameter (default: ``false``), to determine how many lines to remove from all collected files except for the first (where no lines will be removed).
 ``name``        Name of the file where all received values are stored.
 ``newLine``     Appends a ``newline`` character automatically after each entry (default: ``false``).


### PR DESCRIPTION
I came across two instances of features that were not documented
* `.collectFile(cache:true)`
* `conda.createOptions`
