### PR TITLE
Add the tip for GCP exitStatus

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -203,6 +203,7 @@ if the virtual machine was terminated preemptively::
       maxRetries = 5
     }
 
+.. tip:: For an exhaustive list of all possible error codes, please refer to the official Google LifeSciences `documentation <https://cloud.google.com/life-sciences/docs/troubleshooting#error_codes>`_.
 
 Hybrid execution
 ----------------


### PR DESCRIPTION
This PR adds a reference the possible `exitStatus` available for GCP.


![image](https://user-images.githubusercontent.com/12799326/108718073-cd4eb480-74fc-11eb-9ebc-1ce2caca7104.png)



**References:**
https://github.com/nextflow-io/nextflow/issues/1912
https://github.com/nextflow-io/nextflow/discussions/1913
