### PR TITLE
Update the default AZ vm for vanilla accounts

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -38,7 +38,7 @@ class AzPoolOpts implements CacheFunnel {
 
     static public final String DEFAULT_PUBLISHER = "microsoft-azure-batch"
     static public final String DEFAULT_OFFER = "centos-container"
-    static public final String DEFAULT_VM_TYPE = "Standard_A3"
+    static public final String DEFAULT_VM_TYPE = "STANDARD_D2_V3"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final Duration DEFAULT_SCALE_INTERVAL = Duration.of('5 min')
 


### PR DESCRIPTION
Hi @pditommaso ,

I was testing the plugin (and updating the docs) wrt to a new vanilla azure account.

I feel that we should choose the default VM as the one which is available for all default/vanilla/capped Azure accounts. 

For testing, I've used the `nextflow-io/hello` and the `nextflow-io/rnaseq-nf` pipelines with the default settings, but both of these fail due to quota issues. However, after passing 

```nextflow
 azure.batch.pools.auto.vmType = 'STANDARD_D2_V3'
```

... as extra configs in the Launch dialog, both pipeline successfully complete execution.

![image](https://user-images.githubusercontent.com/12799326/108766799-5a613000-7534-11eb-82df-823b9407ddfb.png)


Would it be possible to make an edge release with the new default or shall I stick to the explicit mention of this tweak as part of the docs?