### PR TITLE
Install azcopy when not using an auto pool

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -539,7 +539,7 @@ class AzBatchService implements Closeable {
         def resourceFiles = new ArrayList(10)
         
         resourceFiles << new ResourceFile()
-                .withHttpUrl("https://nf-xpack.s3-eu-west-1.amazonaws.com/azcopy/linux_amd64_10.8.0/azcopy")
+                .withHttpUrl("https://github.com/nextflow-io/azcopy-tool/raw/linux_amd64_10.8.0/azcopy")
                 .withFilePath('azcopy')
 
         def poolStartTask = new StartTask()

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -342,7 +342,7 @@ class AzBatchService implements Closeable {
         if( config.batch().installAzCopy!=Boolean.FALSE && !config.batch().canCreatePool() ) {
             log.debug "[AZURE BATCH] installing azcopy as task resource"
             resFiles << new ResourceFile()
-                    .withHttpUrl('https://nf-xpack.s3-eu-west-1.amazonaws.com/azcopy/linux_amd64_10.8.0/azcopy')
+                    .withHttpUrl('https://github.com/nextflow-io/azcopy-tool/raw/linux_amd64_10.8.0/azcopy')
                     .withFilePath('.nextflow-bin/azcopy')
         }
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -339,6 +339,13 @@ class AzBatchService implements Closeable {
 
         final resFiles = new ArrayList(10)
 
+        if( config.batch().installAzCopy!=Boolean.FALSE && !config.batch().canCreatePool() ) {
+            log.debug "[AZURE BATCH] installing azcopy as task resource"
+            resFiles << new ResourceFile()
+                    .withHttpUrl('https://nf-xpack.s3-eu-west-1.amazonaws.com/azcopy/linux_amd64_10.8.0/azcopy')
+                    .withFilePath('.nextflow-bin/azcopy')
+        }
+
         resFiles << new ResourceFile()
                 .withHttpUrl(AzHelper.toHttpUrl(cmdRun, sas))
                 .withFilePath(TaskRun.CMD_RUN)

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -70,6 +70,8 @@ import org.joda.time.Period
 @CompileStatic
 class AzBatchService implements Closeable {
 
+    static private final String AZCOPY_URL = 'https://github.com/nextflow-io/azcopy-tool/raw/linux_amd64_10.8.0/azcopy'
+
     static private final long _1GB = 1 << 30
 
     static final private Map<String,AzVmPoolSpec> allPools = new HashMap<>(50)
@@ -342,7 +344,7 @@ class AzBatchService implements Closeable {
         if( config.batch().installAzCopy!=Boolean.FALSE && !config.batch().canCreatePool() ) {
             log.debug "[AZURE BATCH] installing azcopy as task resource"
             resFiles << new ResourceFile()
-                    .withHttpUrl('https://github.com/nextflow-io/azcopy-tool/raw/linux_amd64_10.8.0/azcopy')
+                    .withHttpUrl(AZCOPY_URL)
                     .withFilePath('.nextflow-bin/azcopy')
         }
 
@@ -539,7 +541,7 @@ class AzBatchService implements Closeable {
         def resourceFiles = new ArrayList(10)
         
         resourceFiles << new ResourceFile()
-                .withHttpUrl("https://github.com/nextflow-io/azcopy-tool/raw/linux_amd64_10.8.0/azcopy")
+                .withHttpUrl(AZCOPY_URL)
                 .withFilePath('azcopy')
 
         def poolStartTask = new StartTask()

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -45,6 +45,7 @@ class AzBatchOpts implements CloudTransferOptions {
     Boolean allowPoolCreation
     Boolean deleteJobsOnCompletion
     Boolean deletePoolsOnCompletion
+    Boolean installAzCopy
 
     Map<String,AzPoolOpts> pools
 
@@ -58,6 +59,7 @@ class AzBatchOpts implements CloudTransferOptions {
         allowPoolCreation = config.allowPoolCreation
         deleteJobsOnCompletion = config.deleteJobsOnCompletion
         deletePoolsOnCompletion = config.deletePoolsOnCompletion
+        installAzCopy = config.installAzCopy
         pools = parsePools(config.pools instanceof Map ? config.pools as Map<String,Map> : Collections.<String,Map>emptyMap())
         maxParallelTransfers = config.maxParallelTransfers ? config.maxParallelTransfers as int : MAX_TRANSFER
         maxTransferAttempts = config.maxTransferAttempts ? config.maxTransferAttempts as int : MAX_TRANSFER_ATTEMPTS


### PR DESCRIPTION
- Download as a job resource `azcopy` for user provider Azure Batch pools.
- Add the boolean property `azure.batch.installAzCopy` to enable/disable this behaviour
- By default `azcopy` is only downloaded when the pool is not created by nextflow.   