### PR TITLE
Clarify how template files can be tested independently from the pipeline

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -216,7 +216,7 @@ Template
 --------
 
 Process script can be externalised by using *template* files which can be reused across different processes and tested
-independently by the overall pipeline execution.
+independently from the overall pipeline execution.
 
 A template is simply a shell script file that Nextflow is able to execute by using the ``template`` function
 as shown below::


### PR DESCRIPTION
This is a super minor change but may prevent some confusion about one of the benefits of using template files—being able to test them independently from the nextflow pipeline.

In this case, using the ablative preposition *from* indicates how the template files may be tested apart from the pipeline.

Signed-off-by: Brandon Cazander <bcazander@canexiahealth.com>