### PR TITLE
Patch getBaseName for nested  repos

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -491,7 +491,7 @@ class AssetManager {
 
     String getBaseName() {
         def result = project.tokenize('/')
-        return result.size() == 1 ? result[0] : result[-1]
+        return result[-1]
     }
 
     boolean isLocal() {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -491,8 +491,7 @@ class AssetManager {
 
     String getBaseName() {
         def result = project.tokenize('/')
-        if( result.size() > 2 ) throw new IllegalArgumentException("Not a valid project name: $project")
-        return result.size()==1 ? result[0] : result[1]
+        return result.size() == 1 ? result[0] : result[-1]
     }
 
     boolean isLocal() {


### PR DESCRIPTION
This PR patches the `getBaseName` method to accomodate arbitrarily nested repo names. 

For e.g. `https://gitlab.com/org/project/folder/folder/folder/repo`