### PR TITLE
Sleep with decimal numbers not supported

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
@@ -52,7 +52,7 @@ class BashFunLib {
                 pid=("\${copy[@]}")
                 
                 if ((\${#pid[@]}>=\$max)); then
-                  sleep 0.2
+                  sleep 0.2 2>/dev/null || sleep 1
                 else
                   eval "\${cmd[\$i]}" &
                   pid+=(\$!)

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
@@ -170,7 +170,7 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                             pid=("${copy[@]}")
                     
                             if ((${#pid[@]}>=$max)); then
-                              sleep 0.2
+                              sleep 0.2 2>/dev/null || sleep 1
                             else
                               eval "${cmd[$i]}" &
                               pid+=($!)
@@ -257,7 +257,7 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                         pid=("${copy[@]}")
                 
                         if ((${#pid[@]}>=$max)); then
-                          sleep 0.2
+                          sleep 0.2 2>/dev/null || sleep 1
                         else
                           eval "${cmd[$i]}" &
                           pid+=($!)

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -101,7 +101,7 @@ class AwsBatchScriptLauncherTest extends Specification {
                         pid=("${copy[@]}")
                 
                         if ((${#pid[@]}>=$max)); then
-                          sleep 0.2
+                          sleep 0.2 2>/dev/null || sleep 1
                         else
                           eval "${cmd[$i]}" &
                           pid+=($!)
@@ -276,7 +276,7 @@ class AwsBatchScriptLauncherTest extends Specification {
                             pid=("${copy[@]}")
                     
                             if ((${#pid[@]}>=$max)); then
-                              sleep 0.2
+                              sleep 0.2 2>/dev/null || sleep 1
                             else
                               eval "${cmd[$i]}" &
                               pid+=($!)
@@ -417,7 +417,7 @@ class AwsBatchScriptLauncherTest extends Specification {
                             pid=("${copy[@]}")
                     
                             if ((${#pid[@]}>=$max)); then
-                              sleep 0.2
+                              sleep 0.2 2>/dev/null || sleep 1
                             else
                               eval "${cmd[$i]}" &
                               pid+=($!)

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/S3HelperTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/S3HelperTest.groovy
@@ -79,7 +79,7 @@ class S3HelperTest extends Specification {
                             pid=("${copy[@]}")
                     
                             if ((${#pid[@]}>=$max)); then
-                              sleep 0.2
+                              sleep 0.2 2>/dev/null || sleep 1
                             else
                               eval "${cmd[$i]}" &
                               pid+=($!)
@@ -174,7 +174,7 @@ class S3HelperTest extends Specification {
                             pid=("${copy[@]}")
                     
                             if ((${#pid[@]}>=$max)); then
-                              sleep 0.2
+                              sleep 0.2 2>/dev/null || sleep 1
                             else
                               eval "${cmd[$i]}" &
                               pid+=($!)

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderS3Test.groovy
@@ -104,7 +104,7 @@ class BashWrapperBuilderS3Test extends Specification {
                     pid=("${copy[@]}")
             
                     if ((${#pid[@]}>=$max)); then
-                      sleep 0.2
+                      sleep 0.2 2>/dev/null || sleep 1
                     else
                       eval "${cmd[$i]}" &
                       pid+=($!)

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -137,7 +137,7 @@ class AzFileCopyStrategyTest extends Specification {
                         pid=("${copy[@]}")
                 
                         if ((${#pid[@]}>=$max)); then
-                          sleep 0.2
+                          sleep 0.2 2>/dev/null || sleep 1
                         else
                           eval "${cmd[$i]}" &
                           pid+=($!)
@@ -262,7 +262,7 @@ class AzFileCopyStrategyTest extends Specification {
                         pid=("${copy[@]}")
                 
                         if ((${#pid[@]}>=$max)); then
-                          sleep 0.2
+                          sleep 0.2 2>/dev/null || sleep 1
                         else
                           eval "${cmd[$i]}" &
                           pid+=($!)
@@ -411,7 +411,7 @@ class AzFileCopyStrategyTest extends Specification {
                             pid=("${copy[@]}")
 
                             if ((${#pid[@]}>=$max)); then
-                              sleep 0.2
+                              sleep 0.2 2>/dev/null || sleep 1
                             else
                               eval "${cmd[$i]}" &
                               pid+=($!)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -46,7 +46,7 @@ nxf_parallel() {
         pid=("${copy[@]}")
 
         if ((${#pid[@]}>=$max)); then
-          sleep 0.2
+          sleep 0.2 2>/dev/null || sleep 1
         else
           eval "${cmd[$i]}" &
           pid+=($!)


### PR DESCRIPTION
With some non-GNU versions of sleep (like in busybox), sleep does not accept decimal numbers. Here I worked around by sleeping for 1 sec when the first sleep fails. 

These changes have been tested on Azure Batch, locally on MacOS and Ubuntu, and on a SGE cluster.