### PR TITLE
Encode path parameter at GitLab getContentUrl

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -85,7 +85,8 @@ class GitlabRepositoryProvider extends RepositoryProvider {
         //  https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
         //
         final ref = revision ?: getDefaultBranch()
-        return "${config.endpoint}/api/v4/projects/${getProjectName()}/repository/files/${path}?ref=${ref}"
+        final encodedPath = URLEncoder.encode(path,'utf-8')
+        return "${config.endpoint}/api/v4/projects/${getProjectName()}/repository/files/${encodedPath}?ref=${ref}"
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
@@ -113,5 +113,9 @@ class GitlabRepositoryProviderTest extends Specification {
                 .setRevision('the-commit-id')
                 .getContentUrl('main.nf') == 'https://gitlab.com/api/v4/projects/pditommaso%2Fhello/repository/files/main.nf?ref=the-commit-id'
 
+        and:
+        new GitlabRepositoryProvider('pditommaso/hello', obj)
+                .getContentUrl('conf/extra.conf') == 'https://gitlab.com/api/v4/projects/pditommaso%2Fhello/repository/files/conf%2Fextra.conf?ref=master'
+
     }
 }


### PR DESCRIPTION
# Description
Current Gitlab provider implementation fails to retrieve content of files that are not at the root of the repository. This is due to that the `path` parameter at the API URL must be encoded to escape URL characters like a slash.