### PR TITLE
Google Lifesciences API slow file staging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Tests
       run: make test
       env:
-        GRADLE_OPTS: '-Dorg.gradle.daemon=false --stacktrace'
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         NXF_BITBUCKET_ACCESS_TOKEN: ${{ secrets.NXF_BITBUCKET_ACCESS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Tests
       run: make test
       env:
-        GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+        GRADLE_OPTS: '-Dorg.gradle.daemon=false --stacktrace'
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         NXF_BITBUCKET_ACCESS_TOKEN: ${{ secrets.NXF_BITBUCKET_ACCESS_TOKEN }}

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
@@ -40,7 +40,7 @@ import nextflow.util.MemoryUnit
 @CompileStatic
 class GoogleLifeSciencesConfig implements CloudTransferOptions {
 
-    public final static String DEFAULT_COPY_IMAGE = 'google/cloud-sdk:alpine'
+    public final static String DEFAULT_COPY_IMAGE = 'google/cloud-sdk:slim'
 
     public final static String DEFAULT_SSH_IMAGE = 'gcr.io/cloud-genomics-pipelines/tools'
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
@@ -46,6 +46,10 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
 
     public final static String DEFAULT_ENTRY_POINT = '/bin/bash'
 
+    public final static Integer DEFAULT_PARALLEL_THREAD_COUNT = 5
+
+    public final static Integer DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS = 4
+
     String project
     List<String> zones
     List<String> regions
@@ -63,6 +67,8 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
     boolean enableRequesterPaysBuckets
     String network
     String subnetwork
+    Integer parallelThreadCount
+    Integer slicedObjectDownloadMaxComponents
 
     int maxParallelTransfers = MAX_TRANSFER
     int maxTransferAttempts = MAX_TRANSFER_ATTEMPTS
@@ -131,6 +137,9 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
         final delayBetweenAttempts = config.navigate('aws.batch.delayBetweenAttempts', DEFAULT_DELAY_BETWEEN_ATTEMPTS) as Duration
         final network = config.navigate('google.lifeSciences.network') as String
         final subnetwork = config.navigate('google.lifeSciences.subnetwork') as String
+        //
+        final parallelThreadCount = config.navigate('google.lifeSciences.parallelThreadCount', DEFAULT_PARALLEL_THREAD_COUNT) as int
+        final slicedObjectDownloadMaxComponents = config.navigate('google.lifeSciences.slicedObjectDownloadMaxComponents', DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS) as int
 
         def zones = (config.navigate("google.zone") as String)?.split(",")?.toList() ?: Collections.<String>emptyList()
         def regions = (config.navigate("google.region") as String)?.split(",")?.toList() ?: Collections.<String>emptyList()

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesConfig.groovy
@@ -138,8 +138,8 @@ class GoogleLifeSciencesConfig implements CloudTransferOptions {
         final network = config.navigate('google.lifeSciences.network') as String
         final subnetwork = config.navigate('google.lifeSciences.subnetwork') as String
         //
-        final parallelThreadCount = config.navigate('google.lifeSciences.parallelThreadCount', DEFAULT_PARALLEL_THREAD_COUNT) as int
-        final slicedObjectDownloadMaxComponents = config.navigate('google.lifeSciences.slicedObjectDownloadMaxComponents', DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS) as int
+        final parallelThreadCount = config.navigate('google.lifeSciences.parallelThreadCount', DEFAULT_PARALLEL_THREAD_COUNT) as Integer
+        final slicedObjectDownloadMaxComponents = config.navigate('google.lifeSciences.slicedObjectDownloadMaxComponents', DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS) as Integer
 
         def zones = (config.navigate("google.zone") as String)?.split(",")?.toList() ?: Collections.<String>emptyList()
         def regions = (config.navigate("google.region") as String)?.split(",")?.toList() ?: Collections.<String>emptyList()

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesFileCopyStrategy.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesFileCopyStrategy.groovy
@@ -55,9 +55,8 @@ class GoogleLifeSciencesFileCopyStrategy extends SimpleFileCopyStrategy {
         def attempts = config.maxTransferAttempts ?: CloudTransferOptions.MAX_TRANSFER_ATTEMPTS
         def delayBetweenAttempts = config.delayBetweenAttempts ?: CloudTransferOptions.DEFAULT_DELAY_BETWEEN_ATTEMPTS
 
-        def threads = config.parallelThreadCount ?: GoogleLifeSciencesConfig.DEFAULT_PARALLEL_THREAD_COUNT
-        def slices = config.slicedObjectDownloadMaxComponents ?: GoogleLifeSciencesConfig.DEFAULT_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS
-
+        def threads = config.parallelThreadCount ?: 5
+        def slices = config.slicedObjectDownloadMaxComponents ?: 4
         def gsutil_opts = "local opts=('-q' '-m' '-o' 'GSUtil:parallel_thread_count=$threads' '-o' 'GSUtil:sliced_object_download_max_components=$slices')"
 
         BashFunLib.body(maxConnect, attempts, delayBetweenAttempts) +

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesFileCopyStrategy.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesFileCopyStrategy.groovy
@@ -57,42 +57,42 @@ class GoogleLifeSciencesFileCopyStrategy extends SimpleFileCopyStrategy {
 
         def threads = config.parallelThreadCount ?: 5
         def slices = config.slicedObjectDownloadMaxComponents ?: 4
-        def gsutil_opts = "local opts=('-q' '-m' '-o' 'GSUtil:parallel_thread_count=$threads' '-o' 'GSUtil:sliced_object_download_max_components=$slices')"
+        def gsutil_opts = "('-q' '-m' '-o' 'GSUtil:parallel_thread_count=$threads' '-o' 'GSUtil:sliced_object_download_max_components=$slices')"
 
         BashFunLib.body(maxConnect, attempts, delayBetweenAttempts) +
-        '''
+        """
         # google storage helper
         nxf_gs_download() {
-            local source=$1
-            local target=$2
-            local project=$3
-            local basedir=$(dirname $2)
+            local source=\$1
+            local target=\$2
+            local project=\$3
+            local basedir=\$(dirname \$2)
             local ret
-        '''  + gsutil_opts +
-        '''    
-            if [[ $project ]]; then
-              opts+=('-u' "$project")
+            local opts=$gsutil_opts
+
+            if [[ \$project ]]; then
+              opts+=('-u' "\$project")
             fi
              
             ## download assuming it's a file download
-            mkdir -p $basedir
-            ret=$(gsutil ${opts[@]} cp "$source" "$target" 2>&1) || {
+            mkdir -p \$basedir
+            ret=\$(gsutil \${opts[@]} cp "\$source" "\$target" 2>&1) || {
                 ## if fails check if it was trying to download a directory
-                mkdir $target
-                gsutil ${opts[@]} cp -R "$source/*" "$target" || {
-                  rm -rf $target
-                  >&2 echo "Unable to download path: $source"
+                mkdir \$target
+                gsutil \${opts[@]} cp -R "\$source/*" "\$target" || {
+                  rm -rf \$target
+                  >&2 echo "Unable to download path: \$source"
                   exit 1
                 }
             }
         }
 
         nxf_gs_upload() {
-            local name=$1
-            local target=$2
-            gsutil -m -q cp -R "$name" "$target/$name"
+            local name=\$1
+            local target=\$2
+            gsutil -m -q cp -R "\$name" "\$target/\$name"
         }
-        '''.stripIndent()
+        """.stripIndent()
     }
 
     @Override


### PR DESCRIPTION
Improved the speed of google lifescience file staging by allowing two key gsutil parameters to be set using the nextflow config file.  Currently the nextflow defaults are set to the same defaults used by gsutil so no change in performance should be seen.  The only default that I changed was google-sdk:alpine to google-sdk:slim because alpine does not support multiprocessing

More discussion of the issue and benchmarking I did of gsutil on the nextflow forum:
https://groups.google.com/g/nextflow/c/0L7HlD7mmL0
