### PR TITLE
Add support for using mamba with conda

### DIFF
--- a/docs/conda.rst
+++ b/docs/conda.rst
@@ -43,6 +43,13 @@ accessible from all computing nodes.
 .. warning:: The Conda environment feature is not supported by executors which use
   a remote object storage as a work directory eg. AWS Batch.
 
+Use Mamba to resolve packages
+=======================
+
+It is also possible to use `mamba <https://github.com/mamba-org/mamba>`_ for speeding up creation of conda environments. For more information on how to enable this feature please refer :ref:`Conda <config-conda>`.
+
+.. warning:: The use of ``mamba`` to create conda environments is an experimental feature and the functionality may change in future releases.
+
 
 Use Conda package names
 =======================
@@ -155,6 +162,5 @@ The above configuration snippet allows the execution either with Conda or Docker
 Advanced settings
 -----------------
 
-Conda advanced configuration settings are described in the :ref:`Conda <config-conda>` section on the Nextflow
-configuration page.
 
+Conda advanced configuration settings are described in the :ref:`Conda <config-conda>` section on the Nextflow configuration page.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -644,6 +644,7 @@ Name                Description
 cacheDir            Defines the path where Conda environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all computing nodes.
 createOptions       Defines any extra command line options supported by the ``conda create`` command. For details see: https://docs.conda.io/projects/conda/en/latest/commands/create.html.
 createTimeout       Defines the amount of time the Conda environment creation can last. The creation process is terminated when the timeout is exceeded (default: ``20 min``).
+useMamba            Uses the ``mamba`` binary instead of ``conda`` to create the conda environments. For details see: https://github.com/mamba-org/mamba.
 ================== ================
 
 

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -305,20 +305,22 @@ class CondaCache {
      */
     @PackageScope
     DataflowVariable<Path> getLazyImagePath(String condaEnv) {
+
+        final binaryName = useMamba ? "mamba" : "conda"
+
         if( condaEnv in condaPrefixPaths ) {
-            log.trace "Conda found local environment `$condaEnv`"
+            log.trace "${binaryName.capitalize()} found local environment `$condaEnv`"
             return condaPrefixPaths[condaEnv]
         }
 
         synchronized (condaPrefixPaths) {
             def result = condaPrefixPaths[condaEnv]
             if( result == null ) {
-                final binaryName = useMamba ? "mamba" : "conda"
                 result = new LazyDataflowVariable<Path>({ createLocalCondaEnv(condaEnv, binaryName) })
                 condaPrefixPaths[condaEnv] = result
             }
             else {
-                log.trace "Conda found local cache for environment `$condaEnv` (2)"
+                log.trace "${binaryName.capitalize()} found local cache for environment `$condaEnv` (2)"
             }
             return result
         }

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -72,8 +72,6 @@ class CondaCache {
 
     @PackageScope Path getConfigCacheDir0() { configCacheDir0 }
 
-    Boolean isUsingMamba() { useMamba }
-
     /** Only for debugging purpose - do not use */
     @PackageScope
     CondaCache() {}
@@ -315,7 +313,7 @@ class CondaCache {
         synchronized (condaPrefixPaths) {
             def result = condaPrefixPaths[condaEnv]
             if( result == null ) {
-                final binaryName = isUsingMamba() ? "mamba" : "conda"
+                final binaryName = useMamba ? "mamba" : "conda"
                 result = new LazyDataflowVariable<Path>({ createLocalCondaEnv(condaEnv, binaryName) })
                 condaPrefixPaths[condaEnv] = result
             }

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -60,7 +60,7 @@ class CondaCache {
 
     private String createOptions
 
-    private Boolean useMamba = false
+    private boolean useMamba 
 
     private Path configCacheDir0
 
@@ -72,7 +72,7 @@ class CondaCache {
 
     @PackageScope Path getConfigCacheDir0() { configCacheDir0 }
 
-    @PackageScope String binaryName() {
+    @PackageScope String getBinaryName() {
         useMamba ? "mamba" : "conda"
     }
 
@@ -98,7 +98,7 @@ class CondaCache {
             configCacheDir0 = (config.cacheDir as Path).toAbsolutePath()
 
         if( config.useMamba )
-            useMamba = config.useMamba as Boolean
+            useMamba = config.useMamba as boolean
 
     }
 
@@ -222,7 +222,7 @@ class CondaCache {
     Path createLocalCondaEnv(String condaEnv) {
         final prefixPath = condaPrefixPath(condaEnv)
         if( prefixPath.isDirectory() ) {
-            log.debug "The binary '${binaryName()}' found local env for environment=$condaEnv; path=$prefixPath"
+            log.debug "The binary '${binaryName}' found local env for environment=$condaEnv; path=$prefixPath"
             return prefixPath
         }
 
@@ -249,25 +249,25 @@ class CondaCache {
     @PackageScope
     Path createLocalCondaEnv0(String condaEnv, Path prefixPath) {
 
-        log.info "Creating env using ${binaryName()}: $condaEnv [cache $prefixPath]"
+        log.info "Creating env using ${binaryName}: $condaEnv [cache $prefixPath]"
 
         final opts = createOptions ? "$createOptions " : ''
         def cmd
         if( isYamlFilePath(condaEnv) ) {
-            cmd = "${binaryName()} env create --prefix ${Escape.path(prefixPath)} --file ${Escape.path(makeAbsolute(condaEnv))}"
+            cmd = "${binaryName} env create --prefix ${Escape.path(prefixPath)} --file ${Escape.path(makeAbsolute(condaEnv))}"
         }
         else if( isTextFilePath(condaEnv) ) {
 
-            cmd = "${binaryName()} create $opts--mkdir --yes --quiet --prefix ${Escape.path(prefixPath)} --file ${Escape.path(makeAbsolute(condaEnv))}"
+            cmd = "${binaryName} create $opts--mkdir --yes --quiet --prefix ${Escape.path(prefixPath)} --file ${Escape.path(makeAbsolute(condaEnv))}"
         }
 
         else {
-            cmd = "${binaryName()} create $opts--mkdir --yes --quiet --prefix ${Escape.path(prefixPath)} $condaEnv"
+            cmd = "${binaryName} create $opts--mkdir --yes --quiet --prefix ${Escape.path(prefixPath)} $condaEnv"
         }
 
         try {
             runCommand( cmd )
-            log.debug "'${binaryName()}' create complete env=$condaEnv path=$prefixPath"
+            log.debug "'${binaryName}' create complete env=$condaEnv path=$prefixPath"
         }
         catch( Exception e ){
             // clean-up to avoid to keep eventually corrupted image file
@@ -315,7 +315,7 @@ class CondaCache {
     DataflowVariable<Path> getLazyImagePath(String condaEnv) {
 
         if( condaEnv in condaPrefixPaths ) {
-            log.trace "The binary '${binaryName()}' found local environment `$condaEnv`"
+            log.trace "The binary '${binaryName}' found local environment `$condaEnv`"
             return condaPrefixPaths[condaEnv]
         }
 
@@ -326,7 +326,7 @@ class CondaCache {
                 condaPrefixPaths[condaEnv] = result
             }
             else {
-                log.trace "The binary '${binaryName()}' found local cache for environment `$condaEnv` (2)"
+                log.trace "The binary '${binaryName}' found local cache for environment `$condaEnv` (2)"
             }
             return result
         }

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -222,7 +222,7 @@ class CondaCache {
     Path createLocalCondaEnv(String condaEnv) {
         final prefixPath = condaPrefixPath(condaEnv)
         if( prefixPath.isDirectory() ) {
-            log.debug "The binary '${binaryName}' found local env for environment=$condaEnv; path=$prefixPath"
+            log.debug "${binaryName} found local env for environment=$condaEnv; path=$prefixPath"
             return prefixPath
         }
 
@@ -315,7 +315,7 @@ class CondaCache {
     DataflowVariable<Path> getLazyImagePath(String condaEnv) {
 
         if( condaEnv in condaPrefixPaths ) {
-            log.trace "The binary '${binaryName}' found local environment `$condaEnv`"
+            log.trace "${binaryName} found local environment `$condaEnv`"
             return condaPrefixPaths[condaEnv]
         }
 
@@ -326,7 +326,7 @@ class CondaCache {
                 condaPrefixPaths[condaEnv] = result
             }
             else {
-                log.trace "The binary '${binaryName}' found local cache for environment `$condaEnv` (2)"
+                log.trace "${binaryName} found local cache for environment `$condaEnv` (2)"
             }
             return result
         }

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -60,9 +60,13 @@ class CondaCache {
 
     private String createOptions
 
+    private Boolean useMamba
+
     private Path configCacheDir0
 
     @PackageScope String getCreateOptions() { createOptions }
+
+    @PackageScope Boolean getUseMamba() { useMamba }
 
     @PackageScope Duration getCreateTimeout() { createTimeout }
 
@@ -90,6 +94,10 @@ class CondaCache {
 
         if( config.cacheDir )
             configCacheDir0 = (config.cacheDir as Path).toAbsolutePath()
+
+        if( config.useMamba )
+            useMamba = config.useMamba as Boolean
+
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -218,12 +218,12 @@ class CondaCache {
     Path createLocalCondaEnv(String condaEnv, String binaryName = "conda") {
         final prefixPath = condaPrefixPath(condaEnv)
         if( prefixPath.isDirectory() ) {
-            log.debug "${binaryName.capitalize()} found local env for environment=$condaEnv; path=$prefixPath"
+            log.debug "The binary '${binaryName}' found local env for environment=$condaEnv; path=$prefixPath"
             return prefixPath
         }
 
         final file = new File("${prefixPath.parent}/.${prefixPath.name}.lock")
-        final wait = "Another Nextflow instance is creating the ${binaryName.capitalize()} environment $condaEnv -- please wait till it completes"
+        final wait = "Another Nextflow instance is creating the conda environment $condaEnv -- please wait till it completes"
         final err =  "Unable to acquire exclusive lock after $createTimeout on file: $file"
 
         final mutex = new FileMutex(target: file, timeout: createTimeout, waitMessage: wait, errorMessage: err)
@@ -245,15 +245,19 @@ class CondaCache {
     @PackageScope
     Path createLocalCondaEnv0(String condaEnv, Path prefixPath, String binaryName = "conda") {
 
-        log.info "Creating ${binaryName.capitalize()} env: $condaEnv [cache $prefixPath]"
+        log.info "Creating env using ${binaryName}: $condaEnv [cache $prefixPath]"
 
         final opts = createOptions ? "$createOptions " : ''
         def cmd
         if( isYamlFilePath(condaEnv) ) {
             cmd = "${binaryName} env create --prefix ${Escape.path(prefixPath)} --file ${Escape.path(makeAbsolute(condaEnv))}"
-        } else if( isTextFilePath(condaEnv) ) {
+        }
+        else if( isTextFilePath(condaEnv) ) {
+
             cmd = "${binaryName} create $opts--mkdir --yes --quiet --prefix ${Escape.path(prefixPath)} --file ${Escape.path(makeAbsolute(condaEnv))}"
-        } else {
+        }
+
+        else {
             cmd = "${binaryName} create $opts--mkdir --yes --quiet --prefix ${Escape.path(prefixPath)} $condaEnv"
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -66,7 +66,7 @@ class CondaCache {
 
     @PackageScope String getCreateOptions() { createOptions }
 
-    @PackageScope Boolean getUseMamba() { useMamba }
+    @PackageScope Boolean isUsingMamba() { useMamba }
 
     @PackageScope Duration getCreateTimeout() { createTimeout }
 

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -279,7 +279,7 @@ class CondaCache {
 
     @PackageScope
     int runCommand( String cmd ) {
-        log.trace """Conda create
+        log.trace """${binaryName} create
                      command: $cmd
                      timeout: $createTimeout""".stripIndent()
 

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -72,6 +72,8 @@ class CondaCache {
 
     @PackageScope Path getConfigCacheDir0() { configCacheDir0 }
 
+    Boolean isUsingMamba() { useMamba }
+
     /** Only for debugging purpose - do not use */
     @PackageScope
     CondaCache() {}
@@ -313,7 +315,8 @@ class CondaCache {
         synchronized (condaPrefixPaths) {
             def result = condaPrefixPaths[condaEnv]
             if( result == null ) {
-                result = new LazyDataflowVariable<Path>({ createLocalCondaEnv(condaEnv) })
+                final binaryName = isUsingMamba() ? "mamba" : "conda"
+                result = new LazyDataflowVariable<Path>({ createLocalCondaEnv(condaEnv, binaryName) })
                 condaPrefixPaths[condaEnv] = result
             }
             else {

--- a/modules/nextflow/src/main/groovy/nextflow/util/CustomThreadPool.java
+++ b/modules/nextflow/src/main/groovy/nextflow/util/CustomThreadPool.java
@@ -76,7 +76,7 @@ public class CustomThreadPool extends DefaultPool {
     }
 
     static Pool defaultPool(int poolSize, int maxThreads) {
-        log.debug(String.format("Creating default thread pool > poolSzie: %s; maxThreads: %s", poolSize, maxThreads));
+        log.debug(String.format("Creating default thread pool > poolSize: %s; maxThreads: %s", poolSize, maxThreads));
 
         return new CustomThreadPool(
                 new ThreadPoolExecutor(

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -300,7 +300,7 @@ def 'should create conda env with options - using mamba' () {
     def 'should get options from the config' () {
 
         when:
-        def cache = new CondaCache()
+        def cache = new CondaCache(new CondaConfig())
         then:
         cache.createTimeout.minutes == 20
         cache.createOptions == null

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -199,7 +199,7 @@ class CondaCacheTest extends Specification {
 
     }
 
-    def 'should create a conda environment using mamba' () {
+    def 'should create a conda environment - using mamba' () {
 
         given:
         def ENV = 'bwa=1.1.1'
@@ -226,8 +226,6 @@ class CondaCacheTest extends Specification {
 
     }
 
-
-
     def 'should create conda env with options' () {
         given:
         def ENV = 'bwa=1.1.1'
@@ -245,7 +243,7 @@ class CondaCacheTest extends Specification {
         result == PREFIX
     }
 
-    def 'should create mamba env with options' () {
+def 'should create conda env with options - using mamba' () {
         given:
         def ENV = 'bwa=1.1.1'
         def PREFIX = Paths.get('/foo/bar')
@@ -253,16 +251,14 @@ class CondaCacheTest extends Specification {
 
         when:
         cache.createOptions = '--this --that'
-        def result = cache.createLocalCondaEnv0(ENV, PREFIX, "mamba")
+        def result = cache.createLocalCondaEnv0(ENV,PREFIX, "mamba")
         then:
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isTextFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("mamba create --this --that --mkdir --yes --quiet --prefix $PREFIX $ENV") >> null
+        1 * cache.runCommand( "mamba create --this --that --mkdir --yes --quiet --prefix $PREFIX $ENV" ) >> null
         result == PREFIX
     }
-
-
 
     def 'should create a conda env with a yaml file' () {
 

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -31,7 +31,7 @@ class CondaCacheTest extends Specification {
 
         given:
         def cache = new CondaCache()
-        
+
         expect:
         !cache.isYamlFilePath('foo=1.0')
         cache.isYamlFilePath('env.yml')
@@ -196,7 +196,7 @@ class CondaCacheTest extends Specification {
         0 * cache.makeAbsolute(_)
         1 * cache.runCommand( "conda create --mkdir --yes --quiet --prefix $PREFIX $ENV" ) >> null
         result == PREFIX
-        
+
     }
 
     def 'should create conda env with options' () {
@@ -262,13 +262,14 @@ class CondaCacheTest extends Specification {
         cache.createTimeout.minutes == 20
         cache.createOptions == null
         cache.configCacheDir0 == null
-        
+        cache.useMamba == null
         when:
-        cache = new CondaCache(new CondaConfig(createTimeout: '5 min', createOptions: '--foo --bar', cacheDir: '/conda/cache'))
+        cache = new CondaCache(new CondaConfig(createTimeout: '5 min', createOptions: '--foo --bar', cacheDir: '/conda/cache', useMamba: true))
         then:
         cache.createTimeout.minutes == 5
         cache.createOptions == '--foo --bar'
         cache.configCacheDir0 == Paths.get('/conda/cache')
+        cache.useMamba == true
     }
 
     def 'should define cache dir from config' () {

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -309,7 +309,7 @@ def 'should create conda env with options - using mamba' () {
         cache.createOptions == null
         cache.configCacheDir0 == null
         cache.useMamba == false
-        cache.binaryName() == "conda"
+        cache.binaryName == "conda"
         when:
         cache = new CondaCache(new CondaConfig(createTimeout: '5 min', createOptions: '--foo --bar', cacheDir: '/conda/cache', useMamba: true))
         then:
@@ -317,7 +317,7 @@ def 'should create conda env with options - using mamba' () {
         cache.createOptions == '--foo --bar'
         cache.configCacheDir0 == Paths.get('/conda/cache')
         cache.useMamba == true
-        cache.binaryName() == "mamba"
+        cache.binaryName == "mamba"
     }
 
     def 'should define cache dir from config' () {


### PR DESCRIPTION
Initiating the work for `mamba` support in conda.


Planned features are 

~A `mamba` directive with `micromamba` option to users to use `micromamba` which doesn't rely on a base environment - see [here](https://github.com/mamba-org/mamba/blob/master/docs/source/micromamba.md#Installation)~

We have decided to implement this as a config setting for `conda` scope.

```nextflow
conda {
   useMamba = true
}
```