### PR TITLE
Fix: Not all or the wrong files are unstaged from the temporary directory to the work directory

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -263,16 +263,18 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
     protected String stageOutCommand( List<String> source, String target, String mode ) {
         assert mode
 
-        def cmd
+        String cmd
         if( mode == 'copy' )
-            cmd = "cp -fRL --parents \"\$name\" ${Escape.path(target)}"
+            cmd = 'cp -fRL'
         else if( mode == 'move' )
-            cmd = "sh -c 'mkdir -p \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\";' _ \"\$name\""
+            cmd = 'mv'
         else if( mode == 'rsync' )
             //This will not work for glob terms
             return "rsync -rRl ${normalizeGlobStarPaths( source ).collect{ Escape.path( it ) }.join(' ')} ${Escape.path(target)} || true"
         else
             throw new IllegalArgumentException("Unknown stage-out strategy: $mode")
+
+        cmd = "sh -c 'mkdir -p \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\"; $cmd \"\$1\" \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\";' _ \"\$name\""
 
         final List<String> escape = source
                 .collect {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -277,7 +277,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
         final List<String> escape = source
                 .collect {
                     String escaped = Escape.path( it, true )
-                    //Bash glob behaves different than Javan Glob, if the path starts with **
+                    //Bash glob behaves different than Java's Glob, if the path starts with **
                     //https://unix.stackexchange.com/questions/49913/recursive-glob
                     if( escaped.startsWith("**") && escaped.size() > 2 ) {
                         escaped = "**/*" + escaped.substring(2)

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -270,7 +270,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
             cmd = "sh -c 'mkdir -p \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\";' _ \"\$name\""
         else if( mode == 'rsync' )
             //This will not work for glob terms
-            return "rsync -rRl ${source.collect{ Escape.path(it) }.join(' ')} ${Escape.path(target)} || true"
+            return "rsync -rRl ${normalizeGlobStarPaths( source ).collect{ Escape.path( it ) }.join(' ')} ${Escape.path(target)} || true"
         else
             throw new IllegalArgumentException("Unknown stage-out strategy: $mode")
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -291,7 +291,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
         String searchCmd = escape.size() == 1 ? "ls -1d ${escape.get(0)}" : "ls -1d ${escape.join(' ')} | sort | uniq"
 
         return """\
-            shopt -s globstar extglob
+            shopt -s globstar extglob || true
             IFS=\$'\\n'
             pathes=`$searchCmd`
             set -f
@@ -299,7 +299,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
                 $cmd || true
             done
             set +f
-            shopt -u globstar extglob
+            shopt -u globstar extglob || true
             unset IFS""".stripIndent(true)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -274,7 +274,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
         else
             throw new IllegalArgumentException("Unknown stage-out strategy: $mode")
 
-        cmd = "sh -c 'mkdir -p \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\"; $cmd \"\$1\" \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\";' _ \"\$name\""
+        cmd = "sh -c 'mkdir -p \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\"; $cmd \"\$1\" \"${Escape.path(target)}/\$1\";' _ \"\$name\""
 
         final List<String> escape = source
                 .collect {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -287,16 +287,15 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
                     return escaped
                 }
 
-
-        String searchCmd = escape.size() == 1 ? "ls -1d ${escape.get(0)}" : "ls -1d ${escape.join(' ')} | sort | uniq"
-
         return """\
             shopt -s globstar extglob || true
             IFS=\$'\\n'
-            pathes=`$searchCmd`
+            pathes=`ls -1d ${escape.join(' ')} | sort | uniq`
             set -f
             for name in \$pathes; do
-                $cmd || true
+                if [[ ! -e "${Escape.path(target)}/\$name" ]]; then
+                    $cmd || true
+                fi
             done
             set +f
             shopt -u globstar extglob || true

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -265,7 +265,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
 
         def cmd
         if( mode == 'copy' )
-            cmd = "cp -fRLn --parents \"\$name\" ${Escape.path(target)}"
+            cmd = "cp -fRL --parents \"\$name\" ${Escape.path(target)}"
         else if( mode == 'move' )
             cmd = "sh -c 'mkdir -p \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${Escape.path(target)}/`dirname \\\"\$1\\\"`\";' _ \"\$name\""
         else if( mode == 'rsync' )

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -429,9 +429,7 @@ class BashWrapperBuilderTest extends Specification {
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    if [[ ! -e "/another/dir/\$name" ]]; then
-                        sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv "\$1" "/another/dir/\$1";' _ "\$name" || true
-                    fi
+                    sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv -f "\$1" "/another/dir/\$1";' _ "\$name" || true
                 done
                 set +f
                 shopt -u globstar extglob || true

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -405,7 +405,7 @@ class BashWrapperBuilderTest extends Specification {
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    cp -fRLn --parents "\$name" /work/dir || true
+                    cp -fRL --parents "\$name" /work/dir || true
                 done
                 set +f
                 shopt -u globstar extglob

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -406,7 +406,7 @@ class BashWrapperBuilderTest extends Specification {
                 set -f
                 for name in \$pathes; do
                     if [[ ! -e "/work/dir/\$name" ]]; then
-                        sh -c 'mkdir -p "/work/dir/`dirname \\"\$1\\"`"; cp -fRL "\$1" "/work/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
+                        sh -c 'mkdir -p "/work/dir/`dirname \\"\$1\\"`"; cp -fRL "\$1" "/work/dir/\$1";' _ "\$name" || true
                     fi
                 done
                 set +f
@@ -430,7 +430,7 @@ class BashWrapperBuilderTest extends Specification {
                 set -f
                 for name in \$pathes; do
                     if [[ ! -e "/another/dir/\$name" ]]; then
-                        sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv "\$1" "/another/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
+                        sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv "\$1" "/another/dir/\$1";' _ "\$name" || true
                     fi
                 done
                 set +f

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -405,7 +405,9 @@ class BashWrapperBuilderTest extends Specification {
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    sh -c 'mkdir -p "/work/dir/`dirname \\"\$1\\"`"; cp -fRL "\$1" "/work/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
+                    if [[ ! -e "/work/dir/\$name" ]]; then
+                        sh -c 'mkdir -p "/work/dir/`dirname \\"\$1\\"`"; cp -fRL "\$1" "/work/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
+                    fi
                 done
                 set +f
                 shopt -u globstar extglob || true
@@ -427,7 +429,9 @@ class BashWrapperBuilderTest extends Specification {
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv "\$1" "/another/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
+                    if [[ ! -e "/another/dir/\$name" ]]; then
+                        sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv "\$1" "/another/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
+                    fi
                 done
                 set +f
                 shopt -u globstar extglob || true

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -405,7 +405,7 @@ class BashWrapperBuilderTest extends Specification {
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    cp -fRL --parents "\$name" /work/dir || true
+                    sh -c 'mkdir -p "/work/dir/`dirname \\"\$1\\"`"; cp -fRL "\$1" "/work/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
                 done
                 set +f
                 shopt -u globstar extglob

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -400,8 +400,8 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.unstage_outputs == '''\
                 mkdir -p /work/dir
-                cp -fRL test.bam /work/dir || true
-                cp -fRL test.bai /work/dir || true
+                find -L -regex "\\./test\\.bam" -exec cp -fRLn --parents "{}" /work/dir \\; || true
+                find -L -regex "\\./test\\.bai" -exec cp -fRLn --parents "{}" /work/dir \\; || true
                 '''.stripIndent().rightTrim()
 
 
@@ -415,8 +415,8 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.unstage_outputs == '''\
                 mkdir -p /another/dir
-                mv -f test.bam /another/dir || true
-                mv -f test.bai /another/dir || true
+                find -L -regex \"\\./test\\.bam\" -exec sh -c 'mkdir -p \"/another/dir/`dirname \\\"$1\\\"`\"; mv \"$1\" \"/another/dir/`dirname \\\"$1\\\"`\";' _ {} \\; || true
+                find -L -regex \"\\./test\\.bai\" -exec sh -c 'mkdir -p \"/another/dir/`dirname \\\"$1\\\"`\"; mv \"$1\" \"/another/dir/`dirname \\\"$1\\\"`\";' _ {} \\; || true
                 '''.stripIndent().rightTrim()
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -400,7 +400,7 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.unstage_outputs == '''\
                 mkdir -p /work/dir
-                shopt -s globstar extglob
+                shopt -s globstar extglob || true
                 IFS=\$'\\n'
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
@@ -408,7 +408,7 @@ class BashWrapperBuilderTest extends Specification {
                     sh -c 'mkdir -p "/work/dir/`dirname \\"\$1\\"`"; cp -fRL "\$1" "/work/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
                 done
                 set +f
-                shopt -u globstar extglob
+                shopt -u globstar extglob || true
                 unset IFS'''.stripIndent().rightTrim()
 
 
@@ -422,7 +422,7 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.unstage_outputs == '''\
                 mkdir -p /another/dir
-                shopt -s globstar extglob
+                shopt -s globstar extglob || true
                 IFS=\$'\\n'
                 pathes=`ls -1d test.bam test.bai | sort | uniq`
                 set -f
@@ -430,7 +430,7 @@ class BashWrapperBuilderTest extends Specification {
                     sh -c 'mkdir -p "/another/dir/`dirname \\"\$1\\"`"; mv "\$1" "/another/dir/`dirname \\"\$1\\"`";' _ "\$name" || true
                 done
                 set +f
-                shopt -u globstar extglob
+                shopt -u globstar extglob || true
                 unset IFS'''.stripIndent().rightTrim()
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -170,7 +170,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             pathes=`ls -1d ${source_escaped}`
             set -f
             for name in \$pathes; do
-                cp -fRLn --parents \"\$name\" ${target_escaped} || true
+                cp -fRL --parents \"\$name\" ${target_escaped} || true
             done
             set +f
             shopt -u globstar extglob
@@ -587,7 +587,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    cp -fRLn --parents \"\$name\" /target/work\\ dir || true
+                    cp -fRL --parents \"\$name\" /target/work\\ dir || true
                 done
                 set +f
                 shopt -u globstar extglob

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -160,6 +160,30 @@ class SimpleFileCopyStrategyTest extends Specification {
     }
 
     @Unroll
+    def 'glob to regex' () {
+        given:
+        SimpleFileCopyStrategy strategy = [:] as SimpleFileCopyStrategy
+        expect:
+        strategy.globToRegex( glob ) == regex
+
+        where:
+        glob               | regex
+        'abc'              | 'abc'
+        'abc*'             | 'abc[^/]*'
+        'abc**'            | 'abc.*'
+        'abc\\*'           | 'abc\\*'
+        'abc\\**'          | 'abc\\*[^/]*'
+        './[\\ab]'         | '\\./[\\ab]'
+        '{abcd,def}'       | '\\(abcd\\|def\\)'
+        '{abcd*,def}'      | '\\(abcd[^/]*\\|def\\)'
+        '{ab|cd,def}'      | '\\(ab|cd\\|def\\)'
+        '?.\\?.[?]\\[?\\]' | '.\\.\\?\\.[?]\\[.\\]'
+        '[abc]'            | '[abc]'
+        '[a-z,A-Z]'        | '[a-z,A-Z]'
+        '{a\\,b,c}/*.txt'  | '\\(a,b\\|c\\)/[^/]*\\.txt'
+    }
+
+    @Unroll
     def 'should return a valid stage-out command' () {
 
         given:
@@ -168,14 +192,21 @@ class SimpleFileCopyStrategyTest extends Specification {
         strategy.stageOutCommand(source, target, 'copy') == result
 
         where:
-        source              | target    | result
-        'file.txt'          | '/to/dir' | "cp -fRL file.txt /to/dir"
-        "file'3.txt"        | '/to dir' | "cp -fRL file\\'3.txt /to\\ dir"
-        'path_name'         | '/to/dir' | "cp -fRL path_name /to/dir"
-        'input/file.txt'    | '/to/dir' | "mkdir -p /to/dir/input && cp -fRL input/file.txt /to/dir/input"
-        'long/path/name'    | '/to/dir' | "mkdir -p /to/dir/long/path && cp -fRL long/path/name /to/dir/long/path"
-        'path_name/*'       | '/to/dir' | "mkdir -p /to/dir/path_name && cp -fRL path_name/* /to/dir/path_name"
-        'path_name/'        | '/to/dir' | "mkdir -p /to/dir/path_name && cp -fRL path_name/ /to/dir/path_name"
+        source                  | target    | result
+        'file.txt'              | '/to/dir' | "find -L -regex \"\\./file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        "file'3.txt"            | '/to dir' | "find -L -regex \"\\./file'3\\.txt\" -exec cp -fRLn --parents \"{}\" /to\\ dir \\;"
+        'path_name'             | '/to/dir' | "find -L -regex \"\\./path_name\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/file.txt'        | '/to/dir' | "find -L -regex \"\\./input/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'long/path/name'        | '/to/dir' | "find -L -regex \"\\./long/path/name\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'path_name/*'           | '/to/dir' | "find -L -regex \"\\./path_name/[^/]*\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'path_name/'            | '/to/dir' | "find -L -type d -regex \"\\./path_name\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/*/file.txt'      | '/to/dir' | "find -L -regex \"\\./input/[^/]*/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/**/file.txt'     | '/to/dir' | "find -L -regex \"\\./input/.*/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/**/a/**/file.txt'| '/to/dir' | "find -L -regex \"\\./input/.*/a/.*/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/?/file.txt'      | '/to/dir' | "find -L -regex \"\\./input/./file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/{a,b}/file.txt'  | '/to/dir' | "find -L -regex \"\\./input/\\(a\\|b\\)/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/{a,b,c}/file.txt'| '/to/dir' | "find -L -regex \"\\./input/\\(a\\|b\\|c\\)/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
+        'input/[A-Z]/file.txt'  | '/to/dir' | "find -L -regex \"\\./input/[A-Z]/file\\.txt\" -exec cp -fRLn --parents \"{}\" /to/dir \\;"
 
     }
 
@@ -267,14 +298,21 @@ class SimpleFileCopyStrategyTest extends Specification {
         strategy.stageOutCommand(source, target, 'move') == result
 
         where:
-        source              | target    | result
-        'file.txt'          | '/to/dir' | "mv -f file.txt /to/dir"
-        "file'3.txt"        | '/to dir' | "mv -f file\\'3.txt /to\\ dir"
-        'path_name'         | '/to/dir' | "mv -f path_name /to/dir"
-        'input/file.txt'    | '/to/dir' | "mkdir -p /to/dir/input && mv -f input/file.txt /to/dir/input"
-        'long/path/name'    | '/to/dir' | "mkdir -p /to/dir/long/path && mv -f long/path/name /to/dir/long/path"
-        'path_name/*'       | '/to/dir' | "mkdir -p /to/dir/path_name && mv -f path_name/* /to/dir/path_name"
-        'path_name/'        | '/to/dir' | "mkdir -p /to/dir/path_name && mv -f path_name/ /to/dir/path_name"
+        source                  | target    | result
+        'file.txt'              | '/to/dir' | "find -L -regex \"\\./file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        "file'3.txt"            | '/to dir' | "find -L -regex \"\\./file'3\\.txt\" -exec sh -c 'mkdir -p \"/to\\ dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to\\ dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'path_name'             | '/to/dir' | "find -L -regex \"\\./path_name\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/file.txt'        | '/to/dir' | "find -L -regex \"\\./input/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'long/path/name'        | '/to/dir' | "find -L -regex \"\\./long/path/name\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'path_name/*'           | '/to/dir' | "find -L -regex \"\\./path_name/[^/]*\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'path_name/'            | '/to/dir' | "find -L -type d -regex \"\\./path_name\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/*/file.txt'      | '/to/dir' | "find -L -regex \"\\./input/[^/]*/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/**/file.txt'     | '/to/dir' | "find -L -regex \"\\./input/.*/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/**/a/**/file.txt'| '/to/dir' | "find -L -regex \"\\./input/.*/a/.*/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/?/file.txt'      | '/to/dir' | "find -L -regex \"\\./input/./file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/{a,b}/file.txt'  | '/to/dir' | "find -L -regex \"\\./input/\\(a\\|b\\)/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/{a,b,c}/file.txt'| '/to/dir' | "find -L -regex \"\\./input/\\(a\\|b\\|c\\)/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
+        'input/[A-Z]/file.txt'  | '/to/dir' | "find -L -regex \"\\./input/[A-Z]/file\\.txt\" -exec sh -c 'mkdir -p \"/to/dir/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/to/dir/`dirname \\\"\$1\\\"`\";' _ {} \\;"
 
     }
 
@@ -431,8 +469,8 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 mkdir -p /target/work\\ dir
-                cp -fRL simple.txt /target/work\\ dir || true
-                mkdir -p /target/work\\ dir/my/path && cp -fRL my/path/file.bam /target/work\\ dir/my/path || true
+                find -L -regex "\\./simple\\.txt" -exec cp -fRLn --parents "{}" /target/work\\ dir \\; || true
+                find -L -regex "\\./my/path/file\\.bam" -exec cp -fRLn --parents "{}" /target/work\\ dir \\; || true
                 '''
                 .stripIndent().trim()
 
@@ -452,8 +490,8 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 mkdir -p /target/store
-                mv -f simple.txt /target/store || true
-                mkdir -p /target/store/my/path && mv -f my/path/file.bam /target/store/my/path || true
+                find -L -regex \"\\./simple\\.txt\" -exec sh -c 'mkdir -p \"/target/store/`dirname \\\"$1\\\"`\"; mv \"$1\" \"/target/store/`dirname \\\"$1\\\"`\";' _ {} \\; || true
+                find -L -regex \"\\./my/path/file\\.bam\" -exec sh -c 'mkdir -p \"/target/store/`dirname \\\"$1\\\"`\"; mv \"$1\" \"/target/store/`dirname \\\"$1\\\"`\";' _ {} \\; || true
                 '''
                 .stripIndent().trim()
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -167,10 +167,12 @@ class SimpleFileCopyStrategyTest extends Specification {
         def cmd = """\
             shopt -s globstar extglob || true
             IFS=\$'\\n'
-            pathes=`ls -1d ${source_escaped}`
+            pathes=`ls -1d ${source_escaped} | sort | uniq`
             set -f
             for name in \$pathes; do
-                sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                if [[ ! -e "${target_escaped}/\$name" ]]; then
+                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                fi
             done
             set +f
             shopt -u globstar extglob || true
@@ -342,10 +344,12 @@ class SimpleFileCopyStrategyTest extends Specification {
         def cmd = """\
             shopt -s globstar extglob || true
             IFS=\$'\\n'
-            pathes=`ls -1d ${source_escaped}`
+            pathes=`ls -1d ${source_escaped} | sort | uniq`
             set -f
             for name in \$pathes; do
-                sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                if [[ ! -e "${target_escaped}/\$name" ]]; then
+                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                fi
             done
             set +f
             shopt -u globstar extglob || true
@@ -587,7 +591,9 @@ class SimpleFileCopyStrategyTest extends Specification {
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    sh -c 'mkdir -p \"/target/work\\ dir/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"/target/work\\ dir/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                    if [[ ! -e "/target/work\\ dir/\$name" ]]; then
+                        sh -c 'mkdir -p \"/target/work\\ dir/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"/target/work\\ dir/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                    fi
                 done
                 set +f
                 shopt -u globstar extglob || true
@@ -616,7 +622,9 @@ class SimpleFileCopyStrategyTest extends Specification {
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/target/store/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                    if [[ ! -e "/target/store/\$name" ]]; then
+                        sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/target/store/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                    fi
                 done
                 set +f
                 shopt -u globstar extglob || true

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -231,7 +231,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             }
         }
 
-        String command = strategy.getUnstageOutputFilesScript([source], outfolder.toAbsolutePath()).replaceAll( "\n", " && ")
+        String command = strategy.getUnstageOutputFilesScript([source], outfolder.toAbsolutePath())
         println("Command: $command")
         Process process = [ "sh", "-c", command ].execute(null, infolder.toFile() )
         process.consumeProcessOutput( System.out, System.err )
@@ -256,14 +256,18 @@ class SimpleFileCopyStrategyTest extends Specification {
 
         where:
         source              | inputffiles                                                                                           | outputfiles
+        '**.txt'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+        '**.foo'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | []
         '*.txt'             | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt']
-        '*'                 | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt', 'file3.txta']
+        '*'                 | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                    | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
+        '**'                | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                    | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
         'a/*'               | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
         'a/'                | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
         'a'                 | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
         'a b/*'             | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
         'a b/'              | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
         'a b'               | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a|b/*'             | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/', 'file.txt']                                | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/']
         'a/*/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
         'a/**/c/*'          | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
         'a/*/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
@@ -337,7 +341,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             }
         }
 
-        String command = strategy.getUnstageOutputFilesScript([source], outfolder.toAbsolutePath()).replaceAll( "\n", " && ")
+        String command = strategy.getUnstageOutputFilesScript([source], outfolder.toAbsolutePath())
         println("Command: $command")
         Process process = [ "sh", "-c", command ].execute(null, infolder.toFile() )
         process.consumeProcessOutput( System.out, System.err )
@@ -361,14 +365,18 @@ class SimpleFileCopyStrategyTest extends Specification {
 
         where:
         source              | inputffiles                                                                                           | outputfiles
+        '**.txt'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+        '**.foo'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | []
         '*.txt'             | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt']
-        '*'                 | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt', 'file3.txta']
+        '*'                 | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                    | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
+        '**'                | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                    | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
         'a/*'               | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
         'a/'                | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
         'a'                 | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
         'a b/*'             | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
         'a b/'              | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
         'a b'               | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a|b/*'             | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/', 'file.txt']                                | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/']
         'a/*/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
         'a/**/c/*'          | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
         'a/*/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -171,7 +171,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             set -f
             for name in \$pathes; do
                 if [[ ! -e "${target_escaped}/\$name" ]]; then
-                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"${target_escaped}/\$1\";' _ \"\$name\" || true
                 fi
             done
             set +f
@@ -348,7 +348,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             set -f
             for name in \$pathes; do
                 if [[ ! -e "${target_escaped}/\$name" ]]; then
-                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${target_escaped}/\$1\";' _ \"\$name\" || true
                 fi
             done
             set +f
@@ -592,7 +592,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 set -f
                 for name in \$pathes; do
                     if [[ ! -e "/target/work\\ dir/\$name" ]]; then
-                        sh -c 'mkdir -p \"/target/work\\ dir/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"/target/work\\ dir/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                        sh -c 'mkdir -p \"/target/work\\ dir/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"/target/work\\ dir/\$1\";' _ \"\$name\" || true
                     fi
                 done
                 set +f
@@ -623,7 +623,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 set -f
                 for name in \$pathes; do
                     if [[ ! -e "/target/store/\$name" ]]; then
-                        sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/target/store/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
+                        sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/target/store/\$1\";' _ \"\$name\" || true
                     fi
                 done
                 set +f

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -165,7 +165,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         given:
         def strategy = [:] as SimpleFileCopyStrategy
         def cmd = """\
-            shopt -s globstar extglob
+            shopt -s globstar extglob || true
             IFS=\$'\\n'
             pathes=`ls -1d ${source_escaped}`
             set -f
@@ -173,7 +173,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
             done
             set +f
-            shopt -u globstar extglob
+            shopt -u globstar extglob || true
             unset IFS""".stripIndent(true)
 
         expect:
@@ -340,7 +340,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         given:
         def strategy = [:] as SimpleFileCopyStrategy
         def cmd = """\
-            shopt -s globstar extglob
+            shopt -s globstar extglob || true
             IFS=\$'\\n'
             pathes=`ls -1d ${source_escaped}`
             set -f
@@ -348,7 +348,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
             done
             set +f
-            shopt -u globstar extglob
+            shopt -u globstar extglob || true
             unset IFS""".stripIndent(true)
 
         expect:
@@ -582,7 +582,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 mkdir -p /target/work\\ dir
-                shopt -s globstar extglob
+                shopt -s globstar extglob || true
                 IFS=\$'\\n'
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
@@ -590,7 +590,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                     sh -c 'mkdir -p \"/target/work\\ dir/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"/target/work\\ dir/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
                 done
                 set +f
-                shopt -u globstar extglob
+                shopt -u globstar extglob || true
                 unset IFS
                 '''
                 .stripIndent().trim()
@@ -611,7 +611,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 mkdir -p /target/store
-                shopt -s globstar extglob
+                shopt -s globstar extglob || true
                 IFS=\$'\\n'
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
@@ -619,7 +619,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                     sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/target/store/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
                 done
                 set +f
-                shopt -u globstar extglob
+                shopt -u globstar extglob || true
                 unset IFS
                 '''
                 .stripIndent().trim()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -347,9 +347,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             pathes=`ls -1d ${source_escaped} | sort | uniq`
             set -f
             for name in \$pathes; do
-                if [[ ! -e "${target_escaped}/\$name" ]]; then
-                    sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"${target_escaped}/\$1\";' _ \"\$name\" || true
-                fi
+                sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; mv -f \"\$1\" \"${target_escaped}/\$1\";' _ \"\$name\" || true
             done
             set +f
             shopt -u globstar extglob || true
@@ -622,9 +620,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    if [[ ! -e "/target/store/\$name" ]]; then
-                        sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv \"\$1\" \"/target/store/\$1\";' _ \"\$name\" || true
-                    fi
+                    sh -c 'mkdir -p \"/target/store/`dirname \\\"\$1\\\"`\"; mv -f \"\$1\" \"/target/store/\$1\";' _ \"\$name\" || true
                 done
                 set +f
                 shopt -u globstar extglob || true

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -17,8 +17,10 @@
 
 package nextflow.executor
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 
 import nextflow.processor.TaskBean
 import spock.lang.Specification
@@ -177,6 +179,86 @@ class SimpleFileCopyStrategyTest extends Specification {
 
     }
 
+    @Unroll
+    def 'should copy the right files' () {
+
+        given:
+        SimpleFileCopyStrategy strategy = [:] as SimpleFileCopyStrategy
+        strategy.stageoutMode = "copy"
+        Path infolder = Files.createTempDirectory('in')
+        Path outfolder = Files.createTempDirectory('out')
+
+        inputffiles.forEach {
+            String p = infolder.toAbsolutePath().toString()
+            //create subdirectories, if needed
+            if( it.contains("/") ) {
+                println("path: $p/${it.substring(0, it.lastIndexOf('/'))}")
+                new File( p + "/" + it.substring(0, it.lastIndexOf('/')) ).mkdirs()
+            }
+            if( !it.endsWith("/") ) {
+                new File(p + "/" + it).createNewFile()
+            }
+        }
+
+        String command = strategy.getUnstageOutputFilesScript([source], outfolder.toAbsolutePath()).replaceAll( "\n", " && ")
+        println("Command: $command")
+        Process process = [ "sh", "-c", command ].execute(null, infolder.toFile() )
+        process.consumeProcessOutput( System.out, System.err )
+        process.waitFor(2, TimeUnit.SECONDS )
+
+        expect:
+        process.exitValue() == 0
+
+        for( String r : outputfiles ){
+            assert new File(outfolder.toString(), r).exists()
+        }
+        for( String r : inputffiles ){
+            assert new File(infolder.toString(), r).exists()
+        }
+        for( String r : (inputffiles - outputfiles) ){
+            assert !new File(outfolder.toString(), r).exists()
+        }
+
+        cleanup:
+        infolder?.deleteDir()
+        outfolder?.deleteDir()
+
+        where:
+        source              | inputffiles                                                                                           | outputfiles
+        '*.txt'             | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt']
+        '*'                 | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt', 'file3.txta']
+        'a/*'               | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a/'                | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a'                 | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a b/*'             | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b/'              | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b'               | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a/*/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/*'          | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/?/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        '{a,b,c}/*'         | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}/'          | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}'           | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{ab*,b*/*,c}/*'    | ['a/file.txt', 'abcd/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']               | ['abcd/file2.txt']
+        '{a[ab]c,b*/*}/*'   | ['acc/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']              | ['abc/file2.txt']
+        '{a|c*,b*/*}/*'     | ['a|c/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']              | ['a|c/file.txt']
+        '[A-Z]/*'           | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['A/file.txt']
+        '[A-Z]/'            | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['A/file.txt']
+        '[A-Z]'             | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['A/file.txt']
+        'a'                 | ['A/file.txt', 'a/', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                           | ['a/']
+        'a/b/c'             | ['A/file.txt', 'a/b/c/', 'a/b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                     | ['a/b/c/']
+        'abc?\\?.txt'       | ['abcde.txt', 'abcd.txt', 'abcd?.txt']                                                                | ['abcd?.txt']
+        'a"b.txt'           | ['a\\"b.txt', 'a"b.txt', 'abc.txt']                                                                   | ['a"b.txt']
+        'a/**/b/*/d.txt'    | ['a/c/d/b/x/d.txt', 'a/c/d/b/x/Y/d.txt']                                                              | ['a/c/d/b/x/d.txt']
+
+    }
+
     def 'should return a valid `mv` command' () {
 
         given:
@@ -193,6 +275,85 @@ class SimpleFileCopyStrategyTest extends Specification {
         'long/path/name'    | '/to/dir' | "mkdir -p /to/dir/long/path && mv -f long/path/name /to/dir/long/path"
         'path_name/*'       | '/to/dir' | "mkdir -p /to/dir/path_name && mv -f path_name/* /to/dir/path_name"
         'path_name/'        | '/to/dir' | "mkdir -p /to/dir/path_name && mv -f path_name/ /to/dir/path_name"
+
+    }
+
+    @Unroll
+    def 'should move the right files' () {
+
+        given:
+        SimpleFileCopyStrategy strategy = [:] as SimpleFileCopyStrategy
+        strategy.stageoutMode = "move"
+        Path infolder = Files.createTempDirectory('in')
+        Path outfolder = Files.createTempDirectory('out')
+
+        inputffiles.forEach {
+            String p = infolder.toAbsolutePath().toString()
+            //create subdirectories, if needed
+            if( it.contains("/") ) {
+                println("path: $p/${it.substring(0, it.lastIndexOf('/'))}")
+                new File( p + "/" + it.substring(0, it.lastIndexOf('/')) ).mkdirs()
+            }
+            if( !it.endsWith("/") ) {
+                new File(p + "/" + it).createNewFile()
+            }
+        }
+
+        String command = strategy.getUnstageOutputFilesScript([source], outfolder.toAbsolutePath()).replaceAll( "\n", " && ")
+        println("Command: $command")
+        Process process = [ "sh", "-c", command ].execute(null, infolder.toFile() )
+        process.consumeProcessOutput( System.out, System.err )
+        process.waitFor(2, TimeUnit.SECONDS )
+
+        expect:
+        process.exitValue() == 0
+
+        for( String r : outputfiles ){
+            assert new File(outfolder.toString(), r).exists()
+            assert !new File(infolder.toString(), r).exists()
+        }
+        for( String r : (inputffiles - outputfiles) ){
+            assert !new File(outfolder.toString(), r).exists()
+            assert new File(infolder.toString(), r).exists()
+        }
+
+        cleanup:
+        infolder?.deleteDir()
+        outfolder?.deleteDir()
+
+        where:
+        source              | inputffiles                                                                                           | outputfiles
+        '*.txt'             | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt']
+        '*'                 | ['file.txt', 'file2.txt', 'file3.txta']                                                               | ['file.txt', 'file2.txt', 'file3.txta']
+        'a/*'               | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a/'                | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a'                 | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                        | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a b/*'             | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b/'              | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b'               | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a/*/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/*'          | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/?/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']  | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        '{a,b,c}/*'         | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}/'          | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}'           | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{ab*,b*/*,c}/*'    | ['a/file.txt', 'abcd/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']               | ['abcd/file2.txt']
+        '{a[ab]c,b*/*}/*'   | ['acc/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']              | ['abc/file2.txt']
+        '{a|c*,b*/*}/*'     | ['a|c/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']              | ['a|c/file.txt']
+        '[A-Z]/*'           | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['A/file.txt']
+        '[A-Z]/'            | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['A/file.txt']
+        '[A-Z]'             | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                  | ['A/file.txt']
+        'a'                 | ['A/file.txt', 'a/', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                           | ['a/']
+        'a/b/c'             | ['A/file.txt', 'a/b/c/', 'a/b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                     | ['a/b/c/']
+        'abc?\\?.txt'       | ['abcde.txt', 'abcd.txt', 'abcd?.txt']                                                                | ['abcd?.txt']
+        'a"b.txt'           | ['a\\"b.txt', 'a"b.txt', 'abc.txt']                                                                   | ['a"b.txt']
+        'a/**/b/*/d.txt'    | ['a/c/d/b/x/d.txt', 'a/c/d/b/x/Y/d.txt']                                                              | ['a/c/d/b/x/d.txt']
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -170,7 +170,7 @@ class SimpleFileCopyStrategyTest extends Specification {
             pathes=`ls -1d ${source_escaped}`
             set -f
             for name in \$pathes; do
-                cp -fRL --parents \"\$name\" ${target_escaped} || true
+                sh -c 'mkdir -p \"${target_escaped}/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"${target_escaped}/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
             done
             set +f
             shopt -u globstar extglob
@@ -587,7 +587,7 @@ class SimpleFileCopyStrategyTest extends Specification {
                 pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
                 set -f
                 for name in \$pathes; do
-                    cp -fRL --parents \"\$name\" /target/work\\ dir || true
+                    sh -c 'mkdir -p \"/target/work\\ dir/`dirname \\\"\$1\\\"`\"; cp -fRL \"\$1\" \"/target/work\\ dir/`dirname \\\"\$1\\\"`\";' _ \"\$name\" || true
                 done
                 set +f
                 shopt -u globstar extglob

--- a/modules/nf-commons/src/main/nextflow/util/Escape.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/Escape.groovy
@@ -55,7 +55,11 @@ class Escape {
         replace(WILDCARDS, str)
     }
 
-    static String path(String val) {
+    static String path(String val, boolean glob = false) {
+        List<String> SPECIAL_CHARS = Escape.SPECIAL_CHARS
+        if ( glob ){
+            SPECIAL_CHARS = SPECIAL_CHARS.findAll {it != '\\' }
+        }
         replace(SPECIAL_CHARS, val, true)
     }
 

--- a/modules/nf-commons/src/test/nextflow/util/EscapeTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/EscapeTest.groovy
@@ -60,6 +60,16 @@ class EscapeTest extends Specification {
 
     }
 
+    def 'should ignore globs in file names' () {
+
+        expect:
+        Escape.path('hell?.txt', true ) == "hell?.txt"
+        Escape.path('hell\\?.txt', true ) == "hell\\?.txt"
+        Escape.path('hell*.txt', true ) == "hell*.txt"
+        Escape.path('hell**.txt', true ) == "hell**.txt"
+
+    }
+
     def 'should escape wildcards' () {
 
         expect: 


### PR DESCRIPTION
Using Nextflow with Kubernetes I realized that sometimes files are not found, or the wrong ones.
I found the issue in the copying/moving strategy. The current strategy used, does not support the glob notation. 
For example, if I define `“work/*/*.tif”` as an output, it generates the following unstage command: 
```mkdir -p /workdir/work/ea/f44f2e36fe3bba9eae4d4ecbdb18d3/mask/* && cp -fRL mask/*/*.tif /workdir/work/ea/f44f2e36fe3bba9eae4d4ecbdb18d3/mask/* || true```
That leads to a folder _mask/mask/_ with all the tifs in it. 

Furthermore, running that script:
```
process a {

    echo true

    output:
    file("a/*/*.txt") into found

    """
    mkdir -p a/a b/b c/c
    touch a/1.txt
    touch b/1.txt
    touch c/1.txt
    touch a/a/2.txt
    touch b/b/2.txt
    touch c/c/2.txt
    """

}

found.view()
```

results in:
_/workdir/work/c9/9254056eb2a43f396ef6c564b7ee54/a/*/2.txt_

changing the output to `“?/*/*.txt”` results again in one file:
_/workdir/work/61/708e9652d22b6970511dc8b09eb1d4/?/*/2.txt_

To overcome these issues, I changed the unstage strategy and adjusted the tests accordingly. Moreover, I wrote some tests to confirm also the bash command’s execution results. That was missing until now, why the following test cases were excepted as valid, however, they will generate the wrong directory hierarchy.

```
mkdir -p /to/dir/path_name && cp -fRL path_name/ /to/dir/path_name
mkdir -p /to/dir/path_name && mv -f path_name/ /to/dir/path_name 
```

While my new proposed solution passes all the new tests, the old one failed in 21 out of 31 case for ‘should move the right files’. The same applies to ‘should copy the right files’.

I have tested my fix only in regard to the usage of temporary directories in Kubernetes, however, it should work for all execution engines, where temporary directories are used. I assume the same errors occur there, I have observed it in Kubernetes. This fix should also apply to them. 

Additional notes:

In the getUnstageOutputFilesScript method I do not normalize the Glob anymore. This is now done while generating the stageOutCommand. I wrote a new method, transforming a glob expression to a regex expression find understands.

An important aspect is, that the cp command does not yet overwrite files, to avoid copying files more than once. This is fine, if a file is copied into an empty work directory. However, if this command is used to copy into a directory already containing files, new files, with the same name, are not copied. Depending, where this method will also be used, this has to be changed.
Moreover, as the current implementation resolves symlinks, my proposed solution does it again. This is problematic, if the output matches a file, that was staged in. Adding the -P option to cp would overcome this. Otherwise, it could generate a lot of IO-overhead for huge files.

How to evaluate my solution:

My version can be tested, by just adding this to an execution on Kubernetes: -pod-image fabianlehmann/nextflow:fix
If you have any questions, do not hesitate to come back to me.
