### PR TITLE
Azure Batch executor: report error code and messages for failed Tasks.

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -18,6 +18,8 @@ package nextflow.cloud.azure.batch
 import java.nio.file.Path
 
 import com.microsoft.azure.batch.protocol.models.TaskState
+import com.microsoft.azure.batch.protocol.models.TaskExecutionInformation
+import com.microsoft.azure.batch.protocol.models.TaskExecutionResult
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.cloud.types.CloudMachineInfo
@@ -31,7 +33,7 @@ import nextflow.trace.TraceRecord
 
 /**
  * Implements a task handler for Azure Batch service
- * 
+ *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
@@ -120,6 +122,11 @@ class AzBatchTaskHandler extends TaskHandler {
             task.stdout = outputFile
             task.stderr = errorFile
             status = TaskStatus.COMPLETED
+            TaskExecutionInformation info = taskExecutionInfo(taskKey)
+            if (info.result() == TaskExecutionResult.FAILURE) {
+                log.error("[AZURE BATCH] Task failed. ERROR code: ${info.failureInfo().code()}; message: ${info.failureInfo().message()}.")
+                task.error = new ProcessUnrecoverableException(info.failureInfo().message())
+            }
             deleteTask(taskKey, task)
             return true
         }
@@ -162,6 +169,13 @@ class AzBatchTaskHandler extends TaskHandler {
             }
         }
         return taskState
+    }
+
+    /**
+     * @return Retrieve the executionInfo for the executed task
+     */
+    protected TaskExecutionInformation taskExecutionInfo(AzTaskKey key) {
+        return batchService.getTask(key).executionInfo()
     }
 
     protected int readExitFile() {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -124,7 +124,7 @@ class AzBatchTaskHandler extends TaskHandler {
             status = TaskStatus.COMPLETED
             TaskExecutionInformation info = batchService.getTask(taskKey).executionInfo()
             if (info.result() == TaskExecutionResult.FAILURE)
-                task.error = new ProcessUnrecoverableException("ERROR code: ${info.failureInfo().code()}; message: ${info.failureInfo().message()}.")
+                task.error = new ProcessUnrecoverableException(info.failureInfo().message())
             deleteTask(taskKey, task)
             return true
         }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -122,11 +122,9 @@ class AzBatchTaskHandler extends TaskHandler {
             task.stdout = outputFile
             task.stderr = errorFile
             status = TaskStatus.COMPLETED
-            TaskExecutionInformation info = taskExecutionInfo(taskKey)
-            if (info.result() == TaskExecutionResult.FAILURE) {
-                log.error("[AZURE BATCH] Task failed. ERROR code: ${info.failureInfo().code()}; message: ${info.failureInfo().message()}.")
-                task.error = new ProcessUnrecoverableException(info.failureInfo().message())
-            }
+            TaskExecutionInformation info = batchService.getTask(taskKey).executionInfo()
+            if (info.result() == TaskExecutionResult.FAILURE)
+                task.error = new ProcessUnrecoverableException("ERROR code: ${info.failureInfo().code()}; message: ${info.failureInfo().message()}.")
             deleteTask(taskKey, task)
             return true
         }
@@ -169,13 +167,6 @@ class AzBatchTaskHandler extends TaskHandler {
             }
         }
         return taskState
-    }
-
-    /**
-     * @return Retrieve the executionInfo for the executed task
-     */
-    protected TaskExecutionInformation taskExecutionInfo(AzTaskKey key) {
-        return batchService.getTask(key).executionInfo()
     }
 
     protected int readExitFile() {


### PR DESCRIPTION
Instead of reporting a generic error message, with these changes, Nextflow fetches the actual error code and message from the Batch API and returns them to the user.

For instance, this is the output if an invalid docker image is specified in the `container` option of a process:
<pre>
N E X T F L O W  ~  version 21.05.0-edge
Launching `main-azure.nf` [berserk_euler] - revision: 2086f6cebe
executor >  azurebatch (1)
[e9/06af2f] process > sayHelloInItalian (1) [  0%] 0 of 1
[-        ] process > sayHelloInFrench      -
[-        ] process > sayHelloInSpanish     -
[-        ] process > sayHelloInEnglish     -
[AZURE BATCH] Task failed. ERROR code: ContainerInvalidImage; message: One or more container images specified are invalid


Error executing process > 'sayHelloInItalian (1)'

Caused by:
  One or more container images specified are invalid

</pre>

Any other runtime error occurring in the task and detected by the Batch API would be reported as well.