### PR TITLE
AWS Batch: provide additional details about the reason why a job has failed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ check:
 # install compiled artifacts in Maven local dir
 # 
 install:
-	BUILD_PACK=1 ./gradlew installLauncher install -Dmaven.repo.local=${HOME}/.nextflow/capsule/deps/ -x signArchives
+	BUILD_PACK=1 ./gradlew installLauncher install -Dmaven.repo.local=${HOME}/.nextflow/capsule/deps/
 
 #
 # Show dependencies try `make deps config=runtime`, `make deps config=google`

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ dockerImage:
 # Create local docker image
 #
 dockerPack:
-	BUILD_PACK=1 ./gradlew install dockerPack -Dmaven.repo.local=${PWD}/build/docker/.nextflow/capsule/deps/ -x signArchives
+	BUILD_PACK=1 ./gradlew install dockerPack -Dmaven.repo.local=${PWD}/build/docker/.nextflow/capsule/deps/
 
 
 upload-plugins:

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -229,6 +229,8 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         if( done ) {
             // finalize the task
             task.exitStatus = readExitFile()
+            if (job?.status == 'FAILED')
+                task.error = new ProcessUnrecoverableException(job?.getStatusReason())
             task.stdout = outputFile
             task.stderr = errorFile
             status = TaskStatus.COMPLETED


### PR DESCRIPTION
Similarly to https://github.com/nextflow-io/nextflow/pull/2099, this change reports the reason why a job in AWS Batch has failed.

For example:
<pre>
executor >  awsbatch (1)
[de/8a1a36] process > sayHelloInItalian (1) [100%] 1 of 1, failed: 1 ✘
[-        ] process > sayHelloInFrench      -
[-        ] process > sayHelloInSpanish     -
[-        ] process > sayHelloInEnglish     -
Error executing process > 'sayHelloInItalian (1)'

Caused by:
  ECS was unable to assume the role 'arn:aws:iam::.....:role/ecsInstanceRole' that was provided for this task. Please verify that the role being passed has the proper trust relationship and permissions and that your IAM user has permissions to pass this role.

</pre>

Instead of the generic message:
<pre>
executor >  awsbatch (1)
[c7/a76987] process > sayHelloInItalian (1) [100%] 1 of 1, failed: 1 ✘
[-        ] process > sayHelloInFrench      -
[-        ] process > sayHelloInSpanish     -
[-        ] process > sayHelloInEnglish     -
Error executing process > 'sayHelloInItalian (1)'

Caused by:
  Process `sayHelloInItalian (1)` terminated for an unknown reason -- Likely it has been terminated by the external system

</pre>