### PR TITLE
Run tasks under user accounts in Azure Batch

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -267,18 +267,20 @@ azure.batch.accountName                         The batch service account name.
 azure.batch.accountKey                          The batch service account key.
 azure.batch.endpoint                            The batch service endpoint e.g. ``https://nfbatch1.westeurope.batch.azure.com``.
 azure.batch.location                            The batch service location e.g. ``westeurope``. This is not needed when the endpoint is specified.
-azure.batch.autoPoolMode                        Enable the automatic creation of batch pools depending on the pipeline resources demand (default: ``true``)
-azure.batch.allowPoolCreation                   Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: ``false``)
+azure.batch.autoPoolMode                        Enable the automatic creation of batch pools depending on the pipeline resources demand (default: ``true``).
+azure.batch.allowPoolCreation                   Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: ``false``).
 azure.batch.deleteJobsOnCompletion              Enable the automatic deletion of jobs created by the pipeline execution (default: ``true``).
 azure.batch.deletePoolsOnCompletion             Enable the automatic deletion of compute node pools upon pipeline completion (default: ``false``).
-azure.batch.copyToolInstallMode                 Specify where the `azcopy` tool used by Nextflow. When ``node`` is specified it's copied once during the pool creation. When ``task`` is provider, it's installed for each task execution (default: ``node``)
+azure.batch.copyToolInstallMode                 Specify where the `azcopy` tool used by Nextflow. When ``node`` is specified it's copied once during the pool creation. When ``task`` is provider, it's installed for each task execution (default: ``node``).
 azure.batch.pools.<name>.vmType                 Specify the virtual machine type used by the pool identified with ``<name>``.
 azure.batch.pools.<name>.vmCount                Specify the number of virtual machines provisioned by the pool identified with ``<name>``.
 azure.batch.pools.<name>.maxVmCount             Specify the max of virtual machine when using auto scale option.
 azure.batch.pools.<name>.autoScale              Enable autoscaling feature for the pool identified with ``<name>``.
 azure.batch.pools.<name>.scaleFormula           Specify the scale formula for the pool identified with ``<name>``. See Azure Batch `scaling documentation <https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling>`_ for details.
-azure.batch.pools.<name>.scaleInterval          Specify the interval at which to automatically adjust the Pool size according to the autoscale formula. The minimum and maximum value are 5 minutes and 168 hours respectively (default: `10 mins`)
+azure.batch.pools.<name>.scaleInterval          Specify the interval at which to automatically adjust the Pool size according to the autoscale formula. The minimum and maximum value are 5 minutes and 168 hours respectively (default: `10 mins`).
 azure.batch.pools.<name>.schedulePolicy         Specify the scheduling policy for the pool identified with ``<name>``. It can be either ``spread`` or ``pack`` (default: ``spread``).
+azure.batch.pools.<name>.privileged             Enable the task to run with elevated access. Ignored if `runAs` is set (default: ``false``).
+azure.batch.pools.<name>.runAs                  Specify the username under which the task is run. The user must already exist on each node of the pool.
 azure.batch.registry.server                     Specify the container registry from which to pull the Docker images (default: ``docker.io``, requires ``nf-azure@0.9.8``).
 azure.batch.registry.userName                   Specify the username to connect to a private container registry (requires ``nf-azure@0.9.8``).
 azure.batch.registry.password                   Specify the password to connect to a private container registry (requires ``nf-azure@0.9.8``).

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -295,10 +295,10 @@ class AzBatchService implements Closeable {
         // create a batch job
         final jobId = makeJobId(task)
         final poolInfo = new PoolInformation()
-                .withPoolId(poolId)
+                            .withPoolId(poolId)
         client
-                .jobOperations()
-                .createJob(jobId, poolInfo)
+            .jobOperations()
+            .createJob(jobId, poolInfo)
         // add to the map
         allJobIds[mapKey] = jobId
         return jobId
@@ -554,9 +554,9 @@ class AzBatchService implements Closeable {
         if( registryOpts && registryOpts.isConfigured() ) {
             List<ContainerRegistry> containerRegistries = new ArrayList(1)
             containerRegistries << new ContainerRegistry()
-                    .withRegistryServer(registryOpts.server)
-                    .withUserName(registryOpts.userName)
-                    .withPassword(registryOpts.password)
+                .withRegistryServer(registryOpts.server)
+                .withUserName(registryOpts.userName)
+                .withPassword(registryOpts.password)
             containerConfig.withContainerRegistries(containerRegistries).withType('dockerCompatible')
             log.debug "[AZURE BATCH] Connecting Azure Batch pool to Container Registry '$registryOpts.server'"
         }
@@ -585,10 +585,10 @@ class AzBatchService implements Closeable {
         final poolParams = new PoolAddParameter()
                 .withId(spec.poolId)
                 .withVirtualMachineConfiguration(poolVmConfig(spec.opts))
-        // https://docs.microsoft.com/en-us/azure/batch/batch-pool-vm-sizes
+                // https://docs.microsoft.com/en-us/azure/batch/batch-pool-vm-sizes
                 .withVmSize(spec.vmType.name)
-        // same as the num ofd cores
-        // https://docs.microsoft.com/en-us/azure/batch/batch-parallel-node-tasks
+                // same as the num ofd cores
+                // https://docs.microsoft.com/en-us/azure/batch/batch-parallel-node-tasks
                 .withTaskSlotsPerNode(spec.vmType.numberOfCores)
                 .withStartTask(poolStartTask)
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -16,6 +16,11 @@
 
 package nextflow.cloud.azure.batch
 
+import com.microsoft.azure.batch.protocol.models.AutoUserScope
+import com.microsoft.azure.batch.protocol.models.AutoUserSpecification
+import com.microsoft.azure.batch.protocol.models.ElevationLevel
+import com.microsoft.azure.batch.protocol.models.UserIdentity
+
 import java.math.RoundingMode
 import java.nio.file.Path
 import java.time.Instant
@@ -290,10 +295,10 @@ class AzBatchService implements Closeable {
         // create a batch job
         final jobId = makeJobId(task)
         final poolInfo = new PoolInformation()
-                            .withPoolId(poolId)
+                .withPoolId(poolId)
         client
-            .jobOperations()
-            .createJob(jobId, poolInfo)
+                .jobOperations()
+                .createJob(jobId, poolInfo)
         // add to the map
         allJobIds[mapKey] = jobId
         return jobId
@@ -341,12 +346,12 @@ class AzBatchService implements Closeable {
 
         final taskToAdd = new TaskAddParameter()
                 .withId(taskId)
+                .withUserIdentity(userIdentity(pool.opts.privileged, pool.opts.runAs))
                 .withContainerSettings(containerOpts)
                 .withCommandLine("sh -c 'bash ${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}'")
                 .withResourceFiles(resourceFileUrls(task,sas))
                 .withOutputFiles(outputFileUrls(task, sas))
                 .withRequiredSlots(slots)
-
         client.taskOperations().createTask(jobId, taskToAdd)
         return new AzTaskKey(jobId, taskId)
     }
@@ -500,7 +505,7 @@ class AzBatchService implements Closeable {
         final spec = specForTask(task)
         if( spec && allPools.containsKey(spec.poolId) )
             return spec.poolId
-        
+
         // check existence and create if needed
         log.debug "[AZURE BATCH] Checking VM pool id=$spec.poolId; size=$spec.vmType"
         def pool = getPool(spec.poolId)
@@ -549,9 +554,9 @@ class AzBatchService implements Closeable {
         if( registryOpts && registryOpts.isConfigured() ) {
             List<ContainerRegistry> containerRegistries = new ArrayList(1)
             containerRegistries << new ContainerRegistry()
-                .withRegistryServer(registryOpts.server)
-                .withUserName(registryOpts.userName)
-                .withPassword(registryOpts.password)
+                    .withRegistryServer(registryOpts.server)
+                    .withUserName(registryOpts.userName)
+                    .withPassword(registryOpts.password)
             containerConfig.withContainerRegistries(containerRegistries).withType('dockerCompatible')
             log.debug "[AZURE BATCH] Connecting Azure Batch pool to Container Registry '$registryOpts.server'"
         }
@@ -567,7 +572,7 @@ class AzBatchService implements Closeable {
     protected void createPool(AzVmPoolSpec spec) {
 
         def resourceFiles = new ArrayList(10)
-        
+
         resourceFiles << new ResourceFile()
                 .withHttpUrl(AZCOPY_URL)
                 .withFilePath('azcopy')
@@ -580,10 +585,10 @@ class AzBatchService implements Closeable {
         final poolParams = new PoolAddParameter()
                 .withId(spec.poolId)
                 .withVirtualMachineConfiguration(poolVmConfig(spec.opts))
-                // https://docs.microsoft.com/en-us/azure/batch/batch-pool-vm-sizes
+        // https://docs.microsoft.com/en-us/azure/batch/batch-pool-vm-sizes
                 .withVmSize(spec.vmType.name)
-                // same as the num ofd cores
-                // https://docs.microsoft.com/en-us/azure/batch/batch-parallel-node-tasks
+        // same as the num ofd cores
+        // https://docs.microsoft.com/en-us/azure/batch/batch-parallel-node-tasks
                 .withTaskSlotsPerNode(spec.vmType.numberOfCores)
                 .withStartTask(poolStartTask)
 
@@ -600,7 +605,7 @@ class AzBatchService implements Closeable {
             final interval = spec.opts.scaleInterval.seconds as int
             poolParams
                     .withEnableAutoScale(true)
-                    .withAutoScaleEvaluationInterval( new Period().withSeconds(interval) ) 
+                    .withAutoScaleEvaluationInterval( new Period().withSeconds(interval) )
                     .withAutoScaleFormula(scaleFormula(spec.opts))
         }
         else {
@@ -676,6 +681,17 @@ class AzBatchService implements Closeable {
         }
     }
 
+    protected UserIdentity userIdentity(boolean  privileged, String runAs) {
+        UserIdentity identity = new UserIdentity()
+        if (runAs) {
+            identity.withUserName(runAs)
+        } else  {
+            identity.withAutoUser(new AutoUserSpecification()
+                    .withElevationLevel(privileged ? ElevationLevel.ADMIN : ElevationLevel.NON_ADMIN)
+                    .withScope(AutoUserScope.TASK))
+        }
+        return identity
+    }
     @Override
     void close() {
         // cleanup app successful jobs

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -42,6 +42,8 @@ class AzPoolOpts implements CacheFunnel {
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final Duration DEFAULT_SCALE_INTERVAL = Duration.of('5 min')
 
+    String runAs
+    boolean privileged
     String publisher
     String offer
     OSType osType = DEFAULT_OS_TYPE
@@ -64,6 +66,8 @@ class AzPoolOpts implements CacheFunnel {
     }
 
     AzPoolOpts(Map opts) {
+        this.runAs = opts.runAs ?: ''
+        this.privileged = opts.privileged ?: false
         this.publisher = opts.publisher ?: DEFAULT_PUBLISHER
         this.offer = opts.offer ?: DEFAULT_OFFER
         this.vmType = opts.vmType ?: DEFAULT_VM_TYPE
@@ -80,6 +84,8 @@ class AzPoolOpts implements CacheFunnel {
 
     @Override
     Hasher funnel(Hasher hasher, CacheHelper.HashMode mode) {
+        hasher.putUnencodedChars(runAs)
+        hasher.putBoolean(privileged)
         hasher.putUnencodedChars(publisher)
         hasher.putUnencodedChars(offer)
         hasher.putUnencodedChars(vmType)

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -319,7 +319,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-c1575b88d347ebc5c068777405865b39-Standard_X1'
+        spec.poolId == 'nf-pool-a5e122212f86de03464327e6d525eb73-Standard_X1'
 
     }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -92,6 +92,8 @@ class AzureConfigTest extends Specification {
                                                      autoScale: true,
                                                      vmCount: 5,
                                                      maxVmCount: 50,
+                                                     privileged: true,
+                                                     runAs: 'root',
                                                      scaleFormula: 'x + y + z',
                                                      scaleInterval:  '15 min',
                                                      schedulePolicy: 'pack' ]]
@@ -118,6 +120,8 @@ class AzureConfigTest extends Specification {
         cfg.batch().pool('myPool').maxVmCount == 50
         cfg.batch().pool('myPool').scaleFormula == 'x + y + z'
         cfg.batch().pool('myPool').scaleInterval == Duration.of('15 min')
+        cfg.batch().pool('myPool').privileged == true
+        cfg.batch().pool('myPool').runAs == 'root'
     }
 
     def 'should get azure batch endpoint from account and location' () {


### PR DESCRIPTION
This PR attaches the user identity to the pool. There are two options:

1) If the configuration specifies `runAs`, the task is run under that user. The assumption here is that the user already exists on the execution node in the pool.

2) `runAs` is omitted. In this case, the usual auto-user identity is explicitly attached to the task. For this identity, it is also possible to set `privileged` to `true` to run the task under elevated access (see https://docs.microsoft.com/en-us/azure/batch/batch-user-accounts#elevated-access-for-tasks).

Technically, Azure Batch also offers the possibility to create a user on the fly in the pool, but I don't feel it is needed in this context. Either the auto-user or the pre-existing user should cover all the use cases I can think of.


