### PR TITLE
Upgrade AWS SDK minor version

### DIFF
--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -39,11 +39,11 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.4.1'
 
     api ('io.nextflow:nxf-s3fs:1.1.1') { transitive = false }
-    api ('com.amazonaws:aws-java-sdk-s3:1.11.542')
-    api ('com.amazonaws:aws-java-sdk-ec2:1.11.542')
-    api ('com.amazonaws:aws-java-sdk-batch:1.11.542')
-    api ('com.amazonaws:aws-java-sdk-iam:1.11.542')
-    api ('com.amazonaws:aws-java-sdk-ecs:1.11.542')
+    api ('com.amazonaws:aws-java-sdk-s3:1.11.1034')
+    api ('com.amazonaws:aws-java-sdk-ec2:1.11.1034')
+    api ('com.amazonaws:aws-java-sdk-batch:1.11.1034')
+    api ('com.amazonaws:aws-java-sdk-iam:1.11.1034')
+    api ('com.amazonaws:aws-java-sdk-ecs:1.11.1034')
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')


### PR DESCRIPTION
Upgrade AWS SDK minor version from `1.11.542` to `1.11.1034` to allow EFS support.