### PR TITLE
Fix: Connection-reset crashes the workflow

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
@@ -339,18 +339,20 @@ class K8sClient {
      */
     protected K8sResponseApi makeRequest(String method, String path, String body=null) throws K8sResponseException {
 
-        int remainingTrials = 5
+        final int maxTrials = 5
+        int trial = 0
 
-        while ( remainingTrials > 0 ) {
-            remainingTrials--
+        while ( trial < maxTrials ) {
+            trial++
 
             try {
                 return makeRequestCall( method, path, body )
             } catch ( SocketException e ) {
                 log.error "[K8s] API request throw socket exception: $e.message for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
-                if ( remainingTrials ) log.info( "[K8s] Try API request again, remaining trials: $remainingTrials" )
+                if ( trial < maxTrials ) log.info( "[K8s] Try API request again, remaining trials: ${ maxTrials - trial }" )
                 else throw e
-                sleep( 1500 )
+                final long delay = (Math.pow(3, trial - 1) as long) * 250
+                sleep( delay )
             }
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
@@ -347,7 +347,7 @@ class K8sClient {
             try {
                 return makeRequestCall( method, path, body )
             } catch ( SocketException e ) {
-                log.error "[K8s] API request throw socket exception: $e.localizedMessage for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
+                log.error "[K8s] API request throw socket exception: $e.message for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
                 if ( remainingTrials ) log.info( "[K8s] Try API request again, remaining trials: $remainingTrials" )
                 else throw e
                 sleep( 1500 )

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
@@ -348,7 +348,7 @@ class K8sClient {
             try {
                 return makeRequestCall( method, path, body )
             } catch ( SocketException e ) {
-                log.error "[K8s] API request throw socket exception: $e.message for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
+                log.error "[K8s] API request threw socket exception: $e.message for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
                 if ( trial < maxTrials ) log.info( "[K8s] Try API request again, remaining trials: ${ maxTrials - trial }" )
                 else throw e
                 final long delay = (Math.pow(3, trial - 1) as long) * 250


### PR DESCRIPTION
Working with Kubernetes and Nextflow I sometimes got an exception socket-reset, which cases the whole workflow to fail. 

This is the exception trace:
```
...
Jun-17 12:07:25.401 [Task monitor] ERROR nextflow.processor.TaskProcessor - Error executing process > 'preprocessing:preprocess (LT05_L1TP_183035_19891106_20180210_01_T1)'

Caused by:
  Connection reset

java.net.SocketException: Connection reset
    at java.net.SocketInputStream.read(SocketInputStream.java:210)
    at java.net.SocketInputStream.read(SocketInputStream.java:141)
    at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
    at sun.security.ssl.InputRecord.read(InputRecord.java:503)
    at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:975)
    at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1367)
    at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1395)
    at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1379)
    at sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:559)
    at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1564)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
    at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480)
    at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:347)
    at nextflow.k8s.client.K8sClient.makeRequest(K8sClient.groovy:366)
    at nextflow.k8s.client.K8sClient.makeRequest(K8sClient.groovy)
    at nextflow.k8s.client.K8sClient.get(K8sClient.groovy:379)
    at nextflow.k8s.client.K8sClient.podStatus(K8sClient.groovy:196)
    at nextflow.k8s.client.K8sClient.podState(K8sClient.groovy:228)
    at nextflow.k8s.K8sTaskHandler.getState(K8sTaskHandler.groovy:261)
    at nextflow.k8s.K8sTaskHandler.checkIfCompleted(K8sTaskHandler.groovy:318)
    at nextflow.processor.TaskPollingMonitor.checkTaskStatus(TaskPollingMonitor.groovy:605)
    at nextflow.processor.TaskPollingMonitor.checkAllTasks(TaskPollingMonitor.groovy:530)
    at nextflow.processor.TaskPollingMonitor.pollLoop(TaskPollingMonitor.groovy:409)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
    at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1268)
    at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1035)
    at org.codehaus.groovy.runtime.InvokerHelper.invokePogoMethod(InvokerHelper.java:1029)
    at org.codehaus.groovy.runtime.InvokerHelper.invokeMethod(InvokerHelper.java:1012)
    at org.codehaus.groovy.runtime.InvokerHelper.invokeMethodSafe(InvokerHelper.java:101)
    at nextflow.processor.TaskPollingMonitor$_start_closure2.doCall(TaskPollingMonitor.groovy:293)
    at nextflow.processor.TaskPollingMonitor$_start_closure2.call(TaskPollingMonitor.groovy)
    at groovy.lang.Closure.run(Closure.java:493)
    at java.lang.Thread.run(Thread.java:748)
Jun-17 12:07:25.412 [Task monitor] DEBUG nextflow.Session - Session aborted -- Cause: Connection reset
Jun-17 12:07:25.435 [Task monitor] DEBUG nextflow.Session - The following nodes are still active:
...
```

Here is my proposed solution: I wrap the call, and retry the API request, if it fails with a socket exception. This solved it for me.
We can discuss, whether to increase/decrease the sleep time and to catch more than SocketExceptions.
