### PR TITLE
Strip newlines from task name included in bash .command.run wrapper

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -211,7 +211,7 @@ class BashWrapperBuilder {
 
         final binding = new HashMap<String,String>(20)
         binding.header_script = headerScript
-        binding.task_name = name
+        binding.task_name = name.replaceAll("[\n\r]", "");
         binding.helpers_script = getHelpersScript()
 
         if( runWithContainer ) {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -307,6 +307,14 @@ class BashWrapperBuilderTest extends Specification {
         newBashWrapperBuilder(name: 'bar').makeBinding().task_name == 'bar'
     }
 
+    def 'task name should not include newlines' () {
+        expect:
+        newBashWrapperBuilder(name: 'foo\n').makeBinding().task_name == 'foo'
+        newBashWrapperBuilder(name: 'foo\r\nbar').makeBinding().task_name == 'foobar'
+        newBashWrapperBuilder(name: '\n\nfoo').makeBinding().task_name == 'foo'
+        newBashWrapperBuilder(name: '\rbar').makeBinding().task_name == 'bar'
+    }
+
     def 'should return header directives' () {
         when:
         def bash = newBashWrapperBuilder()


### PR DESCRIPTION
A newline can be part of the task name if the `tag` directive on the
process includes a newline (for example, through a variable).

If a newline does happen to be in the task name, the .command.run script
generated by `BashWrapperBuilder` will start with something like:

    #!/bin/bash
    # NEXTFLOW TASK: foo ([foo
    ])

which breaks when the process is executed:

    .command.run: line 3: syntax error near unexpected token `)'

This change will strip newlines (CR and LF) from the task name when
writing the commend in the bash wrapper header.

Fixes: #2188