### PR TITLE
Allow publishDir params to be closures

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -118,6 +118,42 @@ class PublishDir {
         this.mode = mode
     }
 
+    void setEnabled( obj ) {
+        // first check if obj is a closure
+        if (obj instanceof Closure) {
+            obj = obj.call()
+        }
+        // then check if obj is a string-like
+        if (obj instanceof CharSequence) {
+            obj = obj.toString().toBoolean()
+        }
+        this.enabled = obj as boolean
+    }
+
+    void setOverwrite( obj ) {
+        // first check if obj is a closure
+        if (obj instanceof Closure) {
+            obj = obj.call()
+        }
+        // then check if obj is a string-like
+        if (obj instanceof CharSequence) {
+            obj = obj.toString().toBoolean()
+        }
+        this.overwrite = obj as Boolean
+    }
+
+    void setPattern( obj ) {
+        // first check if obj is a closure
+        if (obj instanceof Closure) {
+            obj = obj.call()
+        }
+        // then check if obj is a string-like
+        if (obj instanceof CharSequence) {
+            obj = obj.toString()
+        }
+        this.pattern = obj as String
+    }
+
     @PackageScope boolean checkNull(String str) {
         ( str =~ /\bnull\b/  ).find()
     }
@@ -146,14 +182,14 @@ class PublishDir {
         if( params.pattern )
             result.pattern = params.pattern
 
-        if( params.overwrite != null )
+        if( params.overwrite )
             result.overwrite = params.overwrite
 
         if( params.saveAs )
             result.saveAs = params.saveAs
 
-        if( params.enabled!=null )
-            result.enabled = params.enabled as boolean
+        if( params.enabled )
+            result.enabled = params.enabled
 
         return result
     }


### PR DESCRIPTION
This is related to #2220. Currently, if I specify something like:
```groovy
publishDir "output/$id", mode: 'copy', overwrite: true, enabled: { publish }
```

Then `result.enabled = params.enabled as boolean` ([`PublishDir.groovy#L156`](https://github.com/nextflow-io/nextflow/blob/190aa4e/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy#L156)) turns this into a `true` value, regardless of the closure type. Similarly, specifying `enabled: "false"` will also result in it being converted to `true`.

This PR adds setters for parameters 'enabled', 'overwrite', and 'pattern' such that they can handle closured and convert strings to booleans properly, if necessary. Alternatively, if the output of a closure is not a boolean, an error could be produced.