### PR TITLE
Accomodate the updated URL for ena API

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/datasource/SraExplorer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/datasource/SraExplorer.groovy
@@ -255,7 +255,7 @@ class SraExplorer {
     }
 
     protected String readRunUrl(String acc) {
-        final url = "https://www.ebi.ac.uk/ena/data/warehouse/filereport?result=read_run&fields=fastq_ftp&accession=$acc"
+        final url = "https://www.ebi.ac.uk/ena/portal/api/filereport?result=read_run&fields=fastq_ftp&accession=$acc"
         log.debug "SRA fetch ftp fastq url=$url"
         String result = new URL(url).text.trim()
         log.trace "SRA fetch ftp fastq url result:\n${result?.indent()}"


### PR DESCRIPTION
This PR addresses https://github.com/nextflow-io/nextflow/issues/2237 and implements the fix as per the PR on the `nf-core/fetchngs` workflow https://github.com/nf-core/fetchngs/pull/26/files

