### PR TITLE
Make sure to stage in run script when fixing ownership in aws batch

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -67,9 +67,10 @@ fi
 JAVA_VER=$(echo "$JAVA_VER" | awk '/version/ {gsub(/"/, "", $3); print $3}')
 major=${BASH_REMATCH[1]}
 minor=${BASH_REMATCH[2]}
-version_check="^(1.8|9|10|11|12|13|14|15)"
+supported_versions="1.8|9|10|11|12|13|14|15"
+version_check="^($supported_versions)"
 if [[ ! $JAVA_VER =~ $version_check ]]; then
-    echo "Error: cannot find Java or it's a wrong version -- please make sure that Java 8 or higher is installed"
+    echo "Error: cannot find Java or it's a wrong version -- please make sure that Java 8 or higher is installed (supported versions: $supported_versions)"
     exit 1
 fi
 JVM_ARGS+=" -Dfile.encoding=UTF-8 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
@@ -102,7 +103,7 @@ while [ "$*" != "" ]; do
   if [[ "$1" == '-debug' || "$1" == '-trace' ]]; then
     args+=("$1")
 
-  elif [ "$1" == --with-yourkit ]; then 
+  elif [ "$1" == --with-yourkit ]; then
     JVM_ARGS+=" -agentpath:/Applications/YourKit_Java_Profiler_2014_build_14104.app/bin/mac/libyjpagent.jnilib=onexit=snapshot,tracing,dir=$PWD/snapshot "
   elif [ "$1" == '--with-jrebel' ]; then
     if [ "$JREBEL_HOME" ]; then

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -380,6 +380,9 @@ class BashWrapperBuilder {
         * process stats
         */
         String launcher
+
+        // NOTE: the isTraceRequired() check must match the logic in launchers (i.e. AwsBatchScriptLauncher)
+        // that determines when to stage the file.
         final traceWrapper = isTraceRequired()
         if( traceWrapper ) {
             // executes the stub which in turn executes the target command

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchScriptLauncher.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchScriptLauncher.groovy
@@ -36,7 +36,8 @@ class AwsBatchScriptLauncher extends BashWrapperBuilder {
         // include task script as an input to force its staging in the container work directory
         bean.inputFiles[TaskRun.CMD_SCRIPT] = bean.workDir.resolve(TaskRun.CMD_SCRIPT)
         // add the wrapper file when stats are enabled
-        if( bean.statsEnabled ) {
+        // NOTE: this must match the logic that uses the run script in BashWrapperBuilder
+        if( isTraceRequired() ) {
             bean.inputFiles[TaskRun.CMD_RUN] = bean.workDir.resolve(TaskRun.CMD_RUN)
         }
         // include task stdin file


### PR DESCRIPTION
Weird quirk here -

When fixing container ownership in batch, but not tracing, the run file wasn't staged. This caused the process to erroneously fail.

I thought of adding tests but it doesn't seem useful. There's a fundamental mismatch in dependencies here - the logic to call the script is separate from the staging logic. There's no way (afaict) with the code structured how it is, to validate that _any_ time the trace file is used, it should be staged. Lmk if there's a good way to test for that.

I also improved an error message because I got snagged on that when building from src.