### PR TITLE
Look for templates also in the module directory.

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
@@ -311,6 +311,14 @@ class TaskContext implements Map<String,Object>, Cloneable {
         if( path.isAbsolute() )
             return path
 
+        // make from the module dir
+        def module = this.script.getBinding()?.getVariable('moduleDir') as Path
+        if( module ) {
+            def target = module.resolve('templates').resolve(path)
+            if (Files.exists(target))
+                return target
+        }
+
         // otherwise make from the base dir
         def base = Global.session.baseDir
         if( base ) {
@@ -319,13 +327,6 @@ class TaskContext implements Map<String,Object>, Cloneable {
                 return target
         }
 
-        //.. or make from the module dir
-        def module = this.script.getBinding()?.getVariable('moduleDir') as Path
-        if( module ) {
-            def target = module.resolve('templates').resolve(path)
-            if (Files.exists(target))
-                return target
-        }
         // if the base dir is not available just use as it is
         return path
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
@@ -17,6 +17,8 @@
 
 package nextflow.processor
 
+import nextflow.script.ScriptMeta
+
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.Files
@@ -312,7 +314,7 @@ class TaskContext implements Map<String,Object>, Cloneable {
             return path
 
         // make from the module dir
-        def module = this.script.getBinding()?.getVariable('moduleDir') as Path
+        def module = ScriptMeta.get(this.script)?.getModuleDir()
         if( module ) {
             def target = module.resolve('templates').resolve(path)
             if (Files.exists(target))

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
@@ -19,6 +19,7 @@ package nextflow.processor
 
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.esotericsoftware.kryo.io.Input
@@ -310,11 +311,21 @@ class TaskContext implements Map<String,Object>, Cloneable {
         if( path.isAbsolute() )
             return path
 
-        // otherwise make
+        // otherwise make from the base dir
         def base = Global.session.baseDir
-        if( base )
-            return base.resolve('templates').resolve(path)
+        if( base ) {
+            def target = base.resolve('templates').resolve(path)
+            if (Files.exists(target))
+                return target
+        }
 
+        //.. or make from the module dir
+        def module = this.script.getBinding()?.getVariable('moduleDir') as Path
+        if( module ) {
+            def target = module.resolve('templates').resolve(path)
+            if (Files.exists(target))
+                return target
+        }
         // if the base dir is not available just use as it is
         return path
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -100,7 +100,7 @@ abstract class BaseScript extends Script implements ExecutionContext {
         binding.setVariable( 'workflow', session.workflowMetadata )
         binding.setVariable( 'nextflow', NextflowMeta.instance )
         binding.setVariable('launchDir', Paths.get('./').toRealPath())
-        binding.setVariable('moduleDir', meta.scriptPath?.parent )
+        binding.setVariable('moduleDir', meta.moduleDir )
     }
 
     protected process( String name, Closure<BodyDef> body ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -72,8 +72,11 @@ class ScriptMeta {
     /** the script {@link Class} object */
     private Class<? extends BaseScript> clazz
 
-    /** The location path from there the script has been loaded */
+    /** The location path from where the script has been loaded */
     private Path scriptPath
+
+    /** The location path from where the template file is loaded */
+    private Path moduleDir
 
     /** The list of function, procs and workflow defined in this script */
     private Map<String,ComponentDef> definitions = new HashMap<>(10)
@@ -87,6 +90,10 @@ class ScriptMeta {
     private boolean module
 
     Path getScriptPath() { scriptPath }
+
+    Path getModuleDir () { moduleDir?.parent }
+
+    void setModuleDir(Path path) { moduleDir = path }
 
     String getScriptName() { clazz.getName() }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -93,8 +93,6 @@ class ScriptMeta {
 
     Path getModuleDir () { moduleDir?.parent }
 
-    void setModuleDir(Path path) { moduleDir = path }
-
     String getScriptName() { clazz.getName() }
 
     boolean isModule() { module }
@@ -112,6 +110,7 @@ class ScriptMeta {
     @PackageScope
     void setScriptPath(Path path) {
         scriptPath = path
+        moduleDir = path
     }
 
     @PackageScope

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
@@ -172,6 +172,7 @@ class ScriptParser {
             script = (BaseScript)interpreter.parse(scriptText, clazzName)
             final meta = ScriptMeta.get(script)
             meta.setScriptPath(scriptPath)
+            meta.setModuleDir(scriptPath)
             meta.setModule(module)
             return this
         }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
@@ -172,7 +172,6 @@ class ScriptParser {
             script = (BaseScript)interpreter.parse(scriptText, clazzName)
             final meta = ScriptMeta.get(script)
             meta.setScriptPath(scriptPath)
-            meta.setModuleDir(scriptPath)
             meta.setModule(module)
             return this
         }


### PR DESCRIPTION
This PR is related to DSL2. The proposed change adds the module directory to the locations where NF looks for template files.

**Why?**
Templates go along with processes: there is no template without a process. With DSL2, processes can be defined in a module script located in any arbitrary location and be referred with the `include` keyword. 

To me it makes sense to add the possibility to have a dedicate `templates` folder inside the directory where the process is defined. Why processes can be anywhere while their template must be inside the `baseDir\templates` folder? I know that we can use an absolute template path, but this is something I'd avoid in a pipeline versioned on Git. Also, absolute paths would break the pipeline sharing feature.

**How does it work?**
If the template file is not found in `baseDir\templates`, the moduleDir for the task's script is retrieved and checked. This also means that templates in the baseDir override the ones in the moduleDir. This is consistent with the behavior NF keeps with `params`. 

**Use cases**
I see this feature helpful in 2 cases:

1. This first case is actually the one that prompted to propose the change in this PR. Our team is migrating to DSL2 in order to be able to build libraries of processes to share across pipelines. Let's suppose we have the following projects:

A first project with one module script defining 2 processes (P1 and P2) and both use templates:
```
Library L
  |-myModules.nf 
  |-templates
      |-P1-template.sh
      |-P2-template.sh
```
Then, a second project with a workflow that includes P1 and P2
```
Pipeline A
  |-main.nf
```
Finally, a third project with a workflow that includes again P1 and P2
```
Pipeline B
  |-main.nf

```
With the new template location, Library L can be used by A and B without any changes, because it is self-contained. Processes and templates are both in the Library L project. A future Pipeline C would do the same, just cloning L and including its module script. In this regard, I believe this is a step forward toward the complete externalization of the process definition. 

2. As side effect, the PR promotes a more structured organization within the same project. Let's suppose we have tens of module scripts, and all the processes there use templates. A user can now decide to organize the project grouping module scripts and their templates under the same folder as needed. For example:
```
baseDir
  |-main.nf 
  |-Phase0-Modules
    |-mymodules0.nf
    |-mymodules1.nf
    |-templates
        |-P1-template.sh
        |-P2-template.sh
 |-Phase1-Modules
    |-mymodules0.nf
    |-mymodules1.nf
    |-templates
        |-P3-template.sh
        |-P4-template.sh
 |-Phase2-Modules
    |-mymodules0.nf
    |-mymodules1.nf
    |-templates 
        |-P5-template.sh
        |-P6-template.sh
        |-P7-template.sh
```

