### PR TITLE
Add sqlite jdbc driver for the nf-sqldb plugin

### DIFF
--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     api 'mysql:mysql-connector-java:8.0.22'
     api 'org.mariadb.jdbc:mariadb-java-client:2.7.0'
     api 'org.postgresql:postgresql:42.2.23'
+    api 'org.xerial:sqlite-jdbc:3.36.0.3'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')

--- a/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
@@ -60,6 +60,7 @@ class SqlDataSource {
         if( !url.startsWith('jdbc:') ) throw new IllegalArgumentException("Invalid database JDBC connection url: $url")
         switch (url.tokenize(':')[1]) {
             case 'h2': return 'org.h2.Driver'
+            case 'sqlite': return 'org.sqlite.JDBC'
             case 'mysql': return 'com.mysql.cj.jdbc.Driver'
             case 'mariadb': return 'org.mariadb.jdbc.Driver'
             case 'postgresql': return 'org.postgresql.Driver'

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -64,6 +64,7 @@ class SqlDataSourceTest extends Specification {
         where:
         JBDC_URL                        | DRIVER
         'jdbc:postgresql:database'      | 'org.postgresql.Driver'
+        'jdbc:sqlite:database'          | 'org.sqlite.Driver'
         'jdbc:h2:mem:'                  | 'org.h2.Driver'
         'jdbc:mysql:some-host'          | 'com.mysql.cj.jdbc.Driver'
         'jdbc:mariadb:other-host'       | 'org.mariadb.jdbc.Driver'

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -64,7 +64,7 @@ class SqlDataSourceTest extends Specification {
         where:
         JBDC_URL                        | DRIVER
         'jdbc:postgresql:database'      | 'org.postgresql.Driver'
-        'jdbc:sqlite:database'          | 'org.sqlite.Driver'
+        'jdbc:sqlite:database'          | 'org.sqlite.JDBC'
         'jdbc:h2:mem:'                  | 'org.h2.Driver'
         'jdbc:mysql:some-host'          | 'com.mysql.cj.jdbc.Driver'
         'jdbc:mariadb:other-host'       | 'org.mariadb.jdbc.Driver'


### PR DESCRIPTION
I noticed that through the new `nf-sqldb` plugin, we have already added support for 
- h2
- mysql
- mariadb
- postgresql

I thought that it makes sense to add `sqlite` driver since it is quite popular and is often used by CLI tools as a simpler database.

I'd be happy to accomodate any change/enhancement requests.