### PR TITLE
document disable remote bin distribution opt

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -266,6 +266,7 @@ perJobMemLimit        Specifies Platform LSF *per-job* memory limit mode. See :r
 jobName               Determines the name of jobs submitted to the underlying cluster executor e.g. ``executor.jobName = { "$task.name - $task.hash" }`` Note: when using this option you need to make sure the resulting job name matches the validation constraints of the underlying batch scheduler.
 cpus                  The maximum number of CPUs made available by the underlying system (only used by the ``local`` executor).
 memory                The maximum amount of memory made available by the underlying system (only used by the ``local`` executor).
+disableRemoteBinDir   Disables `bin </docs/latest/faq.html#how-do-i-invoke-custom-scripts-and-tools>`_ directory distribution to remote processes (default: ``false``).
 ===================== =====================
 
 


### PR DESCRIPTION
I found a hidden option - https://github.com/nextflow-io/nextflow/blob/1e485b32b25ba5a369696c2080432eb06391d641/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy#L119

This option is actually valuable. Basically, the bin dir is not namespaced - processes download it to `/tmp/nextflow-bin`.

Now, if you mount in `/tmp` into containers (say, mounting an EBS volume or other NFS from the host to get more space) then multiple containers will fight with each other. NF usually avoids this by using `mktemp` to give each process it's isolated dir. But that doesn't apply for `nextflow-bin`, and launching tons of `aws s3 cp` into the same dir causes them to fail.

I noticed there's a flag to disable this functionality. Sure, it could break some pipelines. For us, it's a safety measure to ensure imported workflows don't use this feature. We'll patch those workflows to include files in their images instead of distributing via S3. NF already puts a bunch of strain on S3 rate limits, which we'd like to avoid. Anyway, if the flag exists, might as well document it.

It would be great to get guidance on staging _large_ files into processes. Is mounting a big host-dir into `/tmp` the right move? Would it be better to configure docker to put ephemeral storage _on_ that volume? I'd be worried about the overlayfs overhead in that case.

Related: https://github.com/nextflow-io/nextflow/issues/1798