### PR TITLE
Replace /bin/bash with /usr/bin/env bash

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ./gradlew -q compile exportClasspath

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright 2013-2019, Centre for Genomic Regulation (CRG)
 #
@@ -43,7 +43,7 @@ if [[ "$NXF_USRMAP" ]]; then
 # create a `nextflow` user with the provided ID 
 # then change the docker socker ownership to `nextflow` user 
 addgroup docker
-adduser -u $NXF_USRMAP -G docker -s /bin/bash -D nextflow
+adduser -u $NXF_USRMAP -G docker -s "$(which bash)" -D nextflow
 chown nextflow /var/run/docker.sock  
 # finally run the target command with `nextflow` user
 su nextflow << EOF

--- a/docs/ignite.rst
+++ b/docs/ignite.rst
@@ -151,7 +151,7 @@ Platform LSF launcher
 
 The following example shows a launcher script for the `Platform LSF <https://en.wikipedia.org/wiki/Platform_LSF/>`_ resource manager::
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     #BSUB -oo output_%J.out
     #BSUB -eo output_%J.err
     #BSUB -J <job name>
@@ -175,7 +175,7 @@ Univa Grid Engine launcher
 
 The following example shows a launcher script for the `Univa Grid Engine <https://en.wikipedia.org/wiki/Univa_Grid_Engine>`_ (aka SGE)::
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     #$ -cwd
     #$ -j y
     #$ -o <output file name>
@@ -195,7 +195,7 @@ Linux SLURM launcher
 
 When using Linux SLURM you will need to use ``srun`` instead ``mpirun`` in your launcher script. For example::
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     #SBATCH --job-name=<job name>
     #SBATCH --output=<log file %j>
     #SBATCH --ntasks=5

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -242,7 +242,7 @@ where the Nextflow script file is located (any other location can be provided by
 
 The template script can contain any piece of code that can be executed by the underlying system. For example::
 
-  #!/bin/bash
+  #!/usr/bin/env bash
   echo "process started at `date`"
   echo $STR
   :

--- a/docs/sync-doc.sh
+++ b/docs/sync-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TARGET=../../nextflow-website/assets
 if egrep "^release = '.*edge|.*SNAPSHOT'$" -c conf.py >/dev/null; then
 MODE=edge

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEST_JDK=${TEST_JDK:=8}
 X_BRANCH=${TRAVIS_BRANCH:-${CIRCLE_BRANCH:-'master'}}
 X_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}

--- a/launch.sh
+++ b/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright 2020-2021, Seqera Labs
 #  Copyright 2013-2019, Centre for Genomic Regulation (CRG)

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -72,7 +72,7 @@ class BashWrapperBuilder {
         catch( Exception e ) {
             log.warn "Invalid value for `NXF_DEBUG` variable: $str -- See http://www.nextflow.io/docs/latest/config.html#environment-variables"
         }
-        BASH = Collections.unmodifiableList( level > 0 ? ['/bin/bash','-uex'] : ['/bin/bash','-ue'] )
+        BASH = Collections.unmodifiableList( level > 0 ? ['/usr/bin/env','bash','-uex'] : ['/usr/bin/env','bash','-ue'] )
 
     }
 
@@ -386,7 +386,7 @@ class BashWrapperBuilder {
         final traceWrapper = isTraceRequired()
         if( traceWrapper ) {
             // executes the stub which in turn executes the target command
-            launcher = "/bin/bash ${fileStr(wrapperFile)} nxf_trace"
+            launcher = "/usr/bin/env bash ${fileStr(wrapperFile)} nxf_trace"
         }
         else {
             launcher = "${interpreter} ${fileStr(scriptFile)}"

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -465,7 +465,7 @@ class K8sDriverLauncher {
         new PodSpecBuilder()
             .withPodName(runName)
             .withImageName(podImage ?: k8sConfig.getNextflowImageName())
-            .withCommand(['/bin/bash', '-c', cmd])
+            .withCommand(['/usr/bin/env', 'bash', '-c', cmd])
             .withLabels([ app: 'nextflow', runName: runName ])
             .withNamespace(k8sClient.config.namespace)
             .withServiceAccount(k8sClient.config.serviceAccount)

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -125,7 +125,7 @@ class PodSpecBuilder {
 
     PodSpecBuilder withCommand( cmd ) {
         assert cmd instanceof List || cmd instanceof CharSequence, "Missing or invalid K8s command parameter: $cmd"
-        this.command = cmd instanceof List ? cmd : ['/bin/bash','-c', cmd.toString()]
+        this.command = cmd instanceof List ? cmd : ['/usr/bin/env','bash','-c', cmd.toString()]
         return this
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -360,7 +360,7 @@ class TaskProcessor {
      *          <pre>
      *              {
      *                 """
-     *                 #!/bin/bash
+     *                 #!/usr/bin/env bash
      *                 do this ${x}
      *                 do that ${y}
      *                 :

--- a/modules/nextflow/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
+++ b/modules/nextflow/src/main/resources/nextflow/cloud/aws/cloud-boot.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 su - !{userName} << 'EndOfScript'
 (
 set -e

--- a/modules/nextflow/src/main/resources/nextflow/cloud/google/cloud-boot.txt
+++ b/modules/nextflow/src/main/resources/nextflow/cloud/google/cloud-boot.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 su - !{userName} << 'EndOfScript'
 (

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -13,7 +13,7 @@
 ##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ##  See the License for the specific language governing permissions and
 ##  limitations under the License.
-#!/bin/bash
+#!/usr/bin/env bash
 {{header_script}}
 # NEXTFLOW TASK: {{task_name}}
 set -e

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
@@ -79,7 +79,7 @@ class BashFunLibTest extends Specification {
         given:
         def scriptFile = Files.createTempFile("test", "sh")
         def script = """
-        #!/bin/bash
+        #!/usr/bin/env bash
 
         set -e
         """.stripIndent() +
@@ -111,7 +111,7 @@ class BashFunLibTest extends Specification {
         given:
         def scriptFile = Files.createTempFile("test", "sh")
         def script = """
-        #!/bin/bash
+        #!/usr/bin/env bash
 
         set -e
         """.stripIndent() +

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashTemplateEngineTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashTemplateEngineTest.groovy
@@ -31,7 +31,7 @@ class BashTemplateEngineTest extends Specification {
         def engine = new BashTemplateEngine()
         def template = '''\
             ## comment
-            #!/bin/bash
+            #!/usr/bin/env bash
             # NEXTFLOW TASK: foo
             line 1
               ## comment
@@ -42,7 +42,7 @@ class BashTemplateEngineTest extends Specification {
 
         expect:
         engine.render(template, [:]) == '''\
-                #!/bin/bash
+                #!/usr/bin/env bash
                 # NEXTFLOW TASK: foo
                 line 1
                 line 2

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -101,7 +101,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env -S bash -ue
                 echo Hello world!
                 ''' .stripIndent().leftTrim()
 
@@ -132,7 +132,7 @@ class BashWrapperBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env -S bash -ue
                 echo Hello world!
                 '''.stripIndent().leftTrim()
 
@@ -475,21 +475,21 @@ class BashWrapperBuilderTest extends Specification {
         when:
         def binding = newBashWrapperBuilder(statsEnabled: false).makeBinding()
         then:
-        binding.launch_cmd == '/bin/bash -ue /work/dir/.command.sh'
+        binding.launch_cmd == '/usr/bin/env bash -ue /work/dir/.command.sh'
         binding.unstage_controls == null
         binding.containsKey('unstage_controls')
 
         when:
         binding = newBashWrapperBuilder(statsEnabled: true).makeBinding()
         then:
-        binding.launch_cmd == '/bin/bash /work/dir/.command.run nxf_trace'
+        binding.launch_cmd == '/usr/bin/env bash /work/dir/.command.run nxf_trace'
         binding.unstage_controls == null
         binding.containsKey('unstage_controls')
 
         when:
         binding = newBashWrapperBuilder(statsEnabled: true, scratch: true).makeBinding()
         then:
-        binding.launch_cmd == '/bin/bash /work/dir/.command.run nxf_trace'
+        binding.launch_cmd == '/usr/bin/env bash /work/dir/.command.run nxf_trace'
         binding.unstage_controls == '''\
                         cp .command.out /work/dir/.command.out || true
                         cp .command.err /work/dir/.command.err || true
@@ -503,13 +503,13 @@ class BashWrapperBuilderTest extends Specification {
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
-        binding.launch_cmd == '/bin/bash -ue /work/dir/.command.sh'
+        binding.launch_cmd == '/usr/bin/env bash -ue /work/dir/.command.sh'
         binding.trace_cmd == binding.launch_cmd
 
         when:
         binding = newBashWrapperBuilder(input: 'Ciao ciao').makeBinding()
         then:
-        binding.launch_cmd == '/bin/bash -ue /work/dir/.command.sh < /work/dir/.command.in'
+        binding.launch_cmd == '/usr/bin/env bash -ue /work/dir/.command.sh < /work/dir/.command.in'
         binding.trace_cmd == binding.launch_cmd
 
         when:
@@ -851,6 +851,8 @@ class BashWrapperBuilderTest extends Specification {
         builder.isBash('/usr/bin/bash')
         builder.isBash('/bin/env bash')
         builder.isBash('/bin/bash -eu')
+        builder.isBash('/usr/bin/env bash')
+        builder.isBash('/usr/bin/env bash -eu')
         !builder.isBash('/bin/env perl')
 
     }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/CondorExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/CondorExecutorTest.groovy
@@ -253,7 +253,7 @@ class CondorExecutorTest extends Specification {
         folder.resolve('.command.run').canExecute()
 
         folder.resolve('.command.sh').text == '''
-                #!/bin/bash -ue
+                #!/usr/bin/env -S bash -ue
                 echo Hello world!
                 '''
                 .stripIndent()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # NEXTFLOW TASK: Hello 2
 set -e
 set -u
@@ -120,7 +120,7 @@ nxf_write_trace() {
 nxf_trace_mac() {
     local start_millis=$(nxf_date)
 
-    /bin/bash -ue {{folder}}/.command.sh
+    bash -ue {{folder}}/.command.sh
 
     local end_millis=$(nxf_date)
     local wall_time=$((end_millis-start_millis))
@@ -145,7 +145,7 @@ nxf_trace_linux() {
     local start_millis=$(nxf_date)
     trap 'kill $mem_proc' ERR
     
-    /bin/bash -ue {{folder}}/.command.sh &
+    bash -ue {{folder}}/.command.sh &
     local task=$!
 
     mem_fd=$(nxf_fd)
@@ -270,7 +270,7 @@ on_term() {
 }
 
 nxf_launch() {
-    /bin/bash {{folder}}/.command.run nxf_trace
+    bash {{folder}}/.command.run nxf_trace
 }
 
 nxf_stage() {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #BSUB -x 1
 #BSUB -y 2
 # NEXTFLOW TASK: Hello 1
@@ -85,7 +85,7 @@ on_term() {
 }
 
 nxf_launch() {
-    /bin/bash -ue {{folder}}/.command.sh
+    bash -ue {{folder}}/.command.sh
 }
 
 nxf_stage() {

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
@@ -163,7 +163,7 @@ class K8sDriverLauncherTest extends Specification {
                         containers:[
                                 [name:'foo-boo',
                                  image:'the-image',
-                                 command:['/bin/bash', '-c', "source /etc/nextflow/init.sh; nextflow run foo"],
+                                 command:['/usr/bin/env'. 'bash', '-c', "source /etc/nextflow/init.sh; nextflow run foo"],
                                  env:[
                                          [name:'NXF_WORK', value:'/the/work/dir'],
                                          [name:'NXF_ASSETS', value:'/the/project/dir'],
@@ -212,7 +212,7 @@ class K8sDriverLauncherTest extends Specification {
                         containers:[
                                 [name:'foo-boo',
                                  image:'foo/bar',
-                                 command:['/bin/bash', '-c', "source /etc/nextflow/init.sh; nextflow run foo"],
+                                 command:['/usr/bin/env', 'bash', '-c', "source /etc/nextflow/init.sh; nextflow run foo"],
                                  env:[
                                          [name:'NXF_WORK', value:'/the/work/dir'],
                                          [name:'NXF_ASSETS', value:'/the/project/dir'],

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -86,7 +86,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name:'nf-123',
                                      image:'debian:latest',
-                                     command:['/bin/bash', '-ue','.command.run'],
+                                     command:['/usr/bin/env', 'bash', '-ue','.command.run'],
                                      workingDir:'/some/work/dir']
                             ]
                     ]
@@ -116,7 +116,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name:'nf-foo',
                                      image:'debian:latest',
-                                     command:['/bin/bash', '-ue','.command.run'],
+                                     command:['/usr/bin/env', 'bash', '-ue','.command.run'],
                                      workingDir:'/some/work/dir',
                                      resources:[ requests: [cpu:1], limits:[cpu:1] ],
                                      env: [  [name:'NXF_OWNER', value:'501:502'] ]
@@ -148,7 +148,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name:'nf-abc',
                                      image:'user/alpine:1.0',
-                                     command:['/bin/bash', '-ue', '.command.run'],
+                                     command:['/usr/bin/env', 'bash', '-ue', '.command.run'],
                                      workingDir:'/some/work/dir',
                                      resources:[ requests: [cpu:4, memory:'16384Mi'], limits:[cpu:4, memory:'16384Mi'] ]
                                     ]
@@ -195,7 +195,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name:'nf-123',
                                      image:'debian:latest',
-                                     command:['/bin/bash', '-ue','.command.run'],
+                                     command:['/usr/bin/env', 'bash', '-ue','.command.run'],
                                      workingDir:'/some/work/dir',
                                      resources:[requests:[cpu:1], limits:[cpu:1]]
                                     ]
@@ -243,7 +243,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name:'nf-123',
                                      image:'debian:latest',
-                                     command:['/bin/bash', '-ue','.command.run'],
+                                     command:['/usr/bin/env', 'bash', '-ue','.command.run'],
                                      workingDir:'/some/work/dir',
                                      env:[[name:'FOO', value:'bar']],
                                      volumeMounts:[ [name:'vol-1', mountPath:'/etc'],
@@ -299,7 +299,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name: 'nf-123',
                                      image: 'debian:latest',
-                                     command: ['/bin/bash', '-ue', '.command.run'],
+                                     command: ['/usr/bin/env', 'bash', '-ue', '.command.run'],
                                      workingDir: '/some/work/dir',
                                      volumeMounts: [
                                              [name:'vol-1', mountPath:'/work'],
@@ -335,7 +335,7 @@ class K8sTaskHandlerTest extends Specification {
                             containers:[
                                     [name: 'nf-123',
                                      image: 'debian:latest',
-                                     command: ['/bin/bash', '-ue', '.command.run'],
+                                     command: ['/usr/bin/env', 'bash', '-ue', '.command.run'],
                                      workingDir: '/some/work/dir',
                                      volumeMounts: [
                                              [name:'vol-3', mountPath:'/tmp'],

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -180,7 +180,7 @@ class PodSpecBuilderTest extends Specification {
                            containers:[
                                    [name:'foo',
                                     image:'busybox',
-                                    command:['/bin/bash', '-c', 'echo hello'],
+                                    command:['/usr/bin/env', 'bash', '-c', 'echo hello'],
                                     workingDir:'/some/work/dir',
                                     env: [
                                             [name:'ALPHA', value:'hello'],

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -43,15 +43,18 @@ class TaskConfigTest extends Specification {
         config.getShell() == expected
 
         where:
-        expected             | value
-        ['/bin/bash', '-ue'] | null
-        ['/bin/bash', '-ue'] | []
-        ['/bin/bash', '-ue'] | ''
-        ['bash']             | 'bash'
-        ['bash']             | ['bash']
-        ['bash', '-e']       | ['bash', '-e']
-        ['zsh', '-x']        | ['zsh', '-x']
-        ['hello']            | { "$my_shell" }
+        expected                        | value
+        ['/bin/bash', '-ue']            | null
+        ['/bin/bash', '-ue']            | []
+        ['/bin/bash', '-ue']            | ''
+        ['/usr/bin/env', 'bash', '-ue'] | null
+        ['/usr/bin/env', 'bash', '-ue'] | []
+        ['/usr/bin/env', 'bash', '-ue'] | ''
+        ['bash']                        | 'bash'
+        ['bash']                        | ['bash']
+        ['bash', '-e']                  | ['bash', '-e']
+        ['zsh', '-x']                   | ['zsh', '-x']
+        ['hello']                       | { "$my_shell" }
     }
 
     def testErrorStrategy() {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -46,7 +46,7 @@ class ProcessConfigTest extends Specification {
         def config = new ProcessConfig(script)
 
         expect:
-        config.shell ==  ['/bin/bash','-ue']
+        config.shell ==  ['/usr/bin/env', 'bash','-ue']
         config.cacheable
         config.validExitStatus == [0]
         config.maxRetries == 0

--- a/nextflow
+++ b/nextflow
@@ -178,7 +178,7 @@ function launch_nextflow() {
 }
 
 # check self-install
-if [ "$0" = "bash" ] || [ "$0" = "/bin/bash" ]; then
+if [ "$0" = "bash" ] || [ "$0" = "/bin/bash" ] || { [ "$0" = "/usr/bin/env" ] && [ "$1" = "bash" ]; } ; then
     if [ -d nextflow ]; then
         echo 'Please note:'
         echo "- The install procedure needs to create a file named 'nextflow' in this folder, but a directory with this name already exists."

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -54,7 +54,7 @@ class AwsBatchScriptLauncherTest extends Specification {
                 nxf_s3_upload .command.err s3://work/dir || true
                 '''.stripIndent()
 
-        binding.launch_cmd == '/bin/bash -ue .command.sh < .command.in'
+        binding.launch_cmd == '/usr/bin/env bash -ue .command.sh < .command.in'
         binding.unstage_outputs == null
 
         binding.helpers_script == '''\
@@ -228,7 +228,7 @@ class AwsBatchScriptLauncherTest extends Specification {
                     nxf_parallel "${uploads[@]}"
                     '''.stripIndent().leftTrim()
 
-        binding.launch_cmd == '/bin/bash .command.run nxf_trace'
+        binding.launch_cmd == '/usr/bin/env bash .command.run nxf_trace'
         
         binding.task_env == ''
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -92,7 +92,7 @@ class AzFileCopyStrategyTest extends Specification {
                 nxf_az_upload .command.err 'http://account.blob.core.windows.net/my-data/work/dir' || true
                 '''.stripIndent()
 
-        binding.launch_cmd == '/bin/bash -ue .command.sh < .command.in'
+        binding.launch_cmd == '/usr/bin/env bash -ue .command.sh < .command.in'
         binding.unstage_outputs == null
 
         binding.helpers_script == '''\
@@ -361,7 +361,7 @@ class AzFileCopyStrategyTest extends Specification {
                     nxf_parallel "${uploads[@]}"
                     '''.stripIndent().leftTrim()
 
-        binding.launch_cmd == '/bin/bash .command.run nxf_trace'
+        binding.launch_cmd == '/usr/bin/env bash .command.run nxf_trace'
 
         binding.task_env == '''\
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -163,7 +163,7 @@ class TesTaskHandler extends TaskHandler {
     protected final TesTask newTesTask() {
         // the cmd list to launch it
         def job = new ArrayList(BashWrapperBuilder.BASH) << wrapperFile.getName()
-        List cmd = ['/bin/bash','-c', job.join(' ') + " &> $TaskRun.CMD_LOG" ]
+        List cmd = ['/usr/bin/env','bash','-c', job.join(' ') + " &> $TaskRun.CMD_LOG" ]
 
         def exec = new TesExecutorModel()
         exec.command = cmd

--- a/plugins/nf-ga4gh/src/test/nextflow/ga4gh/tes/executor/TesBashBuilderTest.groovy
+++ b/plugins/nf-ga4gh/src/test/nextflow/ga4gh/tes/executor/TesBashBuilderTest.groovy
@@ -51,7 +51,7 @@ class TesBashBuilderTest extends Specification {
 
         folder.resolve('.command.sh').text ==
                 '''
-                #!/bin/bash -ue
+                #!/usr/bin/env -S bash -ue
                 echo Hello world!
                 '''
                         .stripIndent().leftTrim()

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # NEXTFLOW TASK: Hello 1
 set -e
 set -u
@@ -170,7 +170,7 @@ on_term() {
 }
 
 nxf_launch() {
-    /bin/bash -ue {{folder}}/.command.sh
+    bash -ue {{folder}}/.command.sh
 }
 
 nxf_stage() {

--- a/plugins/nf-ignite/src/main/nextflow/executor/IgScriptTask.groovy
+++ b/plugins/nf-ignite/src/main/nextflow/executor/IgScriptTask.groovy
@@ -110,7 +110,7 @@ class IgScriptTask extends IgBaseTask<Integer>   {
         // NOTE: the actual command is wrapped by another bash whose streams
         // are redirected to null. This is important  to consume the stdout/stderr
         // of the wrapped job otherwise that output will cause the inner `tee`s hang
-        List cmd = ['/bin/bash','-c', job.join(' ') + ' &>' + TaskRun.CMD_LOG]
+        List cmd = ['/usr/bin/env','bash','-c', job.join(' ') + ' &>' + TaskRun.CMD_LOG]
 
         log.debug "Running task > ${bean.name} -- taskId=${taskId}; workdir=${localWorkDir}; remote=${isRemoteWorkDir}"
         ProcessBuilder builder = new ProcessBuilder()

--- a/tests/checks/run.sh
+++ b/tests/checks/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 set -u 
 trap "exit" INT
 

--- a/tests/subworkflow-dsl2.nf
+++ b/tests/subworkflow-dsl2.nf
@@ -1,4 +1,4 @@
-#!/bin/bash nextflow
+#!/usr/bin/env -S bash nextflow
 nextflow.enable.dsl=2
 
 process foo {

--- a/tests/templates/bar.txt
+++ b/tests/templates/bar.txt
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo Bar $x

--- a/tests/templates/bash-script.txt
+++ b/tests/templates/bash-script.txt
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo 'Hello ${family}' > file.out

--- a/tests/templates/foo.txt
+++ b/tests/templates/foo.txt
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo Foo $x

--- a/tests/templates/shell-script.txt
+++ b/tests/templates/shell-script.txt
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Hello $USER !{family} !{params.data}" > file.out

--- a/validation/await.sh
+++ b/validation/await.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 TIMEOUT=3600    # terminate after one hour

--- a/validation/awsbatch.sh
+++ b/validation/awsbatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e 
 
 get_abs_filename() {

--- a/validation/test.sh
+++ b/validation/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 set -e 
 
 get_abs_filename() {


### PR DESCRIPTION
This replaces all hardcoded `/bin/bash` paths to `/usr/bin/env bash`.

When additional arguments are given to bash (e.g. `bash -ue`), `/usr/bin/env -S bash -ue` is used instead.
The `env -S` functionality requires coreutils 8.30 or newer. This or a newer version of coreutils is present since Ubuntu 19.04, CentOS 8 and many others.

This PR also addresses issues with containers and Linux OSes where `/bin/bash` doesn't exist or where `bash` is installed in a different path (e.g. NixOS).
The PR should also fix partially or entirely the issues #73 #1598 and #1732 

Additional potential issues remain in the files:
```
modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
modules/nextflow/src/test/groovy/nextflow/container/PodmanBuilderTest.groovy
modules/nextflow/src/test/groovy/nextflow/container/ShifterBuilderTest.groovy
modules/nextflow/src/test/groovy/nextflow/container/UdockerBuilderTest.groovy
modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
```

Where `/bin/bash` is still hardcoded to work with different images.
In fact, some of that code is likely non-functional as, for instance, the latest `busybox` docker image no longer includes `/bin/bash`.