### PR TITLE
Allow selecting the agent SKU on the Azure pool.

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -275,6 +275,9 @@ azure.batch.allowPoolCreation                   Enable the automatic creation of
 azure.batch.deleteJobsOnCompletion              Enable the automatic deletion of jobs created by the pipeline execution (default: ``true``).
 azure.batch.deletePoolsOnCompletion             Enable the automatic deletion of compute node pools upon pipeline completion (default: ``false``).
 azure.batch.copyToolInstallMode                 Specify where the `azcopy` tool used by Nextflow. When ``node`` is specified it's copied once during the pool creation. When ``task`` is provider, it's installed for each task execution (default: ``node``).
+azure.batch.pools.<name>.publisher              Specify the publisher of virtual machine type used by the pool identified with ``<name>`` (default ``microsoft-azure-batch``).
+azure.batch.pools.<name>.offer                  Specify the offer type of the virtual machine type used by the pool identified with ``<name>`` (default ``centos-container``).
+azure.batch.pools.<name>.sku                    Specify the ID of the Compute Node agent SKU which the pool identified with ``<name>`` supports (default ``batch.node.centos 8``).
 azure.batch.pools.<name>.vmType                 Specify the virtual machine type used by the pool identified with ``<name>``.
 azure.batch.pools.<name>.vmCount                Specify the number of virtual machines provisioned by the pool identified with ``<name>``.
 azure.batch.pools.<name>.maxVmCount             Specify the max of virtual machine when using auto scale option.

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -410,6 +410,8 @@ class AzBatchService implements Closeable {
         List<ImageInformation> images = client.accountOperations().listSupportedImages()
 
         for (ImageInformation it : images) {
+            if( !it.nodeAgentSKUId().equalsIgnoreCase(opts.sku) )
+                continue
             if( it.osType() != opts.osType )
                 continue
             if( it.verificationType() != opts.verification )

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -38,6 +38,7 @@ class AzPoolOpts implements CacheFunnel {
 
     static public final String DEFAULT_PUBLISHER = "microsoft-azure-batch"
     static public final String DEFAULT_OFFER = "centos-container"
+    static public final String DEFAULT_SKU = "batch.node.centos 8"
     static public final String DEFAULT_VM_TYPE = "Standard_D4_v3"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final Duration DEFAULT_SCALE_INTERVAL = Duration.of('5 min')
@@ -46,6 +47,7 @@ class AzPoolOpts implements CacheFunnel {
     boolean privileged
     String publisher
     String offer
+    String sku
     OSType osType = DEFAULT_OS_TYPE
     VerificationType verification = VerificationType.VERIFIED
 
@@ -70,6 +72,7 @@ class AzPoolOpts implements CacheFunnel {
         this.privileged = opts.privileged ?: false
         this.publisher = opts.publisher ?: DEFAULT_PUBLISHER
         this.offer = opts.offer ?: DEFAULT_OFFER
+        this.sku = opts.sku ?: DEFAULT_SKU
         this.vmType = opts.vmType ?: DEFAULT_VM_TYPE
         this.vmCount = opts.vmCount as Integer ?: 1
         this.autoScale = opts.autoScale as boolean
@@ -88,6 +91,7 @@ class AzPoolOpts implements CacheFunnel {
         hasher.putBoolean(privileged)
         hasher.putUnencodedChars(publisher)
         hasher.putUnencodedChars(offer)
+        hasher.putUnencodedChars(sku)
         hasher.putUnencodedChars(vmType)
         hasher.putUnencodedChars(registry ?: '')
         hasher.putUnencodedChars(userName ?: '')


### PR DESCRIPTION
This change allows users to select the agent SKU, and therefore the OS version, on each Azure pool. 

**Use case**
I was using some advanced features of bwa-mem in a task and found out that the pools created by NF in Azure were always based on CentOS 7. Because of that, the latest version of bwa was returning  this error:

Please verify that both the operating system and the processor support Intel(R) CLWB instructions.

**Why this is needed in NF?**
With some investigation I realized that there was no way to create pool nodes with CentOS 8+ (which natively supports CLWB instructions). Without specifying the SKU, Nextflow was always selecting the **first** centoOS image reference from the list provided by Azure Batch, which happens to be the following:
```
offer: centos-container
publisher: microsoft-azure-batch
sku: batch.node.centos 7
```
This is because only the offer, publisher and osType were matched against the list of images. 

** Proposed Solution **
With this PR, I'm adding the agent SKU to the information specified in the pool configuration and matching it against the image info. Also, centOS 8 is now defaulted, therefore, if the user does not input any information for the image, NF now selects the following image reference:
```
sku = "batch.node.centos 8"
offer = "centos-container"
publisher = "microsoft-azure-batch"
```
If the user wants Ubuntu based nodes, he/she can now specify the following in the pool config:
```
sku = "batch.node.ubuntu 20.04"
offer = "ubuntu-server-container"
publisher = "microsoft-azure-batch"
```
or, if Debian: 
```
sku = "batch.node.debian 10"
offer = "debian-10"
publisher = "debian"
```

I believe this is a critical point to address in the nf-azure plugin.
