### PR TITLE
Add missing config for Azure repos integration

### DIFF
--- a/docs/sharing.rst
+++ b/docs/sharing.rst
@@ -319,7 +319,7 @@ using the configuration snippet shown below::
         azurerepos {
             server = 'https://dev.azure.com'
             endpoint = 'https://dev.azure.com'
-            platform = 'gitea'
+            platform = 'azurerepos'
             user = 'your-user'
             password = 'your-password'
             token = 'your-api-token'

--- a/docs/sharing.rst
+++ b/docs/sharing.rst
@@ -318,11 +318,11 @@ using the configuration snippet shown below::
 
         azurerepos {
             server = 'https://dev.azure.com'
-            endpoint = 'https://dev.azure.com'
+            endpoint = 'https://dev.azure.com' // Can be omitted when it has the same value as the server field.
             platform = 'azurerepos'
             user = 'your-user'
             password = 'your-password'
-            token = 'your-api-token'
+            token = 'your-api-token' // When token is used, password is not necessary.
 
         }
 

--- a/docs/sharing.rst
+++ b/docs/sharing.rst
@@ -312,13 +312,18 @@ Azure Repos credentials
 
 Nextflow has a builtin support for `Azure Repos <https://azure.microsoft.com/en-us/services/devops/repos/>`_, a Git source
 code management service hosted in the Azure cloud. To access your Azure Repos with Nextflow provide the repository credentials
-using the configuration snippet shown below:
+using the configuration snippet shown below::
 
     providers {
 
         azurerepos {
-            user = 'your-user-name'
-            password = 'your-personal-access-token'
+            server = 'https://dev.azure.com'
+            endpoint = 'https://dev.azure.com'
+            platform = 'gitea'
+            user = 'your-user'
+            password = 'your-password'
+            token = 'your-api-token'
+
         }
 
     }

--- a/docs/sharing.rst
+++ b/docs/sharing.rst
@@ -322,7 +322,7 @@ using the configuration snippet shown below::
             platform = 'azurerepos'
             user = 'your-user'
             password = 'your-password'
-            token = 'your-api-token' // When token is used, password is not necessary.
+            token = 'your-api-token' // Only token is allowed
 
         }
 


### PR DESCRIPTION
I noticed that even though[ tests](https://github.com/nextflow-io/nextflow/blob/78570b11e77e26cb9d607b28e929816bcbbc28ff/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy#L29) seem to indicate there are more config fields they seemed to be missing from the docs.