### PR TITLE
Process label regex allows starting with numeric

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -42,7 +42,7 @@ import nextflow.script.params.*
 @Slf4j
 class ProcessConfig implements Map<String,Object>, Cloneable {
 
-    static final public transient LABEL_REGEXP = ~/[a-zA-Z]([a-zA-Z0-9_]*[a-zA-Z0-9]+)?/
+    static final public transient LABEL_REGEXP = ~/[a-zA-Z0-9]([a-zA-Z0-9_]*[a-zA-Z0-9]+)?/
 
     static final public List<String> DIRECTIVES = [
             'accelerator',


### PR DESCRIPTION
Got an error when trying to use a label that starts with a number.

```
Not a valid process label: 1foo -- Label must consist of alphanumeric characters or '_', must start with an alphabetic character and must end with an alphanumeric character
```

The error command says that the label may start with an ~alphanumeric~ ***alphabetic (oops)***, but the regex does not. I updated the regex to match the documentation.


```groovy
groovy> LABEL_REGEXP = ~/[a-zA-Z]([a-zA-Z0-9_]*[a-zA-Z0-9]+)?/ 
groovy> LABEL_REGEXP.matcher('1foo').matches() 
 
Result: false



groovy> LABEL_REGEXP = ~/[a-zA-Z0-9]([a-zA-Z0-9_]*[a-zA-Z0-9]+)?/ 
groovy> LABEL_REGEXP.matcher('1foo').matches() 
 
Result: true
```
