### PR TITLE
add retries to container env vars on batch

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -663,6 +663,11 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         def vars = []
         if( this.environment?.containsKey('NXF_DEBUG') )
             vars << new KeyValuePair().withName('NXF_DEBUG').withValue(this.environment['NXF_DEBUG'])
+        if( this.getAwsOptions().retryMode )
+            vars << new KeyValuePair().withName('AWS_RETRY_MODE').withValue(this.getAwsOptions().retryMode)
+        if( this.getAwsOptions().maxTransferAttempts )
+            vars << new KeyValuePair().withName('AWS_MAX_ATTEMPTS').withValue(this.getAwsOptions().maxTransferAttempts)
+            vars << new KeyValuePair().withName('AWS_METADATA_SERVICE_NUM_ATTEMPTS').withValue(this.getAwsOptions().maxTransferAttempts)
         return vars
     }
 

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -663,11 +663,12 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         def vars = []
         if( this.environment?.containsKey('NXF_DEBUG') )
             vars << new KeyValuePair().withName('NXF_DEBUG').withValue(this.environment['NXF_DEBUG'])
-        if( this.getAwsOptions().retryMode )
+        if( this.getAwsOptions().retryMode && this.getAwsOptions().retryMode in AwsOptions.VALID_RETRY_MODES)
             vars << new KeyValuePair().withName('AWS_RETRY_MODE').withValue(this.getAwsOptions().retryMode)
-        if( this.getAwsOptions().maxTransferAttempts )
-            vars << new KeyValuePair().withName('AWS_MAX_ATTEMPTS').withValue(this.getAwsOptions().maxTransferAttempts)
-            vars << new KeyValuePair().withName('AWS_METADATA_SERVICE_NUM_ATTEMPTS').withValue(this.getAwsOptions().maxTransferAttempts)
+        if( this.getAwsOptions().maxTransferAttempts ) {
+            vars << new KeyValuePair().withName('AWS_MAX_ATTEMPTS').withValue(this.getAwsOptions().maxTransferAttempts as String)
+            vars << new KeyValuePair().withName('AWS_METADATA_SERVICE_NUM_ATTEMPTS').withValue(this.getAwsOptions().maxTransferAttempts as String)
+        }
         return vars
     }
 


### PR DESCRIPTION
So the first command that a batch container exec's is of the shape:
`aws --region <region> s3 cp --only-show-errors`

By this point, no bash scripts have executed. So the exported aws retry env vars haven't hit yet. When running a bunch of batch jobs through a single instance, it's possible to overwhelm the metadata endpoint or s3 rate limits. This makes achieving throughput difficult.

This PR adds explicit env vars to the container to achieve retries even on the initial s3 pull.

I wrote a test, but `gradle test` wasn't passing for me locally (408 failed - something must be wrong). If you point me in the right direction, I can run only the single test I modified to see if its passing. Or, feel free to check out locally and fix it up.

Thanks!