### PR TITLE
fix docker bin in image PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV NXF_HOME=/.nextflow
 ARG TARGETPLATFORM
 
 # copy docker client
-COPY dist/${TARGETPLATFORM} /usr/local/bin/docker
+COPY dist/${TARGETPLATFORM}/docker /usr/local/bin/docker
 COPY entry.sh /usr/local/bin/entry.sh
 COPY nextflow /usr/local/bin/nextflow
 


### PR DESCRIPTION
So when we went to targeted platform builds, instead of copying `docker` (the bin), we started copying `docker` the folder.

See my local `dist` after a `make dist/docker`:
```
nextflow $ find docker/dist 
docker/dist      
docker/dist/linux
docker/dist/linux/amd64                                                                                   
docker/dist/linux/amd64/docker                                                                            
docker/dist/linux/amd64/docker-runc                                                                       
docker/dist/linux/amd64/docker-init           
docker/dist/linux/amd64/dockerd                                                                           
docker/dist/linux/amd64/docker-containerd-ctr                                                             
docker/dist/linux/amd64/docker-containerd
docker/dist/linux/amd64/docker-proxy
docker/dist/linux/amd64/docker-containerd-shim
```

And in the new docker image:
```
bash-4.2# find / -name docker -type f
/usr/local/bin/docker/docker
bash-4.2# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

So obv the docker bin won't be found in `$PATH`.


Compare that to before https://github.com/nextflow-io/nextflow/commit/68c18449929d190bf5e9f3e2279190da368f4c6e:
```
root@f99920aec9c2:/work/docker# find dist/
dist/
dist/docker
dist/completion
dist/completion/zsh
dist/completion/zsh/_docker
dist/completion/bash
dist/completion/bash/docker
dist/completion/fish
dist/completion/fish/docker.fish
dist/docker-runc
dist/docker-init
dist/dockerd
dist/docker-containerd-ctr
dist/docker-containerd
dist/docker-proxy
dist/docker-containerd-shim
```

and the path/bin:
```
bash-4.4# find / -name docker -type f
/usr/local/bin/docker
bash-4.4# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
```

@pditommaso this is pretty disruptive, it means all local docker exec will fail, because nf internally relies on docker being in `$PATH`. I can hack around it for now, but would be rad to get this in.