### PR TITLE
Correct description of cross

### DIFF
--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -1325,7 +1325,7 @@ emitted by the target channel (on the right) having the same key.
 
 There are two important caveats when using the ``cross`` operator:
 
-	#. The operator is not `reflexive`, i.e. the result of ``a.cross(b)`` is different from ``b.cross(a)`` 
+	#. The operator is not `commutative`, i.e. the result of ``a.cross(b)`` is different from ``b.cross(a)`` 
 	#. The source channel should emits items for which there's no key repetition i.e. the emitted 
 	   items have an unique key identifier. 
 


### PR DESCRIPTION
The property that `a.cross(b)` is not equal to `b.cross(a)` reflects non-commutativity of the operator not reflexivity.