### PR TITLE
Allow to use environment variables at parameters

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -325,7 +325,6 @@ class ConfigBuilder {
         final binding = new HashMap(10)
         binding.put('baseDir', baseDir)
         binding.put('projectDir', baseDir)
-        binding.put('workDir', workDir)
         binding.put('launchDir', Paths.get('.').toRealPath())
         if( SecretsLoader.isEnabled() )
             binding.put('secrets', new SecretsContext())
@@ -531,7 +530,11 @@ class ConfigBuilder {
             config.stubRun = cmdRun.stubRun
 
         // -- sets the working directory
-        config.workDir = workDir
+        if( cmdRun.workDir )
+            config.workDir = cmdRun.workDir
+
+        else if( !config.workDir )
+            config.workDir = env.get('NXF_WORK') ?: 'work'
 
         if( cmdRun.bucketDir )
             config.bucketDir = cmdRun.bucketDir
@@ -820,13 +823,6 @@ class ConfigBuilder {
         else {
             return config.get(key)
         }
-    }
-
-    private String getWorkDir() {
-        if( cmdRun.workDir )
-            return cmdRun.workDir
-
-        return env.get('NXF_WORK') ?: 'work'
     }
 
     static String resolveConfig(Path baseDir, CmdRun cmdRun) {

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -325,6 +325,7 @@ class ConfigBuilder {
         final binding = new HashMap(10)
         binding.put('baseDir', baseDir)
         binding.put('projectDir', baseDir)
+        binding.put('workDir', workDir)
         binding.put('launchDir', Paths.get('.').toRealPath())
         if( SecretsLoader.isEnabled() )
             binding.put('secrets', new SecretsContext())
@@ -530,11 +531,7 @@ class ConfigBuilder {
             config.stubRun = cmdRun.stubRun
 
         // -- sets the working directory
-        if( cmdRun.workDir )
-            config.workDir = cmdRun.workDir
-
-        else if( !config.workDir )
-            config.workDir = env.get('NXF_WORK') ?: 'work'
+        config.workDir = workDir
 
         if( cmdRun.bucketDir )
             config.bucketDir = cmdRun.bucketDir
@@ -823,6 +820,13 @@ class ConfigBuilder {
         else {
             return config.get(key)
         }
+    }
+
+    private String getWorkDir() {
+        if( cmdRun.workDir )
+            return cmdRun.workDir
+
+        return env.get('NXF_WORK') ?: 'work'
     }
 
     static String resolveConfig(Path baseDir, CmdRun cmdRun) {

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -263,7 +263,7 @@ class ConfigBuilder {
     @PackageScope
     ConfigObject buildGivenFiles(List<Path> files) {
 
-        final Map<String,String> vars = cmdRun?.env
+        final env = cmdRun?.envResolved ?: [:]
         final boolean exportSysEnv = cmdRun?.exportSysEnv
 
         def items = []
@@ -275,16 +275,6 @@ class ConfigBuilder {
             else {
                 items << file
             }
-        }
-
-        Map env = [:]
-        if( exportSysEnv ) {
-            log.debug "Adding current system environment to session environment"
-            env.putAll(System.getenv())
-        }
-        if( vars ) {
-            log.debug "Adding following variables to session environment: $vars"
-            env.putAll(vars)
         }
 
         // set the cluster options for the node command

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
@@ -157,17 +157,19 @@ class CmdRunTest extends Specification {
         json.text = '''\
             {
                 "alpha": "This is alpha",
+                 "beta": "${workDir}/work",
                 "delta": "${launchDir}/more",
                 "gamma": "$should_not_replace",
-                "omega": "${baseDir}/end"
+                "omega": "${baseDir}/end"             
             }
             '''.stripIndent()
         when:
         def cmd = new CmdRun(paramsFile: json.toString())
         and:
-        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR'] )
+        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR', workDir: 'scheme://work_path'] )
         then:
         result.alpha == 'This is alpha'
+        result.beta  == 'scheme://work_path/work'
         result.delta == '/WORK/DIR/more'
         result.gamma == '$should_not_replace'
         result.omega == '/BASE/DIR/end'
@@ -187,16 +189,18 @@ class CmdRunTest extends Specification {
                 beta: "${launchDir}/more"
                 gamma: "$should_not_replace"
                 omega: "${baseDir}/end"
+                theta: "${workDir}/work"
             '''.stripIndent()
         when:
         def cmd = new CmdRun(paramsFile: json.toString())
         and:
-        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR'] )
+        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR', workDir: 'scheme://work_path'] )
         then:
         result.alpha == 'This is alpha'
         result.delta.beta == '/WORK/DIR/more'
         result.delta.gamma == '$should_not_replace'
         result.delta.omega == '/BASE/DIR/end'
+        result.delta.theta == 'scheme://work_path/work'
 
         cleanup:
         folder.deleteDir()
@@ -226,13 +230,15 @@ class CmdRunTest extends Specification {
             delta: "${launchDir}/world"
             gamma: "${012345}"
             omega: "${unknown}"
+            theta: "${workDir}/work"
             '''.stripIndent()
         
-        new CmdRun().replaceVars0(text, [baseDir:'/HOME', launchDir: '/WORK' ] ) == '''\
+        new CmdRun().replaceVars0(text, [baseDir:'/HOME', launchDir: '/WORK', workDir: "scheme://work_path" ] ) == '''\
             alpha: "/HOME/hello"
             delta: "/WORK/world"
             gamma: "${012345}"
             omega: "${unknown}"
+            theta: "scheme://work_path/work"
             '''.stripIndent()
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
@@ -157,19 +157,17 @@ class CmdRunTest extends Specification {
         json.text = '''\
             {
                 "alpha": "This is alpha",
-                 "beta": "${workDir}/work",
                 "delta": "${launchDir}/more",
                 "gamma": "$should_not_replace",
-                "omega": "${baseDir}/end"             
+                "omega": "${baseDir}/end"
             }
             '''.stripIndent()
         when:
         def cmd = new CmdRun(paramsFile: json.toString())
         and:
-        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR', workDir: 'scheme://work_path'] )
+        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR'] )
         then:
         result.alpha == 'This is alpha'
-        result.beta  == 'scheme://work_path/work'
         result.delta == '/WORK/DIR/more'
         result.gamma == '$should_not_replace'
         result.omega == '/BASE/DIR/end'
@@ -189,18 +187,16 @@ class CmdRunTest extends Specification {
                 beta: "${launchDir}/more"
                 gamma: "$should_not_replace"
                 omega: "${baseDir}/end"
-                theta: "${workDir}/work"
             '''.stripIndent()
         when:
         def cmd = new CmdRun(paramsFile: json.toString())
         and:
-        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR', workDir: 'scheme://work_path'] )
+        def result = cmd.parsedParams( [baseDir: '/BASE/DIR', launchDir: '/WORK/DIR'] )
         then:
         result.alpha == 'This is alpha'
         result.delta.beta == '/WORK/DIR/more'
         result.delta.gamma == '$should_not_replace'
         result.delta.omega == '/BASE/DIR/end'
-        result.delta.theta == 'scheme://work_path/work'
 
         cleanup:
         folder.deleteDir()
@@ -230,15 +226,15 @@ class CmdRunTest extends Specification {
             delta: "${launchDir}/world"
             gamma: "${012345}"
             omega: "${unknown}"
-            theta: "${workDir}/work"
+            sigma: "${env.SOME_ENV}/sigma"
             '''.stripIndent()
         
-        new CmdRun().replaceVars0(text, [baseDir:'/HOME', launchDir: '/WORK', workDir: "scheme://work_path" ] ) == '''\
+        new CmdRun(env: ["SOME_ENV": "/my_environment"]).replaceVars0(text, [baseDir:'/HOME', launchDir: '/WORK' ] ) == '''\
             alpha: "/HOME/hello"
             delta: "/WORK/world"
             gamma: "${012345}"
             omega: "${unknown}"
-            theta: "scheme://work_path/work"
+            sigma: "/my_environment/sigma"
             '''.stripIndent()
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -416,7 +416,6 @@ class ConfigBuilderTest extends Specification {
             beta: "World" 
             omega: "Last"
             theta: "${baseDir}/something"
-            sigma: "${workDir}/work"
             '''.stripIndent()
         and:
         def file = Files.createTempFile('test',null)
@@ -426,7 +425,6 @@ class ConfigBuilderTest extends Specification {
         }
         params.beta = 'y'
         params.delta = 'Foo'
-        params.sigma = './work'
         params.gamma = params.alpha
         params {
             omega = 'Bar'
@@ -438,7 +436,7 @@ class ConfigBuilderTest extends Specification {
         '''
         when:
         def opt = new CliOptions()
-        def run = new CmdRun(paramsFile: params, workDir: "scheme://work_path")
+        def run = new CmdRun(paramsFile: params)
         def result = new ConfigBuilder().setOptions(opt).setCmdRun(run).setBaseDir(baseDir).buildGivenFiles(file)
 
         then:
@@ -448,7 +446,6 @@ class ConfigBuilderTest extends Specification {
         result.params.omega == 'Last'
         result.params.delta == 'Foo'
         result.params.theta == "$baseDir/something"
-        result.params.sigma == "scheme://work_path/work"
         result.process.publishDir == [path: 'Hello']
 
         cleanup:
@@ -1121,6 +1118,13 @@ class ConfigBuilderTest extends Specification {
         config = new ConfigObject()
         config.workDir = 'hello/there'
         builder.configRunOptions(config, [:], new CmdRun(workDir: 'my/work/dir'))
+        then:
+        config.workDir == 'my/work/dir'
+
+        when: "config.workDir has precedence over NXF_WORK environment variable"
+        config = new ConfigObject()
+        config.workDir = 'my/work/dir'
+        builder.configRunOptions(config, [NXF_WORK: '/foo/bar'], new CmdRun())
         then:
         config.workDir == 'my/work/dir'
     }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -416,6 +416,7 @@ class ConfigBuilderTest extends Specification {
             beta: "World" 
             omega: "Last"
             theta: "${baseDir}/something"
+            sigma: "${workDir}/work"
             '''.stripIndent()
         and:
         def file = Files.createTempFile('test',null)
@@ -425,6 +426,7 @@ class ConfigBuilderTest extends Specification {
         }
         params.beta = 'y'
         params.delta = 'Foo'
+        params.sigma = './work'
         params.gamma = params.alpha
         params {
             omega = 'Bar'
@@ -436,7 +438,7 @@ class ConfigBuilderTest extends Specification {
         '''
         when:
         def opt = new CliOptions()
-        def run = new CmdRun(paramsFile: params)
+        def run = new CmdRun(paramsFile: params, workDir: "scheme://work_path")
         def result = new ConfigBuilder().setOptions(opt).setCmdRun(run).setBaseDir(baseDir).buildGivenFiles(file)
 
         then:
@@ -446,6 +448,7 @@ class ConfigBuilderTest extends Specification {
         result.params.omega == 'Last'
         result.params.delta == 'Foo'
         result.params.theta == "$baseDir/something"
+        result.params.sigma == "scheme://work_path/work"
         result.process.publishDir == [path: 'Hello']
 
         cleanup:


### PR DESCRIPTION
## Description

Current implementation only allows to use `baseDir`, `projectDir`, `launchDir` and `secrets` at the parameters file or from the command line. 

This pull request adds also the option to access the environment variable available at config scope. They can be referenced using the prefix `env.`,  like `${env.MY_ENV_VAR}`.

## Usage

Example on how to use it:
```
$ cat ../params.yml 
outdir: ${env.NXF_WORK}/results_workdir

$ ./launch.sh run nextflow-io/rnatoy -params-file ~/tmp/params.yml -e.NXF_WORK=/home/jordeu/tmp/nextflow -with-docker
```