### PR TITLE
Test with java-17 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [8, 11, 16]
+        java_version: [8, 11, 17]
 
     steps:
     - name: Environment


### PR DESCRIPTION
Since Java 17 is the new LTS and is already supported by NF, I thought it might be the right to update the automated test template as well.