### PR TITLE
Fix: broken symlinks with scratch and move

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -81,9 +81,25 @@ nxf_fs_copy() {
 nxf_fs_move() {
   local source=$1
   local target=$2
-  local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  mv -f $source $target/$basedir
+  local basedir=$(dirname -- $source)
+  local filename=$(basename -- $source)
+  mkdir -p "$target/$basedir"
+  if [[ -L "$source" ]]
+  then
+    local realPath=$(readlink -f $source)
+    if [[ $realPath == $PWD* ]]
+    then
+        #local symlink
+        other=${realPath:((${#PWD}+1))}
+        nxf_fs_move "$other" "$target"
+    else
+        #external symlink
+        ln -s "$realPath" "$target/$basedir/$filename"
+        rm "$source"
+        return
+    fi
+  fi
+  mv -f "$source" "$target/$basedir"
 }
 
 nxf_fs_rsync() {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -245,9 +245,25 @@ nxf_fs_copy() {
 nxf_fs_move() {
   local source=$1
   local target=$2
-  local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  mv -f $source $target/$basedir
+  local basedir=$(dirname -- $source)
+  local filename=$(basename -- $source)
+  mkdir -p "$target/$basedir"
+  if [[ -L "$source" ]]
+  then
+    local realPath=$(readlink -f $source)
+    if [[ $realPath == $PWD* ]]
+    then
+        #local symlink
+        other=${realPath:((${#PWD}+1))}
+        nxf_fs_move "$other" "$target"
+    else
+        #external symlink
+        ln -s "$realPath" "$target/$basedir/$filename"
+        rm "$source"
+        return
+    fi
+  fi
+  mv -f "$source" "$target/$basedir"
 }
 
 nxf_fs_rsync() {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
@@ -60,9 +60,25 @@ nxf_fs_copy() {
 nxf_fs_move() {
   local source=$1
   local target=$2
-  local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  mv -f $source $target/$basedir
+  local basedir=$(dirname -- $source)
+  local filename=$(basename -- $source)
+  mkdir -p "$target/$basedir"
+  if [[ -L "$source" ]]
+  then
+    local realPath=$(readlink -f $source)
+    if [[ $realPath == $PWD* ]]
+    then
+        #local symlink
+        other=${realPath:((${#PWD}+1))}
+        nxf_fs_move "$other" "$target"
+    else
+        #external symlink
+        ln -s "$realPath" "$target/$basedir/$filename"
+        rm "$source"
+        return
+    fi
+  fi
+  mv -f "$source" "$target/$basedir"
 }
 
 nxf_fs_rsync() {


### PR DESCRIPTION
In an old version of [nf-core/viralrecon](https://github.com/nf-core/viralrecon/) I found the following code:

https://github.com/nf-core/viralrecon/blob/75a2f9763e9b4c1aa20ad342ae3ce148c33cc65a/main.nf#L660-L661

Creating symlinks leads to problems if the workflow is executed in a scratch directory, moving the outputs.

This PR solves this issue.

To test my fix, I run the following script, which fails with the current Nextflow version:

```
nextflow run test.nf -process.scratch true -process.stageOutMode move
...

Error executing process > 'aGlobal (1)'

Caused by:
  Missing output file(s) `file.txt` expected by process `aGlobal (1)`

Command executed:

  ln -s test.txt file.txt

Command exit status:
  0

Command output:
  (empty)
```

Script:

```
process aLocal {

    output:
    file 'file.txt' into aOut1

    """
    echo "This is the file" > original.txt
    ln -s original.txt file.txt
    """

}

process aGlobal {

    input:
    file a from Channel.fromPath("test.txt")

    output:
    file 'file.txt' into aOut2

    """
    ln -s $a file.txt
    """

}

process b {

    input:
    path a from aOut1.mix(aOut2)

    """
    stat $a
    """

}

```

Looking forward to feedback.