### PR TITLE
Fix for nested params with the same name

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
@@ -346,7 +346,7 @@ class ConfigParser {
                 }
             }
             if( name=='params' && result instanceof Map && paramVars ) {
-                result.putAll(paramVars)
+                result.putAll(Bolts.deepMerge(result, paramVars, true))
             }
             result
         }
@@ -408,7 +408,7 @@ class ConfigParser {
                         co = current.config.get(name)
                     }
                     else if (current.scope.get(name) instanceof ConfigObject) {
-                        co = current.scope.get(name)
+                        co = current.scope.get(name).clone()
                     }
                     else {
                         co = new ConfigObject()

--- a/modules/nextflow/src/test/groovy/FunctionalTests.groovy
+++ b/modules/nextflow/src/test/groovy/FunctionalTests.groovy
@@ -176,7 +176,7 @@ class FunctionalTests extends Specification {
                     alpha = "aaa"
                     delta = "ddd"
                 }
-                $foo {
+                withName: foo {
                     ext {
                         beta = "BBB"
                         delta = "DDD"

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigParserTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigParserTest.groovy
@@ -642,7 +642,26 @@ class ConfigParserTest extends Specification {
         config.params.baz == 'baz1'
         config.params.nested.baz == 'baz2'
         config.params.nested.foo.bar == 'bar2'
+
+        when:
+        CONFIG = '''
+            params {
+              foo.bar = 'bar1'
+              baz = 'baz1'
+              nested.baz = 'baz2'
+              nested.foo.bar = 'bar2'
+            }
+        '''
+        and:
+        config = new ConfigParser().parse(CONFIG)
+
+        then:
+        config.params.foo.bar == 'bar1'
+        config.params.baz == 'baz1'
+        config.params.nested.baz == 'baz2'
+        config.params.nested.foo.bar == 'bar2'
     }
+
 
     static class ConfigFileHandler implements HttpHandler {
 

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigParserTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigParserTest.groovy
@@ -617,6 +617,32 @@ class ConfigParserTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should not overwrite param values with nested values of with the same name' () {
+        given:
+        def CONFIG = '''
+            params {
+              foo {
+                bar = 'bar1'
+              }
+              baz = 'baz1'
+              nested {
+                baz = 'baz2'
+                foo {
+                  bar = 'bar2'
+                }
+              }
+            }
+        '''
+
+        when:
+        def config = new ConfigParser().parse(CONFIG)
+
+        then:
+        config.params.foo.bar == 'bar1'
+        config.params.baz == 'baz1'
+        config.params.nested.baz == 'baz2'
+        config.params.nested.foo.bar == 'bar2'
+    }
 
     static class ConfigFileHandler implements HttpHandler {
 

--- a/modules/nf-commons/src/main/nextflow/extension/Bolts.groovy
+++ b/modules/nf-commons/src/main/nextflow/extension/Bolts.groovy
@@ -925,4 +925,17 @@ class Bolts {
         }
         return (T)result
     }
+
+    static <T extends Map> T deepMerge(T mergeIntoMap, T mergeFromMap, boolean replaceValues) {
+        for (Object key : mergeFromMap.keySet()) {
+            if (mergeFromMap.get(key) instanceof Map && mergeIntoMap.get(key) instanceof Map) {
+                mergeIntoMap.put(key, deepMerge((Map) mergeIntoMap.get(key), (Map) mergeFromMap.get(key), replaceValues));
+            } else {
+                if (!mergeIntoMap.containsKey(key) || replaceValues) {
+                    mergeIntoMap.put(key, mergeFromMap.get(key));
+                }
+            }
+        }
+        return deepClone(mergeIntoMap)
+    }
 }

--- a/modules/nf-commons/src/test/nextflow/extension/BoltsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/extension/BoltsTest.groovy
@@ -365,4 +365,31 @@ class BoltsTest extends Specification {
         map.bar.x == 2
     }
 
+    def 'should deep merge map and overwrite values when `replaceValues` is true'() {
+        given:
+        Map origMap = [foo: 1, bar: [x: 2, y: 3]]
+        Map newMap = [bar: [x: 4, z: 5]]
+
+        when:
+        def merge = Bolts.deepMerge(origMap, newMap, true)
+
+        then:
+        merge.bar.x == 4
+        merge.bar.y == 3
+        merge.bar.z == 5
+    }
+
+    def 'should deep merge map and not overwrite values when `replaceValues` is false'() {
+        given:
+        Map origMap = [foo: 1, bar: [x: 2, y: 3]]
+        Map newMap = [bar: [x: 4, z: 5]]
+
+        when:
+        def merge = Bolts.deepMerge(origMap, newMap, false)
+
+        then:
+        merge.bar.x == 2
+        merge.bar.y == 3
+        merge.bar.z == 5
+    }
 }


### PR DESCRIPTION
This fixes #1982, #2166, #2247 and #2358

The first three issues were caused by a lack of cloning which allowed mutability of values where they should have been immutable.  

The last issue required a deep merge vs a `putAll` to avoid overwriting multiple values at the same level when you are overriding them on the command line.