### PR TITLE
Nextflow couldn't parse generated nextflow.config under some circumstances.

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/util/ConfigHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/ConfigHelper.groovy
@@ -141,10 +141,13 @@ class ConfigHelper {
 
                     writer.append(TAB*level)
                     writer.append(wrap1(key))
-                    writer.append(' {\n')
+                    writer.append( level == 0 ? ' = ' : ' : ' )
+                    writer.append( '[\n' )
                     canonicalFormat(writer, value, level+1,sort,stack)
                     writer.append(TAB*level)
-                    writer.append('}\n')
+                    writer.append(']')
+                    if ( level > 0 ) writer.append(',')
+                    writer.append( '\n' )
                 }
                 else {
                     // add a new-line to separate simple values from a previous config object
@@ -154,8 +157,9 @@ class ConfigHelper {
 
                     writer.append(TAB*level)
                     writer.append(wrap1(key))
-                    writer.append(' = ')
+                    writer.append( level == 0 ? ' = '  : ' : ')
                     writer.append( render0(value) )
+                    if ( level > 0 ) writer.append(',')
                     writer.append('\n')
                 }
             }
@@ -167,15 +171,7 @@ class ConfigHelper {
 
     static @PackageScope String wrap1(param) {
         final key = param.toString()
-        if( key.startsWith('withLabel:') )  {
-            return 'withLabel:' + wrap0(key.substring('withLabel:'.length()))
-        }
-        else if( key.startsWith('withName:') )  {
-            return 'withName:' + wrap0(key.substring('withName:'.length()))
-        }
-        else {
-            return wrap0(key)
-        }
+        return wrap0(key)
     }
 
     static @PackageScope String wrap0( param ) {

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
@@ -106,23 +106,23 @@ class CmdConfigTest extends Specification {
         cmd.printCanonical0(config, buffer)
         then:
         buffer.toString() == '''
-                    process {
-                       executor = 'slurm'
-                       queue = 'long'
-                    }
+                    process = [
+                       executor : 'slurm',
+                       queue : 'long',
+                    ]
                     
-                    docker {
-                       enabled = true
-                    }
+                    docker = [
+                       enabled : true,
+                    ]
 
-                    mail {
-                       from = 'yo@mail.com'
-                       smtp {
-                          host = 'mail.com'
-                          port = 25
-                          user = 'yo'
-                       }
-                    }
+                    mail = [
+                       from : 'yo@mail.com',
+                       smtp : [
+                          host : 'mail.com',
+                          port : 25,
+                          user : 'yo',
+                       ],
+                    ]
                     '''
                     .stripIndent().leftTrim()
 
@@ -194,20 +194,20 @@ class CmdConfigTest extends Specification {
         
         then:
         buffer.toString() == '''
-        manifest {
-           author = 'me'
-           mainScript = 'foo.nf'
-        }
+        manifest = [
+           author : 'me',
+           mainScript : 'foo.nf',
+        ]
         
-        process {
-           queue = 'cn-el7'
-           cpus = 4
-           memory = '10 GB'
-           time = '5h'
-           ext {
-              other = { 10.GB * task.attempt }
-           }
-        }
+        process = [
+           queue : 'cn-el7',
+           cpus : 4,
+           memory : '10 GB',
+           time : '5h',
+           ext : [
+              other : { 10.GB * task.attempt },
+           ],
+        ]
         '''
         .stripIndent().leftTrim()
 
@@ -249,12 +249,12 @@ class CmdConfigTest extends Specification {
         X2 = ['SOMETHING']
         X3 = [p:111, q:'bbb']
         
-        params {
-           alpha = ['SOMETHING/a', 'b', 'c']
-           delta = [['SOMETHING'], 'z']
-           gamma = [p:'SOMETHING/a', q:['SOMETHING']]
-           omega = [p:111, q:'bbb']
-        }
+        params = [
+           alpha : ['SOMETHING/a', 'b', 'c'],
+           delta : [['SOMETHING'], 'z'],
+           gamma : [p:'SOMETHING/a', q:['SOMETHING']],
+           omega : [p:111, q:'bbb'],
+        ]
         '''.stripIndent()
 
         when:
@@ -285,9 +285,9 @@ class CmdConfigTest extends Specification {
         cmd.run()
         then:
         buffer.toString() == '''\
-            process {
-               container = 'quay.io/nextflow/bash'
-            }
+            process = [
+               container : 'quay.io/nextflow/bash',
+            ]
             '''
             .stripIndent()
     }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -1996,21 +1996,21 @@ class ConfigBuilderTest extends Specification {
         def txt = ConfigBuilder.resolveConfig(base, cmd)
         then:
         txt == '''\
-            params {
-               foo = 'Hello world'
-               awsKey = '[secret]'
-            }
+            params = [
+               foo : 'Hello world',
+               awsKey : '[secret]',
+            ]
             
-            process {
-               executor = { 'local' }
-            }
+            process = [
+               executor : { 'local' },
+            ]
 
             workDir = 'work'
             
-            tower {
-               enabled = true
-               endpoint = 'http://foo.com'
-            }
+            tower = [
+               enabled : true,
+               endpoint : 'http://foo.com',
+            ]
             '''.stripIndent()
 
         cleanup:

--- a/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy
@@ -121,23 +121,23 @@ class ConfigHelperTest extends Specification {
         def result = ConfigHelper.toCanonicalString(config)
         then:
         result == '''
-                    process {
-                       executor = 'slurm'
-                       queue = 'long'
-                    }
+                    process = [
+                       executor : 'slurm',
+                       queue : 'long',
+                    ]
                     
-                    docker {
-                       enabled = true
-                    }
+                    docker = [
+                       enabled : true,
+                    ]
 
-                    mail {
-                       from = 'yo@mail.com'
-                       smtp {
-                          port = 25
-                          user = 'yo'
-                          host = 'mail.com'
-                       }
-                    }
+                    mail = [
+                       from : 'yo@mail.com',
+                       smtp : [
+                          port : 25,
+                          user : 'yo',
+                          host : 'mail.com',
+                       ],
+                    ]
                     '''
                 .stripIndent().leftTrim()
 
@@ -146,23 +146,23 @@ class ConfigHelperTest extends Specification {
         result = ConfigHelper.toCanonicalString(config, true)
         then:
         result == '''
-                    docker {
-                       enabled = true
-                    }
+                    docker = [
+                       enabled : true,
+                    ]
                     
-                    mail {
-                       from = 'yo@mail.com'
-                       smtp {
-                          host = 'mail.com'
-                          port = 25
-                          user = 'yo'
-                       }
-                    }
+                    mail = [
+                       from : 'yo@mail.com',
+                       smtp : [
+                          host : 'mail.com',
+                          port : 25,
+                          user : 'yo',
+                       ],
+                    ]
 
-                    process {
-                       executor = 'slurm'
-                       queue = 'long'
-                    }
+                    process = [
+                       executor : 'slurm',
+                       queue : 'long',
+                    ]
                     '''
                 .stripIndent().leftTrim()
 
@@ -182,10 +182,10 @@ class ConfigHelperTest extends Specification {
         result == '''
                     'alpha-bravo' = 1
 
-                    'fizz+buzz' {
-                       x = 'hello'
-                       y = 'world'
-                    }
+                    'fizz+buzz' = [
+                       x : 'hello',
+                       y : 'world',
+                    ]
                     '''
                     .stripIndent().leftTrim()
     }
@@ -252,11 +252,11 @@ class ConfigHelperTest extends Specification {
         "foo"               | "foo"                 | 'foo'
         "foo-1"             | "'foo-1'"             | "'foo-1'"
 
-        "withLabel:foo"     | "'withLabel:foo'"     | "withLabel:foo"
-        "withLabel:1foo"    | "'withLabel:1foo'"    | "withLabel:'1foo'"
+        "withLabel:foo"     | "'withLabel:foo'"     | "'withLabel:foo'"
+        "withLabel:1foo"    | "'withLabel:1foo'"    | "'withLabel:1foo'"
 
-        "withName:foo"      | "'withName:foo'"      | "withName:foo"
-        "withName:2foo"     | "'withName:2foo'"     | "withName:'2foo'"
+        "withName:foo"      | "'withName:foo'"      | "'withName:foo'"
+        "withName:2foo"     | "'withName:2foo'"     | "'withName:2foo'"
     }
 
 

--- a/tests/checks/profiles.nf/.expected_profile_advanced.txt
+++ b/tests/checks/profiles.nf/.expected_profile_advanced.txt
@@ -1,7 +1,7 @@
 echo = true
 foo = 'bar'
 
-process [
+process = [
    cpus : 8,
    memory : '10GB',
    disk : '300GB',

--- a/tests/checks/profiles.nf/.expected_profile_advanced.txt
+++ b/tests/checks/profiles.nf/.expected_profile_advanced.txt
@@ -1,8 +1,8 @@
 echo = true
 foo = 'bar'
 
-process {
-   cpus = 8
-   memory = '10GB'
-   disk = '300GB'
-}
+process [
+   cpus : 8,
+   memory : '10GB',
+   disk : '300GB',
+]

--- a/tests/checks/profiles.nf/.expected_profile_all.txt
+++ b/tests/checks/profiles.nf/.expected_profile_all.txt
@@ -1,18 +1,18 @@
 echo = true
 foo = 'bar'
 
-profiles {
-   standard {
-      process {
-         cpus = 2
-         memory = '2GB'
-      }
-   }
-   advanced {
-      process {
-         cpus = 8
-         memory = '10GB'
-         disk = '300GB'
-      }
-   }
-}
+profiles = [
+   standard : [
+      process : [
+         cpus : 2,
+         memory : '2GB',
+      ],
+   ],
+   advanced : [
+      process : [
+         cpus : 8,
+         memory : '10GB',
+         disk : '300GB',
+      ],
+   ],
+]

--- a/tests/checks/profiles.nf/.expected_profile_standard.txt
+++ b/tests/checks/profiles.nf/.expected_profile_standard.txt
@@ -1,7 +1,7 @@
 echo = true
 foo = 'bar'
 
-process {
-   cpus = 2
-   memory = '2GB'
-}
+process = [
+   cpus : 2,
+   memory : '2GB',
+]


### PR DESCRIPTION
Running some nf-core workflows on Kubernetes is currently not possible.
I tested viralrecon and eager. Both fail with errors parsing the generated nextflow.config file on Kubernetes if keys in the config are quoted.

For example:
```
params {
    modules {
       ...
        'sra_fastq_ftp' {
            args            = '-C - --max-time 1200'
            publish_dir     = 'public_data'
            publish_files   = ['fastq.gz':'', 'md5':'md5']
        }
...
```
becomes
```
params {
    ...
    modules {
        ...
        sra_fastq_ftp {
            args = '-C - --max-time 1200'
            publish_dir = 'public_data'
            publish_files {
                'fastq.gz' = ''
                md5 = 'md5'
            }
        }
...
```
when I run:
`nextflow kuberun https://github.com/nf-core/viralrecon -v pvc-host-shared-data:/pvcdata -v project-pvc-host-shared-data:/project -config nextflow.config -profile test,kubernetesConf`
it throws
```
Unable to parse config file: '/pvcdata/fabian/nextflow.config'

  Compile failed for sources FixedSetSources[name='/groovy/script/ScriptBEFEBE235A7D5B7ACE613A834576E6FA/_nf_config_ec39096b']. Cause: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
  /groovy/script/ScriptBEFEBE235A7D5B7ACE613A834576E6FA/_nf_config_ec39096b: 161: The LHS of an assignment should be a variable or a field accessing expression @ line 161, column 13.
                 'fastq.gz' = ''
                 ^
  
  1 error
```
With my adjustments, the generated file looks like this:
```
params = [
   modules : [
      ...
      sra_fastq_ftp : [
         args : '-C - --max-time 1200',
         publish_dir : 'public_data',
         publish_files : [
            'fastq.gz' : '',
            md5 : 'md5',
         ],
      ],
```
This is successfully parsed.

Moreover, I found the following test case:
https://github.com/Lehmann-Fabian/nextflow/blob/parseFailure/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy#L171-L191
While the test passes, the String it checks for wouldn't be parsable. Maybe I should delete the test?