### PR TITLE
Parse tests

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
@@ -297,7 +297,7 @@ class CmdConfigTest extends Specification {
 
         then:
         def result = buffer.toString()
-        buffer.toString() == '''
+        result == '''
         params {
            x = { 1 + 2 }
         }

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
@@ -221,11 +221,6 @@ class CmdConfigTest extends Specification {
         def CONFIG = folder.resolve('nextflow.config')
 
         CONFIG.text = '''
-        manifest {
-            author = 'me'
-            mainScript = 'foo.nf'
-        }
-        
         process {
           cpus = { getCpuValue() }
         }
@@ -246,11 +241,6 @@ class CmdConfigTest extends Specification {
 
         then:
         buffer.toString() == '''
-        manifest {
-           author = 'me'
-           mainScript = 'foo.nf'
-        }
-        
         process {
            cpus = { getCpuValue() }
         }


### PR DESCRIPTION
This PR adds two tests for yet not working cases. However, I was unable to fix them.


The **first issu**e occurs if you define a method in a configuration file. The method is forgotten in the output.

Input:
nextflow.config
```
process {
  cpus = { getCpuValue() }
}

def getCpuValue() {
  4
}
```
`$ nextflow config nextflow.config`
Output:
```
process {
  cpus = { getCpuValue() }
}
```

-----
The **second issue** is more complex. I broke down the configuration of nf-core/eager. If you have a three-level configuration structure, the third level ignores the `renderClosureAsString`.
Inputs:
nextflow.config
```
profiles {
  test { includeConfig 'nextflow2.config'}
}
```
nextflow2.config
```
includeConfig 'nextflow3.config'
```
nextflow3.config
```
params {
  x = { 1 + 2 }
}
```
`$ nextflow config nextflow.config -profile test`
Output:
```
params {
   x = Script45F3112A5F44215D3409D59317499615$_run_closure1$_closure2@f29353f
}
```


Both issues cause problems with the execution of some nf-core workflows.