### PR TITLE
Add the AWS Athena JDBC driver for nf-sqldb plugin

### DIFF
--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -18,6 +18,12 @@ apply plugin: 'java-test-fixtures'
 apply plugin: 'idea'
 apply plugin: 'groovy'
 
+repositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
 sourceSets {
     main.java.srcDirs = []
     main.groovy.srcDirs = ['src/main']
@@ -43,6 +49,7 @@ dependencies {
     api 'org.postgresql:postgresql:42.2.23'
     api 'org.xerial:sqlite-jdbc:3.36.0.3'
     api 'org.duckdb:duckdb_jdbc:0.3.0'
+    implementation name: 'AthenaJDBC42_2.0.25.1001'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -23,14 +23,14 @@ plugins {
  * for Simba Athena JDBC driver and extract its contents to the build directory
  */
 task downloadZipFile(type: Download) {
-    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1002/SimbaAthenaJDBC-2.0.25.1002.zip'
-    dest new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1002.zip')
+    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/SimbaAthenaJDBC-2.0.25.1001.zip'
+    dest new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1001.zip')
 }
 
 task verifyFile(type: Verify, dependsOn: downloadZipFile) {
-    src new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1002.zip')
+    src new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1001.zip')
     algorithm 'MD5'
-    checksum '9dfef9e578a709b863b1135a21bb3857'
+    checksum '71504d0317656d790978363358d0c068'
 }
 
 task downloadAndUnzipFile(dependsOn: [downloadZipFile, verifyFile] , type: Copy) {
@@ -38,14 +38,22 @@ task downloadAndUnzipFile(dependsOn: [downloadZipFile, verifyFile] , type: Copy)
     into "${projectDir}/libs"
 }
 
-task copyAthenaSimbaJar (dependsOn: downloadAndUnzipFile, type: Copy) {
-    from "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1002/AthenaJDBC42_2.0.25.1002.jar"
+task copyAthenaSimbaJar(dependsOn: downloadAndUnzipFile, type: Copy) {
+    from "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar"
     into "${projectDir}/libs"
 }
 
-task cleanUpLibsFolder (dependsOn: copyAthenaSimbaJar, type: Delete) {
-    delete "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1002"
+task downloadAndCleanUpLibsFolder(dependsOn: copyAthenaSimbaJar, type: Delete) {
+    delete "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1001/"
 }
+
+defaultTasks 'downloadAndCleanUpLibsFolder'
+
+build.dependsOn downloadAndCleanUpLibsFolder
+compileGroovy.dependsOn downloadAndCleanUpLibsFolder
+compileTestGroovy.dependsOn downloadAndCleanUpLibsFolder
+test.dependsOn downloadAndCleanUpLibsFolder
+copyPluginLibs.dependsOn downloadAndCleanUpLibsFolder
 
 apply plugin: 'java'
 apply plugin: 'java-test-fixtures'

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -23,11 +23,6 @@ apply plugin: 'java-test-fixtures'
 apply plugin: 'idea'
 apply plugin: 'groovy'
 
-repositories {
-    flatDir {
-        dirs 'libs'
-    }
-}
 
 sourceSets {
     main.java.srcDirs = []
@@ -55,7 +50,7 @@ dependencies {
     api 'org.postgresql:postgresql:42.2.23'
     api 'org.xerial:sqlite-jdbc:3.36.0.3'
     api 'org.duckdb:duckdb_jdbc:0.3.0'
-    api name: 'AthenaJDBC42_2.0.25.1001'
+    api files('downloads/unzip/AthenaJDBC42_2.0.25.1001.jar')
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
@@ -68,29 +63,21 @@ dependencies {
  * The following tasks download and confirm the MD5 checksum of the ZIP archive
  * for Simba Athena JDBC driver and extract its contents to the build directory
  */
-tasks.register('downloadZipFile', Download) {
+task downloadAthenDep(type: Download) {
     src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/SimbaAthenaJDBC-2.0.25.1001.zip'
     dest new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
     overwrite false
 }
 
-tasks.register('verifyFile', Verify) {
-    dependsOn 'downloadZipFile'
+task verifyAthenDep(type: Verify, dependsOn: downloadAthenDep) {
     src new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
     algorithm 'MD5'
     checksum '71504d0317656d790978363358d0c068'
 }
 
-tasks.register('downloadAndUnzipFile', Copy) {
-    dependsOn 'downloadZipFile', 'verifyFile'
-    from zipTree(downloadZipFile.dest)
+task unzipAthenDep(dependsOn: verifyAthenDep, type: Copy) {
+    from zipTree(new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip'))
     into "${buildDir}/downloads/unzip"
 }
 
-tasks.register('copyAthenaSimbaJar', Copy) {
-    dependsOn 'downloadAndUnzipFile'
-    from "${buildDir}/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar"
-    into "libs"
-}
-
-compileGroovy.dependsOn('copyAthenaSimbaJar')
+project.compileGroovy.dependsOn('unzipAthenDep')

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -24,36 +24,27 @@ plugins {
  */
 task downloadZipFile(type: Download) {
     src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/SimbaAthenaJDBC-2.0.25.1001.zip'
-    dest new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1001.zip')
+    dest new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
+    overwrite false
 }
 
 task verifyFile(type: Verify, dependsOn: downloadZipFile) {
-    src new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1001.zip')
+    src new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
     algorithm 'MD5'
     checksum '71504d0317656d790978363358d0c068'
 }
 
 task downloadAndUnzipFile(dependsOn: [downloadZipFile, verifyFile] , type: Copy) {
     from zipTree(downloadZipFile.dest)
-    into "${projectDir}/libs"
+    into "${buildDir}/downloads/unzip"
 }
 
 task copyAthenaSimbaJar(dependsOn: downloadAndUnzipFile, type: Copy) {
-    from "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar"
-    into "${projectDir}/libs"
+    from "${buildDir}/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar"
+    into "libs"
 }
 
-task downloadAndCleanUpLibsFolder(dependsOn: copyAthenaSimbaJar, type: Delete) {
-    delete "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1001/"
-}
-
-defaultTasks 'downloadAndCleanUpLibsFolder'
-
-build.dependsOn downloadAndCleanUpLibsFolder
-compileGroovy.dependsOn downloadAndCleanUpLibsFolder
-compileTestGroovy.dependsOn downloadAndCleanUpLibsFolder
-test.dependsOn downloadAndCleanUpLibsFolder
-copyPluginLibs.dependsOn downloadAndCleanUpLibsFolder
+compileGroovy.dependsOn copyAthenaSimbaJar
 
 apply plugin: 'java'
 apply plugin: 'java-test-fixtures'
@@ -84,6 +75,7 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:1.7.10'
     compileOnly 'org.pf4j:pf4j:3.4.1'
+    compileOnly "org.slf4j:log4j-over-slf4j:1.7.32"
     api("org.codehaus.groovy:groovy-sql:3.0.9") { transitive = false }
     api 'com.h2database:h2:1.4.200'
     api 'mysql:mysql-connector-java:8.0.22'
@@ -91,8 +83,7 @@ dependencies {
     api 'org.postgresql:postgresql:42.2.23'
     api 'org.xerial:sqlite-jdbc:3.36.0.3'
     api 'org.duckdb:duckdb_jdbc:0.3.0'
-    implementation name: 'AthenaJDBC42_2.0.25.1001'
-    api "org.slf4j:log4j-over-slf4j:1.7.32"
+    api name: 'AthenaJDBC42_2.0.25.1001'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -18,34 +18,6 @@ plugins {
     id 'de.undercouch.download' version '4.1.2'
 }
 
-/**
- * The following tasks download and confirm the MD5 checksum of the ZIP archive
- * for Simba Athena JDBC driver and extract its contents to the build directory
- */
-task downloadZipFile(type: Download) {
-    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/SimbaAthenaJDBC-2.0.25.1001.zip'
-    dest new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
-    overwrite false
-}
-
-task verifyFile(type: Verify, dependsOn: downloadZipFile) {
-    src new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
-    algorithm 'MD5'
-    checksum '71504d0317656d790978363358d0c068'
-}
-
-task downloadAndUnzipFile(dependsOn: [downloadZipFile, verifyFile] , type: Copy) {
-    from zipTree(downloadZipFile.dest)
-    into "${buildDir}/downloads/unzip"
-}
-
-task copyAthenaSimbaJar(dependsOn: downloadAndUnzipFile, type: Copy) {
-    from "${buildDir}/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar"
-    into "libs"
-}
-
-compileGroovy.dependsOn copyAthenaSimbaJar
-
 apply plugin: 'java'
 apply plugin: 'java-test-fixtures'
 apply plugin: 'idea'
@@ -91,3 +63,34 @@ dependencies {
     testImplementation "org.codehaus.groovy:groovy-nio:3.0.9"
 }
 
+
+/**
+ * The following tasks download and confirm the MD5 checksum of the ZIP archive
+ * for Simba Athena JDBC driver and extract its contents to the build directory
+ */
+tasks.register('downloadZipFile', Download) {
+    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1001/SimbaAthenaJDBC-2.0.25.1001.zip'
+    dest new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
+    overwrite false
+}
+
+tasks.register('verifyFile', Verify) {
+    dependsOn 'downloadZipFile'
+    src new File(buildDir, 'downloads/SimbaAthenaJDBC-2.0.25.1001.zip')
+    algorithm 'MD5'
+    checksum '71504d0317656d790978363358d0c068'
+}
+
+tasks.register('downloadAndUnzipFile', Copy) {
+    dependsOn 'downloadZipFile', 'verifyFile'
+    from zipTree(downloadZipFile.dest)
+    into "${buildDir}/downloads/unzip"
+}
+
+tasks.register('copyAthenaSimbaJar', Copy) {
+    dependsOn 'downloadAndUnzipFile'
+    from "${buildDir}/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar"
+    into "libs"
+}
+
+compileGroovy.dependsOn('copyAthenaSimbaJar')

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -13,6 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+plugins {
+    id 'de.undercouch.download' version '4.1.2'
+}
+
+/**
+ * The following tasks download and confirm the MD5 checksum of the ZIP archive
+ * for Simba Athena JDBC driver and extract its contents to the build directory
+ */
+task downloadZipFile(type: Download) {
+    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.25.1002/SimbaAthenaJDBC-2.0.25.1002.zip'
+    dest new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1002.zip')
+}
+
+task verifyFile(type: Verify, dependsOn: downloadZipFile) {
+    src new File(buildDir, 'SimbaAthenaJDBC-2.0.25.1002.zip')
+    algorithm 'MD5'
+    checksum '9dfef9e578a709b863b1135a21bb3857'
+}
+
+task downloadAndUnzipFile(dependsOn: [downloadZipFile, verifyFile] , type: Copy) {
+    from zipTree(downloadZipFile.dest)
+    into "${projectDir}/libs"
+}
+
+task copyAthenaSimbaJar (dependsOn: downloadAndUnzipFile, type: Copy) {
+    from "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1002/AthenaJDBC42_2.0.25.1002.jar"
+    into "${projectDir}/libs"
+}
+
+task cleanUpLibsFolder (dependsOn: copyAthenaSimbaJar, type: Delete) {
+    delete "${projectDir}/libs/SimbaAthenaJDBC-2.0.25.1002"
+}
+
 apply plugin: 'java'
 apply plugin: 'java-test-fixtures'
 apply plugin: 'idea'
@@ -50,6 +84,7 @@ dependencies {
     api 'org.xerial:sqlite-jdbc:3.36.0.3'
     api 'org.duckdb:duckdb_jdbc:0.3.0'
     implementation name: 'AthenaJDBC42_2.0.25.1001'
+    api "org.slf4j:log4j-over-slf4j:1.7.32"
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')

--- a/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
@@ -65,6 +65,7 @@ class SqlDataSource {
             case 'mariadb': return 'org.mariadb.jdbc.Driver'
             case 'postgresql': return 'org.postgresql.Driver'
             case 'duckdb': return 'org.duckdb.DuckDBDriver'
+            case 'awsathena': return 'com.simba.athena.jdbc.Driver'
         }
         return null
     }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -69,6 +69,7 @@ class SqlDataSourceTest extends Specification {
         'jdbc:mysql:some-host'          | 'com.mysql.cj.jdbc.Driver'
         'jdbc:mariadb:other-host'       | 'org.mariadb.jdbc.Driver'
         'jdbc:duckdb:'                  | 'org.duckdb.DuckDBDriver'
+        'jdbc:awsathena:'               | 'com.simba.athena.jdbc.Driver'
     }
 
     def 'should get default config' () {


### PR DESCRIPTION
This PR follows up from the discussion on https://github.com/nextflow-io/nf-sqldb/discussions/5 


## Open database used for testing

I've relied on the Athena database generated by crawling the SRA Metadata as described here the instructions shared in https://www.ncbi.nlm.nih.gov/sra/docs/sra-athena.

The exact instructruction to setup the necessary tables/database on the AWS side are descibed in the official walkthrough https://www.youtube.com/watch?v=_F4FhcDWSJg


## Instructions to use the `Athena` JDBC integration

1. Populate the JDBC URL correctly for the Athena driver with the correct 
- `AWSRegion`
- `S3OutputLocation`


```
jdbc:awsathena://AwsRegion=us-east-1;S3OutputLocation=s3://MY_BUCKET_NAME/AWS_GLUE_OUTPUT_DIR/'

```

2. Add the configuration for your AWS account for the Athena JDBC driver

```

sql {
    db {
        athena {
            url = 'jdbc:awsathena://AwsRegion=us-east-1;S3OutputLocation=s3://MY_BUCKET_NAME/AWS_GLUE_OUTPUT_DIR/'
            user = 'AWS_SECRET_KEY_ID'
            password = 'AWS_SECRET_ACCESS_KEY'
        }
    }
}

```

3. Add a query for the Athena database in your Nextflow code (the example below assumes you have a dataset named `sra-athena-results` with a `metadata` table)


```
# main.nf

def sql = "SELECT * FROM \"sra-athena-results\".metadata WHERE organism = 'Homo sapiens' LIMIT 1;"
Channel.sql.fromQuery(sql, db: 'athena')
.view()


```


4. Run the Nextflow code using the locally compiled binary


```
../launch.sh run main.nf 
```

5. The results are shown as below 

```
(base) Abhinavs-MacBook-Pro:_scratch eklavya$ ../launch.sh run main.nf

N E X T F L O W  ~  version 21.11.0-edge
Launching `main.nf` [loving_northcutt] - revision: aa68ce1be0
log4j:WARN No appenders could be found for logger (com.simba.athena.amazonaws.auth.profile.internal.BasicProfileConfigLoader).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
[SRR363812, WGS, BI, public, SRX105026, PRJNA70759.Subject 1, 454 GS 20, SINGLE, RANDOM, GENOMIC, LS454, SRS269932, SAMN00750733, Homo sapiens, SRP009245, 2011-11-10, PRJNA70759, 56, null, 111, 23, null, 454-134 Flow 1, null, null, null, null, null, null, Subject 1, sra, sff, ncbi, s3, gs, ncbi.public, gs.US, s3.us-east-1, {k=gssr_id_exp, v=146935.0}, {k=lsid_exp, v=BROAD:SEQUENCING_SAMPLE:146935.0}, {k=material_type_exp, v=Genomic DNA}, {k=project_exp, v=R81}, {k=bases, v=23383062}, {k=bytes, v=59372830}, {k=gssr_id_run, v=146935.0}, {k=lsid_run, v=BROAD:SEQUENCING_SAMPLE:146935.0}, {k=project_run, v=R81}, {k=region_run, v=1}, {k=run_barcode_run, v=611540051122}, {k=run_name_run, v=Flow1Flow2Run611540}, {k=geographic_location__country_and_or_sea_region__sam, v=missing}, {k=isolation_source_sam_ss_dpl262, v=missing}, {k=strain_sam, v=missing}, {k=primary_search, v=385256.454-134 Flow 1.611540051122.S}, {k=primary_search, v=611540051122.1.TCAG.sff}, {k=primary_search, v=70759}, {k=primary_search, v=750733}, {k=primary_search, v=B_Cell_Immune_Repertoire_Baseline}, {k=primary_search, v=PRJNA70759}, {k=primary_search, v=PRJNA70759.Subject 1}, {k=primary_search, v=SAMN00750733}, {k=primary_search, v=SRP009245}, {k=primary_search, v=SRR363812}, {k=primary_search, v=SRS269932}, {k=primary_search, v=SRX105026}, {"gssr_id_exp": "146935.0", "lsid_exp": "BROAD:SEQUENCING_SAMPLE:146935.0", "material_type_exp": "Genomic DNA", "project_exp": "R81", "bases": 23383062, "bytes": 59372830, "gssr_id_run": ["146935.0"], "lsid_run": ["BROAD:SEQUENCING_SAMPLE:146935.0"], "project_run": ["R81"], "region_run": "1", "run_barcode_run": ["611540051122"], "run_name_run": ["Flow1Flow2Run611540"], "geographic_location__country_and_or_sea_region__sam": ["missing"], "isolation_source_sam_ss_dpl262": ["missing"], "strain_sam": ["missing"], "primary_search": "385256.454-134 Flow 1.611540051122.S"}]


```


### Concern (Log4J)

Given the recent adventures of `log4j` dependency, we can use `exlude` it using `Gradle` safely right?