### PR TITLE
detail on `include` statements

### DIFF
--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -348,7 +348,7 @@ execution context, as such it can be invoked in the ``workflow`` scope.
 Nextflow implicitly looks for the script file ``./some/module.nf`` resolving the path
 against the *including* script location.
 
-.. note:: Relative paths must begin with the ``./`` prefix.
+.. note:: Relative paths must begin with the ``./`` prefix. Also, the `include` statement must be defined **outside** of the workflow definition.
 
 Multiple inclusions
 -------------------


### PR DESCRIPTION
Make clear that include must be outside of workflow definitions. This worked until 21.04.3 but then was disabled:

- https://github.com/nextflow-io/nextflow/issues/2519
- https://github.com/nextflow-io/nextflow/issues/2162