### PR TITLE
Added affinity option to pod directive

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1982,7 +1982,8 @@ The ``pod`` directive allows the definition of the following options:
 ``imagePullPolicy: <V>``                          Specifies the strategy to be used to pull the container image e.g. ``imagePullPolicy: 'Always'``.
 ``imagePullSecret: <V>``                          Specifies the secret name to access a private container image registry. See `Kubernetes documentation <https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod>`_ for details.
 ``runAsUser: <UID>``                              Specifies the user ID to be used to run the container.
-``nodeSelector: <V>``                             Specifies which node the process will run on. See `Kubernetes nodeSelector <https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector>`_ for details.
+``nodeSelector: <V>``                             Specifies which node the process will run on. See `Kubernetes nodeSelector <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector>`_ for details.
+``affinity: <V>``                                 Specifies affinity for which nodes the process should run on. See `Kubernetes affinity <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity>`_ for details.
 ================================================= =================================================
 
 When defined in the Nextflow configuration file, a pod setting can be defined using the canonical

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -111,7 +111,7 @@ class PodOptions {
         else if( entry.nodeSelector ) {
             this.nodeSelector = new PodNodeSelector(entry.nodeSelector)
         }
-        else if( entry.affinity ) {
+        else if( entry.affinity instanceof Map ) {
             this.affinity = entry.affinity as Map
         }
         else if( entry.annotation && entry.value ) {

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -51,6 +51,8 @@ class PodOptions {
 
     private PodNodeSelector nodeSelector
 
+    private Map affinity
+
     private PodSecurityContext securityContext
 
     PodOptions( List<Map> options=null ) {
@@ -109,6 +111,9 @@ class PodOptions {
         else if( entry.nodeSelector ) {
             this.nodeSelector = new PodNodeSelector(entry.nodeSelector)
         }
+        else if( entry.affinity ) {
+            this.affinity = entry.affinity as Map
+        }
         else if( entry.annotation && entry.value ) {
             this.annotations.put(entry.annotation as String, entry.value as String)
         }
@@ -129,14 +134,16 @@ class PodOptions {
 
     Map<String,String> getAnnotations() { annotations }
 
-    PodSecurityContext getSecurityContext() { securityContext }
-
     PodNodeSelector getNodeSelector() { nodeSelector }
 
     PodOptions setNodeSelector( PodNodeSelector sel ) {
         nodeSelector = sel
         return this
     }
+
+    Map getAffinity() { affinity }
+
+    PodSecurityContext getSecurityContext() { securityContext }
 
     PodOptions setSecurityContext( PodSecurityContext ctx ) {
         this.securityContext = ctx
@@ -159,6 +166,7 @@ class PodOptions {
 
     PodOptions plus( PodOptions other ) {
         def result = new PodOptions()
+
         // env vars
         result.envVars.addAll(envVars)
         result.envVars.addAll( other.envVars )
@@ -181,8 +189,11 @@ class PodOptions {
         else
             result.securityContext = securityContext
 
-        // node select
+        // node selector
         result.nodeSelector = other.nodeSelector ?: this.nodeSelector
+
+        // affinity
+        result.affinity = other.affinity ?: this.affinity
 
         // pull policy
         if (other.imagePullPolicy)

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -80,6 +80,8 @@ class PodSpecBuilder {
 
     PodNodeSelector nodeSelector
 
+    Map affinity
+
     /**
      * @return A sequential volume unique identifier
      */
@@ -252,8 +254,12 @@ class PodSpecBuilder {
         // -- security context
         if( opts.securityContext )
             securityContext = opts.securityContext
+        // -- node selector
         if( opts.nodeSelector )
             nodeSelector = opts.nodeSelector
+        // -- affinity
+        if( opts.affinity )
+            affinity = opts.affinity
 
         return this
     }
@@ -308,6 +314,9 @@ class PodSpecBuilder {
 
         if( nodeSelector )
             spec.nodeSelector = nodeSelector.toSpec()
+
+        if( affinity )
+            spec.affinity = affinity
 
         if( this.serviceAccount )
             spec.serviceAccountName = this.serviceAccount


### PR DESCRIPTION
Closes #2390 

This PR adds support for affinity expressions in the pod directive. Examples of affinity can be found [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). Affinity is used to assign pods to nodes, similar to a node selector, but is more expressive and also allows for soft constraints.

Example:
```groovy
pod = [
  affinity: [
    nodeAffinity: [
      requiredDuringSchedulingIgnoredDuringExecution: [
        nodeSelectorTerms: [
          [key: "gpu-type", operator: "NotIn", values: ["T4"]]
        ]
      ]
    ]
  ]
]
```

maps to pod config:
```yaml
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: gpu-type
            operator: NotIn
            values: [T4]
```