### PR TITLE
Add -entry parameter to pass in k8s executor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -424,6 +424,7 @@ class K8sDriverLauncher {
         addOption(result, cmd.&env )
         addOption(result, cmd.&process )
         addOption(result, cmd.&params )
+        addOption(result, cmd.&entryName )
 
         if( paramsFile ) {
             result << "-params-file $paramsFile"

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
@@ -117,6 +117,7 @@ class K8sDriverLauncherTest extends Specification {
         new CmdKubeRun(process: [mem: '100',cpus:'2'])  | 'nextflow run foo -process.mem 100 -process.cpus 2'
         new CmdKubeRun(params: [alpha:'x', beta:'y'])   | 'nextflow run foo --alpha x --beta y'
         new CmdKubeRun(params: [alpha: '/path/*.txt'])  | 'nextflow run foo --alpha /path/\\*.txt'
+        new CmdKubeRun(entryName: 'lala')               | 'nextflow run foo -entry lala'
     }
 
     def 'should set the run name' () {


### PR DESCRIPTION
Some pipelines need to pass -entry parameter. Make it work with kuberun executor.