### PR TITLE
Fix docker timeout issues.

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -20,6 +20,7 @@ import com.microsoft.azure.batch.protocol.models.AutoUserScope
 import com.microsoft.azure.batch.protocol.models.AutoUserSpecification
 import com.microsoft.azure.batch.protocol.models.AzureFileShareConfiguration
 import com.microsoft.azure.batch.protocol.models.ElevationLevel
+import com.microsoft.azure.batch.protocol.models.EnvironmentSetting
 import com.microsoft.azure.batch.protocol.models.MountConfiguration
 import com.microsoft.azure.batch.protocol.models.UserIdentity
 
@@ -352,7 +353,9 @@ class AzBatchService implements Closeable {
 
         final slots = computeSlots(task, pool)
         log.trace "[AZURE BATCH] Submitting task: $taskId, cpus=${task.config.getCpus()}, mem=${task.config.getMemory()?:'-'}, slots: $slots"
-
+        List<EnvironmentSetting> environmentSettings = new ArrayList<>()
+        environmentSettings << new EnvironmentSetting().withName('DOCKER_CLIENT_TIMEOUT').withValue('120')
+        environmentSettings << new EnvironmentSetting().withName('COMPOSE_HTTP_TIMEOUT').withValue('120')
         final taskToAdd = new TaskAddParameter()
                 .withId(taskId)
                 .withUserIdentity(userIdentity(pool.opts.privileged, pool.opts.runAs))
@@ -361,6 +364,7 @@ class AzBatchService implements Closeable {
                 .withResourceFiles(resourceFileUrls(task,sas))
                 .withOutputFiles(outputFileUrls(task, sas))
                 .withRequiredSlots(slots)
+                .withEnvironmentSettings(environmentSettings)
         client.taskOperations().createTask(jobId, taskToAdd)
         return new AzTaskKey(jobId, taskId)
     }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -353,6 +353,7 @@ class AzBatchService implements Closeable {
 
         final slots = computeSlots(task, pool)
         log.trace "[AZURE BATCH] Submitting task: $taskId, cpus=${task.config.getCpus()}, mem=${task.config.getMemory()?:'-'}, slots: $slots"
+        // these env vars help avoid container timeouts, see https://github.com/nextflow-io/nextflow/discussions/2510
         List<EnvironmentSetting> environmentSettings = new ArrayList<>()
         environmentSettings << new EnvironmentSetting().withName('DOCKER_CLIENT_TIMEOUT').withValue('120')
         environmentSettings << new EnvironmentSetting().withName('COMPOSE_HTTP_TIMEOUT').withValue('120')


### PR DESCRIPTION
This PR tries to address the issue mentioned in https://github.com/nextflow-io/nextflow/discussions/2510. 

I tried a loop of 10 executions and didn't get the timeout error. Before this change, I got 2 timeouts out of the 10 executions. I can't be 100% sure this fixes it once and for all. But, at least, it seems to limit its frequency.