### PR TITLE
[Improvement] Extended glob

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/ScriptOutputFiles.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/ScriptOutputFiles.groovy
@@ -45,11 +45,15 @@ class ScriptOutputFiles implements Map<String,Glob> {
 
     static Glob glob(boolean value) { new Glob(value) }
 
-    static ScriptOutputFiles wrap(String... names) {
+    static ScriptOutputFiles wrap( boolean glob, String... names) {
         final result = new ScriptOutputFiles()
         for( String it : names )
-            result.put(it,new Glob(true))
+            result.put(it,new Glob( glob ))
         return result
+    }
+
+    static ScriptOutputFiles wrap(String... names) {
+        return wrap( true, names )
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -168,9 +168,14 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
         final mode = stageoutMode ?: ( workDir==targetDir ? 'copy' : 'move' )
         return """\
             IFS=\$'\\n'
-            for name in \$(eval "ls -1d ${outputFiles.toShellEscapedNames()}" | sort | uniq); do
+            shopt -s globstar extglob || true
+            pathes=`ls -1d ${outputFiles.toShellEscapedNames()} | sort | uniq`
+            shopt -u globstar extglob || true
+            set -f
+            for name in \$pathes; do
                 ${stageOutCommand('$name', targetDir, mode)} || true
             done
+            set +f
             unset IFS""".stripIndent(true)
     }
 

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -74,8 +74,10 @@ nxf_fs_copy() {
   local source=$1
   local target=$2
   local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  cp -fRL $source $target/$basedir
+  if [[ ! -e "$target/$1" ]]; then
+      mkdir -p $target/$basedir
+      cp -fRL $source $target/$basedir
+  fi
 }
 
 nxf_fs_move() {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -408,9 +408,14 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.unstage_outputs == '''\
                 IFS=$'\\n'
-                for name in $(eval "ls -1d test.bam test.bai" | sort | uniq); do
+                shopt -s globstar extglob || true
+                pathes=`ls -1d test.bam test.bai | sort | uniq`
+                shopt -u globstar extglob || true
+                set -f
+                for name in $pathes; do
                     nxf_fs_copy "$name" /work/dir || true
                 done
+                set +f
                 unset IFS
                 '''.stripIndent().rightTrim()
 
@@ -425,9 +430,14 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.unstage_outputs == '''\
                 IFS=$'\\n'
-                for name in $(eval "ls -1d test.bam test.bai" | sort | uniq); do
+                shopt -s globstar extglob || true
+                pathes=`ls -1d test.bam test.bai | sort | uniq`
+                shopt -u globstar extglob || true
+                set -f
+                for name in $pathes; do
                     nxf_fs_move "$name" /another/dir || true
                 done
+                set +f
                 unset IFS
                 '''.stripIndent().rightTrim()
     }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/ScriptOutputFilesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/ScriptOutputFilesTest.groovy
@@ -46,20 +46,6 @@ class ScriptOutputFilesTest extends Specification {
         'fo?.txt'   | true      | 'fo?.txt'
     }
 
-
-    def 'should remove star glob pattern'() {
-
-        expect:
-        ScriptOutputFiles.removeGlobStar('a/b/c') == 'a/b/c'
-        ScriptOutputFiles.removeGlobStar('/a/b/c') == '/a/b/c'
-        ScriptOutputFiles.removeGlobStar('some/*/path') == 'some/*/path'
-        ScriptOutputFiles.removeGlobStar('some/**/path') == 'some'
-        ScriptOutputFiles.removeGlobStar('some/**/path') == 'some'
-        ScriptOutputFiles.removeGlobStar('some*') == 'some*'
-        ScriptOutputFiles.removeGlobStar('some**') == '*'
-
-    }
-
     def 'should return shell escaped names' () {
         given:
         def files = new ScriptOutputFiles()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -17,8 +17,11 @@
 
 package nextflow.executor
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
+import java.util.concurrent.TimeUnit
 import nextflow.processor.TaskBean
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -150,6 +153,161 @@ class SimpleFileCopyStrategyTest extends Specification {
 
     }
 
+    @Unroll
+    def 'should copy the right files' () {
+
+        given:
+
+        Path workDir = Files.createTempDirectory('in')
+        Path outfolder = Files.createTempDirectory('out')
+
+        BashWrapperBuilder bwb = new BashWrapperBuilder([
+                script: 'echo Hello World!',
+                workDir: workDir,
+                targetDir: outfolder,
+                scratch: false,
+                stageOutMode : 'copy',
+                outputGlobs: ScriptOutputFiles.wrap( source ) ] as TaskBean)
+
+        Path scriptPath = bwb.build()
+
+        inputffiles.forEach {
+            String p = workDir.toAbsolutePath().toString()
+            //create subdirectories, if needed
+            if( it.contains("/") ) {
+                println("path: $p/${it.substring(0, it.lastIndexOf('/'))}")
+                new File( p + "/" + it.substring(0, it.lastIndexOf('/')) ).mkdirs()
+            }
+            if( !it.endsWith("/") ) {
+                new File(p + "/" + it).createNewFile()
+            }
+        }
+
+        Process process = [ "bash", scriptPath ].execute(null, workDir.toFile() )
+        process.consumeProcessOutput( System.out, System.err )
+        process.waitFor(2, TimeUnit.SECONDS )
+
+        expect:
+        process.exitValue() == 0
+
+        for( String r : outputfiles ){
+            assert new File(outfolder.toString(), r).exists()
+        }
+        for( String r : inputffiles ){
+            assert new File(workDir.toString(), r).exists()
+        }
+        for( String r : (inputffiles - outputfiles) ){
+            assert !new File(outfolder.toString(), r).exists()
+        }
+
+        cleanup:
+        workDir?.deleteDir()
+        outfolder?.deleteDir()
+
+        where:
+        source              | inputffiles                                                                                                             | outputfiles
+        '**.txt'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                                     | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+        '**.foo'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                                     | []
+        '*.txt'             | ['file.txt', 'file2.txt', 'file3.txta']                                                                                 | ['file.txt', 'file2.txt']
+        '*'                 | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                                      | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
+        '**'                | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                                      | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
+        'a/*'               | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                                          | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a/'                | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                                          | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a'                 | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                                          | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a b/*'             | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                                  | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b/'              | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                                  | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b'               | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                                  | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a|b/*'             | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/', 'file.txt']                                                  | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/']
+        'a/*/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/*'          | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/dir*/file.txt'   | ['a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt']                                          | ['a/dir/file.txt', 'a/dir1/file.txt']
+        'a/dir**/file.txt'  | ['a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt']                   | ['a/dir/file.txt', 'a/dir1/file.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt']
+        'a/dir**file.txt'   | ['a/dirafile.txt', 'a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt'] | ['a/dirafile.txt', 'a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt']
+        'a/?/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        '{a,b,c}/*'         | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}/'          | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}'           | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{ab*,b*/*,c}/*'    | ['a/file.txt', 'abcd/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                 | ['abcd/file2.txt']
+        '{a[ab]c,b*/*}/*'   | ['acc/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                | ['abc/file2.txt']
+        '{a|c*,b*/*}/*'     | ['a|c/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                | ['a|c/file.txt']
+        '[A-Z]/*'           | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['A/file.txt']
+        '[A-Z]/'            | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['A/file.txt']
+        '[A-Z]'             | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['A/file.txt']
+        'a'                 | ['A/file.txt', 'a/', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                             | ['a/']
+        'a/b/c'             | ['A/file.txt', 'a/b/c/', 'a/b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                       | ['a/b/c/']
+        'abc?\\?.txt'       | ['abcde.txt', 'abcd.txt', 'abcd?.txt']                                                                                  | ['abcd?.txt']
+        'a"b.txt'           | ['a\\"b.txt', 'a"b.txt', 'abc.txt']                                                                                     | ['a"b.txt']
+        'a/**/b/*/d.txt'    | ['a/c/d/b/x/d.txt', 'a/c/d/b/x/Y/d.txt']                                                                                | ['a/c/d/b/x/d.txt']
+        'a/bc*h/ij*mn/*'    | ['a/bcdefgh/ijklmn/a.txt', 'a/bcdfgh/ijklmn/a.txt', 'a/bcdefghi/ijklmn/a.txt']                                          | ['a/bcdefgh/ijklmn/a.txt', 'a/bcdfgh/ijklmn/a.txt']
+
+    }
+
+    @Unroll
+    def 'should copy the right files, multiple outputs' () {
+
+        given:
+
+        Path workDir = Files.createTempDirectory('in')
+        Path outfolder = Files.createTempDirectory('out')
+
+        BashWrapperBuilder bwb = new BashWrapperBuilder([
+                script: 'echo Hello World!',
+                workDir: workDir,
+                targetDir: outfolder,
+                scratch: false,
+                stageOutMode : 'copy',
+                outputGlobs: ScriptOutputFiles.wrap( source as String[] ) ] as TaskBean)
+
+        Path scriptPath = bwb.build()
+
+        inputffiles.forEach {
+            String p = workDir.toAbsolutePath().toString()
+            //create subdirectories, if needed
+            if( it.contains("/") ) {
+                println("path: $p/${it.substring(0, it.lastIndexOf('/'))}")
+                new File( p + "/" + it.substring(0, it.lastIndexOf('/')) ).mkdirs()
+            }
+            if( !it.endsWith("/") ) {
+                new File(p + "/" + it).createNewFile()
+            }
+        }
+
+        Process process = [ "bash", scriptPath ].execute(null, workDir.toFile() )
+        process.consumeProcessOutput( System.out, System.err )
+        process.waitFor(2, TimeUnit.SECONDS )
+
+        expect:
+        process.exitValue() == 0
+
+        for( String r : outputfiles ){
+            assert new File(outfolder.toString(), r).exists()
+        }
+        for( String r : inputffiles ){
+            assert new File(workDir.toString(), r).exists()
+        }
+        for( String r : (inputffiles - outputfiles) ){
+            assert !new File(outfolder.toString(), r).exists()
+        }
+
+        cleanup:
+        workDir?.deleteDir()
+        outfolder?.deleteDir()
+
+        where:
+        source                          | inputffiles                                                                                           | outputfiles
+        ['*.txt', 'a/*.txt']            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt']
+        ['a/*.txt', '*.txt']            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt']
+        ['a/*.txt', '**.txt']           | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+        ['**.txt', 'a/*.txt']           | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+
+    }
+
     def 'should return a valid `mv` command' () {
 
         given:
@@ -168,6 +326,160 @@ class SimpleFileCopyStrategyTest extends Specification {
         'path_name/'        | '/to/dir' | "mkdir -p /to/dir/path_name && mv -f path_name/ /to/dir/path_name"
 
     }
+
+    @Unroll
+    def 'should move the right files' () {
+
+        given:
+
+        Path workDir = Files.createTempDirectory('in')
+        Path outfolder = Files.createTempDirectory('out')
+
+        BashWrapperBuilder bwb = new BashWrapperBuilder([
+                script: 'echo Hello World!',
+                workDir: workDir,
+                targetDir: outfolder,
+                scratch: false,
+                stageOutMode : 'move',
+                outputGlobs: ScriptOutputFiles.wrap( source ) ] as TaskBean)
+
+        Path scriptPath = bwb.build()
+
+        inputffiles.forEach {
+            String p = workDir.toAbsolutePath().toString()
+            //create subdirectories, if needed
+            if( it.contains("/") ) {
+                println("path: $p/${it.substring(0, it.lastIndexOf('/'))}")
+                new File( p + "/" + it.substring(0, it.lastIndexOf('/')) ).mkdirs()
+            }
+            if( !it.endsWith("/") ) {
+                new File(p + "/" + it).createNewFile()
+            }
+        }
+
+        Process process = [ "bash", scriptPath ].execute(null, workDir.toFile() )
+        process.consumeProcessOutput( System.out, System.err )
+        process.waitFor(2, TimeUnit.SECONDS )
+
+        expect:
+        process.exitValue() == 0
+
+        for( String r : outputfiles ){
+            assert new File(outfolder.toString(), r).exists()
+            assert !new File(workDir.toString(), r).exists()
+        }
+        for( String r : (inputffiles - outputfiles) ){
+            assert !new File(outfolder.toString(), r).exists()
+            assert new File(workDir.toString(), r).exists()
+        }
+
+        cleanup:
+        workDir?.deleteDir()
+        outfolder?.deleteDir()
+
+        where:
+        source              | inputffiles                                                                                                             | outputfiles
+        '**.txt'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                                     | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+        '**.foo'            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                                     | []
+        '*.txt'             | ['file.txt', 'file2.txt', 'file3.txta']                                                                                 | ['file.txt', 'file2.txt']
+        '*'                 | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                                      | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
+        '**'                | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']                                                                      | ['file.txt', 'file2.txt', 'file3.txta', 'a/b.txt']
+        'a/*'               | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                                          | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a/'                | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                                          | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a'                 | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/', 'file.txt']                                                          | ['a/file.txt', 'a/file2.txt', 'a/b/a.txt', 'a/d/']
+        'a b/*'             | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                                  | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b/'              | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                                  | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a b'               | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/', 'file.txt']                                                  | ['a b/file.txt', 'a b/file2.txt', 'a b/b/a.txt', 'a b/d/']
+        'a|b/*'             | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/', 'file.txt']                                                  | ['a|b/file.txt', 'a|b/file2.txt', 'a|b/b/a.txt', 'a|b/d/']
+        'a/*/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/*'          | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c/'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/*/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/**/c'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt']
+        'a/dir*/file.txt'   | ['a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt']                                          | ['a/dir/file.txt', 'a/dir1/file.txt']
+        'a/dir**/file.txt'  | ['a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt']                   | ['a/dir/file.txt', 'a/dir1/file.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt']
+        'a/dir**file.txt'   | ['a/dirafile.txt', 'a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt'] | ['a/dirafile.txt', 'a/dir/file.txt', 'a/dir1/file.txt', 'a/dir2/afile.txt', 'a/dir1/a/file.txt', 'a/dir1/a/b/file.txt']
+        'a/?/c/*'           | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c/'            | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        'a/?/c'             | ['a/b/c/file.txt', 'a/b/c/file2.txt', 'a/b/d/c/file2.txt', 'a/b/file.txt', 'a/file.txt', 'file.txt']                    | ['a/b/c/file.txt', 'a/b/c/file2.txt']
+        '{a,b,c}/*'         | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}/'          | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{a,b,c}'           | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['a/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt']
+        '{ab*,b*/*,c}/*'    | ['a/file.txt', 'abcd/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                 | ['abcd/file2.txt']
+        '{a[ab]c,b*/*}/*'   | ['acc/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                | ['abc/file2.txt']
+        '{a|c*,b*/*}/*'     | ['a|c/file.txt', 'abc/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                | ['a|c/file.txt']
+        '[A-Z]/*'           | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['A/file.txt']
+        '[A-Z]/'            | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['A/file.txt']
+        '[A-Z]'             | ['A/file.txt', 'a/file2.txt', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                    | ['A/file.txt']
+        'a'                 | ['A/file.txt', 'a/', 'b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                             | ['a/']
+        'a/b/c'             | ['A/file.txt', 'a/b/c/', 'a/b/file.txt', 'b/file2.txt', 'd/file.txt', 'file.txt']                                       | ['a/b/c/']
+        'abc?\\?.txt'       | ['abcde.txt', 'abcd.txt', 'abcd?.txt']                                                                                  | ['abcd?.txt']
+        'a"b.txt'           | ['a\\"b.txt', 'a"b.txt', 'abc.txt']                                                                                     | ['a"b.txt']
+        'a/**/b/*/d.txt'    | ['a/c/d/b/x/d.txt', 'a/c/d/b/x/Y/d.txt']                                                                                | ['a/c/d/b/x/d.txt']
+        'a/bc*h/ij*mn/*'    | ['a/bcdefgh/ijklmn/a.txt', 'a/bcdfgh/ijklmn/a.txt', 'a/bcdefghi/ijklmn/a.txt']                                          | ['a/bcdefgh/ijklmn/a.txt', 'a/bcdfgh/ijklmn/a.txt']
+
+    }
+
+    @Unroll
+    def 'should move the right files, multiple outputs' () {
+
+        given:
+
+        Path workDir = Files.createTempDirectory('in')
+        Path outfolder = Files.createTempDirectory('out')
+
+        BashWrapperBuilder bwb = new BashWrapperBuilder([
+                script: 'echo Hello World!',
+                workDir: workDir,
+                targetDir: outfolder,
+                scratch: false,
+                stageOutMode : 'move',
+                outputGlobs: ScriptOutputFiles.wrap( source as String[] ) ] as TaskBean)
+
+        Path scriptPath = bwb.build()
+
+        inputffiles.forEach {
+            String p = workDir.toAbsolutePath().toString()
+            //create subdirectories, if needed
+            if( it.contains("/") ) {
+                println("path: $p/${it.substring(0, it.lastIndexOf('/'))}")
+                new File( p + "/" + it.substring(0, it.lastIndexOf('/')) ).mkdirs()
+            }
+            if( !it.endsWith("/") ) {
+                new File(p + "/" + it).createNewFile()
+            }
+        }
+
+        Process process = [ "bash", scriptPath ].execute(null, workDir.toFile() )
+        process.consumeProcessOutput( System.out, System.err )
+        process.waitFor(2, TimeUnit.SECONDS )
+
+        expect:
+        process.exitValue() == 0
+
+        for( String r : outputfiles ){
+            assert new File(outfolder.toString(), r).exists()
+            assert !new File(workDir.toString(), r).exists()
+        }
+        for( String r : (inputffiles - outputfiles) ){
+            assert !new File(outfolder.toString(), r).exists()
+            assert new File(workDir.toString(), r).exists()
+        }
+
+        cleanup:
+        workDir?.deleteDir()
+        outfolder?.deleteDir()
+
+        where:
+        source                          | inputffiles                                                                                           | outputfiles
+        ['*.txt', 'a/*.txt']            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt']
+        ['a/*.txt', '*.txt']            | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt']
+        ['a/*.txt', '**.txt']           | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+        ['**.txt', 'a/*.txt']           | ['file.txt', 'file2.txt', 'file3.txta', 'a/file.txt', 'a/file3.txta', 'b/file.txt']                   | ['file.txt', 'file2.txt', 'a/file.txt', 'b/file.txt']
+
+    }
+
 
     def 'should return a valid `rsync` command' () {
 
@@ -243,9 +555,14 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 IFS=$'\\n'
-                for name in $(eval "ls -1d simple.txt my/path/file.bam" | sort | uniq); do
+                shopt -s globstar extglob || true
+                pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
+                shopt -u globstar extglob || true
+                set -f
+                for name in $pathes; do
                     nxf_fs_copy "$name" /target/work\\ dir || true
                 done
+                set +f
                 unset IFS
                 '''
                 .stripIndent().trim()
@@ -266,9 +583,14 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 IFS=$'\\n'
-                for name in $(eval "ls -1d simple.txt my/path/file.bam" | sort | uniq); do
+                shopt -s globstar extglob || true
+                pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
+                shopt -u globstar extglob || true
+                set -f
+                for name in $pathes; do
                     nxf_fs_move "$name" /target/store || true
                 done
+                set +f
                 unset IFS
                 '''
                 .stripIndent().trim()
@@ -288,9 +610,14 @@ class SimpleFileCopyStrategyTest extends Specification {
         then:
         script == '''
                 IFS=$'\\n'
-                for name in $(eval "ls -1d simple.txt my/path/file.bam" | sort | uniq); do
+                shopt -s globstar extglob || true
+                pathes=`ls -1d simple.txt my/path/file.bam | sort | uniq`
+                shopt -u globstar extglob || true
+                set -f
+                for name in $pathes; do
                     nxf_fs_rsync "$name" /target/work\\'s || true
                 done
+                set +f
                 unset IFS
                 '''
                 .stripIndent().trim()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -238,8 +238,10 @@ nxf_fs_copy() {
   local source=$1
   local target=$2
   local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  cp -fRL $source $target/$basedir
+  if [[ ! -e "$target/$1" ]]; then
+      mkdir -p $target/$basedir
+      cp -fRL $source $target/$basedir
+  fi
 }
 
 nxf_fs_move() {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
@@ -53,8 +53,10 @@ nxf_fs_copy() {
   local source=$1
   local target=$2
   local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  cp -fRL $source $target/$basedir
+  if [[ ! -e "$target/$1" ]]; then
+      mkdir -p $target/$basedir
+      cp -fRL $source $target/$basedir
+  fi
 }
 
 nxf_fs_move() {

--- a/modules/nf-commons/src/main/nextflow/util/Escape.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/Escape.groovy
@@ -55,7 +55,11 @@ class Escape {
         replace(WILDCARDS, str)
     }
 
-    static String path(String val) {
+    static String path(String val, boolean glob = false) {
+        List<String> SPECIAL_CHARS = Escape.SPECIAL_CHARS
+        if ( glob ){
+            SPECIAL_CHARS = SPECIAL_CHARS.findAll {it != '\\' }
+        }
         replace(SPECIAL_CHARS, val, true)
     }
 

--- a/modules/nf-commons/src/test/nextflow/util/EscapeTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/EscapeTest.groovy
@@ -70,6 +70,16 @@ class EscapeTest extends Specification {
         Escape.wildcards('file_[!a].txt') == 'file_\\[\\!a\\].txt'
     }
 
+    def 'should ignore globs in file names' () {
+
+        expect:
+        Escape.path('hell?.txt', true ) == "hell?.txt"
+        Escape.path('hell\\?.txt', true ) == "hell\\?.txt"
+        Escape.path('hell*.txt', true ) == "hell*.txt"
+        Escape.path('hell**.txt', true ) == "hell**.txt"
+
+    }
+
     def 'should escape cli' () {
         expect: 
         Escape.cli('nextflow','run','this') == 'nextflow run this'

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
@@ -58,9 +58,14 @@ class BashWrapperBuilderWithS3Test extends Specification {
         then:
         binding.unstage_outputs == '''\
                     IFS=$'\\n'
-                    for name in $(eval "ls -1d test.bam test.bai" | sort | uniq); do
+                    shopt -s globstar extglob || true
+                    pathes=`ls -1d test.bam test.bai | sort | uniq`
+                    shopt -u globstar extglob || true
+                    set -f
+                    for name in $pathes; do
                         nxf_s3_upload '$name' s3://some/bucket || true
                     done
+                    set +f
                     unset IFS
                     '''.stripIndent().rightTrim()
 

--- a/plugins/nf-azure/src/test/nextflow/executor/BashWrapperBuilderWithAzTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/executor/BashWrapperBuilderWithAzTest.groovy
@@ -46,9 +46,14 @@ class BashWrapperBuilderWithAzTest extends Specification {
         then:
         binding.unstage_outputs == """\
                     IFS=\$'\\n'
-                    for name in \$(eval "ls -1d test.bam test.bai" | sort | uniq); do
+                    shopt -s globstar extglob || true
+                    pathes=`ls -1d test.bam test.bai | sort | uniq`
+                    shopt -u globstar extglob || true
+                    set -f
+                    for name in \$pathes; do
                         nxf_az_upload '\$name' '${AzHelper.toHttpUrl(target)}' || true
                     done
+                    set +f
                     unset IFS
                     """.stripIndent().rightTrim()
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -138,8 +138,10 @@ nxf_fs_copy() {
   local source=$1
   local target=$2
   local basedir=$(dirname $1)
-  mkdir -p $target/$basedir
-  cp -fRL $source $target/$basedir
+  if [[ ! -e "$target/$1" ]]; then
+      mkdir -p $target/$basedir
+      cp -fRL $source $target/$basedir
+  fi
 }
 
 nxf_fs_move() {


### PR DESCRIPTION
This PR merges the logic of https://github.com/nextflow-io/nextflow/pull/2182 into https://github.com/nextflow-io/nextflow/pull/2379

With this PR, Nextflow behaves similarly using `-process.scratch true` and not. Moreover, it reduces the number of files copied/moved if the output path contains `**` and the glob parameter is now correctly validated.

Still, all other parameters defined here: https://www.nextflow.io/docs/latest/process.html?highlight=stage#output-path are interpreted as default values. This may still copy/move more files than necessary but could not break functionality. This could be addressed in a following contributions.