### PR TITLE
Docs: Warn about AWS CLI grandparent path in container

### DIFF
--- a/docs/awscloud.rst
+++ b/docs/awscloud.rst
@@ -329,6 +329,10 @@ configuration as shown below::
 
 Replace the path above with the one matching the location where ``aws`` tool is installed in your AMI.
 
+.. note:: The grandparent directory of the ``aws`` tool will be mounted into the container at the same path as the host,
+  e.g. ``/home/ec2-user/miniconda``, which will shadow existing files in the container.
+  Ensure you use a path that is not already present in the container.
+
 .. note:: Using a version of Nextflow prior 19.07.x the config setting `executor.awscli` should be used
   instead of `aws.batch.cliPath`.
 


### PR DESCRIPTION
This should help avoid https://github.com/nextflow-io/nextflow/issues/2322

Should we modify the miniconda example to use a path that's definitely unique, e.g. `/opt/aws-ecs-mount/conda` instead of something in `$HOME`, to further reduce the chance of a conflict?