### PR TITLE
Resolve config when Tower is enabled using the config file

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -303,7 +303,9 @@ class CmdRun extends CmdBase implements HubOptions {
         runner.session.commandLine = launcher.cliString
         runner.session.ansiLog = launcher.options.ansiLog
         runner.session.disableJobsCancellation = getDisableJobsCancellation()
-        if( withTower || log.isTraceEnabled() )
+
+        Boolean isTowerEnabled = config.navigate('tower.enabled') as Boolean
+        if( isTowerEnabled || log.isTraceEnabled() )
             runner.session.resolvedConfig = ConfigBuilder.resolveConfig(scriptFile.parent, this)
         // note config files are collected during the build process
         // this line should be after `ConfigBuilder#build`

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -304,7 +304,7 @@ class CmdRun extends CmdBase implements HubOptions {
         runner.session.ansiLog = launcher.options.ansiLog
         runner.session.disableJobsCancellation = getDisableJobsCancellation()
 
-        Boolean isTowerEnabled = config.navigate('tower.enabled') as Boolean
+        final isTowerEnabled = config.navigate('tower.enabled') as Boolean
         if( isTowerEnabled || log.isTraceEnabled() )
             runner.session.resolvedConfig = ConfigBuilder.resolveConfig(scriptFile.parent, this)
         // note config files are collected during the build process


### PR DESCRIPTION
## Description

Resolve the configuration to show at Tower when it is only enable using configuration file. 

Example config file:
```
tower {
  enabled = true
}
```

See issue #2641 and https://github.com/seqeralabs/nf-tower/issues/338


Signed-off-by: Jordi Deu-Pons <jordi@jordeu.net>