### PR TITLE
bugfix: allow blank spaces in java path

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -396,14 +396,14 @@ else
 
     # first string between double quotes is the full path to java, also blank spaces are included
     # remainder string are arguments
-    # we extract first part into cmd and remainder into rest and convert them to array as previous version
-    pat='"([^"]*)"(.*)'
-    [[ "${cli[@]}" =~ $pat ]]
-    cmd=(${BASH_REMATCH[1]})
-    rest=(${BASH_REMATCH[2]})
+    # we extract first part into `cmd_base`` and remainder into `cmd_tail`` and convert them to array as previous version
+    cmd_pattern='"([^"]*)"(.*)'
+    [[ "${cli[@]}" =~ $cmd_pattern ]]
+    cmd_base=(${BASH_REMATCH[1]})
+    cmd_tail=(${BASH_REMATCH[2]})
 
     if [[ "$JAVA_VER" =~ ^(9|10|11|12|13|14|15|16|17) ]]; then
-      launcher="${cmd[@]}"
+      launcher="${cmd_base[@]}"
       launcher+=(--add-opens=java.base/java.lang=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.io=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.nio=ALL-UNNAMED)
@@ -420,11 +420,11 @@ else
       launcher+=(--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED)
       [[ "$NXF_JVM_ARGS" ]] && launcher+=($NXF_JVM_ARGS)
-      launcher+=("${rest[@]}")
+      launcher+=("${cmd_tail[@]}")
     else
-      launcher="${cmd[@]}"
+      launcher="${cmd_base[@]}"
       [[ "$NXF_JVM_ARGS" ]] && launcher+=($NXF_JVM_ARGS)
-      launcher+=("${rest[@]}")
+      launcher+=("${cmd_tail[@]}")
     fi
 
     # Don't show errors if the LAUNCH_FILE can't be created

--- a/nextflow
+++ b/nextflow
@@ -394,8 +394,13 @@ else
     cli=($("$JAVA_CMD" "${JAVA_OPTS[@]}" -jar "$NXF_BIN"))
     [[ $? -ne 0 ]] && echo_red 'Unable to initialize nextflow environment' && exit 1
 
+    pat='"([^"]*)"(.*)'
+    [[ "${cli[@]}" =~ $pat ]]
+    cmd=(${BASH_REMATCH[1]})
+    rest=(${BASH_REMATCH[2]})
+
     if [[ "$JAVA_VER" =~ ^(9|10|11|12|13|14|15|16|17) ]]; then
-      launcher=("${cli[@]:0:1}")
+      launcher="${cmd[@]}"
       launcher+=(--add-opens=java.base/java.lang=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.io=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.nio=ALL-UNNAMED)
@@ -412,11 +417,11 @@ else
       launcher+=(--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED)
       [[ "$NXF_JVM_ARGS" ]] && launcher+=($NXF_JVM_ARGS)
-      launcher+=("${cli[@]:1}")
+      launcher+=("${rest[@]}")
     else
-      launcher=("${cli[@]:0:1}")
+      launcher="${cmd[@]}"
       [[ "$NXF_JVM_ARGS" ]] && launcher+=($NXF_JVM_ARGS)
-      launcher+=("${cli[@]:1}")
+      launcher+=("${rest[@]}")
     fi
 
     # Don't show errors if the LAUNCH_FILE can't be created

--- a/nextflow
+++ b/nextflow
@@ -394,6 +394,9 @@ else
     cli=($("$JAVA_CMD" "${JAVA_OPTS[@]}" -jar "$NXF_BIN"))
     [[ $? -ne 0 ]] && echo_red 'Unable to initialize nextflow environment' && exit 1
 
+    # first string between double quotes is the full path to java, also blank spaces are included
+    # remainder string are arguments
+    # we extract first part into cmd and remainder into rest and convert them to array as previous version
     pat='"([^"]*)"(.*)'
     [[ "${cli[@]}" =~ $pat ]]
     cmd=(${BASH_REMATCH[1]})


### PR DESCRIPTION
resolve #2298

the idea is to extract the first param between double quotes as the java path using a regexp 

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>