### PR TITLE
Dirwatch deeper

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/file/DirWatcherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/file/DirWatcherTest.groovy
@@ -102,7 +102,7 @@ class DirWatcherTest extends Specification {
         folder.resolve('ciao.txt').delete()
         TestHelper.stopUntil { results.size() == 2 }
         watcher.terminate()
-        
+
         then:
         results.size() == 2
         results.contains('hello.txt')
@@ -206,7 +206,102 @@ class DirWatcherTest extends Specification {
 
     }
 
+    def 'should watch when glob is early in pattern' () {
 
+        given:
+        def folder = Files.createTempDirectory('test')
+
+        def watcher = new DirWatcher('glob', "$folder/", '*/b??/car/*.txt', false, 'create', folder.getFileSystem())
+
+        when:
+        List results = []
+        watcher.apply { Path file -> results.add(file.name) }
+        sleep 500
+        Files.createDirectories(folder.resolve('ant/bat/car'))
+        Files.createDirectories(folder.resolve('ant/box/car'))
+        Files.createDirectories(folder.resolve('axe/zap/car'))
+        Files.createDirectories(folder.resolve('ant/box/car/car'))
+        folder.resolve('ant/bat/ciao.txt').text          = '.' // No match
+        folder.resolve('ant/bat/car/bonjour.txt').text   = '1' // Matches
+        folder.resolve('ant/bat/car/hi.txt').text        = '2' // Matches
+        folder.resolve('axe/zap/car/goodbye.txt').text   = '.' // No match
+        folder.resolve('ant/box/car/car/holla.txt').text = '.' // No match
+        folder.resolve('ant/box/car/salut.txt').text     = '3' // Matches
+        TestHelper.stopUntil { results.size() == 3 }
+        watcher.terminate()
+
+        then:
+        results.size() == 3
+        results.contains('hi.txt')
+        results.contains('salut.txt')
+        results.contains('bonjour.txt')
+
+        cleanup:
+        folder?.deleteDir()
+
+    }
+
+    def 'should see files created immediatly after directories' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def watcher = new DirWatcher('glob', "$folder/", '*/foo/*.txt', false, 'create', folder.getFileSystem())
+
+        when:
+        List results = []
+        watcher.apply { Path file -> results.add(file.name) }
+        sleep 500
+        Files.createDirectories(folder.resolve('blah/foo'))
+        folder.resolve('blah/foo/a.txt').text = '1'
+        folder.resolve('blah/foo/b.txt').text = '2'
+        folder.resolve('blah/foo/c.txt').text = '3'
+        TestHelper.stopUntil { results.size() == 3 }
+        watcher.terminate()
+
+        then:
+        results.size == 3
+        results.contains('a.txt')
+        results.contains('b.txt')
+        results.contains('c.txt')
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    def 'should not terminate unless parent target is deleted' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        Files.createDirectories(folder.resolve('ant/bat/car'))
+        Files.createDirectories(folder.resolve('ant/box/car'))
+
+        def watcher = new DirWatcher('glob', "$folder/", '*/b??/car/*.txt', false, 'create', folder.getFileSystem())
+
+        when:
+        List results = []
+        watcher.apply { Path file -> results.add(file.name)}
+        sleep 500
+        folder.resolve('ant/bat/car/bonjour.txt').text = '1'
+        folder.resolve('ant/bat/car/hi.txt').text = '2'
+        TestHelper.stopUntil { results.size() == 2 }
+        Files.delete(folder.resolve('ant/bat/car/bonjour.txt'))
+        Files.delete(folder.resolve('ant/bat/car/hi.txt'))
+        Files.delete(folder.resolve('ant/bat/car'))
+        Files.delete(folder.resolve('ant/bat'))
+        folder.resolve('ant/box/car/salut.txt').text = '3'
+        TestHelper.stopUntil { results.size() == 3 }
+        watcher.terminate()
+
+        then:
+        results.size == 3
+        results.contains('bonjour.txt')
+        results.contains('hi.txt')
+        results.contains('salut.txt')
+
+        cleanup:
+        folder?.deleteDir()
+    }
 
     def 'should convert string events'() {
         given:


### PR DESCRIPTION
A PR to address https://github.com/nextflow-io/nextflow/issues/2721. 

Three main changes to `DirWatcher` class:

**Allow more complex paths**
The first (and motivating) change was to increase the flexibility of the `Channel.watchPath` pattern to allow users to specify known directory names after the glob. That is, paths like `projects/*/outputs/*.done`

**Don't close the channel early**
The second change is to change the behaviour of the watchPath channel closing. By default if any of the watched directories are deleted, the Channel closes. In the example above, if the folder `projects/human` is deleted, then the channel closes, and any files in `projects/mouse/outputs/*.done` will be missed. The changed includes a check to only close the channel if the base folder is removed (`projects/`).

**Don't accidentally miss files**
The last change is to ensure that if a file is quickly created in a newly created directory, these files are added to the Channel, even if the file is created before Nextflow has had a change to attach a listener object to that directory. In essence, if Nextflow is scanning a newly created directory (looking for child dirs to register watchers) and comes across a file that matches the pattern, it is assumed to be a newly created file and emitted in the channel.

