### PR TITLE
Include SCHEMA in toString output

### DIFF
--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3Path.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3Path.java
@@ -481,17 +481,7 @@ public class S3Path implements Path, TagAwareFile {
 
 	@Override
 	public String toString() {
-		StringBuilder builder = new StringBuilder();
-
-		if (isAbsolute()) {
-			builder.append(PATH_SEPARATOR);
-			builder.append(bucket);
-			builder.append(PATH_SEPARATOR);
-		}
-
-		builder.append(Joiner.on(PATH_SEPARATOR).join(parts));
-
-		return builder.toString();
+		return toUri().toString();
 	}
 
 	@Override


### PR DESCRIPTION
The toString is often used to define subpaths / files e.g. file("${myS3dir}/important/file.txt")
When myS3dir is a S3Path (e.g. s3://my/s3/path/to/the/,  the output currently result in a local path and the pipeilne breaks e.g. "/my/s3/path/to/the/important/file.txt" 

Workaround:
The current workaround requires to use the "toUri()" method to be called for a complete definition of the resource e.g. file("${myS3dir.toUri()}/important/file.txt")

Solution:
The proposed solution returns by default a valid string representation of an URI, is more specific (tracking down issues) and allows the simple as well as consistent use of a "Path" variable. 
Also implemented the same way here:
https://github.com/Upplication/Amazon-S3-FileSystem-NIO2/blob/4fe1a64942cd565bb871a4e8c5add19687313f6b/src/main/java/com/upplication/s3fs/S3Path.java#L555