### PR TITLE
log '(empty)' when command stderr is empty

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1162,7 +1162,7 @@ class TaskProcessor {
             }
             
             // - this is likely a task wrapper issue
-            if( task.exitStatus != 0 & lines.size() == 0) {
+            if( task.exitStatus != 0 && lines.size() == 0) {
                 lines = task.dumpLogFile(max)
                 if( lines ) {
                     message << "\nCommand wrapper:"

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1152,15 +1152,17 @@ class TaskProcessor {
             }
 
             // - the tail of the process stderr
+            message << "\nCommand error:"
             lines = task.dumpStderr(max)
-            if( lines ) {
-                message << "\nCommand error:"
-                for( String it : lines ) {
-                    message << "  ${stripWorkDir(it, task.workDir)}"
-                }
+            if( lines.size() == 0 ) {
+                message << "  (empty)"
             }
+            for( String it : lines ) {
+                message << "  ${stripWorkDir(it, task.workDir)}"
+            }
+            
             // - this is likely a task wrapper issue
-            else if( task.exitStatus != 0 ) {
+            if( task.exitStatus != 0 & lines.size() == 0) {
                 lines = task.dumpLogFile(max)
                 if( lines ) {
                     message << "\nCommand wrapper:"


### PR DESCRIPTION
Sometimes a process will exit with an error code, but without printing anything to stderr.  When this happens, stdout is logged as `(empty)` but stderr is not.

This came up for me because we have a retry strategy that increases memory with each retry.  For an enduser running the workflow, it looks like the error is due to limited memory because there is a `Caused by` entry but not a `Command error` entry.

```
[7c/a9e7a0] Submitted process > Test:TestProcess
[7c/a9e7a0] NOTE: Process `Test:TestProcess` terminated with an error exit status (1) -- Execution is retried (1)
Error executing process > 'Test:TestProcess'

Caused by:
  Process requirement exceed available memory -- req: 20 GB; avail: 16 GB

Command executed:

  exit 1

Command exit status:
  -

Command output:
  (empty)

Work dir:
  /path/to/workdir
```

This change alters the logic of printing `Command error:` to match that of `Command output:`, which I believe makes things slightly more clear.

```
Error executing process > 'Test:TestProcess'

Caused by:
  Process requirement exceed available memory -- req: 20 GB; avail: 16 GB

Command executed:

  exit 1

Command exit status:
  -

Command output:
  (empty)

Command error:
  (empty)

Work dir:
  /path/to/workdir
```


Signed-off-by: John McGuigan <jrm5100@gmail.com>