### PR TITLE
Deal with k8s api timeouts and similar errors

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
@@ -387,7 +387,9 @@ class K8sClient {
 
             try {
                 return makeRequestCall( method, path, body )
-            } catch ( SocketException e ) {
+            } catch ( K8sResponseException | SocketException e ) {
+                if ( ( e instanceof K8sResponseException ) && ( e.response.code != 500 ))
+                    throw e
                 log.error "[K8s] API request threw socket exception: $e.message for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
                 if ( trial < maxTrials ) log.info( "[K8s] Try API request again, remaining trials: ${ maxTrials - trial }" )
                 else throw e

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
@@ -388,7 +388,7 @@ class K8sClient {
             try {
                 return makeRequestCall( method, path, body )
             } catch ( K8sResponseException | SocketException e ) {
-                if ( ( e instanceof K8sResponseException ) && ( e.response.code != 500 ))
+                if ( e instanceof K8sResponseException && e.response.code != 500 )
                     throw e
                 log.error "[K8s] API request threw socket exception: $e.message for $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
                 if ( trial < maxTrials ) log.info( "[K8s] Try API request again, remaining trials: ${ maxTrials - trial }" )


### PR DESCRIPTION
Return code 500 from kubernetes api is mostly a temporary error like timeout, so we should try again in these cases.