### PR TITLE
Use compiled nextflow instead of system wide

### DIFF
--- a/packing.gradle
+++ b/packing.gradle
@@ -308,7 +308,7 @@ task dockerPack(type: Exec, dependsOn: ['pack']) {
     cd $buildDir/docker  
     mkdir -p dist
     curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-17.03.1-ce.tgz && tar --strip-components=1 -xvzf docker-17.03.1-ce.tgz -C dist
-    NXF_HOME=\$PWD/.nextflow nextflow info
+    NXF_HOME=\$PWD/.nextflow ./nextflow info
     docker build -t nextflow/nextflow:$version .
     """.stripIndent()
 


### PR DESCRIPTION
When building docker, use just compiled version of nextflow, not system wide that might not be even installed.