### PR TITLE
Deprecate pullPolicy in favor of imagePullPolicy

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -397,7 +397,7 @@ launchDir           Defines the path where the workflow is launched and the user
 workDir             Defines the path where the workflow temporary data is stored. This must be a path in a shared K8s persistent volume (default:``<user-dir>/work``).
 projectDir          Defines the path where Nextflow projects are downloaded. This must be a path in a shared K8s persistent volume (default: ``<volume-claim-mount-path>/projects``).
 pod                 Allows the definition of one or more pod configuration options such as environment variables, config maps, secrets, etc. It allows the same settings as the :ref:`process-pod` process directive.
-pullPolicy          Defines the strategy to be used to pull the container image e.g. ``pullPolicy: 'Always'``.
+imagePullPolicy     Defines the strategy to be used to pull the container image e.g. ``imagePullPolicy: 'Always'``.
 runAsUser           Defines the user ID to be used to run the containers. Shortcut for the ``securityContext`` option.
 securityContext     Defines the `security context <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>`_ for all pods.
 storageClaimName    The name of the persistent volume claim where store workflow result data.

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sConfig.groovy
@@ -55,11 +55,14 @@ class K8sConfig implements Map<String,Object> {
             this.podOptions.volumeClaims.add(new PodVolumeClaim(name, mount, subPath))
         }
 
-        // -- shortcut to pod image pull-policy
-        if( target.pullPolicy )
+        // -- shortcut to pod image pull policy
+        if( target.pullPolicy ) {
+            log.warn "The `pullPolicy` option is deprecated -- Use `imagePullPolicy` instead."
             podOptions.imagePullPolicy = target.pullPolicy.toString()
-        else if( target.imagePullPolicy )
+        }
+        else if( target.imagePullPolicy ) {
             podOptions.imagePullPolicy = target.imagePullPolicy.toString()
+        }
 
         // -- shortcut to pod security context
         if( target.runAsUser != null )

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -21,6 +21,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.PackageScope
 import groovy.transform.ToString
+import groovy.util.logging.Slf4j
 
 /**
  * Model K8s pod options such as environment variables,
@@ -28,6 +29,7 @@ import groovy.transform.ToString
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
+@Slf4j
 @CompileStatic
 @ToString(includeNames = true)
 @EqualsAndHashCode(includeFields = true)
@@ -98,8 +100,12 @@ class PodOptions {
         else if( entry.mountPath && entry.volumeClaim ) {
             mountClaims << new PodVolumeClaim(entry)
         }
-        else if( entry.pullPolicy || entry.imagePullPolicy ) {
-            this.imagePullPolicy = entry.pullPolicy ?: entry.imagePullPolicy as String
+        else if( entry.pullPolicy ) {
+            log.warn "The `pullPolicy` option is deprecated -- Use `imagePullPolicy` instead."
+            this.imagePullPolicy = entry.pullPolicy as String
+        }
+        else if( entry.imagePullPolicy ) {
+            this.imagePullPolicy = entry.imagePullPolicy as String
         }
         else if( entry.imagePullSecret || entry.imagePullSecrets ) {
             this.imagePullSecret = entry.imagePullSecret ?: entry.imagePullSecrets

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sConfigTest.groovy
@@ -185,7 +185,7 @@ class K8sConfigTest extends Specification {
 
 
         when:
-        opts = new K8sConfig(pod: [ [pullPolicy: 'Always'], [env: 'HELLO', value: 'WORLD'] ]).getPodOptions()
+        opts = new K8sConfig(pod: [ [imagePullPolicy: 'Always'], [env: 'HELLO', value: 'WORLD'] ]).getPodOptions()
         then:
         opts.getImagePullPolicy() == 'Always'
         opts.getEnvVars() == [ PodEnv.value('HELLO','WORLD') ] as Set
@@ -332,8 +332,8 @@ class K8sConfigTest extends Specification {
 
     def 'should set the image pull policy' () {
         when:
-        def cfg = new K8sConfig( pullPolicy: 'always' )
+        def cfg = new K8sConfig( imagePullPolicy: 'Always' )
         then:
-        cfg.getPodOptions().getImagePullPolicy() == 'always'
+        cfg.getPodOptions().getImagePullPolicy() == 'Always'
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
@@ -45,7 +45,7 @@ class PodOptionsTest extends Specification {
         options.getImagePullPolicy() == null
         
         when:
-        options = new PodOptions([ [imagePullPolicy: 'Always'] ])
+        options = new PodOptions([ [pullPolicy: 'Always'] ])
         then:
         options.getImagePullPolicy() == 'Always'
 

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
@@ -37,7 +37,7 @@ class PodOptionsTest extends Specification {
         options.getAutomountServiceAccountToken() == true
     }
 
-    def 'should set pullPolicy' () {
+    def 'should set imagePullPolicy' () {
 
         when:
         def options = new PodOptions()
@@ -45,12 +45,12 @@ class PodOptionsTest extends Specification {
         options.getImagePullPolicy() == null
         
         when:
-        options = new PodOptions([ [pullPolicy:'Always'] ])
+        options = new PodOptions([ [imagePullPolicy: 'Always'] ])
         then:
         options.getImagePullPolicy() == 'Always'
 
         when:
-        options = new PodOptions([ [imagePullPolicy:'latest'] ])
+        options = new PodOptions([ [imagePullPolicy: 'latest'] ])
         then:
         options.getImagePullPolicy() == 'latest'
     }


### PR DESCRIPTION
The `pollPolicy` pod option is an unnecessary shortcut for `imagePullPolicy` and should be removed in order to tighten up the nextflow / k8s interface. This PR simply deprecates `pullPolicy` so that users are warned that it may be removed in a future release.