### PR TITLE
Fix S3 file staging when there are spaces in the filename

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
@@ -90,8 +90,8 @@ class S3BashLib extends BashFunLib<S3BashLib> {
         nxf_s3_download() {
             local source=\$1
             local target=\$2
-            local file_name=\$(basename \$1)
-            local is_dir=\$($cli s3 ls \$source | grep -F "PRE \${file_name}/" -c)
+            local file_name=\$(basename "\$1")
+            local is_dir=\$($cli s3 ls "\$source" | grep -F "PRE \${file_name}/" -c)
             if [[ \$is_dir == 1 ]]; then
                 $cli s3 cp --only-show-errors --recursive "\$source" "\$target"
             else 

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
@@ -200,8 +200,8 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                     nxf_s3_download() {
                         local source=$1
                         local target=$2
-                        local file_name=$(basename $1)
-                        local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                        local file_name=$(basename "$1")
+                        local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                         if [[ $is_dir == 1 ]]; then
                             aws s3 cp --only-show-errors --recursive "$source" "$target"
                         else 
@@ -289,8 +289,8 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                 nxf_s3_download() {
                     local source=$1
                     local target=$2
-                    local file_name=$(basename $1)
-                    local is_dir=$(/foo/aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                    local file_name=$(basename "$1")
+                    local is_dir=$(/foo/aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                     if [[ $is_dir == 1 ]]; then
                         /foo/aws s3 cp --only-show-errors --recursive "$source" "$target"
                     else 

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -129,8 +129,8 @@ class AwsBatchScriptLauncherTest extends Specification {
                 nxf_s3_download() {
                     local source=$1
                     local target=$2
-                    local file_name=$(basename $1)
-                    local is_dir=$(/conda/bin/aws --region eu-west-1 s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                    local file_name=$(basename "$1")
+                    local is_dir=$(/conda/bin/aws --region eu-west-1 s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                     if [[ $is_dir == 1 ]]; then
                         /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --recursive "$source" "$target"
                     else 
@@ -306,8 +306,8 @@ class AwsBatchScriptLauncherTest extends Specification {
                     nxf_s3_download() {
                         local source=$1
                         local target=$2
-                        local file_name=$(basename $1)
-                        local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                        local file_name=$(basename "$1")
+                        local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                         if [[ $is_dir == 1 ]]; then
                             aws s3 cp --only-show-errors --recursive "$source" "$target"
                         else 
@@ -449,8 +449,8 @@ class AwsBatchScriptLauncherTest extends Specification {
                     nxf_s3_download() {
                         local source=$1
                         local target=$2
-                        local file_name=$(basename $1)
-                        local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                        local file_name=$(basename "$1")
+                        local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                         if [[ $is_dir == 1 ]]; then
                             aws s3 cp --only-show-errors --recursive "$source" "$target"
                         else 
@@ -566,8 +566,8 @@ class AwsBatchScriptLauncherTest extends Specification {
                     nxf_s3_download() {
                         local source=$1
                         local target=$2
-                        local file_name=$(basename $1)
-                        local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                        local file_name=$(basename "$1")
+                        local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                         if [[ $is_dir == 1 ]]; then
                             aws s3 cp --only-show-errors --recursive "$source" "$target"
                         else 

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
@@ -98,8 +98,8 @@ class S3BashLibTest extends Specification {
                     nxf_s3_download() {
                         local source=$1
                         local target=$2
-                        local file_name=$(basename $1)
-                        local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                        local file_name=$(basename "$1")
+                        local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                         if [[ $is_dir == 1 ]]; then
                             aws s3 cp --only-show-errors --recursive "$source" "$target"
                         else 
@@ -195,8 +195,8 @@ class S3BashLibTest extends Specification {
                     nxf_s3_download() {
                         local source=$1
                         local target=$2
-                        local file_name=$(basename $1)
-                        local is_dir=$(/foo/bin/aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                        local file_name=$(basename "$1")
+                        local is_dir=$(/foo/bin/aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                         if [[ $is_dir == 1 ]]; then
                             /foo/bin/aws s3 cp --only-show-errors --recursive "$source" "$target"
                         else 
@@ -237,8 +237,8 @@ class S3BashLibTest extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 
@@ -275,8 +275,8 @@ class S3BashLibTest extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 
@@ -310,8 +310,8 @@ class S3BashLibTest extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 
@@ -348,8 +348,8 @@ class S3BashLibTest extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(/some/bin/aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(/some/bin/aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     /some/bin/aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 
@@ -440,8 +440,8 @@ class S3BashLibTest extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 
@@ -529,8 +529,8 @@ class S3BashLibTest extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
@@ -84,8 +84,8 @@ class BashWrapperBuilderWithS3Test extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 
@@ -202,8 +202,8 @@ class BashWrapperBuilderWithS3Test extends Specification {
             nxf_s3_download() {
                 local source=$1
                 local target=$2
-                local file_name=$(basename $1)
-                local is_dir=$(aws s3 ls $source | grep -F "PRE ${file_name}/" -c)
+                local file_name=$(basename "$1")
+                local is_dir=$(aws s3 ls "$source" | grep -F "PRE ${file_name}/" -c)
                 if [[ $is_dir == 1 ]]; then
                     aws s3 cp --only-show-errors --recursive "$source" "$target"
                 else 


### PR DESCRIPTION
Add quotes around the file paths in the `nxf_s3_download` function.

Currently it errors out if it receives a file with a space in it.

Here is an example of what the `nxf_stage` function in `command.run` looks like

```
downloads+=("nxf_s3_download s3://<bucket>/resources/data/references/barcodes/test\ space/barcode.txt barcodes.txt")
```

The command log looks like this after running:

```
nxf-scratch-dir ip-10-0-1-196.us-west-2.compute.internal:/tmp/nxf.GW2vFFIgyN

Unknown options: space/barcode.txt

Unknown options: barcodes.txt
```
