### PR TITLE
Add tolerations pod option

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -2021,6 +2021,7 @@ The ``pod`` directive allows the definition of the following options:
 ``affinity: <V>``                                 Specifies affinity for which nodes the process should run on. See `Kubernetes affinity <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity>`_ for details.
 ``automountServiceAccountToken: <V>``             Specifies whether to `automount service account token <https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/>`_ into process pods. If ``V`` is true, service account token is automounted into task pods (default).
 ``priorityClassName: <V>``                        Specifies the `priority class name <https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/>`_ for pods.
+``toleration: <V>``                               Specifies a toleration for a node taint. See `Taints and Tolerations <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>`_ for details.
 ================================================= =================================================
 
 When defined in the Nextflow configuration file, a pod setting can be defined using the canonical
@@ -2036,6 +2037,7 @@ When more than one setting needs to be provides they must be enclosed in a list 
     pod = [ [env: 'FOO', value: 'bar'], [secret: 'my-secret/key1', mountPath: '/etc/file.txt'] ]
   }
 
+Some settings, including environment variables, configs, secrets, volume claims, and tolerations, can be specified multiple times for different values.
 
 .. _process-publishDir:
 

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -59,6 +59,8 @@ class PodOptions {
 
     private String priorityClassName
 
+    private List<Map> tolerations
+
     PodOptions( List<Map> options=null ) {
         int size = options ? options.size() : 0
         envVars = new HashSet<>(size)
@@ -66,6 +68,7 @@ class PodOptions {
         mountConfigMaps = new HashSet<>(size)
         mountClaims = new HashSet<>(size)
         automountServiceAccountToken = true
+        tolerations = new ArrayList<Map>(size)
         init(options)
     }
 
@@ -128,6 +131,9 @@ class PodOptions {
         else if( entry.priorityClassName ) {
             this.priorityClassName = entry.priorityClassName
         }
+        else if( entry.toleration instanceof Map ) {
+            tolerations << (entry.toleration as Map)
+        }
         else 
             throw new IllegalArgumentException("Unknown pod options: $entry")
     }
@@ -183,6 +189,8 @@ class PodOptions {
     }
 
     String getPriorityClassName() { priorityClassName }
+
+    List<Map> getTolerations() { tolerations }
 
     PodOptions plus( PodOptions other ) {
         def result = new PodOptions()
@@ -240,6 +248,9 @@ class PodOptions {
 
         // priority class name
         result.priorityClassName = other.priorityClassName ?: this.priorityClassName
+
+        // tolerations
+        result.tolerations = other.tolerations ?: this.tolerations
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -86,6 +86,8 @@ class PodSpecBuilder {
 
     String priorityClassName
 
+    List<Map> tolerations = []
+
     /**
      * @return A sequential volume unique identifier
      */
@@ -268,6 +270,9 @@ class PodSpecBuilder {
         automountServiceAccountToken = opts.automountServiceAccountToken
         // -- priority class name
         priorityClassName = opts.priorityClassName
+        // -- tolerations
+        if( opts.tolerations )
+            tolerations.addAll(opts.tolerations)
 
         return this
     }
@@ -340,6 +345,10 @@ class PodSpecBuilder {
 
         if( priorityClassName )
             spec.priorityClassName = priorityClassName
+
+        // tolerations
+        if( this.tolerations )
+            spec.tolerations = this.tolerations
 
         // add labels
         if( labels )


### PR DESCRIPTION
This PR adds the `tolerations` pod option, which allows a pod to "tolerate" certain node taints during scheduling. Can be useful for situations where a node is designated for a specific use case (special CPU type, belongs to certain user group, etc), so it will only be scheduled to users who specifically tolerate the taint.

I also reorganized some of the pod-related classes to be more readable. I pushed two separate commits so that you can distinguish the toleration-specific changes from the general changes.