### PR TITLE
Wait for pod End background scenario 

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -159,6 +159,8 @@ class K8sDriverLauncher {
     }
 
     protected void waitPodEnd() {
+        if( background )
+            return
         final currentState = k8sClient.podState(runName)
         if (currentState && currentState?.running instanceof Map) {
             final name = runName
@@ -174,7 +176,7 @@ class K8sDriverLauncher {
                 }
             }
             catch( Exception e ) {
-                log.warn "Catch exception waiting for pod to stop running"
+                log.warn "Caught exception waiting for pod to stop running"
             }
         }
     }


### PR DESCRIPTION
- Account for background scenario.
- A user who launches nextflow with background flag wants to exit after pod has started.
- Fix grammer in log message.
- Fixes an issue if a user launches nextflow with "-bg", the application will wait until the run pod state has changed from running. 

Signed-off-by: kfrancisdev <kfrancisdev@gmail.com>