### PR TITLE
Cleanup K8s code

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -2021,6 +2021,7 @@ The ``pod`` directive allows the definition of the following options:
 ``priorityClassName: <V>``                        Specifies the `priority class name <https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/>`_ for pods.
 ``runAsUser: <UID>``                              Specifies the user ID to be used to run the container. Shortcut for the ``securityContext`` option.
 ``securityContext: <V>``                          Specifies the pod security context. See `Kubernetes security context <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>`_ for details.
+``toleration: <V>``                               Specifies a toleration for a node taint. See `Taints and Tolerations <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>`_ for details.
 ================================================= =================================================
 
 When defined in the Nextflow configuration file, a pod setting can be defined using the canonical
@@ -2036,6 +2037,7 @@ When more than one setting needs to be provides they must be enclosed in a list 
     pod = [ [env: 'FOO', value: 'bar'], [secret: 'my-secret/key1', mountPath: '/etc/file.txt'] ]
   }
 
+Some settings, including environment variables, configs, secrets, volume claims, and tolerations, can be specified multiple times for different values.
 
 .. _process-publishDir:
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -2004,23 +2004,23 @@ The above snippet defines an environment variable named ``FOO`` which value is `
 The ``pod`` directive allows the definition of the following options:
 
 ================================================= =================================================
-``label: <K>, value: <V>``                        Defines a pod label with key ``K`` and value ``V``.
+``affinity: <V>``                                 Specifies affinity for which nodes the process should run on. See `Kubernetes affinity <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity>`_ for details.
 ``annotation: <K>, value: <V>``                   Defines a pod annotation with key ``K`` and value ``V``.
-``env: <E>, value: <V>``                          Defines an environment variable with name ``E`` and whose value is given by the ``V`` string.
-``env: <E>, fieldPath: <V>``                      Defines an environment variable with name ``E`` and whose value is given by the ``V`` `field path <https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/>`_.
+``automountServiceAccountToken: <V>``             Specifies whether to `automount service account token <https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/>`_ into process pods. If ``V`` is true, service account token is automounted into task pods (default).
 ``env: <E>, config: <C/K>``                       Defines an environment variable with name ``E`` and whose value is given by the entry associated to the key with name ``K`` in the `ConfigMap <https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/>`_ with name ``C``.
+``env: <E>, fieldPath: <V>``                      Defines an environment variable with name ``E`` and whose value is given by the ``V`` `field path <https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/>`_.
 ``env: <E>, secret: <S/K>``                       Defines an environment variable with name ``E`` and whose value is given by the entry associated to the key with name ``K`` in the `Secret <https://kubernetes.io/docs/concepts/configuration/secret/>`_ with name ``S``.
+``env: <E>, value: <V>``                          Defines an environment variable with name ``E`` and whose value is given by the ``V`` string.
+``imagePullPolicy: <V>``                          Specifies the strategy to be used to pull the container image e.g. ``imagePullPolicy: 'Always'``.
+``imagePullSecret: <V>``                          Specifies the secret name to access a private container image registry. See `Kubernetes documentation <https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod>`_ for details.
+``label: <K>, value: <V>``                        Defines a pod label with key ``K`` and value ``V``.
 ``config: <C/K>, mountPath: </absolute/path>``    The content of the `ConfigMap <https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/>`_ with name ``C`` with key ``K`` is made available to the path ``/absolute/path``. When the key component is omitted the path is interpreted as a directory and all the `ConfigMap` entries are exposed in that path.
 ``secret: <S/K>, mountPath: </absolute/path>``    The content of the `Secret <https://kubernetes.io/docs/concepts/configuration/secret/>`_ with name ``S`` with key ``K`` is made available to the path ``/absolute/path``. When the key component is omitted the path is interpreted as a directory and all the `Secret` entries are exposed in that path.
 ``volumeClaim: <V>, mountPath: </absolute/path>`` Mounts a `Persistent volume claim <https://kubernetes.io/docs/concepts/storage/persistent-volumes/>`_ with name ``V`` to the specified path location. Use the optional `subPath` parameter to mount a directory inside the referenced volume instead of its root. The volume may be mounted with `readOnly: true`, but is read/write by default.
-``imagePullPolicy: <V>``                          Specifies the strategy to be used to pull the container image e.g. ``imagePullPolicy: 'Always'``.
-``imagePullSecret: <V>``                          Specifies the secret name to access a private container image registry. See `Kubernetes documentation <https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod>`_ for details.
+``nodeSelector: <V>``                             Specifies which node the process will run on. See `Kubernetes nodeSelector <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector>`_ for details.
+``priorityClassName: <V>``                        Specifies the `priority class name <https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/>`_ for pods.
 ``runAsUser: <UID>``                              Specifies the user ID to be used to run the container. Shortcut for the ``securityContext`` option.
 ``securityContext: <V>``                          Specifies the pod security context. See `Kubernetes security context <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>`_ for details.
-``nodeSelector: <V>``                             Specifies which node the process will run on. See `Kubernetes nodeSelector <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector>`_ for details.
-``affinity: <V>``                                 Specifies affinity for which nodes the process should run on. See `Kubernetes affinity <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity>`_ for details.
-``automountServiceAccountToken: <V>``             Specifies whether to `automount service account token <https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/>`_ into process pods. If ``V`` is true, service account token is automounted into task pods (default).
-``priorityClassName: <V>``                        Specifies the `priority class name <https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/>`_ for pods.
 ================================================= =================================================
 
 When defined in the Nextflow configuration file, a pod setting can be defined using the canonical

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -2021,7 +2021,6 @@ The ``pod`` directive allows the definition of the following options:
 ``priorityClassName: <V>``                        Specifies the `priority class name <https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/>`_ for pods.
 ``runAsUser: <UID>``                              Specifies the user ID to be used to run the container. Shortcut for the ``securityContext`` option.
 ``securityContext: <V>``                          Specifies the pod security context. See `Kubernetes security context <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>`_ for details.
-``toleration: <V>``                               Specifies a toleration for a node taint. See `Taints and Tolerations <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>`_ for details.
 ================================================= =================================================
 
 When defined in the Nextflow configuration file, a pod setting can be defined using the canonical
@@ -2037,7 +2036,6 @@ When more than one setting needs to be provides they must be enclosed in a list 
     pod = [ [env: 'FOO', value: 'bar'], [secret: 'my-secret/key1', mountPath: '/etc/file.txt'] ]
   }
 
-Some settings, including environment variables, configs, secrets, volume claims, and tolerations, can be specified multiple times for different values.
 
 .. _process-publishDir:
 

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
@@ -192,9 +192,9 @@ class K8sTaskHandler extends TaskHandler {
         if( acc )
             builder.withAccelerator(acc)
 
-        final List<String> hostMounts = getContainerMounts()
-        for( String mount : hostMounts ) {
-            builder.withHostMount(mount,mount)
+        final List<String> hostPaths = getContainerMounts()
+        for( String mount : hostPaths ) {
+            builder.withHostPath(mount,mount)
         }
 
         return builder.build()

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodMountHostPath.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodMountHostPath.groovy
@@ -22,20 +22,20 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
 /**
- * Model a K8s pod host mount defintion
+ * Model a K8s hostPath volume defintion
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @EqualsAndHashCode
 @ToString(includeNames = true)
 @CompileStatic
-class PodHostMount {
+class PodMountHostPath {
 
     String hostPath
 
     String mountPath
 
-    PodHostMount(String host, String container) {
+    PodMountHostPath(String host, String container) {
         this.hostPath = host
         this.mountPath = container
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -59,6 +59,8 @@ class PodOptions {
 
     private PodSecurityContext securityContext
 
+    private List<Map> tolerations
+
     PodOptions( List<Map> options=null ) {
         int size = options ? options.size() : 0
         automountServiceAccountToken = true
@@ -66,6 +68,7 @@ class PodOptions {
         mountConfigMaps = new HashSet<>(size)
         mountSecrets = new HashSet<>(size)
         mountVolumeClaims = new HashSet<>(size)
+        tolerations = new ArrayList<Map>(size)
         init(options)
     }
 
@@ -128,6 +131,9 @@ class PodOptions {
         else if( entry.securityContext instanceof Map ) {
             this.securityContext = new PodSecurityContext(entry.securityContext as Map)
         }
+        else if( entry.toleration instanceof Map ) {
+            tolerations << (entry.toleration as Map)
+        }
         else 
             throw new IllegalArgumentException("Unknown pod options: $entry")
     }
@@ -183,6 +189,8 @@ class PodOptions {
         this.securityContext = ctx
         return this
     }
+
+    List<Map> getTolerations() { tolerations }
 
     PodOptions plus( PodOptions other ) {
         def result = new PodOptions()
@@ -240,6 +248,9 @@ class PodOptions {
             result.securityContext = other.securityContext
         else
             result.securityContext = securityContext
+
+        // tolerations
+        result.tolerations = other.tolerations ?: this.tolerations
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -59,8 +59,6 @@ class PodOptions {
 
     private PodSecurityContext securityContext
 
-    private List<Map> tolerations
-
     PodOptions( List<Map> options=null ) {
         int size = options ? options.size() : 0
         automountServiceAccountToken = true
@@ -68,7 +66,6 @@ class PodOptions {
         mountConfigMaps = new HashSet<>(size)
         mountSecrets = new HashSet<>(size)
         mountVolumeClaims = new HashSet<>(size)
-        tolerations = new ArrayList<Map>(size)
         init(options)
     }
 
@@ -131,9 +128,6 @@ class PodOptions {
         else if( entry.securityContext instanceof Map ) {
             this.securityContext = new PodSecurityContext(entry.securityContext as Map)
         }
-        else if( entry.toleration instanceof Map ) {
-            tolerations << (entry.toleration as Map)
-        }
         else 
             throw new IllegalArgumentException("Unknown pod options: $entry")
     }
@@ -190,8 +184,6 @@ class PodOptions {
         return this
     }
 
-    List<Map> getTolerations() { tolerations }
-
     PodOptions plus( PodOptions other ) {
         def result = new PodOptions()
 
@@ -239,9 +231,6 @@ class PodOptions {
 
         // security context
         result.securityContext = other.securityContext ?: this.securityContext
-
-        // tolerations
-        result.tolerations = other.tolerations ?: this.tolerations
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -210,16 +210,10 @@ class PodOptions {
         result.envVars.addAll( other.envVars )
 
         // image pull policy
-        if (other.imagePullPolicy)
-            result.imagePullPolicy = other.imagePullPolicy
-        else
-            result.imagePullPolicy = imagePullPolicy
+        result.imagePullPolicy = other.imagePullPolicy ?: this.imagePullPolicy
 
         // image pull secret
-        if (other.imagePullSecret)
-            result.imagePullSecret = other.imagePullSecret
-        else
-            result.imagePullSecret = imagePullSecret
+        result.imagePullSecret = other.imagePullSecret ?: this.imagePullSecret
 
         // labels
         result.labels.putAll(labels)
@@ -244,10 +238,7 @@ class PodOptions {
         result.priorityClassName = other.priorityClassName ?: this.priorityClassName
 
         // security context
-        if( other.securityContext )
-            result.securityContext = other.securityContext
-        else
-            result.securityContext = securityContext
+        result.securityContext = other.securityContext ?: this.securityContext
 
         // tolerations
         result.tolerations = other.tolerations ?: this.tolerations

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -86,6 +86,8 @@ class PodSpecBuilder {
 
     String workDir
 
+    List<Map> tolerations = []
+
     /**
      * @return A sequential volume unique identifier
      */
@@ -279,6 +281,10 @@ class PodSpecBuilder {
         if( opts.securityContext )
             securityContext = opts.securityContext
 
+        // -- tolerations
+        if( opts.tolerations )
+            tolerations.addAll(opts.tolerations)
+
         return this
     }
 
@@ -374,6 +380,10 @@ class PodSpecBuilder {
         // service account
         if( this.serviceAccount )
             spec.serviceAccountName = this.serviceAccount
+
+        // tolerations
+        if( this.tolerations )
+            spec.tolerations = this.tolerations
 
         // work dir
         if( this.workDir )

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -86,8 +86,6 @@ class PodSpecBuilder {
 
     String workDir
 
-    List<Map> tolerations = []
-
     /**
      * @return A sequential volume unique identifier
      */
@@ -281,10 +279,6 @@ class PodSpecBuilder {
         if( opts.securityContext )
             securityContext = opts.securityContext
 
-        // -- tolerations
-        if( opts.tolerations )
-            tolerations.addAll(opts.tolerations)
-
         return this
     }
 
@@ -380,10 +374,6 @@ class PodSpecBuilder {
         // service account
         if( this.serviceAccount )
             spec.serviceAccountName = this.serviceAccount
-
-        // tolerations
-        if( this.tolerations )
-            spec.tolerations = this.tolerations
 
         // work dir
         if( this.workDir )

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
@@ -161,7 +161,11 @@ class K8sDriverLauncherTest extends Specification {
         spec == [
             apiVersion: 'v1',
             kind: 'Pod',
-            metadata: [name:'foo-boo', namespace:'foo', labels:[app:'nextflow', runName:'foo-boo']],
+            metadata: [
+                name:'foo-boo',
+                namespace:'foo',
+                labels:[app:'nextflow', runName:'foo-boo']
+            ],
             spec: [
                 restartPolicy: 'Never',
                 containers: [
@@ -219,7 +223,11 @@ class K8sDriverLauncherTest extends Specification {
         spec == [
             apiVersion: 'v1',
             kind: 'Pod',
-            metadata: [name:'foo-boo', namespace:'foo', labels:[app:'nextflow', runName:'foo-boo']],
+            metadata: [
+                name:'foo-boo',
+                namespace:'foo',
+                labels:[app:'nextflow', runName:'foo-boo']
+            ],
             spec: [
                 restartPolicy: 'Never',
                 containers: [

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -420,8 +420,8 @@ class PodSpecBuilderTest extends Specification {
                 .withImageName('busybox')
                 .withWorkDir('/path')
                 .withCommand(['echo'])
-                .withHostMount('/tmp','/scratch')
-                .withHostMount('/host/data','/mnt/container')
+                .withHostPath('/tmp','/scratch')
+                .withHostPath('/host/data','/mnt/container')
                 .build()
 
         then:
@@ -608,7 +608,7 @@ class PodSpecBuilderTest extends Specification {
         given:
         def builder = new PodSpecBuilder(imagePullSecret: 'MySecret')
         when:
-        def result = builder.createPullSecret()
+        def result = builder.createImagePullSecret()
         then:
         result.size() == 1 
         result.get(0).name == 'MySecret'

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -532,47 +532,34 @@ class PodSpecBuilderTest extends Specification {
 
         given:
         def opts = Mock(PodOptions)
-        def builder = new PodSpecBuilder([
-            podName: 'foo',
-            imageName: 'image',
-            command: ['echo'],
-            labels: [runName: 'crazy_john'],
-            annotations: [evict: 'false']
-        ])
+        def builder = new PodSpecBuilder(podName: 'foo', imageName: 'image', command: ['echo'], labels: [runName: 'crazy_john'], annotations: [evict: 'false'])
 
         def affinity = [
             nodeAffinity: [
                 requiredDuringSchedulingIgnoredDuringExecution: [
                     nodeSelectorTerms: [
-                        [key: 'foo', operator: 'In', values: ['bar', 'baz']]
+                        [key: "foo", operator: "In", values: ["bar", "baz"]]
                     ]
                 ]
             ]
         ]
 
-        def tolerations = [[
-            key: 'example-key',
-            operator: 'Exists',
-            effect: 'NoSchedule'
-        ]]
-
         when:
         def spec = builder.withPodOptions(opts).build()
         then:
-        _ * opts.getAffinity() >> affinity
-        _ * opts.getAnnotations() >> [OMEGA:'zzz', SIGMA:'www']
-        _ * opts.getAutomountServiceAccountToken() >> false
-        2 * opts.getEnvVars() >> [ PodEnv.value('HELLO','WORLD') ]
         2 * opts.getImagePullPolicy() >> 'always'
         2 * opts.getImagePullSecret() >> 'myPullSecret'
-        _ * opts.getLabels() >> [ALPHA: 'xxx', GAMMA: 'yyy']
         2 * opts.getVolumeClaims() >> [ new PodVolumeClaim('pvc1', '/work') ]
         2 * opts.getMountConfigMaps() >> [ new PodMountConfig('data', '/home/user') ]
         2 * opts.getMountSecrets() >> [ new PodMountSecret('blah', '/etc/secret.txt') ]
-        _ * opts.getNodeSelector() >> new PodNodeSelector(gpu:true, queue: 'fast')
-        _ * opts.getPriorityClassName() >> 'high-priority'
+        2 * opts.getEnvVars() >> [ PodEnv.value('HELLO','WORLD') ]
+        _ * opts.getLabels() >> [ALPHA: 'xxx', GAMMA: 'yyy']
+        _ * opts.getAnnotations() >> [OMEGA:'zzz', SIGMA:'www']
         _ * opts.getSecurityContext() >> new PodSecurityContext(1000)
-        _ * opts.getTolerations() >> tolerations
+        _ * opts.getNodeSelector() >> new PodNodeSelector(gpu:true, queue: 'fast')
+        _ * opts.getAffinity() >> affinity
+        _ * opts.getAutomountServiceAccountToken() >> false
+        _ * opts.getPriorityClassName() >> 'high-priority'
 
         spec == [
             apiVersion: 'v1',
@@ -584,27 +571,28 @@ class PodSpecBuilderTest extends Specification {
                 annotations: [evict: 'false', OMEGA:'zzz', SIGMA:'www']
             ],
             spec: [
-                affinity: affinity,
-                automountServiceAccountToken: false,
-                imagePullSecrets: [[ name: 'myPullSecret' ]],
-                nodeSelector: [gpu: 'true', queue: 'fast'],
-                priorityClassName: 'high-priority',
                 restartPolicy:'Never',
                 securityContext: [ runAsUser: 1000 ],
-                tolerations: tolerations,
-
-                containers:[[
-                    name:'foo',
-                    image:'image',
-                    imagePullPolicy: 'always',
-                    command:['echo'],
-                    env:[[name:'HELLO', value:'WORLD']],
-                    volumeMounts:[
-                        [name:'vol-1', mountPath:'/work'],
-                        [name:'vol-2', mountPath:'/home/user'],
-                        [name:'vol-3', mountPath:'/etc/secret.txt']
-                    ],
-                ]],
+                imagePullSecrets: [[ name: 'myPullSecret' ]],
+                nodeSelector: [gpu: 'true', queue: 'fast'],
+                affinity: affinity,
+                automountServiceAccountToken: false,
+                priorityClassName: 'high-priority',
+                
+                containers:[
+                    [
+                        name:'foo',
+                        image:'image',
+                        imagePullPolicy: 'always',
+                        command:['echo'],
+                        env:[[name:'HELLO', value:'WORLD']],
+                        volumeMounts:[
+                            [name:'vol-1', mountPath:'/work'],
+                            [name:'vol-2', mountPath:'/home/user'],
+                            [name:'vol-3', mountPath:'/etc/secret.txt']
+                        ],
+                    ]
+                ],
                 volumes:[
                     [name:'vol-1', persistentVolumeClaim:[claimName:'pvc1']],
                     [name:'vol-2', configMap:[name:'data']],


### PR DESCRIPTION
This PR includes a few general changes to K8s classes to improve readability. I might review the rest of the K8s code before making this PR ready to review.

- reorganize pod options to alphabetical order
- reorganize pod spec builder to be more readable
- rename HostMount to HostPath (corresponds to `hostPath` volume in K8s)