### PR TITLE
2422 process.ext set with withname overrides configuration of all processes

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
@@ -337,9 +337,6 @@ class ConfigParser {
             def result = null
             if (current.config.get(name)) {
                 result = current.config.get(name)
-            } else if (current.scope.entrySet().find{ it.key==profileStack.last.toString()} ) {
-                result = current.scope.entrySet().find{ it.key==profileStack.last.toString()}.value[name]
-            } else if (current.scope[name]) {
             } else if (current.scope.get(name)) {
                 result = current.scope[name]
             }

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
@@ -337,6 +337,9 @@ class ConfigParser {
             def result
             if (current.config.get(name)) {
                 result = current.config.get(name)
+            } else if (current.scope.entrySet().find{ it.key==profileStack.last.toString()} ) {
+                result = current.scope.entrySet().find{ it.key==profileStack.last.toString()}.value[name]
+            } else if (current.scope[name]) {
             } else if (current.scope.get(name)) {
                 result = current.scope[name]
             } else {

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -1817,13 +1817,15 @@ class ConfigBuilderTest extends Specification {
 
     // issue 2422 - https://github.com/nextflow-io/nextflow/issues/2422
     // ideally this should behave as the previous test
-    //@Ignore
     def 'should resolve ext config with properties' () {
 
         given:
         def folder = Files.createTempDirectory('test')
         def file1 = folder.resolve('test.conf')
         file1.text = '''
+            params{
+                REPLACE_WITH = 'Hola'
+            }
             process {
                 ext.args = "Hello World!" 
                 cpus = 1 
@@ -1831,10 +1833,8 @@ class ConfigBuilderTest extends Specification {
                     ext.args = "Ciao mondo!"
                     cpus = 2
                     withName:FOO {
-                        ext.args = "Hola caracola!"
-                        ext {
-                            args2 = 'Hola mundo!'
-                        }
+                        ext.args = "${params.REPLACE_WITH} mundo!"
+                        cpus = 3
                     }
                 }
             }
@@ -1847,8 +1847,8 @@ class ConfigBuilderTest extends Specification {
         cfg1.process.ext.args == 'Hello World!'
         cfg1.process.'withName:BAR'.cpus == 2
         cfg1.process.'withName:BAR'.ext.args == "Ciao mondo!"
-        cfg1.process.'withName:BAR'.'withName:FOO'.ext.args == "Hola caracola!"
-        cfg1.process.'withName:BAR'.'withName:FOO'.ext.args2 == "Hola mundo!"
+        cfg1.process.'withName:BAR'.'withName:FOO'.cpus == 3
+        cfg1.process.'withName:BAR'.'withName:FOO'.ext.args == "Hola mundo!"
 
         cleanup:
         folder?.deleteDir()

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -1817,7 +1817,7 @@ class ConfigBuilderTest extends Specification {
 
     // issue 2422 - https://github.com/nextflow-io/nextflow/issues/2422
     // ideally this should behave as the previous test
-    @Ignore
+    //@Ignore
     def 'should resolve ext config with properties' () {
 
         given:
@@ -1830,6 +1830,12 @@ class ConfigBuilderTest extends Specification {
                 withName:BAR {
                     ext.args = "Ciao mondo!"
                     cpus = 2
+                    withName:FOO {
+                        ext.args = "Hola caracola!"
+                        ext {
+                            args2 = 'Hola mundo!'
+                        }
+                    }
                 }
             }
             '''
@@ -1841,6 +1847,8 @@ class ConfigBuilderTest extends Specification {
         cfg1.process.ext.args == 'Hello World!'
         cfg1.process.'withName:BAR'.cpus == 2
         cfg1.process.'withName:BAR'.ext.args == "Ciao mondo!"
+        cfg1.process.'withName:BAR'.'withName:FOO'.ext.args == "Hola caracola!"
+        cfg1.process.'withName:BAR'.'withName:FOO'.ext.args2 == "Hola mundo!"
 
         cleanup:
         folder?.deleteDir()


### PR DESCRIPTION

We maintain in `profileStack` a list of sections visited but we were checking if the property requested was only into the scope of the current stack instead to check if present in the last profile

Another issue was we were checking if the var is present with `if( current.scope[name] )` but this expression creates the variable if not present, so I've changed for `containsKey`

Lastly a little refactor removing the `if-else-if` chain for independents `if` who check if previous didn't find a valid result to return

closes #2422 