### PR TITLE
Evict pod and decrease process forks if pod is restarted after exception

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -577,6 +577,7 @@ class TaskPollingMonitor implements TaskMonitor {
     final protected void handleException( TaskHandler handler, Throwable error ) {
         def fault = null
         try {
+            if (evict(handler)) handler.decProcessForks()
             fault = handler.task.processor.resumeOrDie(handler?.task, error)
         }
         finally {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -577,7 +577,9 @@ class TaskPollingMonitor implements TaskMonitor {
     final protected void handleException( TaskHandler handler, Throwable error ) {
         def fault = null
         try {
-            if (evict(handler)) handler.decProcessForks()
+            if (evict(handler)) { 
+                handler.decProcessForks()
+            }
             fault = handler.task.processor.resumeOrDie(handler?.task, error)
         }
         finally {


### PR DESCRIPTION
In rare cases, the following code
https://github.com/nextflow-io/nextflow/blob/7f7cdadc6a36d0fb99ef125f6c6f89bfca8ca52e/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy#L301-L324
throws an exception which is then handled here:
https://github.com/nextflow-io/nextflow/blob/7f7cdadc6a36d0fb99ef125f6c6f89bfca8ca52e/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy#L537
In that cases, the failed pod is again and again recognized as failed, and another new instance is started (maxRetries often).
In the maxRetries + 1 case, Nextflow fails the workflow, as all retries are exhausted. 
The problem here is that the failed pod is never evicted, and the exception handling happens again and again.

I can hardly reproduce the error.