### PR TITLE
bugfix:  overwrite process configuration by command line argument

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -557,7 +557,19 @@ class ConfigBuilder {
 
         // -- override 'process' parameters defined on the cmd line
         cmdRun.process.each { name, value ->
-            config.process[name] = parseValue(value)
+            String[] keys = name.split('\\.')
+            if( keys.length == 1 ) {
+                config.process[name] = parseValue(value)
+                return
+            }
+            def iter = config.process
+            for(String key : keys.dropRight(1)){
+                if( !iter.containsKey(key)) {
+                    iter[key] = [:]
+                }
+                iter = iter[key]
+            }
+            iter[keys.last()] = parseValue(value)
         }
 
         // -- apply the conda environment


### PR DESCRIPTION
currently, we are overwriting only the "top" process configuration. With this patch, we iterate over nested configurations

resolve #2652

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>