### PR TITLE
Implementation AWS CodeCommit provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ install:
 	BUILD_PACK=1 ./gradlew installLauncher publishToMavenLocal -Dmaven.repo.local=${HOME}/.nextflow/capsule/deps/
 
 #
+# install compiled plugins artifacts in Maven local dir
+#
+installPlugins:
+	BUILD_PACK=1 ./gradlew plugins:assemble
+	mkdir -p ${HOME}/.nextflow/plugins
+	cp -R build/plugins/* ${HOME}/.nextflow/plugins
+
+#
 # Show dependencies try `make deps config=runtime`, `make deps config=google`
 #
 deps:

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -287,11 +287,6 @@ class CmdRun extends CmdBase implements HubOptions {
         log.info "N E X T F L O W  ~  version ${Const.APP_VER}"
 
         // -- specify the arguments
-        if( plugins ){
-            //require if some plugin provides a scm factory
-            final tmp = [plugins: plugins.tokenize(',')]
-            Plugins.setup( tmp )
-        }
         final scriptFile = getScriptFile(pipeline)
 
         // create the config object
@@ -306,7 +301,6 @@ class CmdRun extends CmdBase implements HubOptions {
 
         // -- load plugins
         final cfg = plugins ? [plugins: plugins.tokenize(',')] : config
-        Plugins.stop()
         Plugins.setup( cfg )
 
         // -- load secret provider

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -287,6 +287,11 @@ class CmdRun extends CmdBase implements HubOptions {
         log.info "N E X T F L O W  ~  version ${Const.APP_VER}"
 
         // -- specify the arguments
+        if( plugins ){
+            //require if some plugin provides a scm factory
+            final tmp = [plugins: plugins.tokenize(',')]
+            Plugins.setup( tmp )
+        }
         final scriptFile = getScriptFile(pipeline)
 
         // create the config object
@@ -301,6 +306,7 @@ class CmdRun extends CmdBase implements HubOptions {
 
         // -- load plugins
         final cfg = plugins ? [plugins: plugins.tokenize(',')] : config
+        Plugins.stop()
         Plugins.setup( cfg )
 
         // -- load secret provider

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -127,7 +127,7 @@ class AssetManager {
         this.project = resolveName(pipelineName)
         this.localPath = checkProjectDir(project)
         this.hub = checkHubProvider(cliOpts)
-        this.provider = createHubProvider(hub)
+        this.provider = createHubProvider(hub, pipelineName)
         setupCredentials(cliOpts)
         validateProjectDir()
 
@@ -305,7 +305,8 @@ class AssetManager {
     @PackageScope
     String resolveNameFromGitUrl( String repository ) {
 
-        if( repository.startsWith('http://') || repository.startsWith('https://') || repository.startsWith('file:/')) {
+        final List<String> gitProtocols = ['http://', 'https://', 'file:/', 'codecommit::']
+        if( gitProtocols.find {repository.startsWith(it)} ) {
             try {
                 def url = new GitUrl(repository)
 
@@ -363,13 +364,13 @@ class AssetManager {
      * @return
      */
     @PackageScope
-    RepositoryProvider createHubProvider(String providerName) {
+    RepositoryProvider createHubProvider(String providerName, String url=null) {
 
         final config = providerConfigs.find { it.name == providerName }
         if( !config )
             throw new AbortOperationException("Unknown repository configuration provider: $providerName")
 
-        return RepositoryFactory.create(config, project)
+        return RepositoryFactory.create(config, project, url)
     }
 
     AssetManager setLocalPath(File path) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -122,6 +122,8 @@ class AssetManager {
     @PackageScope
     AssetManager build( String pipelineName, Map config = null, HubOptions cliOpts = null ) {
 
+        RepositoryProvider.loadRequiredPlugins(pipelineName)
+
         this.providerConfigs = ProviderConfig.createFromMap(config)
 
         this.project = resolveName(pipelineName)
@@ -130,6 +132,8 @@ class AssetManager {
         this.provider = createHubProvider(hub, pipelineName)
         setupCredentials(cliOpts)
         validateProjectDir()
+
+        RepositoryProvider.unloadRequiredPlugins(pipelineName)
 
         return this
     }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -369,8 +369,7 @@ class AssetManager {
         if( !config )
             throw new AbortOperationException("Unknown repository configuration provider: $providerName")
 
-        RepositoryProvider .create(config, project)
-
+        return RepositoryFactory.create(config, project)
     }
 
     AssetManager setLocalPath(File path) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -17,6 +17,8 @@
 
 package nextflow.scm
 
+import static nextflow.Const.*
+
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
@@ -43,14 +45,8 @@ import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
-import org.eclipse.jgit.merge.MergeStrategy
 import org.eclipse.jgit.lib.SubmoduleConfig.FetchRecurseSubmodulesMode
-import static nextflow.Const.DEFAULT_HUB
-import static nextflow.Const.DEFAULT_MAIN_FILE_NAME
-import static nextflow.Const.DEFAULT_ORGANIZATION
-import static nextflow.Const.DEFAULT_ROOT
-import static nextflow.Const.MANIFEST_FILE_NAME
+import org.eclipse.jgit.merge.MergeStrategy
 /**
  * Handles operation on remote and local installed pipelines
  *
@@ -321,7 +317,7 @@ class AssetManager {
                 }
                 else {
                     // find the provider config for this server
-                    def config = providerConfigs.find { it.domain == url.domain }
+                    def config = providerConfigs.find { it.domain == url.domain || url.domain.matches(it.domain) }
                     this.hub = config?.name
                     result = resolveProjectName0(url.path, config?.server)
                 }
@@ -609,7 +605,7 @@ class AssetManager {
             // clone it
             def clone = Git.cloneRepository()
             if( provider.hasCredentials() )
-                clone.setCredentialsProvider( new UsernamePasswordCredentialsProvider(provider.user, provider.password) )
+                clone.setCredentialsProvider( provider.getGitCredentials() )
 
             clone
                 .setURI(cloneURL)
@@ -664,7 +660,7 @@ class AssetManager {
         }
 
         if( provider.hasCredentials() )
-            pull.setCredentialsProvider( new UsernamePasswordCredentialsProvider(provider.user, provider.password))
+            pull.setCredentialsProvider( provider.getGitCredentials() )
 
         if( manifest.recurseSubmodules ) {
             pull.setRecurseSubmodules(FetchRecurseSubmodulesMode.YES)
@@ -696,7 +692,7 @@ class AssetManager {
         clone.setDirectory(directory)
         clone.setCloneSubmodules(manifest.recurseSubmodules)
         if( provider.hasCredentials() )
-            clone.setCredentialsProvider(new UsernamePasswordCredentialsProvider(provider.user, provider.password))
+            clone.setCredentialsProvider( provider.getGitCredentials() )
 
         if( revision )
             clone.setBranch(revision)
@@ -953,7 +949,7 @@ class AssetManager {
         try {
             def fetch = git.fetch()
             if(provider.hasCredentials()) {
-                fetch.setCredentialsProvider( new UsernamePasswordCredentialsProvider(provider.user, provider.password) )
+                fetch.setCredentialsProvider( provider.getGitCredentials() )
             }
             if( manifest.recurseSubmodules ) {
                 fetch.setRecurseSubmodules(FetchRecurseSubmodulesMode.YES)
@@ -1006,7 +1002,7 @@ class AssetManager {
         init.call()
         // call submodule update
         if( provider.hasCredentials() )
-            update.setCredentialsProvider( new UsernamePasswordCredentialsProvider(provider.user, provider.password) )
+            update.setCredentialsProvider( provider.getGitCredentials() )
         def updatedList = update.call()
         log.debug "Update submodules $updatedList"
     }
@@ -1015,7 +1011,7 @@ class AssetManager {
         final tag = rev.type == RevisionInfo.Type.TAG
         final cmd = git.lsRemote().setTags(tag)
         if( provider.hasCredentials() )
-            cmd.setCredentialsProvider(new UsernamePasswordCredentialsProvider(provider.user, provider.password) )
+            cmd.setCredentialsProvider( provider.getGitCredentials() )
         final list = cmd.call()
         final ref = list.find { Repository.shortenRefName(it.name) == rev.name }
         if( !ref ) {
@@ -1103,6 +1099,10 @@ class AssetManager {
             throw new AbortOperationException(message)
         }
 
+        if ( domain && domain.matches("git-codecommit\\..*?\\.amazonaws\\.com") ) {
+            return "codecommit"
+        }
+
         final result = providerConfigs.find { it -> it.domain == domain }
         if( !result && failFast ) {
             def message = "Can't find any configured provider for git server `$domain` -- Make sure to have specified it in your `scm` file. For details check https://www.nextflow.io/docs/latest/sharing.html#scm-configuration-file"
@@ -1153,7 +1153,7 @@ class AssetManager {
                 return "${commitId.substring(0,10)} [${name}]"
             }
 
-            commitId
+            return commitId
         }
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
@@ -17,6 +17,7 @@
 
 package nextflow.scm
 
+import groovy.util.logging.Slf4j
 import nextflow.plugin.Plugins
 import nextflow.scm.config.ScmConfig
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
@@ -44,13 +44,6 @@ class ProviderConfig {
     @PackageScope
     static Path DEFAULT_SCM_FILE = Const.APP_HOME_DIR.resolve('scm')
 
-    private static final List<String> DEFAULT_SCMS = [
-            'github',
-            'gitlab',
-            'gitea',
-            'bitbucket',
-            'azurerepos']
-
     @PackageScope
     static Map<String,String> env = new HashMap<>(System.getenv())
 
@@ -310,9 +303,10 @@ class ProviderConfig {
     }
 
     static private void addDefaults(List<ProviderConfig> result) {
-        result.addAll( DEFAULT_SCMS.collect{
-            new ProviderConfig(it)
-        })
+        def factories = Plugins.getExtensions(ProviderConfigFactory) ?:[ProviderConfigFactory.INSTANCE]
+        factories.each { factory->
+            result.addAll( factory.allProviderConfigs())
+        }
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
@@ -92,6 +92,14 @@ class ProviderConfig {
                 if( !attr.server ) attr.server = 'https://dev.azure.com'
                 if( !attr.endpoint ) attr.endpoint = 'https://dev.azure.com'
                 break
+
+            case 'codecommit':
+                attr.platform = name
+                // this config is ignored when accessing repositories - the actual server/domain is
+                // determined by the configured or specified AWS region.
+                // it is required here for compatibility for provider server/domain processing
+                attr.server = "https://git-codecommit.[a-z1-9-]+.amazonaws.com/v1"
+                break
         }
 
         if( attr.path )
@@ -339,6 +347,9 @@ class ProviderConfig {
 
         if( !result.find{ it.name == 'azurerepos' })
             result << new ProviderConfig('azurerepos')
+
+        if( !result.find{ it.name == 'codecommit' })
+            result << new ProviderConfig('codecommit')
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfigFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfigFactory.groovy
@@ -1,0 +1,27 @@
+package nextflow.scm
+
+import org.pf4j.ExtensionPoint
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+class ProviderConfigFactory implements ExtensionPoint {
+
+    private static final List<String> DEFAULT_SCMS = [
+            'github',
+            'gitlab',
+            'gitea',
+            'bitbucket',
+            'azurerepos']
+
+    protected static final ProviderConfigFactory INSTANCE = new ProviderConfigFactory()
+
+    List<ProviderConfig> allProviderConfigs() {
+        DEFAULT_SCMS.collect{
+            new ProviderConfig(it)
+        }
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy
@@ -70,10 +70,6 @@ class RepositoryFactory implements ExtensionPoint {
     }
 
     static RepositoryProvider create( ProviderConfig config, String project ) {
-        // force amazon plugin loading if `codecommit` is specified
-        if(config.platform == 'codecommit') {
-            Plugins.startIfMissing('nf-amazon')
-        }
         // scan for available plugins
         final all = Plugins.getPriorityExtensions(RepositoryFactory)
         final result = all.findResult( it -> it.newInstance(config, project) )

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy
@@ -38,7 +38,7 @@ class RepositoryFactory implements ExtensionPoint {
      *      An instance of a {@link RepositoryProvider} that matches the specified config
      *      or {@code null} if no match is found
      */
-    protected RepositoryProvider newInstance(ProviderConfig config, String project) {
+    RepositoryProvider newInstance(ProviderConfig config, String project, String url) {
 
         switch(config.platform) {
             case 'github':
@@ -69,10 +69,10 @@ class RepositoryFactory implements ExtensionPoint {
         }
     }
 
-    static RepositoryProvider create( ProviderConfig config, String project ) {
+    static RepositoryProvider create( ProviderConfig config, String project, String url) {
         // scan for available plugins
-        final all = Plugins.getPriorityExtensions(RepositoryFactory)
-        final result = all.findResult( it -> it.newInstance(config, project) )
+        final all = Plugins.getExtensions(RepositoryFactory)
+        final result = all.findResult( it -> it.newInstance(config, project, url) )
         if( !result ) {
             throw new AbortOperationException("Unknown project repository platform: ${config.platform}")
         }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020-2022, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.scm
+
+import nextflow.exception.AbortOperationException
+import nextflow.plugin.Plugins
+import org.pf4j.ExtensionPoint
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class RepositoryFactory implements ExtensionPoint {
+
+    /**
+     * Create a new instance of the {@link RepositoryProvider} if a matching configuration
+     * is found
+     *
+     * @param config
+     *      The {@link ProviderConfig} object holding the Git configuration
+     * @param project
+     *      The Git project name e.g. `nextflow-io/hello`
+     * @return
+     *      An instance of a {@link RepositoryProvider} that matches the specified config
+     *      or {@code null} if no match is found
+     */
+    protected RepositoryProvider newInstance(ProviderConfig config, String project) {
+
+        switch(config.platform) {
+            case 'github':
+                return new GithubRepositoryProvider(project, config)
+
+            case 'bitbucket':
+                return new BitbucketRepositoryProvider(project, config)
+
+            case 'bitbucketserver':
+                return new BitbucketServerRepositoryProvider(project, config)
+
+            case 'gitlab':
+                return new GitlabRepositoryProvider(project, config)
+
+            case 'gitea':
+                return new GiteaRepositoryProvider(project, config)
+
+            case 'azurerepos':
+                return new AzureRepositoryProvider(project, config)
+
+            case 'file':
+                // remove the 'local' prefix for the file provider
+                def localName = project.tokenize('/').last()
+                return new LocalRepositoryProvider(localName, config)
+
+            default:
+                return null
+        }
+    }
+
+    static RepositoryProvider create( ProviderConfig config, String project ) {
+        // force amazon plugin loading if `codecommit` is specified
+        if(config.platform == 'codecommit') {
+            Plugins.startIfMissing('nf-amazon')
+        }
+        // scan for available plugins
+        final all = Plugins.getPriorityExtensions(RepositoryFactory)
+        final result = all.findResult( it -> it.newInstance(config, project) )
+        if( !result ) {
+            throw new AbortOperationException("Unknown project repository platform: ${config.platform}")
+        }
+        // return matching provider
+        return result
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -21,10 +21,12 @@ import groovy.json.JsonSlurper
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
+import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.Const
 import nextflow.exception.AbortOperationException
 import nextflow.exception.RateLimitExceededException
+import nextflow.plugin.Plugins
 import org.eclipse.jgit.transport.CredentialsProvider
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 /**
@@ -270,4 +272,23 @@ abstract class RepositoryProvider {
         }
     }
 
+    static private Map<String,String> PLUGINS_MAP = ['git-codecommit':'nf-amazon']
+
+    @PackageScope
+    static void loadRequiredPlugins(String pipelineName){
+        def plugins = PLUGINS_MAP.findResults{
+            if( pipelineName.indexOf(it.key) != -1){
+                log.debug "Starting plugin '$it.value' required to handle $pipelineName repo"
+                return it.value
+            }
+            null
+        }
+        final tmp = [plugins: plugins]
+        Plugins.setup( tmp )
+    }
+
+    @PackageScope
+    static void unloadRequiredPlugins(String pipelineName){
+        Plugins.stop()
+    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -17,7 +17,6 @@
 
 package nextflow.scm
 
-
 import groovy.json.JsonSlurper
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
@@ -26,10 +25,8 @@ import groovy.util.logging.Slf4j
 import nextflow.Const
 import nextflow.exception.AbortOperationException
 import nextflow.exception.RateLimitExceededException
-import nextflow.plugin.Plugins
 import org.eclipse.jgit.transport.CredentialsProvider
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
-
 /**
  *
  * Base class for a generic source repository provider
@@ -270,54 +267,6 @@ abstract class RepositoryProvider {
         }
         catch( IOException e ) {
             throw new AbortOperationException("Cannot find `$project` -- Make sure exists a ${name.capitalize()} repository at this address `${getRepositoryUrl()}`", e)
-        }
-    }
-    /**
-     * Factory method
-     *
-     * @param provider
-     * @return
-     */
-    static RepositoryProvider create( ProviderConfig config, String project ) {
-        switch(config.platform) {
-            case 'github':
-                return new GithubRepositoryProvider(project, config)
-
-            case 'bitbucket':
-                return new BitbucketRepositoryProvider(project, config)
-
-            case 'bitbucketserver':
-                return new BitbucketServerRepositoryProvider(project, config)
-
-            case 'gitlab':
-                return new GitlabRepositoryProvider(project, config)
-
-            case 'gitea':
-                return new GiteaRepositoryProvider(project, config)
-
-            case 'azurerepos':
-                return new AzureRepositoryProvider(project, config)
-
-            case 'codecommit':
-                Plugins.startIfMissing('nf-amazon')
-                return loadCodeCommitProvider(project, config)
-
-            case 'file':
-                // remove the 'local' prefix for the file provider
-                def localName = project.tokenize('/').last()
-                return new LocalRepositoryProvider(localName, config)
-        }
-
-        throw new AbortOperationException("Unknown project repository platform: ${config.platform}")
-    }
-
-    static private RepositoryProvider loadCodeCommitProvider(String project, ProviderConfig config) {
-        try {
-            final clazz = Class.forName('nextflow.cloud.aws.codecommit.AwsCodeCommitRepositoryProvider')
-            (RepositoryProvider) clazz.newInstance(project, config)
-        }
-        catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException("Unable to load AWS CodeCommit provider - Make sure nf-amazon plugins was included")
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/config/AzureRepoConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/config/AzureRepoConfig.groovy
@@ -1,0 +1,25 @@
+package nextflow.scm.config
+
+import org.pf4j.Extension
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+@Extension
+class AzureRepoConfig implements ScmConfig{
+
+    @Override
+    String getName() {
+        'azurerepos'
+    }
+
+    @Override
+    Map enrichConfiguration(Map attr) {
+        attr.platform = name
+        if( !attr.server ) attr.server = 'https://dev.azure.com'
+        if( !attr.endpoint ) attr.endpoint = 'https://dev.azure.com'
+        attr
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/config/BitBucketConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/config/BitBucketConfig.groovy
@@ -1,0 +1,24 @@
+package nextflow.scm.config
+
+import org.pf4j.Extension
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+@Extension
+class BitBucketConfig implements ScmConfig{
+
+    @Override
+    String getName() {
+        'bitbucket'
+    }
+
+    @Override
+    Map enrichConfiguration(Map attr) {
+        attr.platform = name
+        if( !attr.server ) attr.server = 'https://bitbucket.org'
+        attr
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/config/GiteaConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/config/GiteaConfig.groovy
@@ -1,0 +1,25 @@
+package nextflow.scm.config
+
+import org.pf4j.Extension
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+@Extension
+class GiteaConfig implements ScmConfig{
+
+    @Override
+    String getName() {
+        'gitea'
+    }
+
+    @Override
+    Map enrichConfiguration(Map attr) {
+        attr.platform = name
+        if( !attr.server ) attr.server = 'https://try.gitea.io'
+        if( !attr.endpoint ) attr.endpoint = attr.server.toString().stripEnd('/') + '/api/v1'
+        attr
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/config/GithubConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/config/GithubConfig.groovy
@@ -1,0 +1,25 @@
+package nextflow.scm.config
+
+import org.pf4j.Extension
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+@Extension
+class GithubConfig implements ScmConfig{
+
+    @Override
+    String getName() {
+        'github'
+    }
+
+    @Override
+    Map enrichConfiguration(Map attr) {
+        attr.platform = name
+        if( !attr.server ) attr.server = 'https://github.com'
+        if( !attr.endpoint ) attr.endpoint = 'https://api.github.com'
+        attr
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/config/GitlabConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/config/GitlabConfig.groovy
@@ -1,0 +1,24 @@
+package nextflow.scm.config
+
+import org.pf4j.Extension
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+@Extension
+class GitlabConfig implements ScmConfig{
+
+    @Override
+    String getName() {
+        'gitlab'
+    }
+
+    @Override
+    Map enrichConfiguration(Map attr) {
+        attr.platform = name
+        if( !attr.server ) attr.server = 'https://gitlab.com'
+        attr
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/scm/config/ScmConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/config/ScmConfig.groovy
@@ -1,0 +1,14 @@
+package nextflow.scm.config
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+interface ScmConfig {
+
+    String getName()
+
+    Map enrichConfiguration(Map map)
+
+}

--- a/modules/nextflow/src/main/resources/META-INF/extensions.idx
+++ b/modules/nextflow/src/main/resources/META-INF/extensions.idx
@@ -20,3 +20,10 @@ nextflow.util.DefaultSerializers
 nextflow.secret.LocalSecretsProvider
 nextflow.cache.DefaultCacheFactory
 nextflow.scm.RepositoryFactory
+
+# Scm configurations
+nextflow.scm.config.AzureRepoConfig
+nextflow.scm.config.BitBucketConfig
+nextflow.scm.config.GiteaConfig
+nextflow.scm.config.GithubConfig
+nextflow.scm.config.GitlabConfig

--- a/modules/nextflow/src/main/resources/META-INF/extensions.idx
+++ b/modules/nextflow/src/main/resources/META-INF/extensions.idx
@@ -19,3 +19,4 @@ nextflow.trace.DefaultObserverFactory
 nextflow.util.DefaultSerializers
 nextflow.secret.LocalSecretsProvider
 nextflow.cache.DefaultCacheFactory
+nextflow.scm.RepositoryFactory

--- a/modules/nextflow/src/test/groovy/nextflow/scm/ProviderConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/ProviderConfigTest.groovy
@@ -204,7 +204,7 @@ class ProviderConfigTest extends Specification {
         when:
         def result = ProviderConfig.createFromText(CONFIG)
         then:
-        result.size() == 7
+        result.size() == 8
 
         result.find { it.name == 'github' }.server == 'https://github.com'
         result.find { it.name == 'github' }.auth == '12732:35454'

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -30,25 +30,25 @@ class RepositoryProviderTest extends Specification {
         def provider
 
         when:
-        provider = RepositoryFactory.create(new ProviderConfig('github'),'project/x')
+        provider = RepositoryFactory.create(new ProviderConfig('github'),'project/x', null)
         then:
         provider instanceof GithubRepositoryProvider
         provider.endpointUrl == 'https://api.github.com/repos/project/x'
 
         when:
-        provider = RepositoryFactory.create(new ProviderConfig('gitlab'),'project/y')
+        provider = RepositoryFactory.create(new ProviderConfig('gitlab'),'project/y', null)
         then:
         provider instanceof GitlabRepositoryProvider
         provider.endpointUrl == 'https://gitlab.com/api/v4/projects/project%2Fy'
 
         when:
-        provider = RepositoryFactory.create(new ProviderConfig('bitbucket'),'project/z')
+        provider = RepositoryFactory.create(new ProviderConfig('bitbucket'),'project/z', null)
         then:
         provider instanceof BitbucketRepositoryProvider
         provider.endpointUrl == 'https://bitbucket.org/api/2.0/repositories/project/z'
 
         when:
-        provider = RepositoryFactory.create(new ProviderConfig('local', [path:'/user/data']),'local/w')
+        provider = RepositoryFactory.create(new ProviderConfig('local', [path:'/user/data']),'local/w', null)
         then:
         provider.endpointUrl == 'file:/user/data/w'
     }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -30,25 +30,25 @@ class RepositoryProviderTest extends Specification {
         def provider
 
         when:
-        provider = RepositoryProvider.create(new ProviderConfig('github'),'project/x')
+        provider = RepositoryFactory.create(new ProviderConfig('github'),'project/x')
         then:
         provider instanceof GithubRepositoryProvider
         provider.endpointUrl == 'https://api.github.com/repos/project/x'
 
         when:
-        provider = RepositoryProvider.create(new ProviderConfig('gitlab'),'project/y')
+        provider = RepositoryFactory.create(new ProviderConfig('gitlab'),'project/y')
         then:
         provider instanceof GitlabRepositoryProvider
         provider.endpointUrl == 'https://gitlab.com/api/v4/projects/project%2Fy'
 
         when:
-        provider = RepositoryProvider.create(new ProviderConfig('bitbucket'),'project/z')
+        provider = RepositoryFactory.create(new ProviderConfig('bitbucket'),'project/z')
         then:
         provider instanceof BitbucketRepositoryProvider
         provider.endpointUrl == 'https://bitbucket.org/api/2.0/repositories/project/z'
 
         when:
-        provider = RepositoryProvider.create(new ProviderConfig('local', [path:'/user/data']),'local/w')
+        provider = RepositoryFactory.create(new ProviderConfig('local', [path:'/user/data']),'local/w')
         then:
         provider.endpointUrl == 'file:/user/data/w'
     }

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     api ('com.amazonaws:aws-java-sdk-iam:1.12.129')
     api ('com.amazonaws:aws-java-sdk-ecs:1.12.129')
     api ('com.amazonaws:aws-java-sdk-logs:1.12.129')
+    api ('com.amazonaws:aws-java-sdk-codecommit:1.12.129')
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy
@@ -86,11 +86,15 @@ class AmazonClientFactory {
 
     @Memoized
     static AmazonClientFactory instance(ISession session) {
-        return new AmazonClientFactory(session.config)
+        return new AmazonClientFactory(session?.config ?: [:])
     }
 
     static AmazonClientFactory instance() {
         return instance(Global.session)
+    }
+
+    static AmazonClientFactory instance(Map config) {
+        return new AmazonClientFactory(config)
     }
 
     /**

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy
@@ -24,6 +24,8 @@ import com.amazonaws.auth.BasicSessionCredentials
 import com.amazonaws.regions.Region
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.batch.AWSBatchClient
+import com.amazonaws.services.codecommit.AWSCodeCommit
+import com.amazonaws.services.codecommit.AWSCodeCommitClientBuilder
 import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.ecs.AmazonECS
 import com.amazonaws.services.ecs.AmazonECSClientBuilder
@@ -33,6 +35,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
 import nextflow.Global
+import nextflow.ISession
 import nextflow.exception.AbortOperationException
 /**
  *
@@ -81,6 +84,14 @@ class AmazonClientFactory {
 
     String getSessionToken() { sessionToken }
 
+    @Memoized
+    static AmazonClientFactory instance(ISession session) {
+        return new AmazonClientFactory(session.config)
+    }
+
+    static AmazonClientFactory instance() {
+        return instance(Global.session)
+    }
 
     /**
      * Initialise the Amazon cloud driver with default (empty) parameters
@@ -251,7 +262,7 @@ class AmazonClientFactory {
         if( region )
             clientBuilder.withRegion(region)
 
-        final credentials = getCredentialsProvider0()
+        final credentials = getCredentialsProvider()
         if( credentials )
             clientBuilder.withCredentials(credentials)
 
@@ -265,7 +276,21 @@ class AmazonClientFactory {
         if( region )
             clientBuilder.withRegion(region)
 
-        final credentials = getCredentialsProvider0()
+        final credentials = getCredentialsProvider()
+        if( credentials )
+            clientBuilder.withCredentials(credentials)
+
+        return clientBuilder.build()
+    }
+
+    @Memoized
+    AWSCodeCommit getCodeCommitClient() {
+
+        final clientBuilder = AWSCodeCommitClientBuilder.standard()
+        if( region )
+            clientBuilder.withRegion(region)
+
+        final credentials = getCredentialsProvider()
         if( credentials )
             clientBuilder.withCredentials(credentials)
 
@@ -283,11 +308,10 @@ class AmazonClientFactory {
             new BasicAWSCredentials(accessKey, secretKey)
     }
 
-    protected AWSStaticCredentialsProvider getCredentialsProvider0() {
+    AWSStaticCredentialsProvider getCredentialsProvider() {
         final creds = getCredentials0()
         if( !creds ) return null
         return new AWSStaticCredentialsProvider(creds)
     }
-
 
 }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
@@ -137,7 +137,7 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint {
         /*
          * retrieve config and credentials and create AWS client
          */
-        final driver = new AmazonClientFactory(session.config)
+        final driver = AmazonClientFactory.instance(session)
 
         /*
          * create a proxy for the aws batch client that manages the request throttling

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitCredentialProvider.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitCredentialProvider.groovy
@@ -191,12 +191,12 @@ final class AwsCodeCommitCredentialProvider extends CredentialsProvider {
                     return true
                 }
             }
+            return false
         }
-        catch (Throwable t) {
+        catch (Throwable ignored) {
             // ignore all, we can't handle it
+            return false
         }
-
-        return false
     }
 
     /**

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitCredentialProvider.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitCredentialProvider.groovy
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2020-2021, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.aws.codecommit
+
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import javax.security.auth.login.CredentialException
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import java.text.SimpleDateFormat
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.AWSSessionCredentials
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.eclipse.jgit.errors.UnsupportedCredentialItem
+import org.eclipse.jgit.transport.CredentialItem
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.URIish
+/**
+ * Provides a jgit {@link CredentialsProvider} implementation that can provide the
+ * appropriate credentials to connect to an AWS CodeCommit repository.
+ *
+ * From the command line, you can configure git to use AWS code commit with a credential
+ * helper. However, jgit does not support credential helper commands, but it does provide
+ * a CredentialsProvider abstract class we can extend. Connecting to an AWS CodeCommit
+ * (codecommit) repository requires an AWS access key and secret key. These are used to
+ * calculate a signature for the git request. The AWS access key is used as the codecommit
+ * username, and the calculated signature is used as the password. The process for
+ * calculating this signature is documented very well at
+ * https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html.
+ *
+ * @author Don Laidlaw
+ *
+ * This class mostly a direct port of the AwsCodeCommitCredentialProvider class provided by the
+ * spring framework in org.springframwork.cloud.config.server.support with some minor
+ * modifications and simplifications that leverage the Groovy language.
+ *
+ * @author W. Lee Pang <wleepang@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+final class AwsCodeCommitCredentialProvider extends CredentialsProvider {
+
+    private static final String SHA_256 = "SHA-256"
+    private static final String UTF8 = "UTF8"
+    private static final String HMAC_SHA256 = "HmacSHA256"
+
+    private AWSCredentialsProvider awsCredentialsProvider
+    private String username
+    private String password
+
+    /**
+     * Calculate the AWS CodeCommit password for the provided URI and AWS secret key. This
+     * uses the algorithm published by AWS at
+     * https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+     * @param uri the codecommit repository uri
+     * @param awsSecretKey the aws secret key
+     * @return the password to use in the git request
+     */
+    protected static String calculateCodeCommitPassword(URIish uri, String awsSecretKey, Date now) {
+        String[] split = uri.getHost().split("\\.")
+        if (split.length < 4) {
+            throw new CredentialException("Cannot detect AWS region from URI $uri")
+        }
+        String region = split[1]
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HHmmss")
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+
+        String dateStamp = dateFormat.format(now)
+        String shortDateStamp = dateStamp.substring(0, 8)
+
+        String codeCommitPassword
+        try {
+            def stringToSign = "AWS4-HMAC-SHA256\n${dateStamp}\n${shortDateStamp}/$region/codecommit/aws4_request\n${bytesToHexString(canonicalRequestDigest(uri))}"
+            def signedRequest = bytesToHexString(
+                    sign(awsSecretKey, shortDateStamp, region, stringToSign)
+            )
+
+            codeCommitPassword = "${dateStamp}Z${signedRequest}"
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Error calculating AWS CodeCommit password", e)
+        }
+
+        return codeCommitPassword
+    }
+
+    private static byte[] hmacSha256(String data, byte[] key) {
+        String algorithm = HMAC_SHA256
+        Mac mac = Mac.getInstance(algorithm)
+        mac.init(new SecretKeySpec(key, algorithm))
+        return mac.doFinal(data.getBytes(UTF8))
+    }
+
+    private static byte[] sign(String secret, String shortDateStamp, String region, String toSign) {
+        byte[] kSecret = ("AWS4" + secret).getBytes(UTF8)
+        byte[] kDate = hmacSha256(shortDateStamp, kSecret)
+        byte[] kRegion = hmacSha256(region, kDate)
+        byte[] kService = hmacSha256("codecommit", kRegion)
+        byte[] kSigning = hmacSha256("aws4_request", kService)
+        return hmacSha256(toSign, kSigning)
+    }
+
+    /**
+     * Creates a message digest.
+     * @param uri uri to process
+     * @return a message digest
+     * @throws NoSuchAlgorithmException when the SHA 256 algorithm is not found
+     */
+    private static byte[] canonicalRequestDigest(URIish uri) {
+        def canonicalRequest = ""
+
+        // this could be done faster with a templated multi-line GString but is broken out here
+        // to maintain documentation of each part
+        canonicalRequest += "GIT\n"  						// codecommit uses GIT as the request method
+        canonicalRequest += "${uri.getPath()}\n"  			// URI request path
+        canonicalRequest += "\n"  							// Query string, always empty for codecommit
+
+        // Next are canonical headers, codecommit only requires the host header
+        canonicalRequest += "host:${uri.getHost()}\n\n"  	// canonical headers are alays terminated with \n
+        canonicalRequest += "host\n"  						// The list of canonical headers, only one for, only one for codecommit
+
+        MessageDigest digest = MessageDigest.getInstance(SHA_256);
+
+        return digest.digest(canonicalRequest.getBytes());
+    }
+
+    /**
+     * Convert bytes to a hex string.
+     * @param bytes the bytes
+     * @return a string of hex characters encoding the bytes.
+     */
+    private static String bytesToHexString(byte[] bytes) { bytes.encodeHex().toString() }
+
+    /**
+     * This provider can handle uris like
+     * https://git-codecommit.$AWS_REGION.amazonaws.com/v1/repos/$REPO .
+     * @param uri uri to parse
+     * @return {@code true} if the URI can be handled
+     */
+    static boolean canHandle(String uri) {
+        if ( !uri?.trim() ) {
+            return false
+        }
+
+        try {
+            URL url = new URL(uri)
+            URI u = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(),
+                    url.getPort(), url.getPath(), url.getQuery(), url.getRef())
+            if (u.getScheme().equals("https")) {
+                String host = u.getHost()
+                if (host.endsWith(".amazonaws.com")
+                        && host.startsWith("git-codecommit.")) {
+                    return true
+                }
+            }
+        }
+        catch (Throwable t) {
+            // ignore all, we can't handle it
+        }
+
+        return false
+    }
+
+    /**
+     * Get the AWSCredentials. If an AWSCredentialProvider was specified, use that,
+     * otherwise, create a new AWSCredentialsProvider. If the username and password are
+     * provided, then use those directly as AWSCredentials. Otherwise us the
+     * {@link DefaultAWSCredentialsProviderChain} as is standard with AWS applications.
+     * @return the AWS credentials.
+     */
+    private AWSCredentials retrieveAwsCredentials() {
+        if ( !awsCredentialsProvider ) {
+            if ( username && password ) {
+                log.debug "Creating a static AWSCredentialsProvider"
+                awsCredentialsProvider = new AWSStaticCredentialsProvider(
+                        new BasicAWSCredentials( username, password ))
+            }
+            else {
+                log.debug "Creating a default AWSCredentialsProvider"
+                awsCredentialsProvider = new DefaultAWSCredentialsProviderChain()
+            }
+        }
+        return awsCredentialsProvider.getCredentials()
+    }
+
+    /**
+     * This credentials provider cannot run interactively.
+     * @return false
+     * @see org.eclipse.jgit.transport.CredentialsProvider#isInteractive()
+     */
+    @Override
+    boolean isInteractive() { false }
+
+    /**
+     * We support username and password credential items only.
+     * @see org.eclipse.jgit.transport.CredentialsProvider#supports(org.eclipse.jgit.transport.CredentialItem[])
+     */
+    @Override
+    boolean supports(CredentialItem... items) {
+        for ( i in items ) {
+            if (i instanceof CredentialItem.Username) {
+                continue
+            }
+            else if (i instanceof CredentialItem.Password) {
+                continue
+            }
+            else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
+     * Get the username and password to use for the given uri.
+     * @see org.eclipse.jgit.transport.CredentialsProvider#get(org.eclipse.jgit.transport.URIish,
+     * org.eclipse.jgit.transport.CredentialItem[])
+     */
+    @Override
+    boolean get(URIish uri, CredentialItem... items) {
+        String codeCommitPassword
+        String awsAccessKey
+        String awsSecretKey
+
+        try {
+            AWSCredentials awsCredentials = retrieveAwsCredentials()
+            StringBuilder awsKey = new StringBuilder();
+            awsKey.append(awsCredentials.getAWSAccessKeyId());
+            awsSecretKey = awsCredentials.getAWSSecretKey();
+            if (awsCredentials instanceof AWSSessionCredentials) {
+                AWSSessionCredentials sessionCreds = (AWSSessionCredentials) awsCredentials;
+                if ( sessionCreds.getSessionToken() ) {
+                    awsKey.append('%').append(sessionCreds.getSessionToken())
+                }
+            }
+            awsAccessKey = awsKey.toString()
+        }
+        catch (Throwable t) {
+            log.warn("Unable to retrieve AWS Credentials", t)
+            return false;
+        }
+
+        try {
+            codeCommitPassword = calculateCodeCommitPassword(uri, awsSecretKey, new Date());
+        }
+        catch (Throwable t) {
+            log.warn("Error calculating the AWS CodeCommit password", t)
+            return false
+        }
+
+        for ( i in items ) {
+            if (i instanceof CredentialItem.Username) {
+                ((CredentialItem.Username) i).setValue(awsAccessKey);
+                log.trace("Returning username " + awsAccessKey);
+                continue;
+            }
+            if (i instanceof CredentialItem.Password) {
+                ((CredentialItem.Password) i).setValue(codeCommitPassword.toCharArray());
+                log.trace("Returning password " + codeCommitPassword);
+                continue;
+            }
+            if (i instanceof CredentialItem.StringType
+                    && i.getPromptText().equals("Password: ")) {
+                ((CredentialItem.StringType) i).setValue(codeCommitPassword);
+                log.trace("Returning password string " + codeCommitPassword);
+                continue;
+            }
+            throw new UnsupportedCredentialItem(uri,
+                    i.getClass().getName() + ":" + i.getPromptText());
+        }
+
+        return true;
+    }
+
+    /**
+     * Throw out cached data and force retrieval of AWS credentials.
+     * @param uri This parameter is not used in this implementation.
+     */
+    @Override
+    void reset(URIish uri) {
+        // Should throw out cached info.
+        // Note that even though the credentials (password) we calculate here is
+        // valid for 15 minutes, we do not cache it. Instead we just re-calculate
+        // it each time we need it. However, the AWSCredentialProvider will cache
+        // its AWSCredentials object.
+    }
+
+    /**
+     * @param awsCredentialProvider the awsCredentialProvider to set
+     */
+    void setAwsCredentialsProvider(AWSCredentialsProvider awsCredentialsProvider) { this.awsCredentialsProvider = awsCredentialsProvider }
+    AWSCredentialsProvider getAwsCredentialsProvider() { awsCredentialsProvider }
+
+    /**
+     * @param username the username to set
+     */
+    void setUsername(String username ) { this.username = username }
+    String getUsername() { username }
+
+    /**
+     * @param password the password to set
+     */
+    void setPassword(String password) { this.password = password }
+    String getPassword() { password }
+
+}

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitRepositoryProvider.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitRepositoryProvider.groovy
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020-2021, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.aws.codecommit
+
+
+import com.amazonaws.services.codecommit.AWSCodeCommit
+import com.amazonaws.services.codecommit.AWSCodeCommitClient
+import com.amazonaws.services.codecommit.model.GetFileRequest
+import com.amazonaws.services.codecommit.model.GetRepositoryRequest
+import com.amazonaws.services.codecommit.model.RepositoryMetadata
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.Global
+import nextflow.cloud.aws.AmazonClientFactory
+import nextflow.exception.AbortOperationException
+import nextflow.scm.ProviderConfig
+import nextflow.scm.RepositoryProvider
+import org.eclipse.jgit.transport.CredentialsProvider
+/**
+ * Implements a repository provider for AWS CodeCommit
+ *
+ * @author W. Lee Pang <wleepang@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+class AwsCodeCommitRepositoryProvider extends RepositoryProvider {
+
+    private AmazonClientFactory clientFactory
+
+    AwsCodeCommitRepositoryProvider(String project, ProviderConfig config=null, AWSCodeCommitClient client=null) {
+
+        this.project = project  // expect: "codecommit:[region]://<repository>"
+        this.config = config ?: new ProviderConfig('codecommit')
+        this.region = getRepositoryRegion()
+        this.repositoryName = getRepositoryName()
+        this.profile = getRepositoryProfile()
+        this.clientFactory = AmazonClientFactory.instance()
+        this.client = client ?: clientFactory.getCodeCommitClient()
+
+    }
+
+    private String region
+    private AWSCodeCommit client
+    private String repositoryName
+    private String profile
+
+
+    /** {@inheritDoc} **/
+    @Override
+    CredentialsProvider getGitCredentials() {
+        def provider = new AwsCodeCommitCredentialProvider()
+        provider.setAwsCredentialsProvider( clientFactory.getCredentialsProvider() )
+        return provider
+    }
+
+    private String getRepositoryName() {
+        def result = project
+                .replaceAll("codecommit:.*?//", "")
+                .replaceAll(".*?@", "")
+        log.debug "project name: $result"
+        return result
+    }
+
+    private String getRepositoryProfile() {
+
+        def result = null
+
+        if ( project.indexOf('@') != -1 ) {
+            result = project
+                    .replaceAll("codecommit:.*?//", "")
+                    .replaceAll("@.*", "")
+
+            log.debug "project profile: $result"
+
+        }
+
+        return result
+    }
+
+    private String getRepositoryRegion() {
+        def region = Global.getAwsRegion()
+
+        // use the repository region if specified
+        def result = project
+                .replaceAll("codecommit:[:]*", "")
+                .replaceAll("[:]*//.*", "")
+        if ( result != "" ) {
+            region = result
+        }
+
+        log.debug "AWS CodeCommit project region: $region"
+        return region
+    }
+
+
+    private RepositoryMetadata getRepositoryMetadata() {
+        def request = new GetRepositoryRequest()
+        request.setRepositoryName( repositoryName)
+
+        def response = client.getRepository( request )
+        return response.getRepositoryMetadata()
+    }
+
+    /** {@inheritDoc} **/
+    // called by AssetManager
+    // used to set credentials for a clone, pull, fetch, operation
+    @Override
+    boolean hasCredentials() {
+        // set to true
+        // uses AWS Credentials instead of username : password
+        // see getGitCredentials()
+        return true
+    }
+
+    /** {@inheritDoc} **/
+    @Override
+    String getName() { "CodeCommit" }
+
+    /** {@inheritDoc} **/
+    @Override
+    String getEndpointUrl() {
+        "https://git-codecommit.${region}.amazonaws.com/v1/repos/${getRepositoryName()}"
+    }
+
+    /** {@inheritDoc} **/
+    // not used, but the abstract method needs to be overriden
+    @Override
+    String getContentUrl( String path ) {
+        throw new UnsupportedOperationException()
+    }
+
+    /** {@inheritDoc} **/
+    // called by AssetManager
+    @Override
+    String getCloneUrl() { getEndpointUrl() }
+
+    /** {@inheritDoc} **/
+    // called by AssetManager
+    @Override
+    String getRepositoryUrl() { getEndpointUrl() }
+
+    /** {@inheritDoc} **/
+    // called by AssetManager
+    // called by RepositoryProvider.readText()
+    @Override
+    protected byte[] readBytes( String path ) {
+
+        def request = new GetFileRequest()
+        request.setRepositoryName( repositoryName )
+        request.setFilePath( path )
+
+        def response = client.getFile( request )
+
+        def contents = response.getFileContent().array()
+        return contents
+    }
+
+    /** {@inheritDoc} **/
+    // called by AssetManager
+    @Override
+    void validateRepo() {
+        try {
+            getRepositoryMetadata()
+        }
+        catch( IOException e ) {
+            throw new AbortOperationException("Cannot find `$project` -- Make sure a repository exists for it in AWS CodeCommit")
+        }
+    }
+
+}

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/CodeCommitConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/CodeCommitConfig.groovy
@@ -1,4 +1,4 @@
-package nextflow.cloud.aws.scm
+package nextflow.cloud.aws.codecommit
 
 import nextflow.scm.config.ScmConfig
 import org.pf4j.Extension

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/CodeCommitProviderConfigFactory.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/CodeCommitProviderConfigFactory.groovy
@@ -1,0 +1,17 @@
+package nextflow.cloud.aws.codecommit
+
+import nextflow.scm.ProviderConfig
+import nextflow.scm.ProviderConfigFactory
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+class CodeCommitProviderConfigFactory extends ProviderConfigFactory{
+
+    @Override
+    List<ProviderConfig> allProviderConfigs() {
+        [new ProviderConfig('codecommit')]
+    }
+}

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/CodeCommitRepositoryFactory.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/CodeCommitRepositoryFactory.groovy
@@ -1,0 +1,30 @@
+package nextflow.cloud.aws.codecommit
+
+
+import nextflow.scm.ProviderConfig
+import nextflow.scm.RepositoryFactory
+import nextflow.scm.RepositoryProvider
+import org.pf4j.ExtensionPoint
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+class CodeCommitRepositoryFactory extends RepositoryFactory{
+
+    @Override
+    RepositoryProvider newInstance(ProviderConfig config, String project, String url) {
+        switch(config.platform) {
+            case 'codecommit':
+                try {
+                    return new AwsCodeCommitRepositoryProvider(project, url, config)
+                }catch(e){
+                    e.printStackTrace()
+                    throw e
+                }
+            default:
+                return null
+        }
+    }
+}

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/scm/CodeCommitConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/scm/CodeCommitConfig.groovy
@@ -1,0 +1,25 @@
+package nextflow.cloud.aws.scm
+
+import nextflow.scm.config.ScmConfig
+import org.pf4j.Extension
+
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+@Extension
+class CodeCommitConfig implements ScmConfig{
+
+    @Override
+    String getName() {
+        'codecommit'
+    }
+
+    @Override
+    Map enrichConfiguration(Map attr) {
+        attr.platform = name
+        attr.server = "https://git-codecommit.[a-z1-9-]+.amazonaws.com/v1"
+        attr
+    }
+}

--- a/plugins/nf-amazon/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-amazon/src/resources/META-INF/extensions.idx
@@ -19,4 +19,6 @@ nextflow.cloud.aws.batch.AwsBatchExecutor
 nextflow.cloud.aws.util.S3PathSerializer
 nextflow.cloud.aws.util.S3PathFactory
 
-nextflow.cloud.aws.scm.CodeCommitConfig
+nextflow.cloud.aws.codecommit.CodeCommitRepositoryFactory
+nextflow.cloud.aws.codecommit.CodeCommitProviderConfigFactory
+nextflow.cloud.aws.codecommit.CodeCommitConfig

--- a/plugins/nf-amazon/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-amazon/src/resources/META-INF/extensions.idx
@@ -18,3 +18,5 @@
 nextflow.cloud.aws.batch.AwsBatchExecutor
 nextflow.cloud.aws.util.S3PathSerializer
 nextflow.cloud.aws.util.S3PathFactory
+
+nextflow.cloud.aws.scm.CodeCommitConfig

--- a/plugins/nf-amazon/src/test/nextflow/scm/CodeCommitProviderConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/scm/CodeCommitProviderConfigTest.groovy
@@ -1,0 +1,40 @@
+package nextflow.scm
+
+import nextflow.plugin.DefaultPlugins
+import nextflow.plugin.PluginSpec
+import nextflow.plugin.Plugins
+import nextflow.plugin.PluginsFacade
+import nextflow.scm.config.ScmConfig
+import spock.lang.Specification
+
+/**
+ * @author : jorge <jorge.aguilera@seqera.io>
+ *
+ */
+class CodeCommitProviderConfigTest extends Specification{
+
+    static final String CONFIG = '''
+        providers {
+              codecommit {
+                user = '12732'
+                password = '35454'
+              }
+        }
+        '''
+
+    def 'should create a ProviderConfig object' () {
+
+        when:
+        def config = new ConfigSlurper().parse(CONFIG)
+        def obj1 = new ProviderConfig('codecommit', config.providers.codecommit as ConfigObject)
+
+        then:
+        obj1.name == 'codecommit'
+        obj1.server == "https://git-codecommit.[a-z1-9-]+.amazonaws.com/v1"
+        obj1.auth == '12732:35454'
+        obj1.domain == 'git-codecommit.[a-z1-9-]+.amazonaws.com'
+        obj1.platform == 'codecommit'
+        obj1.endpoint == 'https://git-codecommit.[a-z1-9-]+.amazonaws.com/v1'
+    }
+
+}


### PR DESCRIPTION
This tentative implementation for support for Git providers via Nextflow plugins system, plus the addition of a new provider for [AWS CodeCommit service](https://aws.amazon.com/codecommit/). 

The main change is the introduction of a new [RepositoryFactory](https://github.com/nextflow-io/nextflow/blob/a0d374624c099b1c08b57a54928773b357949c0b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryFactory.groovy#L41-L86) that creates [RepositoryProvider](https://github.com/nextflow-io/nextflow/blob/a0d374624c099b1c08b57a54928773b357949c0b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy#L38-L38)s instances via the plugin system 

The support CodeCommit is implemented by [AwsCodeCommitRepositoryProvider](https://github.com/nextflow-io/nextflow/blob/a0d374624c099b1c08b57a54928773b357949c0b/plugins/nf-amazon/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitRepositoryProvider.groovy#L41-L41)


What's remaining to do, is to delegate to the plugin system the provider configuration that was hardcoded in the `ProviderConfig` class [here](https://github.com/nextflow-io/nextflow/blob/a0d374624c099b1c08b57a54928773b357949c0b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy#L56-L109) and [here](https://github.com/nextflow-io/nextflow/blob/a0d374624c099b1c08b57a54928773b357949c0b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy#L307-L323)
   