### PR TITLE
Start Github Actions also for edited PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     tags-ignore:
       - '*'
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     tags-ignore:
       - '*'
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
 
 jobs:
   build:


### PR DESCRIPTION
The PR actions are not started automatically: https://github.com/nextflow-io/nextflow/pull/2781
It seems to be related to https://github.com/nextflow-io/nextflow/commit/6e23e0368b2d8baca5a42d45e6de43493e22ef02.

Based on [this](https://frontside.com/blog/2020-05-26-github-actions-pull_request/), synchronize should do the job.