### PR TITLE
[WIP] Use the Sphinx press theme 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,24 +25,12 @@ you have modified.
 Sphinx can be installed either with
 
 ```
-pip install -U sphinx==3.5.4
-```
-
-or
-
-```
-conda install sphinx==3.5.4
+pip install -U sphinx==3.5.4 sphinx_press_theme
 ```
 
 ### Theme 
 
-Nextflow documentation uses the [Read The Docs theme for Sphinx](https://github.com/readthedocs/sphinx_rtd_theme) theme. 
-
-In order to build the document install the Read The Docs theme using the command: 
-
-```
-pip install sphinx_rtd_theme
-```
+Nextflow documentation uses the [Press theme for Sphinx](https://github.com/schettino72/sphinx_press_theme) theme. 
 
 ### License
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # serve to show the default.
 
 import sys, os
-import sphinx_rtd_theme
+#import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -28,7 +28,7 @@ import sphinx_rtd_theme
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
   'sphinx.ext.mathjax',
-  'sphinx_rtd_theme',
+#  'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -99,7 +99,8 @@ pygments_style = 'sphinx'
 #sys.path.append(os.path.abspath('_themes'))
 #html_theme_path = ['_themes']
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "press"
+# html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Creating a placeholder PR for the `press` Sphinx theme.


Here are some points to consider 

#### General look and feel 🤩 

<img width="1258" alt="Screenshot 2022-04-14 at 11 12 41 AM" src="https://user-images.githubusercontent.com/12799326/163353631-f48e657b-19d0-4e1f-be6a-004b05c1c850.png">

<img width="1258" alt="Screenshot 2022-04-14 at 11 12 21 AM" src="https://user-images.githubusercontent.com/12799326/163353659-28144a7a-256b-4617-804c-4b53c5daabe1.png">


-------

#### The image sizes needs to be tweaked (especially in `Tracing and visualization` section) 🚧  📸 


<img width="1258" alt="image" src="https://user-images.githubusercontent.com/12799326/163353826-2abb45c0-8dd8-469f-bf76-1e43d1ed27ef.png">


-------

#### A list of warnings for completeness (similar to the previous theme) 🗒️ 


```
(sphinx-env) Abhinavs-MacBook-Pro:docs eklavya$ make clean html

rm -rf _build/*
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v4.5.0
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 29 source files that are out of date
updating environment: [new config] 29 added, 0 changed, 0 removed
reading sources... [100%] tracing
/code/nextflow/docs/azure.rst:5: WARNING: Duplicate explicit target name: "azure batch".
/code/nextflow/docs/container.rst:5: WARNING: Duplicate explicit target name: "official documentation".
/code/nextflow/docs/dsl2.rst:496: WARNING: Literal block expected; none found.
/code/nextflow/docs/process.rst:5: WARNING: Duplicate explicit target name: "kubernetes".
/code/nextflow/docs/script.rst:5: WARNING: Duplicate explicit target name: "read more".
/code/nextflow/docs/script.rst:5: WARNING: Duplicate explicit target name: "read more".
/code/nextflow/docs/script.rst:5: WARNING: Duplicate explicit target name: "read more".
/code/nextflow/docs/script.rst:5: WARNING: Duplicate explicit target name: "read more".
/code/nextflow/docs/script.rst:5: WARNING: Duplicate explicit target name: "read more".
/code/nextflow/docs/sharing.rst:5: WARNING: Duplicate explicit target name: "bitbucket".
/code/nextflow/docs/sharing.rst:5: WARNING: Duplicate explicit target name: "this link".
looking for now-outdated files... none found
pickling environment... done
checking consistency... /code/nextflow/docs/dnanexus.rst: WARNING: document isn't included in any toctree
/code/nextflow/docs/example.rst: WARNING: document isn't included in any toctree
/code/nextflow/docs/faq.rst: WARNING: document isn't included in any toctree
/code/nextflow/docs/metrics.rst: WARNING: document isn't included in any toctree
done
preparing documents... WARNING: unsupported theme option 'display_version' given
done
writing output... [100%] tracing
generating indices... genindex done
writing additional pages... search done
copying images... [100%] images/dag-mermaid.png
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 16 warnings.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.

```


-------

#### Maintenance 

The original author is looking for others to take over the project ⚠️ 

https://github.com/schettino72/sphinx_press_theme#looking-for-project-maintainers 

