### PR TITLE
Fix 2808 missing sse flag

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -132,10 +132,10 @@ socketTimeout               The amount of time to wait (in milliseconds) for dat
 storageEncryption           The S3 server side encryption to be used when saving objects on S3 (currently only AES256 is supported)
 userAgent                   The HTTP user agent header passed with all HTTP requests.
 uploadMaxThreads            The maximum number of threads used for multipart upload.
-uploadChunkSize             The size of a single part in a multipart upload (default: `10 MB`).
+uploadChunkSize             The size of a single part in a multipart upload (default: `20 MB`).
 uploadStorageClass          The S3 storage class applied to stored objects, one of [`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`] (default: `STANDARD`).
 uploadMaxAttempts           The maximum number of upload attempts after which a multipart upload returns an error (default: `5`).
-uploadRetrySleep            The time to wait after a failed upload attempt to retry the part upload (default: `100ms`).
+uploadRetrySleep            The time to wait after a failed upload attempt to retry the part upload (default: `500ms`).
 =========================== ================
 
 For example::

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -600,8 +600,11 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
     protected List<String> getSubmitCommand() {
         // the cmd list to launch it
         def opts = getAwsOptions()
-        def aws = opts.getAwsCli()
-        def cmd = "trap \"{ ret=\$?; $aws s3 cp --only-show-errors ${TaskRun.CMD_LOG} s3:/${getLogFile()}||true; exit \$ret; }\" EXIT; $aws s3 cp --only-show-errors s3:/${getWrapperFile()} - | bash 2>&1 | tee ${TaskRun.CMD_LOG}"
+        def cli = opts.getAwsCli()
+        def debug = opts.debug ? ' --debug' : ''
+        def sse = opts.storageEncryption ? " --sse $opts.storageEncryption" : ''
+        def aws = "$cli s3 cp --only-show-errors${sse}${debug}"
+        def cmd = "trap \"{ ret=\$?; $aws ${TaskRun.CMD_LOG} s3:/${getLogFile()}||true; exit \$ret; }\" EXIT; $aws s3:/${getWrapperFile()} - | bash 2>&1 | tee ${TaskRun.CMD_LOG}"
         // final launcher command
         return ['bash','-o','pipefail','-c', cmd.toString() ]
     }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsOptions.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsOptions.groovy
@@ -65,6 +65,8 @@ class AwsOptions implements CloudTransferOptions {
 
     int maxSpotAttempts
 
+    Boolean debug
+
     volatile Boolean fetchInstanceType
 
     /**
@@ -92,6 +94,7 @@ class AwsOptions implements CloudTransferOptions {
 
     AwsOptions(Session session) {
         cliPath = getCliPath0(session)
+        debug = session.config.navigate('aws.client.debug') as Boolean
         storageClass = session.config.navigate('aws.client.uploadStorageClass') as String
         storageEncryption = session.config.navigate('aws.client.storageEncryption') as String
         maxParallelTransfers = session.config.navigate('aws.batch.maxParallelTransfers', MAX_TRANSFER) as int

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
@@ -45,7 +45,7 @@ class S3BashLib extends BashFunLib<S3BashLib> {
         return this
     }
 
-    S3BashLib withDebug(boolean  value) {
+    S3BashLib withDebug(Boolean  value) {
         this.debug = value ? '--debug ' : ''
         return this
     }
@@ -115,6 +115,7 @@ class S3BashLib extends BashFunLib<S3BashLib> {
                 .withStorageClass(opts.storageClass )
                 .withStorageEncryption( opts.storageEncryption )
                 .withRetryMode( opts.retryMode )
+                .withDebug( opts.debug )
     }
 
     static String script(AwsOptions opts) {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -123,6 +123,54 @@ class AwsBatchTaskHandlerTest extends Specification {
 
     }
 
+    def 'should create an aws submit request with opts'() {
+
+        given:
+        def task = Mock(TaskRun)
+        task.getName() >> 'batch-task'
+        task.getConfig() >> new TaskConfig(memory: '8GB', cpus: 4, maxRetries: 2, errorStrategy: 'retry')
+
+        def handler = Spy(AwsBatchTaskHandler)
+
+        when:
+        def req = handler.newSubmitRequest(task)
+        then:
+        1 * handler.maxSpotAttempts() >> 5
+        1 * handler.getAwsOptions() >> { new AwsOptions(cliPath: '/bin/aws', storageEncryption: 'AES256') }
+        1 * handler.getJobQueue(task) >> 'queue1'
+        1 * handler.getJobDefinition(task) >> 'job-def:1'
+        1 * handler.getEnvironmentVars() >> []
+        1 * handler.wrapperFile >> Paths.get('/bucket/test/.command.run')
+        1 * handler.getLogFile() >> Paths.get('/bucket/test/.command.log')
+
+        req.getJobName() == 'batchtask'
+        req.getJobQueue() == 'queue1'
+        req.getJobDefinition() == 'job-def:1'
+        req.getContainerOverrides().getResourceRequirements().find { it.type=='VCPU'}.getValue() == '4'
+        req.getContainerOverrides().getResourceRequirements().find { it.type=='MEMORY'}.getValue() == '8192'
+        req.getContainerOverrides().getCommand().join(' ') == ['bash', '-o','pipefail','-c', "trap \"{ ret=\$?; /bin/aws s3 cp --only-show-errors --sse AES256 .command.log s3://bucket/test/.command.log||true; exit \$ret; }\" EXIT; /bin/aws s3 cp --only-show-errors --sse AES256 s3://bucket/test/.command.run - | bash 2>&1 | tee .command.log".toString()].join(' ')
+
+        when:
+        def req2 = handler.newSubmitRequest(task)
+        then:
+        1 * handler.maxSpotAttempts() >> 5
+        1 * handler.getAwsOptions() >> { new AwsOptions(cliPath: '/bin/aws', storageEncryption: 'AES256', debug: true) }
+        1 * handler.getJobQueue(task) >> 'queue1'
+        1 * handler.getJobDefinition(task) >> 'job-def:1'
+        1 * handler.getEnvironmentVars() >> []
+        1 * handler.wrapperFile >> Paths.get('/bucket/test/.command.run')
+        1 * handler.getLogFile() >> Paths.get('/bucket/test/.command.log')
+
+        req2.getJobName() == 'batchtask'
+        req2.getJobQueue() == 'queue1'
+        req2.getJobDefinition() == 'job-def:1'
+        req2.getContainerOverrides().getResourceRequirements().find { it.type=='VCPU'}.getValue() == '4'
+        req2.getContainerOverrides().getResourceRequirements().find { it.type=='MEMORY'}.getValue() == '8192'
+        req2.getContainerOverrides().getCommand().join(' ') == ['bash', '-o','pipefail','-c', "trap \"{ ret=\$?; /bin/aws s3 cp --only-show-errors --sse AES256 --debug .command.log s3://bucket/test/.command.log||true; exit \$ret; }\" EXIT; /bin/aws s3 cp --only-show-errors --sse AES256 --debug s3://bucket/test/.command.run - | bash 2>&1 | tee .command.log".toString()].join(' ')
+
+
+    }
+
 
     def 'should set accelerator' () {
         given:


### PR DESCRIPTION
This PR adds the missing `--sse` in AWS job launcher when the storage encryption is specified. 

It also add the possibility to enable the debugging mode for `aws` cli commands 