### PR TITLE
[New Feature] Automatically detect DSL Version if not user-defined

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
@@ -179,6 +179,9 @@ class NextflowMeta {
             ver = detectDSL( script )
         } else if( mode == 'enable' ) {
             ver = matcher.group(3)
+            if( userDefined && this.enable.dsl != ver as Float ) {
+                log.info("DSL $ver definition in the script overwrites DSL ${this.enable.dsl as int} from the config")
+            }
         } else if( mode == 'preview' ) {
             throw new IllegalArgumentException("Preview nextflow mode 'preview' is not supported anymore -- Please use `nextflow.enable.dsl=2` instead")
         } else {

--- a/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
@@ -159,6 +159,7 @@ class NextflowMeta {
                     =  You have not defined a DSL version: automatically detected DSL1.  =
                     =        If DSL1 is wrong, define the DSL version explicitly.        =
                     = Therefore, call the script with -dsl2 or add nextflow.enable.dsl=2 =
+                    = Check documentation: https://www.nextflow.io/docs/latest/dsl2.html =
                     ======================================================================
                     """.stripIndent())
                 }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -348,12 +348,7 @@ class CmdRun extends CmdBase implements HubOptions {
         } else {
             dsl = defaultDsl
         }
-        if( dsl=='2' )
-            NextflowMeta.instance.enableDsl2()
-        else if( dsl=='1' )
-            NextflowMeta.instance.disableDsl2()
-        else
-            throw new AbortOperationException("Invalid Nextflow DSL value: $dsl")
+        NextflowMeta.instance.setDSL( dsl )
 
         // -- script can still override the DSL version
         NextflowMeta.instance.checkDsl2Mode(scriptFile.main.text, userDefined)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -338,8 +338,16 @@ class CmdRun extends CmdBase implements HubOptions {
         // -- try determine DSL version from config file
         final DSL2 = '2'
         final DSL1 = '1'
+        boolean userDefined = false
         final defaultDsl = sysEnv.get('NXF_DEFAULT_DSL') ?: DSL2
-        final dsl = config.navigate('nextflow.enable.dsl', defaultDsl) as String
+        String value = config.navigate('nextflow.enable.dsl') as String
+        final dsl
+        if ( value ) {
+            userDefined = true
+            dsl = value
+        } else {
+            dsl = defaultDsl
+        }
         if( dsl=='2' )
             NextflowMeta.instance.enableDsl2()
         else if( dsl=='1' )
@@ -348,7 +356,7 @@ class CmdRun extends CmdBase implements HubOptions {
             throw new AbortOperationException("Invalid Nextflow DSL value: $dsl")
 
         // -- script can still override the DSL version
-        NextflowMeta.instance.checkDsl2Mode(scriptFile.main.text)
+        NextflowMeta.instance.checkDsl2Mode(scriptFile.main.text, userDefined)
 
         // -- show launch info 
         final ver = NF.dsl2 ? DSL2 : DSL1


### PR DESCRIPTION
Making DSL 2 the default DSL might confuse because workflows fail with errors that are hard to relate to the DSL version.
I try to detect the DSL if nothing is set automatically. If I am sure it is not DSL 2, it falls back to DSL 1, and a large warning is printed.
Currently, I detect DSL 2 via its `workflow` part:
```
workflow {
a()
b()
c()
}
```

Executing the following script: 
```
process a {

"""
echo hello world
"""

}
```

`nextflow run text.nf` without any config
Prints:

```
N E X T F L O W  ~  version 22.04.0
WARN:
======================================================================
=                               WARNING                              =
=  You have not defined a DSL version: automatically detected DSL1.  =
=        If DSL1 is wrong, define the DSL version explicitly.        =
= Therefore, call the script with -dsl2 or add nextflow.enable.dsl=2 =
= Check documentation: https://www.nextflow.io/docs/latest/dsl2.html =
======================================================================

Launching `test.nf` [maniac_fourier] DSL1 - revision: 0e33a19c82
executor >  local (1)
[6d/53bfc8] process > a [100%] 1 of 1 ✔
```

