### PR TITLE
Customize docs theme

### DIFF
--- a/docs/_static/theme.css
+++ b/docs/_static/theme.css
@@ -1,124 +1,16 @@
 
 /* navbar -- logo */
 
-.wy-side-nav-search {
-    /* background-color: #2980b9; */
-    background-color: rgba(39, 174, 96, 0.6);
-}
-
 .wy-side-nav-search a:before {
     display: block;
-    content: url(https://github.com/nextflow-io/trademark/raw/master/nextflow2014_no-bg.png);
+    content: url(https://github.com/nextflow-io/trademark/raw/master/nextflow2014_black_white.png);
     visibility: visible;
     transform: scale(.43);
     transform-origin: left;
-    margin: -30px 0 -60px 0;
+    margin: -30px 0 -50px 0;
 }
 
 .wy-side-nav-search a {
     visibility: hidden;
 }
 
-
-/* navbar -- top */
-
-.wy-nav-top {
-    /* background-color: #2980b9; */
-    background-color: rgb(39, 174, 96);
-}
-
-
-/* navbar -- vertical */
-
-.wy-menu-vertical a:active {
-    /* background-color: #2980b9; */
-    background-color: rgb(39, 174, 96);
-}
-
-
-/* main content -- code blocks */
-
-.wy-nav-content .highlight {
-    background-color: rgba(0, 0, 0, 0.05);
-}
-
-
-/* main content -- links */
-
-.wy-nav-content a.fa,
-.wy-nav-content a:before,
-.wy-nav-content .admonition a,
-.wy-nav-content footer a {
-    color: rgb(39, 174, 96);
-}
-
-.wy-nav-content a.reference {
-    color: rgb(39, 174, 96);
-    text-decoration: underline;
-}
-
-
-/* admonitions -- danger, error */
-
-.rst-content .danger,
-.rst-content .error {
-    /* background: #fdf3f2 */
-    background: hsl(5, 76%, 94%)
-}
-
-.rst-content .danger .admonition-title,
-.rst-content .error .admonition-title {
-    /* background: #f29f97 */
-    background: hsl(5, 76%, 64%)
-}
-
-
-/* admonitions -- todo, attention, caution, warning */
-
-.rst-content .admonition-todo,
-.rst-content .attention,
-.rst-content .caution,
-.rst-content .warning {
-    /* background: #ffedcc */
-    background: hsl(28, 76%, 94%)
-}
-
-.rst-content .admonition-todo .admonition-title,
-.rst-content .attention .admonition-title,
-.rst-content .caution .admonition-title,
-.rst-content .warning .admonition-title {
-    /* background: #f0b37e */
-    background: hsl(28, 76%, 64%)
-}
-
-
-/* admonitions -- note, seealso */
-
-.rst-content .note,
-.rst-content .seealso {
-    /* background: #e7f2fa */
-    background: hsl(205, 76%, 94%)
-}
-
-.rst-content .note .admonition-title,
-.rst-content .seealso .admonition-title {
-    /* background: #6ab0de */
-    background: hsl(205, 76%, 54%)
-}
-
-
-/* admonitions -- hint, important, tip */
-
-.rst-content .hint,
-.rst-content .important,
-.rst-content .tip {
-    /* background: #dbfaf4 */
-    background: hsl(145, 76%, 94%)
-}
-
-.rst-content .hint .admonition-title,
-.rst-content .important .admonition-title,
-.rst-content .tip .admonition-title {
-    /* background: #1abc9c */
-    background: hsl(145, 76%, 44%)
-}

--- a/docs/_static/theme.css
+++ b/docs/_static/theme.css
@@ -1,0 +1,124 @@
+
+/* navbar -- logo */
+
+.wy-side-nav-search {
+    /* background-color: #2980b9; */
+    background-color: rgba(39, 174, 96, 0.6);
+}
+
+.wy-side-nav-search a:before {
+    display: block;
+    content: url(https://github.com/nextflow-io/trademark/raw/master/nextflow2014_no-bg.png);
+    visibility: visible;
+    transform: scale(.43);
+    transform-origin: left;
+    margin: -30px 0 -60px 0;
+}
+
+.wy-side-nav-search a {
+    visibility: hidden;
+}
+
+
+/* navbar -- top */
+
+.wy-nav-top {
+    /* background-color: #2980b9; */
+    background-color: rgb(39, 174, 96);
+}
+
+
+/* navbar -- vertical */
+
+.wy-menu-vertical a:active {
+    /* background-color: #2980b9; */
+    background-color: rgb(39, 174, 96);
+}
+
+
+/* main content -- code blocks */
+
+.wy-nav-content .highlight {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+
+/* main content -- links */
+
+.wy-nav-content a.fa,
+.wy-nav-content a:before,
+.wy-nav-content .admonition a,
+.wy-nav-content footer a {
+    color: rgb(39, 174, 96);
+}
+
+.wy-nav-content a.reference {
+    color: rgb(39, 174, 96);
+    text-decoration: underline;
+}
+
+
+/* admonitions -- danger, error */
+
+.rst-content .danger,
+.rst-content .error {
+    /* background: #fdf3f2 */
+    background: hsl(5, 76%, 94%)
+}
+
+.rst-content .danger .admonition-title,
+.rst-content .error .admonition-title {
+    /* background: #f29f97 */
+    background: hsl(5, 76%, 64%)
+}
+
+
+/* admonitions -- todo, attention, caution, warning */
+
+.rst-content .admonition-todo,
+.rst-content .attention,
+.rst-content .caution,
+.rst-content .warning {
+    /* background: #ffedcc */
+    background: hsl(28, 76%, 94%)
+}
+
+.rst-content .admonition-todo .admonition-title,
+.rst-content .attention .admonition-title,
+.rst-content .caution .admonition-title,
+.rst-content .warning .admonition-title {
+    /* background: #f0b37e */
+    background: hsl(28, 76%, 64%)
+}
+
+
+/* admonitions -- note, seealso */
+
+.rst-content .note,
+.rst-content .seealso {
+    /* background: #e7f2fa */
+    background: hsl(205, 76%, 94%)
+}
+
+.rst-content .note .admonition-title,
+.rst-content .seealso .admonition-title {
+    /* background: #6ab0de */
+    background: hsl(205, 76%, 54%)
+}
+
+
+/* admonitions -- hint, important, tip */
+
+.rst-content .hint,
+.rst-content .important,
+.rst-content .tip {
+    /* background: #dbfaf4 */
+    background: hsl(145, 76%, 94%)
+}
+
+.rst-content .hint .admonition-title,
+.rst-content .important .admonition-title,
+.rst-content .tip .admonition-title {
+    /* background: #1abc9c */
+    background: hsl(145, 76%, 44%)
+}

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1184,9 +1184,8 @@ facilitates rapid iterations, inspections of any pipeline as well as debugging.
 
     $ nextflow run nextflow-io/hello -with-tower
  
-
 - Invoke the nextflow pipeline execution with a custom parameters ``YAML/JSON`` file. 
-The parameters which are specified through this mechanism are merged with the resolved configuration (base configuration and profiles) and only the common fields are overwritten by the ``YAML/JSON`` file.::
+  The parameters which are specified through this mechanism are merged with the resolved configuration (base configuration and profiles) and only the common fields are overwritten by the ``YAML/JSON`` file.::
 
     $ nextflow run main.nf -params-file pipeline_params.yml
  

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,9 +96,6 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-#sys.path.append(os.path.abspath('_themes'))
-#html_theme_path = ['_themes']
-
 html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -107,6 +104,14 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {
   'display_version': False,
   "analytics_id": "UA-364526-10"
+}
+
+html_context = {
+    "display_github": True,
+    "github_user": "nextflow-io",
+    "github_repo": "nextflow",
+    "github_version": "master",
+    "conf_py_path": "/docs/"
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,6 +114,9 @@ html_context = {
     "conf_py_path": "/docs/"
 }
 
+# Nextflow theme
+html_css_files = ['theme.css']
+
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 

--- a/docs/dsl2.rst
+++ b/docs/dsl2.rst
@@ -18,7 +18,6 @@ your workflow script::
 
     export NXF_DEFAULT_DSL=1
 
-
 .. note::
   As of version ``22.03.0-edge`` the DSL version specification (either 1 or 2) can also be specified in
   the Nextflow configuration file using the same notation shown above.
@@ -496,11 +495,11 @@ Finally, we have a third project B with a workflow that includes again P1 and P2
 With the possibility to keep the template files inside the project L, A and B can use the modules defined in L without any changes.
 A future prject C would do the same, just cloning L (if not available on the system) and including its module script.
 
-Beside promoting sharing modules across pipelines, there are several advantages in keeping the module template under the script path::
+Beside promoting sharing modules across pipelines, there are several advantages in keeping the module template under the script path:
 
-    1. module components are *self-contained*,
-    2. module components can be tested independently from the pipeline(s) importing them,
-    3. it is possible to create libraries of module components.
+1. module components are *self-contained*,
+2. module components can be tested independently from the pipeline(s) importing them,
+3. it is possible to create libraries of module components.
 
 Ultimately, having multiple template locations allows a more structured organization within the same project. If a project
 has several module components, and all them use templates, the project could group module scripts and their templates as needed. For example::


### PR DESCRIPTION
Closes #2819 

This PR includes the following changes:
- Add "Edit on Github" button (top-right)
- Add Nextflow logo (top-left)
- Change code blocks to neutral gray background instead of mild vomit
- Change links to Nextflow green (copied from nextflow.io)
- Adjust admonitions (notes, tips, warnings, etc) to work with Nextflow green

Here is a sample screenshot where I try to represent all the style changes:
![screenshot](https://user-images.githubusercontent.com/7884825/166076149-b9bb8d19-40bd-40f5-9cda-c89b2b30f7a5.png)

Best to view it in your browser to make sure. Let me know if you want to adjust any style rules.