### PR TITLE
Updating the default SKU for Azure Batch

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -37,11 +37,11 @@ import nextflow.util.Duration
 class AzPoolOpts implements CacheFunnel {
 
     static public final String DEFAULT_PUBLISHER = "microsoft-azure-batch"
-    static public final String DEFAULT_OFFER = "centos-container"
-    static public final String DEFAULT_SKU = "batch.node.centos 8"
+    static public final String DEFAULT_OFFER = "ubuntu-server-container"
+    static public final String DEFAULT_SKU = "batch.node.ubuntu 20.04"
     static public final String DEFAULT_VM_TYPE = "Standard_D4_v3"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
-    static public final String DEFAULT_SHARE_ROOT_PATH = "/mnt/resource/batch/tasks/fsmounts"
+    static public final String DEFAULT_SHARE_ROOT_PATH = "/mnt/batch/tasks/fsmounts"
     static public final Duration DEFAULT_SCALE_INTERVAL = Duration.of('5 min')
 
     String runAs

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -321,7 +321,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-a37c437811d7e143223519784ebc55be-Standard_X1'
+        spec.poolId == 'nf-pool-ddb1223ab79edfe07c0af2be7fceeb13-Standard_X1'
 
     }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -194,7 +194,7 @@ class AzureConfigTest extends Specification {
         cfg.batch().pool('myPool2').fileShareRootPath == '/mnt/resource/batch/tasks/fsmounts'
         cfg.batch().pool('myPool3').fileShareRootPath == '/mnt/batch/tasks/fsmounts'
         cfg.batch().pool('myPool4').fileShareRootPath == '/mounting/here'
-        cfg.batch().pool('myPool5').fileShareRootPath == '/mnt/resource/batch/tasks/fsmounts'
+        cfg.batch().pool('myPool5').fileShareRootPath == AzPoolOpts.DEFAULT_SHARE_ROOT_PATH
    }
 
     def 'should get azcopy options' () {


### PR DESCRIPTION
This PR addresses the deprecation of CentOS-8 https://github.com/Azure/Batch/issues/119 , the defaults for a Nextflow pool have become a bit problematic.

From experience with some clients the straight-forward solution seems to be to move to `Ubuntu` based base image rather than `CentOS 7.8` and therefore I've gone ahead and changed those settings.

Happy to accommodate any feedback 😊 