### PR TITLE
Improve missing workflow err message [ci skip]

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -186,17 +186,17 @@ abstract class BaseScript extends Script implements ExecutionContext {
                 log.warn "No entry workflow specified"
             if( meta.getLocalProcessNames() ) {
                 final msg = """\
-                        ==============================================================================
-                        =                                WARNING                                     =
-                        = You are running this script using DSL2 syntax, however it does not contain = 
-                        = any 'workflow' definition so there's nothing for Nextflow to run.          =
-                        =                                                                            =
-                        = If this script was written using Nextflow DSL1 syntax, please add          = 
-                        = 'nextflow.enable.dsl=1' to the nextflow.config file, or use the            =
-                        = command-line flag '-dsl1' when running the pipeline.                       =
-                        =                                                                            =
-                        = More details at this link: https://www.nextflow.io/docs/latest/dsl2.html   =
-                        ==============================================================================
+                        =============================================================================
+                        =                                WARNING                                    =
+                        = You are running this script using DSL2 syntax, however it does not        = 
+                        = contain any 'workflow' definition so there's nothing for Nextflow to run. =
+                        =                                                                           =
+                        = If this script was written using Nextflow DSL1 syntax, please add the     = 
+                        = setting 'nextflow.enable.dsl=1' to the nextflow.config file or use the    =
+                        = command-line option '-dsl1' when running the pipeline.                    =
+                        =                                                                           =
+                        = More details at this link: https://www.nextflow.io/docs/latest/dsl2.html  =
+                        =============================================================================
                         """.stripIndent()
                 throw new AbortOperationException(msg)
             }

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -184,8 +184,22 @@ abstract class BaseScript extends Script implements ExecutionContext {
         if( !entryFlow ) {
             if( meta.getLocalWorkflowNames() )
                 log.warn "No entry workflow specified"
-            if( meta.getLocalProcessNames() )
-                throw new AbortOperationException("Missing workflow definition - DSL2 requires at least a workflow block in the main script")
+            if( meta.getLocalProcessNames() ) {
+                final msg = """\
+                        ==============================================================================
+                        =                                WARNING                                     =
+                        = You are running this script using DSL2 syntax, however it does not contain = 
+                        = any 'workflow' definition and therefore there's anything Nextflow can run. =
+                        =                                                                            =
+                        = If this script was written using Nextflow DSL1 syntax, please run it by    = 
+                        = adding the setting 'nextflow.enable.dsl=1' in the nextflow.config file or  =
+                        = including the option '-dsl1' to the run command.                           =
+                        =                                                                            =
+                        = More details at this link: https://www.nextflow.io/docs/latest/dsl2.html   =
+                        ==============================================================================
+                        """.stripIndent()
+                throw new AbortOperationException(msg)
+            }
             return result
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -189,7 +189,7 @@ abstract class BaseScript extends Script implements ExecutionContext {
                         ==============================================================================
                         =                                WARNING                                     =
                         = You are running this script using DSL2 syntax, however it does not contain = 
-                        = any 'workflow' definition and therefore there's anything Nextflow can run. =
+                        = any 'workflow' definition so there's nothing for Nextflow to run.          =
                         =                                                                            =
                         = If this script was written using Nextflow DSL1 syntax, please run it by    = 
                         = adding the setting 'nextflow.enable.dsl=1' in the nextflow.config file or  =

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -191,9 +191,9 @@ abstract class BaseScript extends Script implements ExecutionContext {
                         = You are running this script using DSL2 syntax, however it does not contain = 
                         = any 'workflow' definition so there's nothing for Nextflow to run.          =
                         =                                                                            =
-                        = If this script was written using Nextflow DSL1 syntax, please run it by    = 
-                        = adding the setting 'nextflow.enable.dsl=1' in the nextflow.config file or  =
-                        = including the option '-dsl1' to the run command.                           =
+                        = If this script was written using Nextflow DSL1 syntax, please add          = 
+                        = 'nextflow.enable.dsl=1' to the nextflow.config file, or use the            =
+                        = command-line flag '-dsl1' when running the pipeline.                       =
                         =                                                                            =
                         = More details at this link: https://www.nextflow.io/docs/latest/dsl2.html   =
                         ==============================================================================


### PR DESCRIPTION
This PR adds a more actionable error message when running a DSL2 script 
missing the `workflow` definition. 

