### PR TITLE
Add support for time process directive in GLS executor

### DIFF
--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -133,6 +133,8 @@ Resource requests and other job characteristics can be controlled via the follow
 * :ref:`process-disk`
 * :ref:`process-machineType`
 * :ref:`process-memory`
+* :ref:`process-time`
+
 
 See the :ref:`Google Life Sciences <google-lifesciences>` page for further configuration details.
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
@@ -151,8 +151,11 @@ class GoogleLifeSciencesHelper {
         return action
     }
 
-    Pipeline createPipeline(List<Action> actions, Resources resources) {
-        new Pipeline().setActions(actions).setResources(resources)
+    Pipeline createPipeline(List<Action> actions, Resources resources, String timeout = null) {
+        final pipeline = new Pipeline()
+        return pipeline.setActions(actions)
+                .setResources(resources)
+                .setTimeout(timeout)
     }
 
     protected List<Action> createActions(GoogleLifeSciencesSubmitRequest req) {
@@ -170,7 +173,7 @@ class GoogleLifeSciencesHelper {
     Operation submitPipeline(GoogleLifeSciencesSubmitRequest req) {
         final actions = new ArrayList(5)
         actions.addAll( createActions(req) )
-        final pipeline = createPipeline( actions, createResources(req) )
+        final pipeline = createPipeline( actions, createResources(req), req.timeout )
         runPipeline(req.project, req.location, pipeline, ["taskName" : req.taskName])
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesSubmitRequest.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesSubmitRequest.groovy
@@ -73,4 +73,6 @@ class GoogleLifeSciencesSubmitRequest {
     String serviceAccountEmail
 
     boolean keepAliveOnFailure
+
+    String timeout
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy
@@ -352,6 +352,8 @@ class GoogleLifeSciencesTaskHandler extends TaskHandler {
         req.subnetwork = executor.config.subnetwork
         req.serviceAccountEmail = executor.config.serviceAccountEmail
         req.keepAliveOnFailure = executor.config.keepAliveOnFailure
+        req.timeout = task.config.getTime() ? "${task.config.getTime().toSeconds()}s" : null
+
         return req
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
@@ -483,11 +483,12 @@ class GoogleLifeSciencesHelperTest extends GoogleSpecification {
 
         then:
         req.taskName >> 'foo'
+        req.timeout >> null
         1 * helper.createStagingAction(req) >> stage
         1 * helper.createUnstagingAction(req) >> unstage
         1 * helper.createMainAction(req) >> main
         1 * helper.createResources(req) >> res
-        1 * helper.createPipeline([stage, main, unstage], res) >> pipeline
+        1 * helper.createPipeline([stage, main, unstage], res, req.timeout) >> pipeline
         1 * helper.runPipeline('PRJ-X','LOC-1', pipeline, [taskName: 'foo']) >> operation
         and:
         result == operation

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandlerTest.groovy
@@ -184,6 +184,7 @@ class GoogleLifeSciencesTaskHandlerTest extends GoogleSpecification {
         req.cpuPlatform == null
         req.entryPoint == GoogleLifeSciencesConfig.DEFAULT_ENTRY_POINT
         !req.usePrivateAddress
+        req.timeout == null
 
         when:
         req = handler.createPipelineRequest()
@@ -226,7 +227,7 @@ class GoogleLifeSciencesTaskHandlerTest extends GoogleSpecification {
         when:
         def req = handler.createPipelineRequest()
         then:
-        task.getConfig() >> new TaskConfig(disk: '250 GB', machineType: 'n1-1234')
+        task.getConfig() >> new TaskConfig(disk: '250 GB', machineType: 'n1-1234', time: "1h")
         and:
         req.machineType == 'n1-1234'
         req.project == 'my-project'
@@ -245,6 +246,7 @@ class GoogleLifeSciencesTaskHandlerTest extends GoogleSpecification {
         req.cpuPlatform =='Intel Skylake'
         req.entryPoint == GoogleLifeSciencesConfig.DEFAULT_ENTRY_POINT
         req.usePrivateAddress
+        req.timeout == "3600s"
 
         when:
         req = handler.createPipelineRequest()


### PR DESCRIPTION
This PR adds support for the time directive in the Google Lifesciences API executor.
Currently, no timeout value is passed in the API requests which means that google will assign a default value of 7 days.
This can be a problem for long running processes and no way to change this value in nextflow.

This PR fixes this by passsing the processes time directive as a timeout parameter.
In case the timeout is exceeded the task will fail with error code 4 and message: `A user defined timeout has expired.`

