### PR TITLE
[Bugfix] Do not crash if scratch dir does not exist

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -65,6 +65,7 @@ nxf_kill() {
 
 nxf_mktemp() {
     local base=${1:-/tmp}
+    mkdir -p "$base"
     if [[ $(uname) = Darwin ]]; then mktemp -d $base/nxf.XXXXXXXXXX
     else TMPDIR="$base" mktemp -d -t nxf.XXXXXXXXXX
     fi

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -229,6 +229,7 @@ nxf_kill() {
 
 nxf_mktemp() {
     local base=${1:-/tmp}
+    mkdir -p "$base"
     if [[ $(uname) = Darwin ]]; then mktemp -d $base/nxf.XXXXXXXXXX
     else TMPDIR="$base" mktemp -d -t nxf.XXXXXXXXXX
     fi

--- a/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/test-bash-wrapper.txt
@@ -44,6 +44,7 @@ nxf_kill() {
 
 nxf_mktemp() {
     local base=${1:-/tmp}
+    mkdir -p "$base"
     if [[ $(uname) = Darwin ]]; then mktemp -d $base/nxf.XXXXXXXXXX
     else TMPDIR="$base" mktemp -d -t nxf.XXXXXXXXXX
     fi

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -129,6 +129,7 @@ nxf_kill() {
 
 nxf_mktemp() {
     local base=${1:-/tmp}
+    mkdir -p "$base"
     if [[ $(uname) = Darwin ]]; then mktemp -d $base/nxf.XXXXXXXXXX
     else TMPDIR="$base" mktemp -d -t nxf.XXXXXXXXXX
     fi


### PR DESCRIPTION
Defining a scratch Directory which not yet exists leads to an exception.
This PR solves that issue.
`nextflow test.nf -process.scratch /tmp/nextflow/`

```
N E X T F L O W  ~  version 22.04.0
Launching `test.nf` [spontaneous_poitras] DSL1 - revision: 0f88566b47
executor >  local (1)
[dd/7f3a23] process > a [  0%] 0 of 1
a: errorCount: 1, retryCount: 1
Error executing process > 'a'

executor >  local (1)
[dd/7f3a23] process > a [100%] 1 of 1, failed: 1 ✘
a: errorCount: 1, retryCount: 1
Error executing process > 'a'

Caused by:
  Process `a` terminated with an error exit status (1)

Command executed:

  echo hello world

Command exit status:
  1

Command output:
  (empty)

Command wrapper:
  mktemp: failed to create directory via template ‘/tmp/nextflow/nxf.XXXXXXXXXX’: No such file or directory

Work dir:
  /home/fabian/fixes/work/dd/7f3a23116fd8814d4eb55e97fa49d1

Tip: view the complete command output by changing to the process work dir and entering the command `cat .command.out`
```