### PR TITLE
bugfix: add AthenaJdbc into distribution zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ gradle.properties
 .launch.classpath
 plugins-prod
 sandbox
+/plugins/nf-sqldb/src/dist/lib/AthenaJDBC42_2.0.25.1001.jar

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     api 'org.postgresql:postgresql:42.2.23'
     api 'org.xerial:sqlite-jdbc:3.36.0.3'
     api 'org.duckdb:duckdb_jdbc:0.3.0'
-    api files('downloads/unzip/AthenaJDBC42_2.0.25.1001.jar')
+    api files('src/dist/lib/AthenaJDBC42_2.0.25.1001.jar')
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
@@ -80,4 +80,11 @@ task unzipAthenDep(dependsOn: verifyAthenDep, type: Copy) {
     into "${buildDir}/downloads/unzip"
 }
 
-project.compileGroovy.dependsOn('unzipAthenDep')
+// Files under src/dist are included into the distribution zip
+// https://docs.gradle.org/current/userguide/application_plugin.html
+task copyAthenDep(dependsOn: unzipAthenDep, type: Copy) {
+    from file("${buildDir}/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar")
+    into "src/dist/lib"
+}
+
+project.compileGroovy.dependsOn('copyAthenDep')

--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:1.7.10'
     compileOnly 'org.pf4j:pf4j:3.4.1'
-    compileOnly "org.slf4j:log4j-over-slf4j:1.7.36"
     api("org.codehaus.groovy:groovy-sql:3.0.10") { transitive = false }
     api 'com.h2database:h2:1.4.200'
     api 'mysql:mysql-connector-java:8.0.22'


### PR DESCRIPTION
Athena Driver is included in test classpath but not in the distribution zip due the `application` gradle plugin doesn't include files if not in `src/dist` directory

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>