### PR TITLE
Hyperqueue executor (WIP)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
@@ -57,7 +57,8 @@ class ExecutorFactory {
             'k8s': K8sExecutor,
             'nqsii': NqsiiExecutor,
             'moab': MoabExecutor,
-            'oar': OarExecutor
+            'oar': OarExecutor,
+            'hq': HyperQueueExecutor
     ]
 
     @PackageScope Map<String, Class<? extends Executor>> executorsMap

--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020-2022, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.executor
+
+import java.nio.file.Path
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import nextflow.processor.TaskRun
+import nextflow.util.ServiceName
+import nextflow.util.TupleHelper
+/**
+ * Implements executor for HyperQueue
+ *  https://github.com/It4innovations/hyperqueue/
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+@ServiceName('hq')
+class HyperQueueExecutor extends AbstractGridExecutor {
+
+    private final JsonSlurper parser = new JsonSlurper()
+
+    @Override
+    protected String getHeaderToken() {
+        return '#HQ'
+    }
+
+    @Override
+    protected List<String> getDirectives(TaskRun task, List<String> result) {
+
+        result << '--name' << getJobNameFor(task)
+        result << '--log' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
+        result << '--task-dir' << quote(task.workDir)
+
+        if( task.config.hasCpus() )
+            result << '--cpus' << task.config.getCpus().toString()
+        if( task.config.getTime() )
+            result << '--time-limit' << (task.config.getTime().toSeconds() + 'sec')
+
+        // -- at the end append the command script wrapped file name
+        if( task.config.clusterOptions ) {
+            result << task.config.clusterOptions.toString() << ''
+        }
+
+        return result
+    }
+
+    @Override
+    List<String> getSubmitCommandLine(TaskRun task, Path scriptFile) {
+        return TupleHelper.listOf('hq', '--output-mode=json','submit', '--', '/bin/bash', scriptFile.getName())
+    }
+
+    @Override
+    def parseJobId(String text) {
+        Map result = null
+        try {
+            result = parser.parseText(text) as Map
+        }
+        catch (Exception e) {
+            throw new IllegalArgumentException("Invalid HyperQueue submit JSON response:\n$text\n\n")
+        }
+
+        if( result.id )
+            return result.id as String
+
+        final err = result.error
+                    ? "HyperQueue submit error: ${result.error}"
+                    : "Invalid HyperQueue submit response:\n$text\n\n"
+        throw new IllegalArgumentException(err)
+    }
+
+    @Override
+    protected List<String> getKillCommand() {
+        return TupleHelper.listOf('hq','job', 'cancel')
+    }
+
+    @Override
+    protected List<String> queueStatusCommand(Object queue) {
+        return TupleHelper.listOf('hq','--output-mode=json','job', 'list', '--all')
+    }
+
+    @Override
+    protected Map<String, QueueStatus> parseQueueStatus(String text) {
+        final jobs = parser.parseText(text) as List<Map>
+        final result = new HashMap()
+        for( Map entry : jobs ) {
+            final id = entry.id as String
+            final status = parseJobStatus(entry)
+            result.put(id, status)
+        }
+        return result
+    }
+
+    protected QueueStatus parseJobStatus( Map entry ) {
+        Map stats = entry.task_stats as Map
+        if( !stats )
+            return QueueStatus.UNKNOWN
+        if( stats.canceled )
+            return QueueStatus.DONE
+        if( stats.failed )
+            return QueueStatus.ERROR
+        if( stats.finished )
+            return QueueStatus.DONE
+        if( stats.running )
+            return QueueStatus.RUNNING
+        if( stats.waiting )
+            return QueueStatus.HOLD
+        else
+            return QueueStatus.UNKNOWN
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/util/TupleHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/TupleHelper.groovy
@@ -47,4 +47,59 @@ class TupleHelper {
         result.add(z)
         return result
     }
+
+    static List listOf(x1, x2, x3, x4) {
+        def result = new ArrayList(4)
+        result.add(x1)
+        result.add(x2)
+        result.add(x3)
+        result.add(x4)
+        return result
+    }
+
+    static List listOf(x1, x2, x3, x4, x5) {
+        def result = new ArrayList(5)
+        result.add(x1)
+        result.add(x2)
+        result.add(x3)
+        result.add(x4)
+        result.add(x5)
+        return result
+    }
+
+    static List listOf(x1, x2, x3, x4, x5, x6) {
+        def result = new ArrayList(6)
+        result.add(x1)
+        result.add(x2)
+        result.add(x3)
+        result.add(x4)
+        result.add(x5)
+        result.add(x6)
+        return result
+    }
+
+    static List listOf(x1, x2, x3, x4, x5, x6, x7) {
+        def result = new ArrayList(7)
+        result.add(x1)
+        result.add(x2)
+        result.add(x3)
+        result.add(x4)
+        result.add(x5)
+        result.add(x6)
+        result.add(x7)
+        return result
+    }
+
+    static List listOf(x1, x2, x3, x4, x5, x6, x7, x8) {
+        def result = new ArrayList(8)
+        result.add(x1)
+        result.add(x2)
+        result.add(x3)
+        result.add(x4)
+        result.add(x5)
+        result.add(x6)
+        result.add(x7)
+        result.add(x8)
+        return result
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2020-2022, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.executor
+
+import java.nio.file.Paths
+
+import nextflow.processor.TaskConfig
+import nextflow.processor.TaskProcessor
+import nextflow.processor.TaskRun
+import spock.lang.Specification
+
+/**
+ * Test HyperQueue executor
+ * 
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class HyperQueueExecutorTest extends Specification {
+
+    def 'should parse status' () {
+        given:
+        def exec = new HyperQueueExecutor()
+        and:
+        def STATUS = '''
+        [
+          {
+            "id": 1,
+            "name": "tash.sk",
+            "task_count": 1,
+            "task_stats": {
+              "canceled": 0,
+              "failed": 1,
+              "finished": 0,
+              "running": 0,
+              "waiting": 0
+            }
+          },
+          {
+            "id": 2,
+            "name": "task.sh",
+            "task_count": 1,
+            "task_stats": {
+              "canceled": 0,
+              "failed": 0,
+              "finished": 1,
+              "running": 0,
+              "waiting": 0
+            }
+          },
+          {
+            "id": 3,
+            "name": "task.sh",
+            "task_count": 1,
+            "task_stats": {
+              "canceled": 0,
+              "failed": 0,
+              "finished": 0,
+              "running": 1,
+              "waiting": 0
+            }
+          }
+        ]
+        '''
+        when:
+        def result = exec.parseQueueStatus(STATUS)
+        then:
+        result.size() == 3
+        and:
+        result.get('1') == AbstractGridExecutor.QueueStatus.ERROR
+        result.get('2') == AbstractGridExecutor.QueueStatus.DONE
+        result.get('3') == AbstractGridExecutor.QueueStatus.RUNNING
+    }
+
+    def 'should decode status' () {
+        given:
+        def exec = new HyperQueueExecutor()
+
+        expect:
+        exec.parseJobStatus([task_stats: [failed: 1]]) == AbstractGridExecutor.QueueStatus.ERROR
+        exec.parseJobStatus([task_stats: [canceled: 1]]) == AbstractGridExecutor.QueueStatus.DONE
+        exec.parseJobStatus([task_stats: [finished: 1]]) == AbstractGridExecutor.QueueStatus.DONE
+        exec.parseJobStatus([task_stats: [running: 1]]) == AbstractGridExecutor.QueueStatus.RUNNING
+        exec.parseJobStatus([task_stats: [waiting: 1]]) == AbstractGridExecutor.QueueStatus.HOLD
+        exec.parseJobStatus([:]) == AbstractGridExecutor.QueueStatus.UNKNOWN
+    }
+
+    def 'should parse job id' () {
+        given:
+        def exec = new HyperQueueExecutor()
+        and:
+        def JOB_OK = '''
+        {
+            "id": 3
+        }
+        '''
+
+        def JOB_FAIL = '''
+        {
+            "error": "submit failed this and that"
+        }
+        '''
+
+        
+        when:
+        def result = exec.parseJobId(JOB_OK)
+        then:
+        result == '3'
+
+        when:
+        exec.parseJobId(JOB_FAIL)
+        then:
+        def err = thrown(IllegalArgumentException)
+        err.message == 'HyperQueue submit error: submit failed this and that'
+
+        when:
+        exec.parseJobId('not ok')
+        then:
+        err = thrown(IllegalArgumentException)
+        err.message == '''\
+            Invalid HyperQueue submit JSON response:
+            not ok
+                    
+            '''.stripIndent()
+    }
+
+    def 'should create submit command' () {
+        given:
+        def exec = new HyperQueueExecutor()
+        and:
+        def task = Mock(TaskRun)
+        def path = Paths.get('/some/work/script.run')
+
+        when:
+        def result = exec.getSubmitCommandLine(task, path)
+        then:
+        result == ['hq', '--output-mode=json','submit', '--', '/bin/bash', 'script.run']
+    }
+
+    def 'should get kill command'() {
+        when:
+        // executor stub object
+        def executor = Spy(HyperQueueExecutor)
+        then:
+        executor.killTaskCommand('12345').join(' ') == 'hq job cancel 12345'
+
+    }
+
+    def "should validate headers"() {
+
+        setup:
+        def executor = new HyperQueueExecutor()
+
+        // mock process
+        def proc = Mock(TaskProcessor)
+
+        // task object
+        def task = new TaskRun()
+        task.processor = proc
+        task.workDir = Paths.get('/work/dir')
+        task.name = 'task-1'
+
+        when:
+        task.config = new TaskConfig()
+        then:
+        executor.getHeaders(task) == '''
+                #HQ --name nf-task-1
+                #HQ --log /work/dir/.command.log
+                #HQ --task-dir /work/dir
+                '''
+                .stripIndent().leftTrim()
+
+
+        when:
+        task.config = new TaskConfig()
+        task.config.cpus = 4
+        task.config.time = '1m'
+        then:
+        executor.getHeaders(task) == '''
+                #HQ --name nf-task-1
+                #HQ --log /work/dir/.command.log
+                #HQ --task-dir /work/dir
+                #HQ --cpus 4
+                #HQ --time-limit 60sec
+                '''
+                .stripIndent().leftTrim()
+
+
+
+    }
+}

--- a/modules/nextflow/src/test/groovy/nextflow/util/TupleHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/TupleHelperTest.groovy
@@ -30,7 +30,11 @@ class TupleHelperTest extends Specification {
         TupleHelper.listOf('a') == ['a']
         TupleHelper.listOf('a','b') == ['a', 'b']
         TupleHelper.listOf('a','b','z') == ['a', 'b', 'z']
+        TupleHelper.listOf('1','2','3', '4') == '1'..'4'
+        TupleHelper.listOf('1','2','3', '4', '5') == '1'..'5'
+        TupleHelper.listOf('1','2','3', '4', '5', '6') == '1'..'6'
+        TupleHelper.listOf('1','2','3', '4', '5', '6', '7') == '1'..'7'
+        TupleHelper.listOf('1','2','3', '4', '5', '6', '7', '8') == '1'..'8'
     }
-
 
 }


### PR DESCRIPTION
This PR adds support for the [HyperQueue](https://github.com/It4innovations/hyperqueue) scheduler.
Earlier discussion in #2867 

> Running large workflows with very many processes on HPC systems ( ~ 10K or more ).
The current batch executors (especially the slurm one https://www.nextflow.io/docs/latest/executor.html#slurm )
are not suitable to due to the usage of individual jobs, and even if jobsteps were to be used, the amount would be to large,
negatively affecting the HPC scheduler stability / hitting hard limits.
So the idea for maximum throughput would be to launch HyperQueue using the system batch scheduler and then start
nextflow.

Supported features are:

- clusterOptions
- cpus
- memory
- time
- accelerator ( type of accelerator is ignored)

**Note** requires hyperqueue v0.11 which is not released yet.