### PR TITLE
bugfix: resolve azure devops repositories when projectId is present

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -35,9 +35,13 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     private String continuationToken
 
     AzureRepositoryProvider(String project, ProviderConfig config=null) {
-        this.project = project
-        this.user = this.project.tokenize('/').first()
-        this.repo = this.project.tokenize('/').last()
+        def tokens = project.tokenize('/')
+        this.repo = tokens.removeLast()
+        if( tokens.size() == 1){
+            this.project = [tokens.first(), this.repo].join('/')
+        }else{
+            this.project = tokens.join('/')
+        }
         this.config = config ?: new ProviderConfig('azurerepos')
         this.continuationToken = null
     }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -35,6 +35,10 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     private String continuationToken
 
     AzureRepositoryProvider(String project, ProviderConfig config=null) {
+        /*
+        Azure repo format follows Organization/Project/Repository where Project can be optional
+        If Project is not present then Repository is used as Project (and also as Repository)
+         */
         def tokens = project.tokenize('/')
         this.repo = tokens.removeLast()
         if( tokens.size() == 1){
@@ -73,7 +77,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
         if( revision )
             queryParams['versionDescriptor.version']=revision
         def queryString = queryParams.collect({ "$it.key=$it.value"}).join('&')
-        def result = "${config.endpoint}/${project}/_apis/git/repositories/${repo}/items?$queryString"
+        def result = "$endpointUrl/items?$queryString"
         result
     }
 
@@ -81,7 +85,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     @CompileDynamic
     List<BranchInfo> getBranches() {
         // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/refs/list?view=azure-devops-rest-6.0#refs-heads
-        final url = "${config.endpoint}/${project}/_apis/git/repositories/${repo}/refs?filter=heads&api-version=6.0"
+        final url = "$endpointUrl/refs?filter=heads&api-version=6.0"
         this.<BranchInfo>invokeAndResponseWithPaging(url, { Map branch ->
             new BranchInfo(strip(branch.name), branch.objectId as String)
         })
@@ -92,7 +96,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     @Memoized
     List<TagInfo> getTags() {
         // https://docs.microsoft.com/en-us/rest/api/azure/devops/git/refs/list?view=azure-devops-rest-6.0#refs-tags
-        final url = "${config.endpoint}/${project}/_apis/git/repositories/${repo}/refs?filter=tags&api-version=6.0"
+        final url = "$endpointUrl/refs?filter=tags&api-version=6.0"
         this.<TagInfo>invokeAndResponseWithPaging(url, { Map tag ->
             new TagInfo(strip(tag.name), tag.objectId as String)
         })

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -53,6 +53,16 @@ class AzureRepositoryProviderTest extends Specification {
         new AzureRepositoryProvider('t-neumann/hello', obj).getEndpointUrl() == 'https://dev.azure.com/t-neumann/hello/_apis/git/repositories/hello'
     }
 
+    def 'should return repo with organization url' () {
+
+        given:
+        def config = new ConfigSlurper().parse(CONFIG)
+        def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
+
+        expect:
+        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getEndpointUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT/_apis/git/repositories/hello'
+    }
+
     def 'should return project URL' () {
 
         given:
@@ -61,6 +71,17 @@ class AzureRepositoryProviderTest extends Specification {
 
         expect:
         new AzureRepositoryProvider('t-neumann/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/t-neumann/hello'
+
+    }
+
+    def 'should return project with organization URL' () {
+
+        given:
+        def config = new ConfigSlurper().parse(CONFIG)
+        def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
+
+        expect:
+        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT/hello'
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -81,7 +81,7 @@ class AzureRepositoryProviderTest extends Specification {
         def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
 
         expect:
-        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT/hello'
+        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT'
 
     }
 


### PR DESCRIPTION

Azure URL can have 2 or 3 tokens in the repo name (organization / project / repo ) but currently we are using only 2 of them


closes #2384 