### PR TITLE
Update link for questions related to Nextflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -10,8 +10,7 @@ configuration options and general Nextflow usage the better
 channels to post this kind of questions are: 
 
 * GitHub discussions: https://github.com/nextflow-io/nextflow/discussions
-* Google group: https://groups.google.com/forum/#!forum/nextflow
-* Gitter channel: https://gitter.im/nextflow-io/nextflow
+* Slack community chat: https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg
 
 
 Also you may also want to have a look at the patterns page 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ community by helping in other ways. This is also a guide to becoming an effectiv
 ## Contributing by Helping Other Users
 
 A great way to contribute to Nextflow is to help answer user questions on the [discussion forum](https://github.com/nextflow-io/nextflow/discussions), 
-the [Gitter channel](https://gitter.im/nextflow-io/nextflow) or the [Slack channel](https://nextflow.slack.com). 
+or the [Slack channel](https://nextflow.slack.com). 
 There are always many new Nextflow users; taking a few minutes to help answer a question is a very valuable community service.
 
 Contributors should ideally subscribe to these channels and follow them in order to keep up to date

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 ![Nextflow CI](https://github.com/nextflow-io/nextflow/workflows/Nextflow%20CI/badge.svg)
 [![Nextflow version](https://img.shields.io/github/release/nextflow-io/nextflow.svg?colorB=26af64&style=popout)](https://github.com/nextflow-io/nextflow/releases/latest)
-[![Chat on Gitter](https://img.shields.io/gitter/room/nextflow-io/nextflow.svg?colorB=26af64&style=popout)](https://gitter.im/nextflow-io/nextflow)
 [![Nextflow Twitter](https://img.shields.io/twitter/url/https/nextflowio.svg?colorB=26af64&&label=%40nextflow&style=popout)](https://twitter.com/nextflowio)
 [![Nextflow Publication](https://img.shields.io/badge/Published-Nature%20Biotechnology-26af64.svg?colorB=26af64&style=popout)](https://www.nature.com/articles/nbt.3820)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?colorB=26af64&style=popout)](http://bioconda.github.io/recipes/nextflow/README.html)
@@ -172,7 +171,7 @@ Community
 =========
 
 You can post questions, or report problems by using the Nextflow [discussion forum](https://groups.google.com/forum/#!forum/nextflow)
-or the [Nextflow channel on Gitter](https://gitter.im/nextflow-io/nextflow).
+or the Nextflow [Slack community chat](https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg).
 
 *Nextflow* also hosts a yearly workshop showcasing researcher's workflows and advancements in the langauge. Talks from the past workshops are available on the [Nextflow YouTube Channel](https://www.youtube.com/channel/UCB-5LCKLdTKVn2F4V4KlPbQ)
 


### PR DESCRIPTION
Nextflow has [recently moved to Slack](https://www.nextflow.io/blog/2022/nextflow-is-moving-to-slack.html) and the link to the Slack community chat is the one shown in the Nextflow official website. This pull request updates the references from the Nextflow Gitter channel to Slack in the README.md, CONTRIBUTING.md and general_question.md file.
