### PR TITLE
bugfix: remove gradle message in nf-sqldb

### DIFF
--- a/plugins/nf-sqldb/build.gradle
+++ b/plugins/nf-sqldb/build.gradle
@@ -82,8 +82,8 @@ task unzipAthenDep(dependsOn: verifyAthenDep, type: Copy) {
 // Files under src/dist are included into the distribution zip
 // https://docs.gradle.org/current/userguide/application_plugin.html
 task copyAthenDep(dependsOn: unzipAthenDep, type: Copy) {
-    from file("${buildDir}/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar")
+    from file(new File(buildDir, '/downloads/unzip/SimbaAthenaJDBC-2.0.25.1001/AthenaJDBC42_2.0.25.1001.jar'))
     into "src/dist/lib"
 }
-
+project.copyPluginLibs.dependsOn('copyAthenDep')
 project.compileGroovy.dependsOn('copyAthenDep')


### PR DESCRIPTION
we missed to link tasks dependencies between copyPlugin and copyAthen tasks

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>