### PR TITLE
Remove undefined variable in Docs / Get started code example

### DIFF
--- a/docs/getstarted.rst
+++ b/docs/getstarted.rst
@@ -170,7 +170,7 @@ process script with the string ``rev $x``, so that the process looks like this::
     process convertToUpper {
 
         input:
-        file x from letters
+        file x
 
         output:
         stdout result


### PR DESCRIPTION
Running the modified example currently outputs an error:
```
No such variable: letters
```
By removing ` from letters`, the error disappears. As the first code example doesn't include it either, it seems it might be a remnant of some earlier code version(?)