### PR TITLE
Update temporary slack join link with a permanent one

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -10,7 +10,7 @@ configuration options and general Nextflow usage the better
 channels to post this kind of questions are: 
 
 * GitHub discussions: https://github.com/nextflow-io/nextflow/discussions
-* Slack community chat: https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg
+* Slack community chat: https://www.nextflow.io/slack-invite.html
 
 
 Also you may also want to have a look at the patterns page 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ community by helping in other ways. This is also a guide to becoming an effectiv
 ## Contributing by Helping Other Users
 
 A great way to contribute to Nextflow is to help answer user questions on the [discussion forum](https://github.com/nextflow-io/nextflow/discussions), 
-or the [Slack channel](https://nextflow.slack.com). 
+or the [Slack channel](https://www.nextflow.io/slack-invite.html).
 There are always many new Nextflow users; taking a few minutes to help answer a question is a very valuable community service.
 
 Contributors should ideally subscribe to these channels and follow them in order to keep up to date

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Community
 =========
 
 You can post questions, or report problems by using the Nextflow [discussion forum](https://groups.google.com/forum/#!forum/nextflow)
-or the Nextflow [Slack community chat](https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg).
+or the Nextflow [Slack community chat](https://www.nextflow.io/slack-invite.html).
 
 *Nextflow* also hosts a yearly workshop showcasing researcher's workflows and advancements in the langauge. Talks from the past workshops are available on the [Nextflow YouTube Channel](https://www.youtube.com/channel/UCB-5LCKLdTKVn2F4V4KlPbQ)
 


### PR DESCRIPTION
This change is related to the updates and discussions that occurred in https://github.com/nextflow-io/nextflow/pull/2917 and
https://github.com/nextflow-io/website/pull/51.