### PR TITLE
feature: fail fast uploads to s3

### DIFF
--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -478,7 +478,6 @@ public final class S3OutputStream extends OutputStream {
                     success=true;
                 }
                 catch (AmazonClientException | IOException e) {
-                    System.out.println("exception subiendo part "+e);
                     if( attempt == request.getMaxAttempts() )
                         throw new IOException("Failed to upload multipart data to Amazon S3", e);
 

--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -57,7 +57,6 @@ import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.util.Base64;
 import com.upplication.s3fs.util.ByteBufferInputStream;
 import com.upplication.s3fs.util.S3MultipartOptions;
-import nextflow.util.Duration;
 import nextflow.util.ThreadPoolBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -181,6 +180,8 @@ public final class S3OutputStream extends OutputStream {
     private CannedAccessControlList cannedAcl;
 
     private List<Tag> tags;
+
+    private AtomicInteger bufferCounter = new AtomicInteger();
 
     /**
      * Creates a new {@code S3OutputStream} that writes data directly into the S3 object with the given {@code objectId}.
@@ -307,13 +308,12 @@ public final class S3OutputStream extends OutputStream {
         }
         else {
             // allocate a new buffer
-            log.debug("Allocating new buffer of {} bytes, total buffers {}", request.getChunkSize(), counter.incrementAndGet());
+            log.debug("Allocating new buffer of {} bytes, total buffers {}", request.getChunkSize(), bufferCounter.incrementAndGet());
             result = ByteBuffer.allocateDirect(request.getChunkSize());
         }
 
         return result;
     }
-    AtomicInteger counter = new AtomicInteger();
 
 
     /**

--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -652,7 +652,7 @@ public final class S3OutputStream extends OutputStream {
             ThreadPoolExecutor pool = ThreadPoolBuilder.io(
                     1,
                     maxThreads,
-                    maxThreads*10,
+                    maxThreads*3,
                     "S3OutputStream");
             executorSingleton = pool;
             log.trace("Created singleton upload executor -- max-treads: {}", maxThreads);

--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -646,14 +646,11 @@ public final class S3OutputStream extends OutputStream {
      */
     static synchronized ExecutorService getOrCreateExecutor(int maxThreads) {
         if( executorSingleton == null ) {
-            ThreadPoolExecutor pool = new ThreadPoolBuilder()
-                    .withName("S3OutputStream")
-                    .withMinSize(maxThreads)
-                    .withMaxSize(maxThreads)
-                    .withQueueSize(maxThreads *3)
-                    .withKeepAliveTime(Duration.of("60sec"))
-                    .withAllowCoreThreadTimeout(true)
-                    .build();
+            ThreadPoolExecutor pool = ThreadPoolBuilder.io(
+                    maxThreads,
+                    maxThreads,
+                    maxThreads*3,
+                    "S3OutputStream");
             executorSingleton = pool;
             log.trace("Created singleton upload executor -- max-treads: {}", maxThreads);
         }

--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -651,7 +651,7 @@ public final class S3OutputStream extends OutputStream {
         if( executorSingleton == null ) {
             ThreadPoolExecutor pool = ThreadPoolBuilder.io(
                     1,
-                    maxThreads*3,
+                    maxThreads,
                     maxThreads*10,
                     "S3OutputStream");
             executorSingleton = pool;

--- a/plugins/nf-amazon/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-amazon/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: nextflow.cloud.aws.AmazonPlugin
 Plugin-Id: nf-amazon
-Plugin-Version: 1.8.0
+Plugin-Version: 1.8.1
 Plugin-Provider: Seqera Labs
 Plugin-Requires: >=22.03.0-edge

--- a/plugins/nf-amazon/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-amazon/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: nextflow.cloud.aws.AmazonPlugin
 Plugin-Id: nf-amazon
-Plugin-Version: 1.8.1
+Plugin-Version: 1.8.0
 Plugin-Provider: Seqera Labs
 Plugin-Requires: >=22.03.0-edge


### PR DESCRIPTION
After several tests with huge files (500GB) and playing with the Xmx param, the only situation I found can be problematic is when some part fails

In this case, we continue uploading parts instead of stopping the upload 


closes #2230 