### PR TITLE
feature: enable running processes on different regions

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchRegionExecutor.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchRegionExecutor.groovy
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020-2022, Seqera Labs
+ * Copyright 2013-2019, Centre for Genomic Regulation (CRG)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cloud.aws.batch
+
+import com.amazonaws.services.batch.AWSBatch
+import com.amazonaws.services.ecs.model.AccessDeniedException
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+import groovy.util.logging.Slf4j
+import nextflow.Session
+import nextflow.cloud.aws.AmazonClientFactory
+import nextflow.cloud.types.CloudMachineInfo
+import nextflow.processor.TaskConfig
+import nextflow.util.ThrottlingExecutor
+
+import java.nio.file.Path
+
+/**
+ * AWS Batch executor
+ * https://aws.amazon.com/batch/
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+class AwsBatchRegionExecutor {
+
+    AwsBatchRegionExecutor(ThrottlingExecutor submitter, ThrottlingExecutor reaper, Path remoteBinDir){
+        this.submitter = submitter
+        this.reaper = reaper
+        this.remoteBinDir = remoteBinDir
+    }
+
+    /**
+     * Reference to current running session
+     */
+    @PackageScope
+    private Session session
+
+    Session getSession(){
+        this.session
+    }
+
+    /**
+     * Proxy to throttle AWS batch client requests
+     */
+    @PackageScope
+    private AwsBatchProxy client
+
+    /** Helper class to resolve Batch related metadata */
+    private AwsBatchHelper helper
+
+    /**
+     * executor service to throttle service requests
+     */
+    private ThrottlingExecutor submitter
+
+    /**
+     * Executor service to throttle cancel requests
+     */
+    private ThrottlingExecutor reaper
+
+    /**
+     * A S3 path where executable scripts need to be uploaded
+     */
+    private Path remoteBinDir = null
+
+    private AwsOptions awsOptions
+
+    AwsOptions getAwsOptions() {  awsOptions  }
+
+
+    protected void createAwsClient(Session session, TaskConfig taskConfig) {
+        this.session = session
+
+        Map config = session.config.deepClone()
+        // AmazonClientFactory is looking into top `region` key but AwsOptions into `aws.region`
+        if( taskConfig?.region ) {
+            config.region = taskConfig.region
+            if( config.aws && config.aws instanceof Map){
+                (config.aws as Map).region = taskConfig.region
+            }
+        }
+
+        /*
+         * retrieve config and credentials and create AWS client
+         */
+        final driver = new AmazonClientFactory(config)
+
+        /*
+         * create a proxy for the aws batch client that manages the request throttling
+         */
+        client = new AwsBatchProxy(driver.batchClient, submitter)
+        helper = new AwsBatchHelper(client, driver)
+        // create the options object
+        awsOptions = new AwsOptions(this, config, remoteBinDir)
+        log.debug "[AWS BATCH] Executor options=$awsOptions"
+    }
+
+    Path getRemoteBinDir() {
+        this.remoteBinDir
+    }
+
+    AWSBatch getClient() {
+        client
+    }
+
+    ThrottlingExecutor getReaper() { reaper }
+
+
+    CloudMachineInfo getMachineInfoByQueueAndTaskArn(String queue, String taskArn) {
+        try {
+            return helper?.getCloudInfoByQueueAndTaskArn(queue, taskArn)
+        }
+        catch ( AccessDeniedException e ) {
+            log.warn "Unable to retrieve AWS Batch instance type | ${e.message}"
+            // disable it since user has not permission to access this info
+            awsOptions.fetchInstanceType = false
+            return null
+        }
+        catch( Exception e ) {
+            log.warn "Unable to retrieve AWS batch instance type for queue=$queue; task=$taskArn | ${e.message}", e
+            return null
+        }
+    }
+
+    String getJobOutputStream(String jobId) {
+        try {
+            return helper.getTaskLogStream(jobId)
+        }
+        catch (Exception e) {
+            log.debug "Unable to retrieve AWS Cloudwatch logs for Batch Job id=$jobId | ${e.message}", e
+            return null
+        }
+    }
+
+}
+
+
+
+
+
+
+
+
+

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -90,7 +90,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
 
     private final Path traceFile
 
-    private AwsBatchExecutor executor
+    private AwsBatchRegionExecutor executor
 
     private AWSBatch client
 
@@ -120,7 +120,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
      * @param task The {@link nextflow.processor.TaskRun} descriptor of the task to run
      * @param executor The {@link AwsBatchExecutor} instance
      */
-    AwsBatchTaskHandler(TaskRun task, AwsBatchExecutor executor) {
+    AwsBatchTaskHandler(TaskRun task, AwsBatchRegionExecutor executor) {
         super(task)
         this.executor = executor
         this.client = executor.client
@@ -519,7 +519,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         return result
     }
 
-    @Memoized 
+    @Memoized
     LogConfiguration getLogConfiguration(String name, String region) {
         new LogConfiguration()
             .withLogDriver('awslogs')

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -547,7 +547,7 @@ class AwsBatchTaskHandlerTest extends Specification {
             getTask() >> Mock(TaskRun) { getConfig() >> Mock(TaskConfig)  }
             fusionEnabled() >> false
         }
-        handler.@executor = Mock(AwsBatchExecutor)
+        handler.@executor = Mock(AwsBatchRegionExecutor)
 
         when:
         def result = handler.makeJobDefRequest(IMAGE)
@@ -606,7 +606,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         given:
         def IMAGE = 'foo/bar:1.0'
         def JOB_NAME = 'nf-foo-bar-1-0'
-        def executor = Mock(AwsBatchExecutor)
+        def executor = Mock(AwsBatchRegionExecutor)
         def opts = Mock(AwsOptions)
         def handler = Spy(AwsBatchTaskHandler) {
             getTask() >> Mock(TaskRun) { getConfig() >> Mock(TaskConfig)  }
@@ -639,7 +639,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         def IMAGE = 'foo/bar:1.0'
         def JOB_NAME = 'nf-foo-bar-1-0'
         def opts = Mock(AwsOptions)
-        def executor = Mock(AwsBatchExecutor)
+        def executor = Mock(AwsBatchRegionExecutor)
         def handler = Spy(AwsBatchTaskHandler) {
             getTask() >> Mock(TaskRun) { getConfig() >> Mock(TaskConfig) }
             fusionEnabled() >> false
@@ -664,7 +664,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         def JOB_NAME = 'nf-foo-bar-1-0'
         def opts = Mock(AwsOptions)
         def taskConfig = new TaskConfig(containerOptions: '--privileged --user foo')
-        def executor = Mock(AwsBatchExecutor)
+        def executor = Mock(AwsBatchRegionExecutor)
         def handler = Spy(AwsBatchTaskHandler) {
             getTask() >> Mock(TaskRun) { getConfig() >> taskConfig }
             fusionEnabled() >> false


### PR DESCRIPTION
enable running processes on different regions when running on cloud executors
(only AWS by the moment)

The idea of this PR is to separate the preparation (current AwsBatchExecutor) from the Execution (AwsBatchRegionExecutor) creating a "merged" config from the session and the task

basically, AwsBatchExecutor creates an AwsBatchRegionExecutor who prepares an AwsClient with the merged config and runs a TaskHandler with it

p.d.
by the moment it's done only in AWS 
