### PR TITLE
Override lsf.conf settings with nextflow config settings

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -344,6 +344,7 @@ exitReadTimeout       Determines how long the executor waits before to an error 
 killBatchSize         Determines the number of jobs that can be `killed` in a single command execution (default: ``100``).
 submitRateLimit       Determines the max rate of job submission per time unit, for example ``'10sec'`` eg. max 10 jobs per second or ``'50/2min'`` i.e. 50 job submissions every 2 minutes (default: `unlimited`).
 perJobMemLimit        Specifies Platform LSF *per-job* memory limit mode. See :ref:`lsf-executor`.
+perTaskReserve        Specifies Platform LSF *per-task* memory reserve mode. See :ref:`lsf-executor`.
 jobName               Determines the name of jobs submitted to the underlying cluster executor e.g. ``executor.jobName = { "$task.name - $task.hash" }`` Note: when using this option you need to make sure the resulting job name matches the validation constraints of the underlying batch scheduler.
 cpus                  The maximum number of CPUs made available by the underlying system (only used by the ``local`` executor).
 memory                The maximum amount of memory made available by the underlying system (only used by the ``local`` executor).

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -90,7 +90,7 @@ class LsfExecutor extends AbstractGridExecutor {
             // When per-process is used (default) the amount of requested memory
             // is divided by the number of used cpus (processes)
             def mem1 = ( task.config.cpus > 1 && !perJobMemLimit ) ? mem.div(task.config.cpus as int) : mem
-            def mem2 = ( task.config.cpus > 1 && perTaskReserve ) ? mem.div(task.config.cpus as int) : mem
+            def mem2 = ( task.config.cpus > 1 &&  perTaskReserve ) ? mem.div(task.config.cpus as int) : mem
 
             result << '-M' << String.valueOf(mem1.toUnit(memUnit))
             result << '-R' << "select[mem>=${mem.toUnit(memUnit)}] rusage[mem=${mem2.toUnit(usageUnit)}]".toString()
@@ -284,9 +284,8 @@ class LsfExecutor extends AbstractGridExecutor {
             perJobMemLimit = str == 'Y'
             log.debug "[LSF] Detected lsf.conf LSB_JOB_MEMLIMIT=$str ($perJobMemLimit)"
         }
-        else {
-            perJobMemLimit = session.getExecConfigProp(name, 'perJobMemLimit', false)
-        }
+
+        perJobMemLimit = session.getExecConfigProp(name, 'perJobMemLimit', perJobMemLimit)
 
         // per task reserve https://github.com/nextflow-io/nextflow/issues/1071#issuecomment-481412239
         if( conf.get('RESOURCE_RESERVE_PER_TASK') ) {
@@ -294,6 +293,8 @@ class LsfExecutor extends AbstractGridExecutor {
             perTaskReserve = str == 'Y'
             log.debug "[LSF] Detected lsf.conf RESOURCE_RESERVE_PER_TASK=$str ($perTaskReserve)"
         }
+
+        perTaskReserve = session.getExecConfigProp(name, 'perTaskReserve', perTaskReserve)
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -90,7 +90,7 @@ class LsfExecutor extends AbstractGridExecutor {
             // When per-process is used (default) the amount of requested memory
             // is divided by the number of used cpus (processes)
             def mem1 = ( task.config.cpus > 1 && !perJobMemLimit ) ? mem.div(task.config.cpus as int) : mem
-            def mem2 = ( task.config.cpus > 1 &&  perTaskReserve ) ? mem.div(task.config.cpus as int) : mem
+            def mem2 = ( task.config.cpus > 1 && perTaskReserve ) ? mem.div(task.config.cpus as int) : mem
 
             result << '-M' << String.valueOf(mem1.toUnit(memUnit))
             result << '-R' << "select[mem>=${mem.toUnit(memUnit)}] rusage[mem=${mem2.toUnit(usageUnit)}]".toString()


### PR DESCRIPTION
Closes #2862 

Also adds `executor.perTaskReserve` config option to override LSF config file.