### PR TITLE
Document aws client parallel download options

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -122,6 +122,11 @@ Name                        Description
 anonymous                   Allow the access of public S3 buckets without the need to provide AWS credentials. Any service that does not accept unsigned requests will return a service access error.
 s3Acl                       Allow the setting of a predefined bucket permissions also known as *canned ACL*. Permitted values are ``Private``, ``PublicRead``, ``PublicReadWrite``, ``AuthenticatedRead``, ``LogDeliveryWrite``, ``BucketOwnerRead``, ``BucketOwnerFullControl`` and ``AwsExecRead``. See `Amazon docs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl>`_ for details.
 connectionTimeout           The amount of time to wait (in milliseconds) when initially establishing a connection before giving up and timing out.
+downloadParallel            Download files from S3 in parallel chunks (multipart download) (requires version ``21.12.1-edge`` or later).
+downloadChunkSize           The size of a single part in a multipart download (default: `20 MB`).
+downloadNumWorkers          The number of worker threads used for multipart download.
+downloadBufferMaxSize       The maximum size of the memory buffer used to store chunks during multipart download.
+downloadMaxAttempts         The maximum number of upload attempts after which a multipart download returns an error (default: `5`).
 endpoint                    The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.
 maxConnections              The maximum number of allowed open HTTP connections.
 maxErrorRetry               The maximum number of retry attempts for failed retryable requests.


### PR DESCRIPTION
Taken from https://github.com/nextflow-io/nextflow/issues/2150#issuecomment-999836354

I couldn't find these options in the code so I'm not sure what the default values are.