### PR TITLE
Make tests pass if user has set git defaultBranch

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -72,6 +72,18 @@ class AssetManagerTest extends Specification {
         AssetManager.root = tempDir.root.toFile()
     }
 
+    // Helper method to grab the default brasnch if set in ~/.gitconfig
+    String getUserDefaultBranch() {
+        def defaultBranch = 'master'
+        def gitconfig = Paths.get(System.getProperty('user.home'),'.gitconfig');
+        if(gitconfig.exists()) {
+            def config = new Config()
+            config.fromText(gitconfig.text)
+            defaultBranch = config.getString('init', null, 'defaultBranch') ?: 'master'
+        }
+        return defaultBranch
+    }
+
     def testList() {
 
         given:
@@ -445,15 +457,6 @@ class AssetManagerTest extends Specification {
         dir.resolve('nextflow.config').text = 'manifest {  }'
         dir.resolve('foo.nf').text = 'this is foo content'
 
-        // Use this user's custom defaultBranch name if set in ~/.gitconfig
-        def defaultBranch = 'master'
-        def gitconfig = Paths.get(System.getProperty('user.home'),'.gitconfig');
-        if(gitconfig.exists()) {
-            def config = new Config()
-            config.fromText(gitconfig.text)
-            defaultBranch = config.getString('init', null, 'defaultBranch') ?: 'master'
-        }
-
         def init = Git.init()
         def repo = init.setDirectory( dir.toFile() ).call()
         repo.add().addFilepattern('.').call()
@@ -474,7 +477,7 @@ class AssetManagerTest extends Specification {
         then:
         script.localPath == dir
         script.commitId == commit.name()
-        script.revision == defaultBranch
+        script.revision == getUserDefaultBranch()
         script.parent == dir
         script.text == "println 'Hello world'"
         script.repository == 'https://github.com/nextflow-io/nextflow'
@@ -491,7 +494,7 @@ class AssetManagerTest extends Specification {
         then:
         script.localPath == dir
         script.commitId == commit.name()
-        script.revision == defaultBranch
+        script.revision == getUserDefaultBranch()
         script.parent == dir
         script.text == "this is foo content"
         script.repository == 'https://github.com/nextflow-io/nextflow'

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -73,7 +73,7 @@ class AssetManagerTest extends Specification {
     }
 
     // Helper method to grab the default brasnch if set in ~/.gitconfig
-    String getUserDefaultBranch() {
+    String getLocalDefaultBranch() {
         def defaultBranch = 'master'
         def gitconfig = Paths.get(System.getProperty('user.home'),'.gitconfig');
         if(gitconfig.exists()) {
@@ -477,7 +477,7 @@ class AssetManagerTest extends Specification {
         then:
         script.localPath == dir
         script.commitId == commit.name()
-        script.revision == getUserDefaultBranch()
+        script.revision == getLocalDefaultBranch()
         script.parent == dir
         script.text == "println 'Hello world'"
         script.repository == 'https://github.com/nextflow-io/nextflow'
@@ -494,7 +494,7 @@ class AssetManagerTest extends Specification {
         then:
         script.localPath == dir
         script.commitId == commit.name()
-        script.revision == getUserDefaultBranch()
+        script.revision == getLocalDefaultBranch()
         script.parent == dir
         script.text == "this is foo content"
         script.repository == 'https://github.com/nextflow-io/nextflow'

--- a/modules/nextflow/src/test/groovy/nextflow/scm/LocalRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/LocalRepositoryProviderTest.groovy
@@ -18,8 +18,10 @@
 package nextflow.scm
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Config
 import spock.lang.Shared
 import spock.lang.Specification
 /**
@@ -160,6 +162,15 @@ class LocalRepositoryProviderTest extends Specification {
         repo.commit().setSign(false).setMessage('Second commit').call()
         def ref2 = repo.branchCreate().setName('branch_2').call()
 
+        // Use this user's custom defaultBranch name if set in ~/.gitconfig
+        def defaultBranch = 'master'
+        def gitconfig = Paths.get(System.getProperty('user.home'),'.gitconfig');
+        if(gitconfig.exists()) {
+            def config = new Config()
+            config.fromText(gitconfig.text)
+            defaultBranch = config.getString('init', null, 'defaultBranch') ?: 'master'
+        }
+
         and:
         def config = new ProviderConfig('local', [path: testFolder])
         def manager = new LocalRepositoryProvider('project_hello', config)
@@ -169,7 +180,7 @@ class LocalRepositoryProviderTest extends Specification {
         then:
         branches.size() == 3
         and:
-        branches.find { it.name == 'master' }
+        branches.find { it.name == defaultBranch }
         and:
         branches.find { it.name == 'branch_1' }.commitId == ref1.getObjectId().name()
         and:


### PR DESCRIPTION
Two test (`AssetManagerTest` and `LocalRepositoryProviderTest`) fail if the user has set their own `defaultBranch` in `~/.gitconfig`.

Before this PR, the tests assume that the git `defaultBranch` is `master` and that assumption is hardcoded into the tests. This PR will use the local value if set in the most common way (in .gitconfig without any subsections).

Changing the `defaultBranch` is increasingly common - [Gitlab](https://about.gitlab.com/blog/2021/03/10/new-git-default-branch-name/), [Github](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/), and [Atlassian](https://bitbucket.org/blog/moving-away-from-master-as-the-default-name-for-branches-in-git) have all moved to using `main` instead of `master`, so many developers now user `main` by default. This does not affect the functionality of Nextflow in any way, but ensures that more devs see all green tests when cloning the repo.

To emphasise - this does not change the default branch name in the nextflow repository, and does not affect the name of the default branch name of the repositories created during tests. The only change is that we try to assume less about the dev environment.