### PR TITLE
fix: add ps shared objects to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ RUN yum install -y procps-ng
 
 FROM amazoncorretto:17.0.3
 COPY --from=0 /bin/ps /bin/ps
+COPY --from=0 /lib64/libprocps.so.4 /lib64/libprocps.so.4
+COPY --from=0 /usr/lib64/libsystemd.so.0 /usr/lib64/libsystemd.so.0
 ENV NXF_HOME=/.nextflow
 ARG TARGETPLATFORM
 
@@ -20,4 +22,3 @@ RUN mkdir /.nextflow \
 
 # define the entry point
 ENTRYPOINT ["/usr/local/bin/entry.sh"]
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,10 @@ RUN yum install -y procps-ng
 FROM amazoncorretto:17.0.3
 COPY --from=0 /bin/ps /bin/ps
 COPY --from=0 /lib64/libprocps.so.4 /lib64/libprocps.so.4
+COPY --from=0 /usr/lib64/libdw.so.1 /usr/lib64/libdw.so.1
+COPY --from=0 /usr/lib64/liblz4.so.1 /usr/lib64/liblz4.so.1
 COPY --from=0 /usr/lib64/libsystemd.so.0 /usr/lib64/libsystemd.so.0
+
 ENV NXF_HOME=/.nextflow
 ARG TARGETPLATFORM
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,6 @@
 FROM amazoncorretto:17.0.3
 RUN yum install -y procps-ng
 
-FROM amazoncorretto:17.0.3
-COPY --from=0 /bin/ps /bin/ps
-COPY --from=0 /lib64/libprocps.so.4 /lib64/libprocps.so.4
-COPY --from=0 /usr/lib64/libdw.so.1 /usr/lib64/libdw.so.1
-COPY --from=0 /usr/lib64/liblz4.so.1 /usr/lib64/liblz4.so.1
-COPY --from=0 /usr/lib64/libsystemd.so.0 /usr/lib64/libsystemd.so.0
-
 ENV NXF_HOME=/.nextflow
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
The Dockerfile uses a clever trick to install the `ps` binary without all the extra stuff in the `procps-ng` package. However, that leaves ps without several shared library files. This PR copies those shared libraries into the final docker image. Tested on my local machine and ps works now.