### PR TITLE
Add notes about merge, multiMap, and multiple input channels

### DIFF
--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -1144,6 +1144,9 @@ taking two parameters that represent two emitted items to be compared. For examp
 merge
 -----
 
+.. warning::
+  The ``merge`` operator is deprecated and no longer available in DSL2 syntax. Use `join`_ instead.
+
 The ``merge`` operator lets you join items emitted by two (or more) channels into a new channel.
 
 For example, the following code merges two channels together: one which emits a series of odd integers

--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -1146,7 +1146,7 @@ merge
 
 The ``merge`` operator lets you join items emitted by two (or more) channels into a new channel.
 
-For example the following code merges two channels together, one which emits a series of odd integers
+For example, the following code merges two channels together: one which emits a series of odd integers
 and the other which emits a series of even integers::
 
     odds  = Channel.from([1, 3, 5, 7, 9]);
@@ -1162,7 +1162,7 @@ and the other which emits a series of even integers::
     [3, 4]
     [5, 6]
 
-An option closure can be provide to customise the items emitted by the resulting merged channel. For example::
+An optional closure can be provided to customise the items emitted by the resulting merged channel. For example::
 
     odds  = Channel.from([1, 3, 5, 7, 9]);
     evens = Channel.from([2, 4, 6]);
@@ -1172,12 +1172,13 @@ An option closure can be provide to customise the items emitted by the resulting
         .view()
 
 .. danger::
-    When this operator is used to *merge* the outputs of two processes, keep in mind that the resulting merged channel
-    will have non-deterministic behavior and may cause your pipeline execution to not resume properly.
-    Because each process is executed in parallel and produces its outputs independently, there is no guarantee
-    that they will be executed in the same order. Therefore the content of the resulting merged channel
-    may have a different order on each run and may cause the resume to not work
-    properly. For a better alternative use the `join`_ operator instead.
+    In general, the use of the ``merge`` operator is discouraged. Processes and channel operators are not
+    guaranteed to emit items in the order that they were received, due to their parallel and asynchronous
+    nature. Therefore, if you try to merge output channels from different processes, the resulting channel
+    may be different on each run, which will cause resumed runs to not work properly.
+
+    You should always use a matching key (e.g. sample ID) to merge multiple channels, so that they are
+    combined in a deterministic way. For this purpose, you can use the `join`_ operator.
 
 
 .. _operator-min:
@@ -1264,12 +1265,12 @@ multiMap
 
 .. note:: Requires Nextflow version ``19.11.0-edge`` or later.
 
-The multiMap operator allows you to forward the items emitted by a source channel to two
-or more output channels mapping each input value as a separate element.
+The ``multiMap`` operator allows you to forward the items emitted by a source channel to two
+or more output channels, mapping each input value as a separate element.
 
-The mapping criteria is defined by specifying a :ref:`closure <script-closure>` that specify the
-target channels labelled by a unique identifier followed by an expression statement that
-evaluates the value to be assigned to such channel.
+The mapping criteria is defined with a :ref:`closure <script-closure>` that specifies the
+target channels (labelled with a unique identifier) followed by an expression that maps each
+item from the input channel to the target channel.
 
 For example::
 
@@ -1295,7 +1296,7 @@ It prints::
     bar 9
     bar 16
 
-The statement expression can be omitted when the value to be emitted is the same as
+The mapping expression can be omitted when the value to be emitted is the same as
 the following one. If you just need to forward the same value to multiple channels,
 you can use the following shorthand::
 
@@ -1304,10 +1305,10 @@ you can use the following shorthand::
         .multiMap { it -> foo: bar: it }
         .set { result }
 
-As before this creates two channels but now both of them receive the same source items.
+As before, this creates two channels, but now both of them receive the same source items.
 
-To create a multi-map criteria as a variable that can be passed as an argument to more than one
-``multiMap`` operator use the ``multiMapCriteria`` built-in method as shown below::
+You can use the ``multiMapCriteria`` method to create a multi-map criteria as a variable
+that can be passed as an argument to one or more ``multiMap`` operations, as shown below::
 
     def criteria = multiMapCriteria {
         small: it < 10
@@ -1316,6 +1317,13 @@ To create a multi-map criteria as a variable that can be passed as an argument t
 
     Channel.from(1,2,30).multiMap(criteria).set { ch1 }
     Channel.from(10,20,1).multiMap(criteria).set { ch2 }
+
+.. note::
+    If you use ``multiMap`` to split a tuple or map into multiple channels, it is
+    recommended that you retain a matching key (e.g. sample ID) with *each* new
+    channel, so that you can re-combine these channels later on if needed. In general,
+    you should not expect to be able to merge channels correctly without a matching key,
+    due to the parallel and asynchronous nature of Nextflow pipelines.
 
 
 .. _operator-phase:

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -765,10 +765,10 @@ In the latter example for any sequence input file emitted by the ``sequences`` c
 3 using the ``regular`` method against each library files, and other 3 by using the ``expresso`` method always
 against the same library files.
 
-.. tip::
-  If you need to repeat the execution of a process over an n-tuple of elements instead of simple values or files,
-  create a channel combining the input values as needed to trigger the process execution multiple times.
-  Refer to the :ref:`operator-combine`, :ref:`operator-cross` and :ref:`operator-phase` operators for more details.
+.. note::
+  Input repeaters currently do not support tuples. However, you can emulate an input repeater on a channel of
+  tuples by using the :ref:`operator-combine` or :ref:`operator-cross` operator with other input channels to
+  produce all of the desired input combinations.
 
 
 .. _process-understand-how-multiple-input-channels-work:

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -839,6 +839,12 @@ channel. It prints::
   1 and b
   1 and c
 
+.. note::
+  In general, multiple input channels should be used to process *combinations* of different inputs,
+  using the ``each`` qualifier or value channels. Having multiple queue channels as inputs is equivalent
+  to using the ``merge`` operator, which is not recommended as it may lead to inputs being combined in
+  a non-deterministic way.
+
 See also: :ref:`channel-types`.
 
 Outputs


### PR DESCRIPTION
From some other discussions (#2113 #2682), it looks like some users like to use the following pattern:
1. start with a channel of tuples or maps
2. use `multiMap` to split tuple/map into individual channels
3. invoke process with the channels from (2) as inputs
4. re-combine any output channels from (3) with `merge`

I think this pattern is used in order to avoid having long tuples for process input/output, but actually I think tuples are the best practice here, and this multiMap+merge pattern should be discouraged, because there is a risk of items not being re-combined correctly. I think it happens to work for now but order preservation is not guaranteed in principle.

I think the broader issue is that users would like to have better support for optional inputs/outputs and named inputs (i.e. map input), and this pattern is a sort of workaround for that. But for now I think we should reinforce the best practice in the docs, so in this PR I added some clarifications around use of merge, multiMap, and multiple input channels.