### PR TITLE
Fix AWS Batch job definition conflict

### DIFF
--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -387,14 +387,15 @@ class AwsBatchTaskHandlerTest extends Specification {
         def JOB_ID= '123'
         def handler = Spy(AwsBatchTaskHandler)
 
-        def req = Mock(RegisterJobDefinitionRequest)
+        def req = Mock(RegisterJobDefinitionRequest) {
+            getJobDefinitionName() >> JOB_NAME
+            getParameters() >> [ 'nf-token': JOB_ID ]
+        }
 
         when:
         handler.resolveJobDefinition(IMAGE)
         then:
         1 * handler.makeJobDefRequest(IMAGE) >> req
-        1 * req.getJobDefinitionName() >> JOB_NAME
-        1 * req.getParameters() >> [ 'nf-token': JOB_ID ]
         1 * handler.findJobDef(JOB_NAME, JOB_ID) >> null
         1 * handler.createJobDef(req) >> null
 
@@ -402,7 +403,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         handler.resolveJobDefinition(IMAGE)
         then:
         // second time are not invoked for the same image
-        0 * handler.makeJobDefRequest(IMAGE) >> req
+        1 * handler.makeJobDefRequest(IMAGE) >> req
         0 * handler.findJobDef(JOB_NAME, JOB_ID) >> null
         0 * handler.createJobDef(req) >> null
 


### PR DESCRIPTION
Nextflow registers AWS batch jobs implicitly when
a new configuration is detected. A local cache maintained
to prevent unnecesary API request to check if job with
the same features is already created.

This commit fixes conflict in the cache keys creation
that caused two or more processes using the same container
image but different task settins e.g. containerOptions
to use a wrong job definition

Signed-off-by: Paolo Di Tommaso <paolo.ditommaso@gmail.com>