### PR TITLE
Add accelerator, boot disk, cpu platform, disk to google batch

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -121,6 +121,8 @@ Name                                           Description
 google.project                                 The Google Project Id to use for the pipeline execution.
 google.location                                The Google *location* where the job executions are deployed (default: ``us-central1``).
 google.enableRequesterPaysBuckets              When ``true`` uses the configured Google project id as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See `Requester Pays on Google Cloud Storage documentation  <https://cloud.google.com/storage/docs/requester-pays>`_ (default: ``false``).
+google.batch.bootDiskSize                      Set the size of the virtual machine boot disk, e.g ``50.GB`` (default: none).
+google.batch.cpuPlatform                       Set the minimum CPU Platform, e.g. ``'Intel Skylake'``. See `Specifying a minimum CPU Platform for VM instances <https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications>`_ (default: none).
 google.batch.spot                              When ``true`` enables the usage of *spot* virtual machines or ``false`` otherwise (default: ``false``).
 google.batch.usePrivateAddress                 When ``true`` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: ``false``).
 google.batch.network                           Set network name to attach the VM's network interface to. The value will be prefixed with global/networks/ unless it contains a /, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used.
@@ -193,8 +195,8 @@ to add the following retry strategy to your config file to instruct Nextflow to 
 if the virtual machine was terminated preemptively::
 
     process {
-      errorStrategy = { task.exitStatus==14 ? 'retry' : 'terminate' }
-      maxRetries = 5
+        errorStrategy = { task.exitStatus==14 ? 'retry' : 'terminate' }
+        maxRetries = 5
     }
 
 Supported directives
@@ -203,14 +205,15 @@ Supported directives
 The integration with Google Batch is a developer preview feature. Currently the following Nextflow directives are
 supported:
 
-* :ref:`process-cpus`
-* :ref:`process-memory`
-* :ref:`process-time`
+* :ref:`process-accelerator`
 * :ref:`process-container`
 * :ref:`process-containeroptions`
-* :ref:`process-machinetype`
+* :ref:`process-cpus`
+* :ref:`process-disk`
 * :ref:`process-executor`
-
+* :ref:`process-machinetype`
+* :ref:`process-memory`
+* :ref:`process-time`
 
 
 .. _google-lifesciences:
@@ -290,10 +293,10 @@ google.region                                  The Google *region* where the com
 google.zone                                    The Google *zone* where the computation is executed in Compute Engine VMs. Multiple zones can be provided separating them by a comma. Do not specify if a region is provided. See  `available Compute Engine regions and zones <https://cloud.google.com/compute/docs/regions-zones/>`_
 google.location                                The Google *location* where the job executions are deployed to Cloud Life Sciences API. See  `available Cloud Life Sciences API locations <https://cloud.google.com/life-sciences/docs/concepts/locations>`_ (default: the same as the region or the zone specified).
 google.enableRequesterPaysBuckets              When ``true`` uses the configured Google project id as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See `Requester Pays on Google Cloud Storage documentation  <https://cloud.google.com/storage/docs/requester-pays>`_ (default: ``false``)
-google.lifeSciences.cpuPlatform                Set the minimum CPU Platform e.g. `'Intel Skylake'`. See `Specifying a minimum CPU Platform for VM instances <https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications>`_ (default: none).
-google.lifeSciences.bootDiskSize               Set the size of the virtual machine boot disk e.g `50.GB` (default: none).
+google.lifeSciences.bootDiskSize               Set the size of the virtual machine boot disk e.g ``50.GB`` (default: none).
 google.lifeSciences.copyImage                  The container image run to copy input and output files. It must include the ``gsutil`` tool (default: ``google/cloud-sdk:alpine``).
-google.lifeSciences.debug                      When ``true`` copies the `/google` debug directory in that task bucket directory (default: ``false``)
+google.lifeSciences.cpuPlatform                Set the minimum CPU Platform e.g. ``'Intel Skylake'``. See `Specifying a minimum CPU Platform for VM instances <https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications>`_ (default: none).
+google.lifeSciences.debug                      When ``true`` copies the ``/google`` debug directory in that task bucket directory (default: ``false``)
 google.lifeSciences.preemptible                When ``true`` enables the usage of *preemptible* virtual machines or ``false`` otherwise (default: ``true``)
 google.lifeSciences.usePrivateAddress          When ``true`` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: ``false``). Requires version ``20.03.0-edge`` or later.
 google.lifeSciences.network                    Set network name to attach the VM's network interface to. The value will be prefixed with global/networks/ unless it contains a /, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used. Requires version ``21.03.0-edge`` or later.

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -22,6 +22,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.cloud.google.GoogleOpts
+import nextflow.util.MemoryUnit
 /**
  * Model Google Batch config settings
  *
@@ -33,6 +34,8 @@ class BatchConfig {
 
     private GoogleOpts googleOpts
     private GoogleCredentials credentials
+    private MemoryUnit bootDiskSize
+    private String cpuPlatform
     private boolean disableBinDir
     private boolean spot
     private boolean preemptible
@@ -43,6 +46,8 @@ class BatchConfig {
 
     GoogleOpts getGoogleOpts() { return googleOpts }
     GoogleCredentials getCredentials() { return credentials }
+    MemoryUnit getBootDiskSize() { bootDiskSize }
+    String getCpuPlatform() { cpuPlatform }
     boolean getDisableBinDir() { disableBinDir }
     boolean getPreemptible() { preemptible }
     boolean getSpot() { spot }
@@ -55,6 +60,8 @@ class BatchConfig {
         final result = new BatchConfig()
         result.googleOpts = GoogleOpts.create(session)
         result.credentials = result.googleOpts.credentials
+        result.bootDiskSize = session.config.navigate('google.batch.bootDiskSize') as MemoryUnit
+        result.cpuPlatform = session.config.navigate('google.batch.cpuPlatform')
         result.disableBinDir = session.config.navigate('google.batch.disableRemoteBinDir',false)
         result.spot = session.config.navigate('google.batch.spot',false)
         result.preemptible = session.config.navigate('google.batch.preemptible',false)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -19,6 +19,7 @@ package nextflow.cloud.google.batch
 
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
 import nextflow.cloud.google.batch.client.BatchConfig
+import nextflow.executor.res.AcceleratorResource
 import nextflow.processor.TaskBean
 import nextflow.processor.TaskConfig
 import nextflow.processor.TaskRun
@@ -31,7 +32,7 @@ import spock.lang.Specification
  */
 class GoogleBatchTaskHandlerTest extends Specification {
 
-    def 'should create submit request/1' () {
+    def 'should create submit request with minimal spec' () {
         given:
         def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')
         def CONTAINER_IMAGE = 'debian:latest'
@@ -60,6 +61,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def runnable = taskGroup.getTaskSpec().getRunnables(0)
         def instancePolicy = req.getAllocationPolicy().getInstances(0).getPolicy()
         and:
+        taskGroup.getTaskSpec().getComputeResource().getBootDiskMib() == 0
         taskGroup.getTaskSpec().getComputeResource().getCpuMilli() == 2_000
         taskGroup.getTaskSpec().getComputeResource().getMemoryMib() == 0
         taskGroup.getTaskSpec().getMaxRunDuration().getSeconds() == 0
@@ -69,26 +71,36 @@ class GoogleBatchTaskHandlerTest extends Specification {
         runnable.getContainer().getOptions() == ''
         runnable.getContainer().getVolumesList() == ['/mnt/foo/scratch:/mnt/foo/scratch:rw']
         and:
+        instancePolicy.getAcceleratorsCount() == 0
+        instancePolicy.getDisksCount() == 0
         instancePolicy.getMachineType() == ''
+        instancePolicy.getMinCpuPlatform() == ''
+        instancePolicy.getProvisioningModel().toString() == 'PROVISIONING_MODEL_UNSPECIFIED'
         and:
         req.getAllocationPolicy().getNetwork().getNetworkInterfacesCount() == 0
         and:
         req.getLogsPolicy().getDestination().toString() == 'CLOUD_LOGGING'
     }
 
-    def 'should create submit request/2' () {
+    def 'should create submit request with maximal spec' () {
         given:
         def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')
         and:
+        def ACCELERATOR = new AcceleratorResource(request: 1, type: 'nvidia-tesla-v100')
+        def BOOT_DISK = MemoryUnit.of('10 GB')
         def CONTAINER_IMAGE = 'ubuntu:22.1'
         def CONTAINER_OPTS = '--this --that'
+        def CPU_PLATFORM = 'Intel Skylake'
         def CPUS = 4
+        def DISK = MemoryUnit.of('50 GB')
+        def MACHINE_TYPE = 'vm-type-2'
         def MEM = MemoryUnit.of('8 GB')
         def TIMEOUT = Duration.of('1 hour')
-        def MACHINE_TYPE = 'vm-type-2'
         and:
         def exec = Mock(GoogleBatchExecutor) {
             getConfig() >> Mock(BatchConfig) {
+                getBootDiskSize() >> BOOT_DISK
+                getCpuPlatform() >> CPU_PLATFORM
                 getSpot() >> true
                 getNetwork() >> 'net-1'
                 getSubnetwork() >> 'subnet-1'
@@ -103,11 +115,13 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getWorkDir() >> WORK_DIR
             getContainer() >> CONTAINER_IMAGE
             getConfig() >> Mock(TaskConfig) {
+                getAccelerator() >> ACCELERATOR
+                getContainerOptions() >> CONTAINER_OPTS
                 getCpus() >> CPUS
+                getDisk() >> DISK
+                getMachineType() >> MACHINE_TYPE
                 getMemory() >> MEM
                 getTime() >> TIMEOUT
-                getMachineType() >> MACHINE_TYPE
-                getContainerOptions() >> CONTAINER_OPTS
             }
         }
 
@@ -122,6 +136,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def instancePolicy = req.getAllocationPolicy().getInstances(0).getPolicy()
         def networkInterface = req.getAllocationPolicy().getNetwork().getNetworkInterfaces(0)
         and:
+        taskGroup.getTaskSpec().getComputeResource().getBootDiskMib() == BOOT_DISK.toMega()
         taskGroup.getTaskSpec().getComputeResource().getCpuMilli() == CPUS * 1_000
         taskGroup.getTaskSpec().getComputeResource().getMemoryMib() == MEM.toMega()
         taskGroup.getTaskSpec().getMaxRunDuration().getSeconds() == TIMEOUT.seconds
@@ -131,8 +146,12 @@ class GoogleBatchTaskHandlerTest extends Specification {
         runnable.getContainer().getOptions() == CONTAINER_OPTS
         runnable.getContainer().getVolumesList() == ['/mnt/foo/scratch:/mnt/foo/scratch:rw']
         and:
-        instancePolicy.getProvisioningModel().toString() == 'SPOT'
+        instancePolicy.getAccelerators(0).getCount() == 1
+        instancePolicy.getAccelerators(0).getType() == ACCELERATOR.type
+        instancePolicy.getDisks(0).getNewDisk().getSizeGb() == DISK.toGiga()
         instancePolicy.getMachineType() == MACHINE_TYPE
+        instancePolicy.getMinCpuPlatform() == CPU_PLATFORM
+        instancePolicy.getProvisioningModel().toString() == 'SPOT'
         and:
         networkInterface.getNetwork() == 'net-1'
         networkInterface.getSubnetwork() == 'subnet-1'


### PR DESCRIPTION
Closes #3039 #3049 #3050 

This PR adds the following features to google batch:
- GPU support via `accelerator` directive
- Boot disk size (same as life sciences)
- Minimum CPU platform (same as life sciences)
- Disk support via `disk` directive