### PR TITLE
Fix #3074

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -310,10 +310,7 @@ class CmdRun extends CmdBase implements HubOptions {
         final nxfEnvs = checkNxfEnv(config)
         if(nxfEnvs) {
             log.warn 'Environment variables in the `env` config scope are not applied to Nextflow -- See https://www.nextflow.io/docs/latest/config.html#scope-env'
-            log.warn 'The following variables should be exported in the environment:'
-            nxfEnvs.each {
-                log.warn it as String
-            }
+            log.warn "The following variables should be exported in the environment: ${nxfEnvs.join(', ')}"
         }
 
         // -- load plugins

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -306,6 +306,18 @@ class CmdRun extends CmdBase implements HubOptions {
         // check DSL syntax in the config
         launchInfo(config, scriptFile)
 
+        // Warn about setting NXF_ environment variables within nextflow
+        // config file
+        def nxfEnvs = config
+                .env
+                .findAll{
+                    it -> it.toString().startsWith('NXF_') && ! it.toString().startsWith('NXF_DEBUG')
+                }
+        if (nxfEnvs.size() > 0) {
+            log.warn "NXF environment variables are ignored in the env scope of nextflow.config. Check https://www.nextflow.io/docs/latest/config.html#scope-env"
+
+        }
+
         // -- load plugins
         final cfg = plugins ? [plugins: plugins.tokenize(',')] : config
         Plugins.load(cfg)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -306,14 +306,8 @@ class CmdRun extends CmdBase implements HubOptions {
         // check DSL syntax in the config
         launchInfo(config, scriptFile)
 
-        // Warn about setting NXF_ environment variables within env config scope
-        final nxfEnvs = config.env.findAll { it ->
-            it.toString().startsWith('NXF_') &&
-            ! it.toString().startsWith('NXF_DEBUG')
-        }
-        if( nxfEnvs.size() > 0 ) {
-            log.warn 'Environment variables in the `env` config scope are not applied to Nextflow -- See https://www.nextflow.io/docs/latest/config.html#scope-env'
-        }
+        // check if NXF_ variables are set in nextflow.config
+        checkNxfEnv(config)
 
         // -- load plugins
         final cfg = plugins ? [plugins: plugins.tokenize(',')] : config
@@ -355,6 +349,19 @@ class CmdRun extends CmdBase implements HubOptions {
 
         // -- run it!
         runner.execute(scriptArgs, this.entryName)
+    }
+
+    protected void checkNxfEnv(ConfigMap config) {
+        // Warn about setting NXF_ environment variables within env config scope
+        final nxfEnvs = config.env.findAll { it ->
+            it.toString().startsWith('NXF_') &&
+                    ! it.toString().startsWith('NXF_DEBUG')
+        }
+        if( nxfEnvs.size() > 0 ) {
+            log.warn 'Environment variables in the `env` config scope are not applied to Nextflow -- See https://www.nextflow.io/docs/latest/config.html#scope-env'
+            log.warn 'The following variables should be exported in the environment:'
+            nxfEnvs.each { log.warn it.toString().split('=')[0] }
+        }
     }
 
     protected void launchInfo(ConfigMap config, ScriptFile scriptFile) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -306,16 +306,13 @@ class CmdRun extends CmdBase implements HubOptions {
         // check DSL syntax in the config
         launchInfo(config, scriptFile)
 
-        // Warn about setting NXF_ environment variables within nextflow
-        // config file
-        def nxfEnvs = config
-                .env
-                .findAll{
-                    it -> it.toString().startsWith('NXF_') &&
-                            ! it.toString().startsWith('NXF_DEBUG')
-                }
-        if (nxfEnvs.size() > 0) {
-            log.warn "NXF environment variables are ignored in the env scope of nextflow.config. Check https://www.nextflow.io/docs/latest/config.html#scope-env"
+        // Warn about setting NXF_ environment variables within env config scope
+        final nxfEnvs = config.env.findAll { it ->
+            it.toString().startsWith('NXF_') &&
+            ! it.toString().startsWith('NXF_DEBUG')
+        }
+        if( nxfEnvs.size() > 0 ) {
+            log.warn 'Environment variables in the `env` config scope are not applied to Nextflow -- See https://www.nextflow.io/docs/latest/config.html#scope-env'
         }
 
         // -- load plugins

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -311,11 +311,11 @@ class CmdRun extends CmdBase implements HubOptions {
         def nxfEnvs = config
                 .env
                 .findAll{
-                    it -> it.toString().startsWith('NXF_') && ! it.toString().startsWith('NXF_DEBUG')
+                    it -> it.toString().startsWith('NXF_') &&
+                            ! it.toString().startsWith('NXF_DEBUG')
                 }
         if (nxfEnvs.size() > 0) {
             log.warn "NXF environment variables are ignored in the env scope of nextflow.config. Check https://www.nextflow.io/docs/latest/config.html#scope-env"
-
         }
 
         // -- load plugins

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -355,14 +355,15 @@ class CmdRun extends CmdBase implements HubOptions {
         runner.execute(scriptArgs, this.entryName)
     }
 
-    protected Collection checkNxfEnv(ConfigMap config) {
+    protected List<String> checkNxfEnv(ConfigMap config) {
         // Warn about setting NXF_ environment variables within env config scope
-        final nxfEnvs = config.env.findAll { it ->
-            it.toString().startsWith('NXF_') &&
-                    ! it.toString().startsWith('NXF_DEBUG')
+        final env = config.env as Map<String, String>
+        final nxfEnvs = env.findAll { Map.Entry<String, String> it ->
+            it.key.startsWith('NXF_') &&
+                    ! it.key.startsWith('NXF_DEBUG')
         }
-        nxfEnvs.collect {
-            it.toString().split('=')[0]
+        nxfEnvs.collect {  it ->
+            it.key
         }
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
@@ -17,6 +17,7 @@
 
 package nextflow.cli
 
+import nextflow.config.ConfigBuilder
 import java.nio.file.Files
 
 import nextflow.config.ConfigMap
@@ -333,5 +334,22 @@ class CmdRunTest extends Specification {
         and:
         // detect version from global default
         CmdRun.detectDslMode(new ConfigMap(), DSL2_SCRIPT, [:]) == '2'
+    }
+
+    def 'should filter NXF_ variables set in config.env' () {
+
+        when:
+        final config = new CmdRun().checkNxfEnv(new ConfigMap([env:MAP]))
+
+        then:
+        config == EXPECTED
+
+        where:
+        MAP | EXPECTED
+        [alpha : 'a1', HOME:"HOME:/some/path"] | []
+        [alpha : 'a1', NXF_DEBUG : 'true', HOME:"HOME:/some/path"] | []
+        [alpha : 'a1', NXF_DEBUG : 'true', NXF_ANSI_SUMMARY : 'false', NXF_ANSI_LOG : 'true', HOME:"HOME:/some/path"] | ['NXF_ANSI_SUMMARY', 'NXF_ANSI_LOG']
+        [alpha : 'a1', NXF_DEBUG : 'true', NXF_ANSI_SUMMARY : 'false', HOME:"HOME:/some/path"] | ['NXF_ANSI_SUMMARY']
+
     }
 }


### PR DESCRIPTION
If NXF environment variables other than NXF_DEBUG are set in the
env scope of nextflow.config, a warning should be thrown because
NXF variables are ignored there. They should be set in the
environment where nextflow is launched.
