### PR TITLE
Add support for aws batch logs group

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -166,6 +166,7 @@ Name                        Description
 =========================== ================
 cliPath                     The path where the AWS command line tool is installed in the host AMI.
 jobRole                     The AWS Job Role ARN that needs to be used to execute the Batch Job.
+logsGroup                   The name of the logs group used by Batch Jobs (default: ``/aws/batch``, requires ``22.09.0-edge`` or later).
 volumes                     One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. ``/host/path:/mount/path[:ro|rw]``. Multiple mounts can be specifid separating them with a comma or using a list object.
 delayBetweenAttempts        Delay between download attempts from S3 (default `10 sec`).
 maxParallelTransfers        Max parallel upload/download transfer operations *per job* (default: ``4``).

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -39,6 +39,7 @@ import com.amazonaws.services.batch.model.JobDefinitionType
 import com.amazonaws.services.batch.model.JobDetail
 import com.amazonaws.services.batch.model.JobTimeout
 import com.amazonaws.services.batch.model.KeyValuePair
+import com.amazonaws.services.batch.model.LogConfiguration
 import com.amazonaws.services.batch.model.MountPoint
 import com.amazonaws.services.batch.model.RegisterJobDefinitionRequest
 import com.amazonaws.services.batch.model.RegisterJobDefinitionResult
@@ -482,6 +483,17 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         final jobRole = opts.getJobRole()
         if( jobRole )
             container.setJobRoleArn(jobRole)
+
+        final logsGroup = opts.getLogsGroup()
+        if( logsGroup )
+            container.setLogConfiguration(
+                new LogConfiguration()
+                    .withLogDriver('awslogs')
+                    .withOptions([
+                        'awslogs-region': opts.getRegion(),
+                        'awslogs-group': logsGroup
+                    ])
+            )
 
         final mountsMap = new LinkedHashMap( 10)
         final awscli = opts.cliPath

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsOptions.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsOptions.groovy
@@ -77,6 +77,11 @@ class AwsOptions implements CloudTransferOptions {
     String jobRole
 
     /**
+     * The name of the logs group used by jobs
+     */
+    String logsGroup
+
+    /**
      * Volume mounts
      */
     List<String> volumes
@@ -112,6 +117,7 @@ class AwsOptions implements CloudTransferOptions {
         region = session.config.navigate('aws.region') as String
         volumes = makeVols(session.config.navigate('aws.batch.volumes'))
         jobRole = session.config.navigate('aws.batch.jobRole')
+        logsGroup = session.config.navigate('aws.batch.logsGroup')
         fetchInstanceType = session.config.navigate('aws.batch.fetchInstanceType')
         retryMode = session.config.navigate('aws.batch.retryMode', 'standard')
         shareIdentifier = session.config.navigate('aws.batch.shareIdentifier')

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -540,16 +540,20 @@ class AwsBatchTaskHandlerTest extends Specification {
         result.jobDefinitionName == JOB_NAME
         result.type == 'container'
         result.parameters.'nf-token' == 'bfd3cc19ee9bdaea5b7edee94adf04bc'
+        !result.containerProperties.logConfiguration
         !result.containerProperties.mountPoints
 
         when:
         result = handler.makeJobDefRequest(IMAGE)
         then:
         1 * handler.normalizeJobDefinitionName(IMAGE) >> JOB_NAME
-        1 * handler.getAwsOptions() >> new AwsOptions(cliPath: '/home/conda/bin/aws')
+        1 * handler.getAwsOptions() >> new AwsOptions(cliPath: '/home/conda/bin/aws', logsGroup: '/aws/batch', region: 'us-east-1')
         result.jobDefinitionName == JOB_NAME
         result.type == 'container'
-        result.parameters.'nf-token' == '38d950a380585c53b43d733a10bae3b4'
+        result.parameters.'nf-token' == 'af124f8899bcfc8a02037599f59a969a'
+        result.containerProperties.logConfiguration.'LogDriver' == 'awslogs'
+        result.containerProperties.logConfiguration.'Options'.'awslogs-region' == 'us-east-1'
+        result.containerProperties.logConfiguration.'Options'.'awslogs-group' == '/aws/batch'
         result.containerProperties.mountPoints[0].sourceVolume == 'aws-cli'
         result.containerProperties.mountPoints[0].containerPath == '/home/conda'
         result.containerProperties.mountPoints[0].readOnly


### PR DESCRIPTION
This PR adds the config option `aws.batch.logsGroup`. When this option is given, the aws batch executor will append the following configuration to each job definition:
```json
"logConfiguration": {
  "logDriver": "awslogs",
  "options": {
    "awslogs-region": "${aws.region}",
    "awslogs-group": "${aws.batch.logsGroup}"
  }
}
```