### PR TITLE
Use quiet output mode for hyperqueue executor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -19,7 +19,6 @@ package nextflow.executor
 
 import java.nio.file.Path
 
-import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.processor.TaskRun
@@ -37,7 +36,13 @@ import nextflow.util.TupleHelper
 @Slf4j
 class HyperQueueExecutor extends AbstractGridExecutor {
 
-    private final JsonSlurper parser = new JsonSlurper()
+    private static final STATUSES = [
+        'CANCELED': QueueStatus.DONE,
+        'FAILED': QueueStatus.ERROR,
+        'FINISHED': QueueStatus.DONE,
+        'RUNNING': QueueStatus.RUNNING,
+        'WAITING': QueueStatus.HOLD
+    ]
 
     @Override
     protected String getHeaderToken() {
@@ -47,7 +52,7 @@ class HyperQueueExecutor extends AbstractGridExecutor {
     @Override
     protected void register() {
         super.register()
-        log.warn "The support for HyperQueue is an experimental feature and it may change in a future release"
+        log.warn 'The support for HyperQueue is an experimental feature and it may change in a future release'
     }
 
     @Override
@@ -66,7 +71,7 @@ class HyperQueueExecutor extends AbstractGridExecutor {
             result << '--time-limit' << (task.config.getTime().toSeconds() + 'sec')
         if( task.config.getAccelerator() )
             result << '--resource' << "gpus=${task.config.getAccelerator().limit}".toString()
-        
+
         // -- At the end append the command script wrapped file name
         if( task.config.clusterOptions ) {
             result << task.config.clusterOptions.toString() << ''
@@ -77,79 +82,51 @@ class HyperQueueExecutor extends AbstractGridExecutor {
 
     @Override
     List<String> getSubmitCommandLine(TaskRun task, Path scriptFile) {
-        return TupleHelper.listOf('hq', '--output-mode=json','submit', '--directives=file', scriptFile.getName())
+        return TupleHelper.listOf('hq', '--output-mode=quiet', 'submit', '--directives=file', scriptFile.getName())
     }
 
     @Override
     def parseJobId(String text) {
-        Map result = null
         try {
-            result = parser.parseText(text) as Map
+            text as Integer as String
         }
         catch (Exception e) {
-            throw new IllegalArgumentException("Invalid HyperQueue submit JSON response:\n$text\n\n")
+            throw new IllegalArgumentException("HyperQueue submit failed or response is invalid:\n$text\n\n")
         }
-
-        if( result.id )
-            return result.id as String
-
-        final err = result.error
-                    ? "HyperQueue submit error: ${result.error}"
-                    : "Invalid HyperQueue submit response:\n$text\n\n"
-        throw new IllegalArgumentException(err)
     }
 
     @Override
     protected List<String> getKillCommand() {
-        return TupleHelper.listOf('hq','job', 'cancel')
+        return TupleHelper.listOf('hq', 'job', 'cancel')
     }
 
-    // JobIds to the cancel command need to be separated by a comma 
     @Override
-    protected List<String> killTaskCommand(def jobId) { 
-        final result = getKillCommand()                 
-        if( jobId instanceof Collection ) {             
+    protected List<String> killTaskCommand(def jobId) {
+        final result = getKillCommand()
+        if( jobId instanceof Collection ) {
             result.add(jobId.join(','))
-    //        log.trace "Kill command: ${result}"         
-        }                                               
-        else {                                          
-            result.add(jobId.toString())                
-        }                                               
-        return result                                   
-    }                                                   
+        }
+        else {
+            result.add(jobId.toString())
+        }
+        return result
+    }
 
     @Override
     protected List<String> queueStatusCommand(Object queue) {
-        return TupleHelper.listOf('hq','--output-mode=json','job', 'list', '--all')
+        return TupleHelper.listOf('hq', '--output-mode=quiet', 'job', 'list', '--all')
     }
 
     @Override
     protected Map<String, QueueStatus> parseQueueStatus(String text) {
-        final jobs = parser.parseText(text) as List<Map>
         final result = new HashMap()
-        for( Map entry : jobs ) {
-            final id = entry.id as String
-            final status = parseJobStatus(entry)
+        for( String line : text.split('\n') ) {
+            final tokens = line.split(' ')
+            final id = tokens[0]
+            final status = STATUSES[tokens[1]]
             result.put(id, status)
         }
         return result
     }
 
-    protected QueueStatus parseJobStatus( Map entry ) {
-        Map stats = entry.task_stats as Map
-        if( !stats )
-            return QueueStatus.UNKNOWN
-        if( stats.canceled )
-            return QueueStatus.DONE
-        if( stats.failed )
-            return QueueStatus.ERROR
-        if( stats.finished )
-            return QueueStatus.DONE
-        if( stats.running )
-            return QueueStatus.RUNNING
-        if( stats.waiting )
-            return QueueStatus.HOLD
-        else
-            return QueueStatus.UNKNOWN
-    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
@@ -37,45 +37,10 @@ class HyperQueueExecutorTest extends Specification {
         def exec = new HyperQueueExecutor()
         and:
         def STATUS = '''
-        [
-          {
-            "id": 1,
-            "name": "tash.sk",
-            "task_count": 1,
-            "task_stats": {
-              "canceled": 0,
-              "failed": 1,
-              "finished": 0,
-              "running": 0,
-              "waiting": 0
-            }
-          },
-          {
-            "id": 2,
-            "name": "task.sh",
-            "task_count": 1,
-            "task_stats": {
-              "canceled": 0,
-              "failed": 0,
-              "finished": 1,
-              "running": 0,
-              "waiting": 0
-            }
-          },
-          {
-            "id": 3,
-            "name": "task.sh",
-            "task_count": 1,
-            "task_stats": {
-              "canceled": 0,
-              "failed": 0,
-              "finished": 0,
-              "running": 1,
-              "waiting": 0
-            }
-          }
-        ]
-        '''
+            1 FAILED
+            2 FINISHED
+            3 RUNNING
+            '''.stripIndent().leftTrim()
         when:
         def result = exec.parseQueueStatus(STATUS)
         then:
@@ -86,34 +51,17 @@ class HyperQueueExecutorTest extends Specification {
         result.get('3') == AbstractGridExecutor.QueueStatus.RUNNING
     }
 
-    def 'should decode status' () {
-        given:
-        def exec = new HyperQueueExecutor()
-
-        expect:
-        exec.parseJobStatus([task_stats: [failed: 1]]) == AbstractGridExecutor.QueueStatus.ERROR
-        exec.parseJobStatus([task_stats: [canceled: 1]]) == AbstractGridExecutor.QueueStatus.DONE
-        exec.parseJobStatus([task_stats: [finished: 1]]) == AbstractGridExecutor.QueueStatus.DONE
-        exec.parseJobStatus([task_stats: [running: 1]]) == AbstractGridExecutor.QueueStatus.RUNNING
-        exec.parseJobStatus([task_stats: [waiting: 1]]) == AbstractGridExecutor.QueueStatus.HOLD
-        exec.parseJobStatus([:]) == AbstractGridExecutor.QueueStatus.UNKNOWN
-    }
-
     def 'should parse job id' () {
         given:
         def exec = new HyperQueueExecutor()
         and:
         def JOB_OK = '''
-        {
-            "id": 3
-        }
-        '''
+            3
+            '''.stripIndent().leftTrim()
 
         def JOB_FAIL = '''
-        {
-            "error": "submit failed this and that"
-        }
-        '''
+            error: submit failed this and that
+            '''.stripIndent().leftTrim()
 
         
         when:
@@ -125,17 +73,12 @@ class HyperQueueExecutorTest extends Specification {
         exec.parseJobId(JOB_FAIL)
         then:
         def err = thrown(IllegalArgumentException)
-        err.message == 'HyperQueue submit error: submit failed this and that'
+        err.message == '''
+            HyperQueue submit failed or response is invalid:
+            error: submit failed this and that
 
-        when:
-        exec.parseJobId('not ok')
-        then:
-        err = thrown(IllegalArgumentException)
-        err.message == '''\
-            Invalid HyperQueue submit JSON response:
-            not ok
-                    
-            '''.stripIndent()
+
+            '''.stripIndent().leftTrim()
     }
 
     def 'should create submit command' () {
@@ -148,28 +91,22 @@ class HyperQueueExecutorTest extends Specification {
         when:
         def result = exec.getSubmitCommandLine(task, path)
         then:
-        result == ['hq', '--output-mode=json','submit', '--directives=file', 'script.run']
+        result == ['hq', '--output-mode=quiet', 'submit', '--directives=file', 'script.run']
     }
 
-    def 'should get kill command'() {
+    def 'should get kill command' () {
         when:
-        // executor stub object
         def executor = Spy(HyperQueueExecutor)
         then:
         executor.killTaskCommand('12345').join(' ') == 'hq job cancel 12345'
         executor.killTaskCommand(['12345','12']).join(' ') == 'hq job cancel 12345,12'
-
     }
 
-    def "should validate headers"() {
+    def 'should validate headers' () {
 
         setup:
         def executor = new HyperQueueExecutor()
-
-        // mock process
         def proc = Mock(TaskProcessor)
-
-        // task object
         def task = new TaskRun()
         task.processor = proc
         task.workDir = Paths.get('/work/dir')
@@ -179,29 +116,28 @@ class HyperQueueExecutorTest extends Specification {
         task.config = new TaskConfig()
         then:
         executor.getHeaders(task) == '''
-                #HQ --name nf-task-1
-                #HQ --log /work/dir/.command.log
-                #HQ --cwd /work/dir
-                '''
-                .stripIndent().leftTrim()
-
+            #HQ --name nf-task-1
+            #HQ --log /work/dir/.command.log
+            #HQ --cwd /work/dir
+            '''
+            .stripIndent().leftTrim()
 
         when:
         task.config = new TaskConfig()
         task.config.cpus = 4
         task.config.time = '1m'
         task.config.memory = '8GB'
-        task.config.accelerator = [request: 1, limit: 2, type: 'nvida']
+        task.config.accelerator = [request: 1, limit: 2]
         then:
         executor.getHeaders(task) == '''
-                #HQ --name nf-task-1
-                #HQ --log /work/dir/.command.log
-                #HQ --cwd /work/dir
-                #HQ --resource mem=8589934592
-                #HQ --cpus 4
-                #HQ --time-limit 60sec
-                #HQ --resource gpus=2
-                '''
-                .stripIndent().leftTrim()
+            #HQ --name nf-task-1
+            #HQ --log /work/dir/.command.log
+            #HQ --cwd /work/dir
+            #HQ --resource mem=8589934592
+            #HQ --cpus 4
+            #HQ --time-limit 60sec
+            #HQ --resource gpus=2
+            '''
+            .stripIndent().leftTrim()
     }
 }


### PR DESCRIPTION
After doing some digging I found that hyperqueue does have a concept of "job state" vs task state, but it doesn't include the job state in the JSON output for `hq job list`. However, the quiet output mode simply returns the id and state of each job. Additionally, submitting a job with quiet output mode simply returns the job id or an error if the submit failed.

Therefore, I changed the executor to use quiet mode for submitting jobs and checking job status. The parsing logic is much simpler and should scale much better because the hq commands now return the minimum required information.