### PR TITLE
Charliecloud support v3

### DIFF
--- a/docs/container.rst
+++ b/docs/container.rst
@@ -21,7 +21,7 @@ suited for use in HPC environments. Its main advantage is that it can be used wi
 making use of user namespaces in the Linux kernel. Charliecloud is able to pull from Docker registries.
 
 .. note::
-    This feature requires Nextflow version ``21.03.0-edge`` or later and Charliecloud ``v0.22`` or later.
+    This feature requires Nextflow version ``21.03.0-edge`` or later.
 
 .. warning::
     This feature is experimental. Using it in a production environment is not recommended.
@@ -29,7 +29,7 @@ making use of user namespaces in the Linux kernel. Charliecloud is able to pull 
 Prerequisites
 -------------
 
-You will need Charliecloud version ``0.22`` or later installed on your execution environment e.g. your computer or a
+You will need Charliecloud version ``0.28`` or later installed on your execution environment e.g. your computer or a
 distributed cluster, depending on where you want to run your pipeline.
 
 How it works

--- a/docs/container.rst
+++ b/docs/container.rst
@@ -21,7 +21,8 @@ suited for use in HPC environments. Its main advantage is that it can be used wi
 making use of user namespaces in the Linux kernel. Charliecloud is able to pull from Docker registries.
 
 .. note::
-    This feature requires Nextflow version ``21.03.0-edge`` or later.
+    This feature requires at least Nextflow version ``21.03.0-edge`` and a Charliecloud version between ``v0.22`` and ``v0.27``.
+    As of Nextflow version ``22.09.0-edge``, Charliecloud ``v0.28`` or later is required.
 
 .. warning::
     This feature is experimental. Using it in a production environment is not recommended.
@@ -29,7 +30,7 @@ making use of user namespaces in the Linux kernel. Charliecloud is able to pull 
 Prerequisites
 -------------
 
-You will need Charliecloud version ``0.28`` or later installed on your execution environment e.g. your computer or a
+You will need Charliecloud installed in your execution environment e.g. on your computer or a
 distributed cluster, depending on where you want to run your pipeline.
 
 How it works

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -80,12 +80,13 @@ class CharliecloudCache {
     String simpleName(String imageUrl) {
         def p = imageUrl.indexOf('://')
         def name = p != -1 ? imageUrl.substring(p+3) : imageUrl
-        name = name.replace(':','-').replace('/','-')
+        name = name.replace(':','+').replace('/','%')
         return name
     }
 
     /**
-     * Create the specified directory if not exists
+     * Check if the specified directory exists and if it is valid
+     * Charliecloud should take care of creating it (and expects to have done so: https://hpc.github.io/charliecloud/faq.html#storage-directory-seems-invalid)
      *
      * @param
      *      str A path string representing a folder where to store the charliecloud containers once downloaded
@@ -95,16 +96,19 @@ class CharliecloudCache {
     @PackageScope
     Path checkDir(String str) {
         def result = Paths.get(str)
-        if( !result.exists() && !result.mkdirs() ) {
-            throw new IOException("Failed to create Charliecloud cache directory: $str -- Make sure a directory with the same does not exist and you have write permission")
+        if( !result.exists() ) {
+            log.info "Charliecloud cache directory: $str does not exist -- Charliecloud will attempt to initialize it at the specified location"
+        } 
+        else if( !result.resolve('img').exists() || !result.resolve('dlcache').exists() ) {
+            throw new IOException("Charliecloud cache directory exists but seems invalid: $str -- See https://hpc.github.io/charliecloud/faq.html#storage-directory-seems-invalid")
         }
         return result.toAbsolutePath()
     }
 
     /**
-     * Retrieve the directory where store the charliecloud images once downloaded.
-     * If tries these setting in the following order:
-     * 1) {@code charliecloud.cacheDir} setting in the nextflow config file;
+     * Retrieve the directory where to store the charliecloud images once downloaded.
+     * It tries these settings in the following order:
+     * 1) {@code charliecloud.cacheDir} setting in the nextflow config file
      * 2) the {@code NXF_CHARLIECLOUD_CACHEDIR} environment variable
      * 3) the {@code $workDir/charliecloud} path
      *
@@ -131,30 +135,29 @@ class CharliecloudCache {
 
         def workDir = Global.session.workDir
         if( workDir.fileSystem != FileSystems.default ) {
-            throw new IOException("Cannot store Charliecloud image to a remote work directory -- Use a POSIX compatible work directory or specify an alternative path with the `NXF_CHARLIECLOUD_CACHEDIR` env variable")
+            throw new IOException("Charliecloud cannot store image in a remote work directory -- Use a POSIX compatible work directory or specify an alternative path with the `NXF_CHARLIECLOUD_CACHEDIR` env variable")
         }
 
         missingCacheDir = true
         def result = workDir.resolve('charliecloud')
-        result.mkdirs()
 
         return result
     }
 
     /**
-     * Get the path on the file system where store a remote charliecloud image
+     * Get the path on the file system where a remote charliecloud image is stored at
      *
      * @param imageUrl The charliecloud remote URL
      * @return the container image local {@link Path}
      */
     @PackageScope
     Path localImagePath(String imageUrl) {
-        getCacheDir().resolve( simpleName(imageUrl) )
+        getCacheDir().resolve('img').resolve(simpleName(imageUrl))
     }
 
     /**
-     * Run ch-image to pull a remote image and store in the file system.
-     * Requires charliecloud 0.21 or later.
+     * Run ch-image to pull a remote image and store it in the file system.
+     * Requires charliecloud 0.28 or later.
      *
      * @param imageUrl The docker image remote URL
      * @return  the container image local {@link Path}
@@ -168,8 +171,8 @@ class CharliecloudCache {
             return localPath
         }
 
-        final file = new File("${localPath.parent}/.${localPath.name}.lock")
-        final wait = "Another Nextflow instance is pulling the Charliecloud image $imageUrl -- please wait until the download completes"
+        final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
+        final wait = "Another Nextflow instance is pulling the image $imageUrl with Charliecloud -- please wait until the download completes"
         final err =  "Unable to acquire exclusive lock after $pullTimeout on file: $file"
 
         final mutex = new FileMutex(target: file, timeout: pullTimeout, waitMessage: wait, errorMessage: err)
@@ -196,11 +199,11 @@ class CharliecloudCache {
         log.trace "Charliecloud pulling remote image `$imageUrl`"
 
         if( missingCacheDir )
-            log.warn1 "Charliecloud cache directory has not been defined -- Remote image will be stored in the path: $targetPath.parent -- Use env variable NXF_CHARLIECLOUD_CACHEDIR to specify a different location"
+            log.warn1 "Charliecloud cache directory has not been defined -- Remote image will be stored in the path: $targetPath.parent.parent -- Use the charliecloud.cacheDir config option or set the NXF_CHARLIECLOUD_CACHEDIR variable to specify a different location"
 
-        log.info "Pulling Charliecloud image $imageUrl [cache $targetPath]"
+        log.info "Charliecloud pulling image $imageUrl [cache $targetPath]"
 
-        String cmd = "ch-image pull $imageUrl $targetPath > /dev/null"
+        String cmd = "ch-image pull -s $targetPath.parent.parent $imageUrl > /dev/null"
         try {
             runCommand( cmd, targetPath )
             log.debug "Charliecloud pull complete image=$imageUrl path=$targetPath"
@@ -230,7 +233,7 @@ class CharliecloudCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Failed to pull charliecloud image\n  command: $cmd\n  status : $status\n  message:\n"
+            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }
@@ -282,7 +285,7 @@ class CharliecloudCache {
         if( promise.isError() )
             throw new IllegalStateException(promise.getError())
         if( !result )
-            throw new IllegalStateException("Cannot pull Charliecloud image `$url`")
+            throw new IllegalStateException("Charliecloud cannot pull image `$url`")
         log.trace "Charliecloud cache for `$url` path=$result"
         return result
     }

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -38,41 +38,34 @@ class CharliecloudBuilderTest extends Specification {
         expect:
         new CharliecloudBuilder('busybox')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .params(runOptions: '-j')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment -j -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" -j busybox --'
         
         new CharliecloudBuilder('busybox')
                 .params(temp: '/foo')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment -b /foo:/tmp -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b /foo:/tmp -b "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .addEnv('X=1')
                 .addEnv(ALPHA:'aaa', BETA: 'bbb')
                 .build()
-                .runCommand == 'ch-run --no-home -w busybox -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=busybox/ch/environment --set-env=<( echo "X=1" ) --set-env=<( echo "ALPHA="aaa"" ) --set-env=<( echo "BETA="bbb"" ) -b "$PWD":"$PWD" -c "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env --set-env=X=1 --set-env=ALPHA=aaa --set-env=BETA=bbb -b "$PWD" busybox --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b /foo/data/file1:/foo/data/file1 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
-
-        new CharliecloudBuilder('ubuntu')
-                .addMount(path1)
-                .addMount(path2)
-                .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b /foo/data/file1 -b "$PWD" ubuntu --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .addMount(path2)
-                .params(readOnlyInputs: true)
                 .build()
-                .runCommand == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p /foo/data/file1 /bar/data/file2 "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b /foo/data/file1:/foo/data/file1 -b /bar/data/file2:/bar/data/file2 -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b /foo/data/file1 -b /bar/data/file2 -b "$PWD" ubuntu --'
     }
 
     def 'should get run command' () {
@@ -80,17 +73,17 @@ class CharliecloudBuilderTest extends Specification {
         when:
         def cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand()
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b "$PWD":"$PWD" -c "$PWD" ubuntu --'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu --'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b "$PWD":"$PWD" -c "$PWD" ubuntu -- bwa --this --that file.fastq'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- bwa --this --that file.fastq'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --no-home -w ubuntu -- bash -c "mkdir -p "$PWD"";ch-run --no-home --unset-env="*" -w --set-env=ubuntu/ch/environment -b "$PWD":"$PWD" -c "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }
 
     @Unroll
@@ -104,9 +97,9 @@ class CharliecloudBuilderTest extends Specification {
 
         where:
         ENV                     | RESULT
-        'X=1'                   | '--set-env=<( echo "X=1" )'
-        'BAR'                   | '${BAR:+--set-env=<( echo "BAR="$BAR"" )}'
-        [VAR_X:1, VAR_Y:2]      | '--set-env=<( echo "VAR_X="1"" ) --set-env=<( echo "VAR_Y="2"" )'
-        [FOO: 'x', BAR: 'y']    | '--set-env=<( echo "FOO="x"" ) --set-env=<( echo "BAR="y"" )'
+        'X=1'                   | '--set-env=X=1'
+        'BAR'                   | '${BAR:+--set-env=BAR=$BAR}'
+        [VAR_X:1, VAR_Y:2]      | '--set-env=VAR_X=1 --set-env=VAR_Y=2'
+        [FOO: 'x', BAR: 'y']    | '--set-env=FOO=x --set-env=BAR=y'
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
@@ -42,22 +42,24 @@ class CharliecloudCacheTest extends Specification {
 
         where:
         url                         | expected
-        'docker://foo/bar'          | 'foo-bar'
-        'docker://foo/bar:tag'      | 'foo-bar-tag'
-        'shub://hello/world'        | 'hello-world'
-        'ftp://hello/world'         | 'hello-world'
-        'foo:bar'                   | 'foo-bar'
+        'docker://foo/bar'          | 'foo%bar'
+        'docker://foo/bar:tag'      | 'foo%bar+tag'
+        'shub://hello/world'        | 'hello%world'
+        'ftp://hello/world'         | 'hello%world'
+        'foo:bar'                   | 'foo+bar'
     }
 
     def 'should return the cache dir from the config file' () {
 
         given:
         def dir = Files.createTempDirectory('test')
+        and:
+        def cacheDir = dir.resolve('nxf.ch')
 
         when:
-        def cache = new CharliecloudCache([cacheDir: "$dir"] as ContainerConfig)
+        def cache = new CharliecloudCache([cacheDir: "$cacheDir"] as ContainerConfig)
         then:
-        cache.getCacheDir() == dir
+        cache.getCacheDir() == cacheDir
 
         cleanup:
         dir.deleteDir()
@@ -67,24 +69,26 @@ class CharliecloudCacheTest extends Specification {
 
         given:
         def dir = Files.createTempDirectory('test')
+        and:
+        def cacheDir = dir.resolve('nxf.ch')
 
         when:
-        def cache = new CharliecloudCache(GroovyMock(ContainerConfig), [NXF_CHARLIECLOUD_CACHEDIR: "$dir"])
+        def cache = new CharliecloudCache(GroovyMock(ContainerConfig), [NXF_CHARLIECLOUD_CACHEDIR: "$cacheDir"])
         then:
-        cache.getCacheDir() == dir
+        cache.getCacheDir() == cacheDir
 
         cleanup:
         dir.deleteDir()
     }
-
 
     def 'should run ch-image pull command'() {
 
         given:
         def dir = Files.createTempDirectory('test')
         def IMAGE = 'busybox:latest'
-        def LOCAL = 'busybox-latest'
-        def TARGET_PATH = dir.resolve(LOCAL)
+        def LOCAL = 'img/busybox+latest'
+        def CACHE_PATH = dir.resolve('charliecloud')
+        def TARGET_PATH = CACHE_PATH.resolve(LOCAL)
         and:
         def cache = Spy(CharliecloudCache)
 
@@ -93,9 +97,9 @@ class CharliecloudCacheTest extends Specification {
         then:
         1 * cache.localImagePath(IMAGE) >> TARGET_PATH
         and:
-        1 * cache.runCommand("ch-image pull $IMAGE $TARGET_PATH > /dev/null", TARGET_PATH) >> 0
+        1 * cache.runCommand("ch-image pull -s $CACHE_PATH $IMAGE > /dev/null", TARGET_PATH) >> 0
         and:
-        TARGET_PATH.parent.exists()
+        CACHE_PATH.parent.exists()
         and:
         result == TARGET_PATH
 
@@ -103,25 +107,24 @@ class CharliecloudCacheTest extends Specification {
         dir.deleteDir()
     }
 
-
     def 'should return cached image'() {
 
         given:
         def dir = Files.createTempDirectory('test')
         def IMAGE = 'busybox:latest'
-        def LOCAL = 'busybox-latest'
-        def container = dir.resolve(LOCAL)
-        container.text = 'dummy'
+        def LOCAL = 'img/busybox+latest'
+        def CACHE_PATH = dir.resolve('charliecloud')
+        def TARGET_PATH = CACHE_PATH.resolve(LOCAL)
         and:
         def cache = Spy(CharliecloudCache)
 
         when:
         def result = cache.downloadCharliecloudImage(IMAGE)
         then:
-        1 * cache.localImagePath(IMAGE) >> container
+        1 * cache.localImagePath(IMAGE) >> TARGET_PATH
         0 * cache.runCommand(_) >> 0
         and:
-        result == dir.resolve(LOCAL)
+        result == TARGET_PATH
 
         cleanup:
         dir.deleteDir()
@@ -133,7 +136,7 @@ class CharliecloudCacheTest extends Specification {
 
         given:
         def IMAGE = 'busybox:latest'
-        def LOCAL = 'busybox-latest'
+        def LOCAL = 'busybox+latest'
         def dir = Paths.get('/test/path')
         def container = dir.resolve(LOCAL)
         and:

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
@@ -117,6 +117,7 @@ class CharliecloudCacheTest extends Specification {
         def TARGET_PATH = CACHE_PATH.resolve(LOCAL)
         and:
         def cache = Spy(CharliecloudCache)
+        TARGET_PATH.mkdirs()
 
         when:
         def result = cache.downloadCharliecloudImage(IMAGE)


### PR DESCRIPTION
As of Charliecloud `v0.28`, support in Nextflow stopped working because the expected CLI arguments for the pull command changed in that release. dd69f62c648cf1126225bbdf7e2e08004e8f4f94 addresses that, raising the required Charliecloud version to >=0.28.

Bonus:
Charliecloud has recently gained some nice additions and default settings. This allows for substantial cleanup of the code that
builds the bash wrapper, making some of my earlier workarounds obsolete. See 799e9c33235a1df8cae83fe769dc79b56cac890b for details.

