### PR TITLE
Alphabetize methods in Nextflow, Channel, Operator classes

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/ChannelEx.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/ChannelEx.groovy
@@ -43,35 +43,6 @@ import static nextflow.util.LoggerHelper.fmtType
 @CompileStatic
 class ChannelEx {
 
-//    static void set(ChannelOut source, Closure holder) {
-//        final names = CaptureProperties.capture(holder)
-//        if( names.size() > source.size() )
-//            throw new IllegalArgumentException("Operation `set` expects ${names.size()} channels but only ${source.size()} are provided")
-//
-//        for( int i=0; i<source.size(); i++ ) {
-//            final ch = source[i]
-//            final nm = names[i]
-//            NF.binding.setVariable(nm, ch)
-//        }
-//    }
-
-    static DataflowWriteChannel dump(final DataflowWriteChannel source, Closure closure = null) {
-        dump(source, Collections.emptyMap(), closure)
-    }
-
-    static DataflowWriteChannel dump(final DataflowWriteChannel source, Map opts, Closure closure = null) {
-        def op = new DumpOp(opts, closure)
-        if( op.isEnabled() ) {
-            op.setSource(source)
-            def target = op.apply()
-            NodeMarker.addOperatorNode('dump', source, target)
-            return target
-        }
-        else {
-            return source
-        }
-    }
-
     /**
      * Creates a channel emitting the entries in the collection to which is applied
      *
@@ -96,29 +67,21 @@ class ChannelEx {
         return CH.close0(source)
     }
 
-    /**
-     * INTERNAL ONLY API
-     * <p>
-     * Add the {@code update} method to an {@code Agent} so that it call implicitly
-     * the {@code Agent#updateValue} method
-     */
-    @CompileDynamic
-    static void update(Agent self, Closure message ) {
-        assert message != null
-
-        self.send {
-            message.call(it)
-            updateValue(it)
-        }
-
+    static DataflowWriteChannel dump(final DataflowWriteChannel source, Closure closure = null) {
+        dump(source, Collections.emptyMap(), closure)
     }
 
-    static private void checkContext(String method, Object operand) {
-        if( !NF.isDsl2() )
-            throw new MissingMethodException(method, operand.getClass())
-
-        if( operand instanceof ComponentDef && !ExecutionStack.withinWorkflow() )
-            throw new IllegalArgumentException("Process invocation are only allowed within a workflow context")
+    static DataflowWriteChannel dump(final DataflowWriteChannel source, Map opts, Closure closure = null) {
+        def op = new DumpOp(opts, closure)
+        if( op.isEnabled() ) {
+            op.setSource(source)
+            def target = op.apply()
+            NodeMarker.addOperatorNode('dump', source, target)
+            return target
+        }
+        else {
+            return source
+        }
     }
 
     /**
@@ -221,6 +184,31 @@ class ChannelEx {
         checkContext('and', left)
         checkContext('and', right)
         left.add(right)
+    }
+
+    static private void checkContext(String method, Object operand) {
+        if( !NF.isDsl2() )
+            throw new MissingMethodException(method, operand.getClass())
+
+        if( operand instanceof ComponentDef && !ExecutionStack.withinWorkflow() )
+            throw new IllegalArgumentException("Process invocation are only allowed within a workflow context")
+    }
+
+    /**
+     * INTERNAL ONLY API
+     * <p>
+     * Add the {@code update} method to an {@code Agent} so that it call implicitly
+     * the {@code Agent#updateValue} method
+     */
+    @CompileDynamic
+    static void update(Agent self, Closure message ) {
+        assert message != null
+
+        self.send {
+            message.call(it)
+            updateValue(it)
+        }
+
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -17,7 +17,7 @@
 
 package nextflow.processor
 
-import java.util.concurrent.ArrayBlockingQueue
+
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.Condition
@@ -135,8 +135,8 @@ class TaskPollingMonitor implements TaskMonitor {
         this.dumpInterval = (params.dumpInterval as Duration) ?: Duration.of('5min')
         this.capacity = (params.capacity ?: 0) as int
 
-        this.pendingQueue = new LinkedBlockingQueue()
-        this.runningQueue = capacity ? new ArrayBlockingQueue<TaskHandler>(capacity) : new LinkedBlockingQueue<TaskHandler>()
+        this.pendingQueue = new LinkedBlockingQueue<TaskHandler>()
+        this.runningQueue = new LinkedBlockingQueue<TaskHandler>()
     }
 
     static TaskPollingMonitor create( Session session, String name, int defQueueSize, Duration defPollInterval ) {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy
@@ -16,7 +16,7 @@
  */
 
 package nextflow.processor
-import java.util.concurrent.ArrayBlockingQueue
+
 
 import nextflow.Session
 import nextflow.util.Duration
@@ -43,7 +43,6 @@ class TaskPollingMonitorTest extends Specification {
         monitor.pollIntervalMillis == Duration.of('1h').toMillis()
         monitor.capacity == 11
         monitor.dumpInterval ==  Duration.of('3h')
-        monitor.runningQueue instanceof ArrayBlockingQueue
 
     }
 

--- a/plugins/nf-amazon/changelog.txt
+++ b/plugins/nf-amazon/changelog.txt
@@ -1,5 +1,8 @@
 nf-amazon changelog
 ===================
+1.10.1 - 15 Aug
+- Fix queueSize setting is not honoured by AWS Batch executor (again) #3117
+
 1.10.0 - 11 Aug
 - Improve S3 copy via xfer manager [02d2beae]
 - Add experimental fusion support [1854f1f2]

--- a/plugins/nf-amazon/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-amazon/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: nextflow.cloud.aws.AmazonPlugin
 Plugin-Id: nf-amazon
-Plugin-Version: 1.10.0
+Plugin-Version: 1.10.1
 Plugin-Provider: Seqera Labs
 Plugin-Requires: >=22.08.0-edge


### PR DESCRIPTION
Just rearranges methods in the "user-facing" classes to be alphabetical, makes them easier to inspect. Helper methods are placed immediately after their parent methods.