### PR TITLE
Re-enable Ignite plugin support

### DIFF
--- a/modules/nextflow/src/main/resources/META-INF/plugins-info.txt
+++ b/modules/nextflow/src/main/resources/META-INF/plugins-info.txt
@@ -6,3 +6,4 @@ nf-azure@0.13.4
 nf-tower@1.5.1
 nf-ga4gh@1.0.3
 nf-codecommit@0.1.2
+nf-ignite@1.2.3

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -400,6 +400,11 @@ class PluginsFacade implements PluginStateListener {
         if( executor == 'azurebatch' || workDir?.startsWith('az://') || bucketDir?.startsWith('az://') )
             plugins << defaultPlugins.getPlugin('nf-azure')
 
+        if( executor == 'ignite' || System.getProperty('nxf.node.daemon')=='true') {
+            plugins << defaultPlugins.getPlugin('nf-ignite')
+            plugins << defaultPlugins.getPlugin('nf-amazon')
+        }
+
         return plugins
     }
 


### PR DESCRIPTION
Hi,

as discussed and approved in the issue #2668 we would like be be able to use the nf-ignite plugin with current Nextflow builds.

These changes are the bare minimum to be able to start an Ignite daemon node via `nextflow node`

Kind regards
Lukas