### PR TITLE
small typo in ConfigBuilder.groovy

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -734,7 +734,7 @@ class ConfigBuilder {
         }
 
         if( !hasContainerDirective(config.process) )
-            throw new AbortOperationException("You have requested to run with ${engine.capitalize()} but no image were specified")
+            throw new AbortOperationException("You have requested to run with ${engine.capitalize()} but no image was specified")
 
     }
 


### PR DESCRIPTION
this is a tiny typo, but its particular location led to a bit of extra confusion for me as a new user learning nextflow. I was specifying containers in each process, and when adding the `-with-docker` flag, because this error said "...but no image *were* specified", i thought it was searching for multiple (like i wanted), ha

Saying "...but no image *was* specified" i think will help anyone in a similar scenario realize more quickly that these particular options are looking for one container for the whole run :)

Signed-off-by: Mike Lee <michael.lee0517@gmail.com>