### PR TITLE
bugfix: s3outputstream exception when session is closing

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -686,6 +686,10 @@ class Session implements ISession {
         }
     }
 
+    final boolean isShutdownInitiated(){
+        shutdownInitiated
+    }
+
     final protected void shutdown0() {
         log.trace "Shutdown: $shutdownCallbacks"
         shutdownInitiated = true

--- a/plugins/nf-amazon/src/test/com/upplication/s3fs/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/com/upplication/s3fs/AwsS3NioTest.groovy
@@ -1156,4 +1156,21 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         local?.deleteDir()
         deleteBucket(bucketName)
     }
+
+    def 'should close executor after upload when no session' () {
+        given:
+        def bucketName = createBucket()
+        and:
+        final path = Paths.get(new URI("s3:///$bucketName/file.txt"))
+
+        when:
+        def writer = Files.newBufferedWriter(path, Charset.forName('UTF-8'))
+        (0..(11*1024)).each { writer.write(it) }
+        writer.close()
+        then:
+        existsPath(path)
+
+        cleanup:
+        deleteBucket(bucketName)
+    }
 }

--- a/plugins/nf-amazon/src/testResources/amazon.properties
+++ b/plugins/nf-amazon/src/testResources/amazon.properties
@@ -1,0 +1,2 @@
+# 5mb minimum by amazon
+upload_chunk_size=5000000


### PR DESCRIPTION
when uploading the report to S3 the session can be closed (or in progress) and an exception is fired

created a test to validate executor is closed after the upload

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>