### PR TITLE
Add before-afterScript warning regarding containers

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1283,8 +1283,7 @@ The ``afterScript`` directive allows you to execute a custom (Bash) snippet imme
 This may be useful to clean up your staging area.
 
 .. warning:: In combination with the :ref:`container directive <process-container>`, the ``afterScript`` will be 
-   executed outside the specified container. The ``afterScript`` is always executed in the environment running 
-   ``nextflow``.
+   executed outside the specified container. The ``afterScript`` is always executed in the host environment.
 
 
 .. _process-beforeScript:
@@ -1306,8 +1305,7 @@ For example::
     }
 
 .. warning:: In combination with the :ref:`container directive <process-container>`, the ``beforeScript`` will be 
-   executed outside the specified container. The ``beforeScript`` is always executed in the environment running 
-   ``nextflow``.
+   executed outside the specified container. The ``beforeScript`` is always executed in the host environment.
 
 
 .. _process-cache:

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1304,7 +1304,7 @@ For example::
       """
     }
 
-.. warning:: When combined with the :ref:`container directive <process-container>`, the ``beforeScript`` will be 
+.. note:: When combined with the :ref:`container directive <process-container>`, the ``beforeScript`` will be 
    executed outside the specified container. In other words, the ``beforeScript`` is always executed in the host environment.
 
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1282,8 +1282,8 @@ afterScript
 The ``afterScript`` directive allows you to execute a custom (Bash) snippet immediately *after* the main process has run.
 This may be useful to clean up your staging area.
 
-.. warning:: In combination with the :ref:`container directive <process-container>`, the ``afterScript`` will be 
-   executed outside the specified container. The ``afterScript`` is always executed in the host environment.
+.. warning:: When combined with the :ref:`container directive <process-container>`, the ``afterScript`` will be 
+   executed outside the specified container. In other words, the ``afterScript`` is always executed in the host environment.
 
 
 .. _process-beforeScript:

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1304,8 +1304,8 @@ For example::
       """
     }
 
-.. warning:: In combination with the :ref:`container directive <process-container>`, the ``beforeScript`` will be 
-   executed outside the specified container. The ``beforeScript`` is always executed in the host environment.
+.. warning:: When combined with the :ref:`container directive <process-container>`, the ``beforeScript`` will be 
+   executed outside the specified container. In other words, the ``beforeScript`` is always executed in the host environment.
 
 
 .. _process-cache:

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1282,6 +1282,10 @@ afterScript
 The ``afterScript`` directive allows you to execute a custom (Bash) snippet immediately *after* the main process has run.
 This may be useful to clean up your staging area.
 
+.. warning:: In combination with the :ref:`container directive <process-container>`, the ``afterScript`` will be 
+   executed outside the specified container. The ``afterScript`` is always executed in the environment running 
+   ``nextflow``.
+
 
 .. _process-beforeScript:
 
@@ -1300,6 +1304,10 @@ For example::
       echo bar
       """
     }
+
+.. warning:: In combination with the :ref:`container directive <process-container>`, the ``beforeScript`` will be 
+   executed outside the specified container. The ``beforeScript`` is always executed in the environment running 
+   ``nextflow``.
 
 
 .. _process-cache:

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1282,7 +1282,7 @@ afterScript
 The ``afterScript`` directive allows you to execute a custom (Bash) snippet immediately *after* the main process has run.
 This may be useful to clean up your staging area.
 
-.. warning:: When combined with the :ref:`container directive <process-container>`, the ``afterScript`` will be 
+.. note:: When combined with the :ref:`container directive <process-container>`, the ``afterScript`` will be 
    executed outside the specified container. In other words, the ``afterScript`` is always executed in the host environment.
 
 


### PR DESCRIPTION
before and afterScript directives are not executed inside the specified process container by design.

This behavior is not intuitive and will be fixed with `prolog` and `epilog` directives once implemented #540

Added a warning for the time being

Signed-off-by: Kirill Bulert <bulert@infai.org>