### PR TITLE
bugfix: intermediate multipart upload requires a minimum size

### DIFF
--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -158,7 +158,7 @@ public final class S3OutputStream extends OutputStream {
 
     private List<Tag> tags;
 
-    private AtomicInteger bufferCounter = new AtomicInteger();
+    private final AtomicInteger bufferCounter = new AtomicInteger();
 
     /**
      * Creates a new {@code S3OutputStream} that writes data directly into the S3 object with the given {@code objectId}.
@@ -276,7 +276,8 @@ public final class S3OutputStream extends OutputStream {
     private ByteBuffer allocate() {
 
         if( partsCount==0 ) {
-            return ByteBuffer.allocate(10 * 1024);
+            log.debug("Allocating new buffer of {} bytes, total buffers {}", request.getChunkSize(), bufferCounter.incrementAndGet());
+            return ByteBuffer.allocate(request.getChunkSize());
         }
 
         // try to reuse a buffer from the poll

--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3OutputStream.java
@@ -288,7 +288,7 @@ public final class S3OutputStream extends OutputStream {
         else {
             // allocate a new buffer
             log.debug("Allocating new buffer of {} bytes, total buffers {}", request.getChunkSize(), bufferCounter.incrementAndGet());
-            result = ByteBuffer.allocateDirect(request.getChunkSize());
+            result = ByteBuffer.allocate(request.getChunkSize());
         }
 
         return result;

--- a/plugins/nf-amazon/src/test/com/upplication/s3fs/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/com/upplication/s3fs/AwsS3NioTest.groovy
@@ -1177,4 +1177,23 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         cleanup:
         deleteBucket(bucketName)
     }
+
+    void "should upload a stream without flush"(){
+        given:
+        def bucketName = createBucket()
+        and:
+        def path = (S3Path) Paths.get(new URI("s3:///$bucketName/alpha.txt"))
+
+        when:
+        PrintWriter writer = new PrintWriter(Files.newBufferedWriter(path, Charset.defaultCharset()))
+        writer.println '*'*20
+        writer.println '*'*20
+        writer.close()
+
+        then:
+        Files.readString(Paths.get(new URI("s3:///$bucketName/alpha.txt"))).length() == 42 // 2*20 + 2 return lines
+
+        cleanup:
+        deleteBucket(bucketName)
+    }
 }

--- a/plugins/nf-amazon/src/test/com/upplication/s3fs/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/com/upplication/s3fs/AwsS3NioTest.groovy
@@ -1156,4 +1156,25 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         local?.deleteDir()
         deleteBucket(bucketName)
     }
+
+    void "should upload a stream with multiple flush"(){
+        given:
+        def bucketName = createBucket()
+        and:
+        def path = (S3Path) Paths.get(new URI("s3:///$bucketName/alpha.txt"))
+
+        when:
+        PrintWriter writer = new PrintWriter(Files.newBufferedWriter(path, Charset.defaultCharset()))
+        writer.println '*'*20
+        writer.flush()
+        writer.println '*'*20
+        writer.flush()
+        writer.close()
+
+        then:
+        Files.readString(Paths.get(new URI("s3:///$bucketName/alpha.txt"))).length() == 42 // 2*20 + 2 return lines
+
+        cleanup:
+        deleteBucket(bucketName)
+    }
 }


### PR DESCRIPTION
if after uploading a few bytes the flush is called, a new multipart is added to the queue but the minimum size required from AWS is 1Mb. 
No error is thrown until the end when completeMultiPart is called 

This PR maintains the current buffer as "active" if flush is calling and buffer length is under minimum