### PR TITLE
Apply GCP resourceLabels to the VirtualMachine

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
@@ -197,7 +197,7 @@ class GoogleLifeSciencesHelper {
                 .setDisks([disk])
                 .setServiceAccount(serviceAccount)
                 .setPreemptible(req.preemptible)
-                .setLabels(req.resourcesLabels)
+                .setLabels(req.resourceLabels)
 
         def network = new Network()
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
@@ -197,6 +197,7 @@ class GoogleLifeSciencesHelper {
                 .setDisks([disk])
                 .setServiceAccount(serviceAccount)
                 .setPreemptible(req.preemptible)
+                .setLabels(req.resourcesLabels)
 
         def network = new Network()
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
@@ -194,7 +194,8 @@ class GoogleLifeSciencesHelperTest extends GoogleSpecification {
                     network: 'net/123',
                     subnetwork: 'sub/192',
                     serviceAccountEmail: 'myaccount@developer.gserviceaccount.com',
-                    usePrivateAddress: true ))
+                    usePrivateAddress: true,
+                    resourceLabels: [foo:'bar'] ))
         then:
         with(resources3) {
             getVirtualMachine().getMachineType() == type
@@ -208,6 +209,7 @@ class GoogleLifeSciencesHelperTest extends GoogleSpecification {
             getVirtualMachine().getAccelerators()[0].getType()=='nvidia-tesla-k80'
             getVirtualMachine().getBootDiskSizeGb() == 75
             getVirtualMachine().getCpuPlatform() == 'Intel Skylake'
+            getVirtualMachine().getLabels() == [foo: 'bar']
             getVirtualMachine().getNetwork().getUsePrivateAddress()
             getVirtualMachine().getNetwork().getNetwork() == 'net/123'
             getVirtualMachine().getNetwork().getSubnetwork() == 'sub/192'


### PR DESCRIPTION
Apply GCP resourceLabels to the VirtualMachine to propagate into the VM's so that the labels can be used for things like GCP billing tracking etc.

Related to https://github.com/nextflow-io/nextflow/pull/2853#issuecomment-1255683926

Signed-off-by: Doug Daniels <daniels.douglas@gmail.com>