### PR TITLE
Update google batch mount point to address

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -40,7 +40,7 @@ import nextflow.util.PathTrie
 @CompileStatic
 class GoogleBatchScriptLauncher extends BashWrapperBuilder {
 
-    private static final String MOUNT_ROOT = '/mnt'
+    private static final String MOUNT_ROOT = '/mnt/disks'
 
     private CloudStoragePath remoteWorkDir
     private Path remoteBinDir


### PR DESCRIPTION
Fixes #3244

This PR addresses the change made by the Google Batch 
team to use the Container-Optimized OS. Mounts on that
system are only allowed below `/mnt/disks` per [this documentation](https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem#working_with_the_file_system).

Signed-off-by: Sean Davis <seandavi@gmail.com>

