### PR TITLE
Remove jobname truncation for hyperqueue executor 

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -129,9 +129,4 @@ class HyperQueueExecutor extends AbstractGridExecutor {
         return result
     }
 
-    @Override
-    protected String sanitizeJobName(String name) {
-        name.size() > 40 ? name.substring(0,40) : name
-    }
-
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
@@ -140,14 +140,4 @@ class HyperQueueExecutorTest extends Specification {
             '''
             .stripIndent().leftTrim()
     }
-
-    def 'should sanitize job name' () {
-        given:
-        def LONG = 'abcd' * 100
-        def exec = Spy(HyperQueueExecutor)
-
-        expect:
-        exec.sanitizeJobName('foo') == 'foo'
-        exec.sanitizeJobName(LONG) == LONG.substring(0,40)
-    }
 }


### PR DESCRIPTION
New version on hyperqueue no longer caps the jobname to 40, so this could be removed
to allow longer jobnames to be used. 

see  #3250