### PR TITLE
Add note about default mail ssl protocol [ci skip]

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -470,6 +470,15 @@ For example, the following snippet shows how to configure Nextflow to send email
         smtp.starttls.required = true
     }
 
+.. note::
+  Some versions of Java (e.g. Java 11 Corretto) do not default to TLS v1.2, and as a result may have
+  issues with 3rd party integrations that enforce TLS v1.2 (e.g. Azure Active Directory OIDC). This problem can be
+  addressed by setting the following config option::
+
+    mail {
+        smtp.ssl.protocols = 'TLSv1.2'
+    }
+
 
 .. _config-manifest:
 


### PR DESCRIPTION
This PR adds a note to the docs about the incompatibility between some Java versions and 3rd party integrations that require TLSv1.2. Motivated by a number of Tower users who had issues configuring their mail notifications.