### PR TITLE
Add nextflow info to be fetched by workflows.community website

### DIFF
--- a/docs/.wci.yml
+++ b/docs/.wci.yml
@@ -1,7 +1,7 @@
 ---
 # Metadata parsed by the workflow community initiative, https://workflows.community/systems
 # Registered at https://github.com/workflowscommunity/workflowscommunity.github.io/blob/main/_data/workflow_systems.yml
-name: nextflow
+name: Nextflow
 
 headline: A DSL for data-driven computational pipelines
 

--- a/docs/.wci.yml
+++ b/docs/.wci.yml
@@ -1,0 +1,57 @@
+---
+# Metadata parsed by the workflow community initiative, https://workflows.community/systems
+# Registered at https://github.com/workflowscommunity/workflowscommunity.github.io/blob/main/_data/workflow_systems.yml
+name: nextflow
+
+headline: A DSL for data-driven computational pipelines
+
+description: |
+  Nextflow is a bioinformatics workflow manager that enables the development of portable and reproducible workflows. It supports deploying workflows on a variety of execution platforms including local, HPC schedulers, AWS Batch, Google Cloud Life Sciences, and Kubernetes. Additionally, it provides support for manage your workflow dependencies through built-in support for Conda, Docker, Podmand, Singularity, and Modules.
+
+language: Groovy
+
+documentation:
+  general: http://docs.nextflow.io
+  installation: https://www.nextflow.io/docs/latest/getstarted.html
+  tutorial: https://training.seqera.io
+
+social:
+  twitter: nextflowio
+  youtube: https://www.youtube.com/c/Nextflow
+
+execution_environment:
+  interfaces:
+    - GitHub
+    - GitLab
+    - BitBucket
+  resource_managers:
+    - Slurm
+    - LSF
+    - PBS/Torque
+    - PBS Pro
+    - SGE
+    - Moab
+    - HTCondor
+    - Bridge
+    - HyperQueue
+    - GLS
+    - NQSII
+    - OAR
+    - Local
+    - AWS
+    - GCP
+    - Azure
+    - Kubernetes
+    - Docker
+    - Podman
+    - Singularity
+    - CharlieCloud
+  transfer_protocols:
+    - HTTP
+    - HTTPS
+    - FTP
+    - Amazon S3
+    - Google Storage
+    - Azure Storage
+    - git+https
+

--- a/docs/.wci.yml
+++ b/docs/.wci.yml
@@ -49,5 +49,5 @@ execution_environment:
     - Amazon S3
     - Google Storage
     - Azure Storage
-    - git+https
+    - Git+https
 

--- a/docs/.wci.yml
+++ b/docs/.wci.yml
@@ -49,5 +49,5 @@ execution_environment:
     - Amazon S3
     - Google Storage
     - Azure Storage
-    - Git+https
+    - Git+HTTPS
 

--- a/docs/.wci.yml
+++ b/docs/.wci.yml
@@ -42,10 +42,6 @@ execution_environment:
     - GCP
     - Azure
     - Kubernetes
-    - Docker
-    - Podman
-    - Singularity
-    - CharlieCloud
   transfer_protocols:
     - HTTP
     - HTTPS

--- a/docs/.wci.yml
+++ b/docs/.wci.yml
@@ -6,7 +6,7 @@ name: nextflow
 headline: A DSL for data-driven computational pipelines
 
 description: |
-  Nextflow is a bioinformatics workflow manager that enables the development of portable and reproducible workflows. It supports deploying workflows on a variety of execution platforms including local, HPC schedulers, AWS Batch, Google Cloud Life Sciences, and Kubernetes. Additionally, it provides support for manage your workflow dependencies through built-in support for Conda, Docker, Podmand, Singularity, and Modules.
+  Nextflow is an open-source workflow orchestrator that simplifies writing and deploying containerised data pipelines in a portable and scalable manner. It supports deploying workflows on a variety of execution platforms including local computers, HPC batch schedulers, Kubernetes and cloud platforms such as AWS, Azure and Google Cloud.
 
 language: Groovy
 


### PR DESCRIPTION
The https://workflows.community/systems/contribute website contains
information about numerous workflow managers. It gets some basic
information such as programming language, icon and headline from the
GitHub repository page of the workflow manager, but the developers
are free to add more details in a .wci.yml file that is fetched
every 12 hours by a GitHub Action of the workflow.community
project.

Signed-off-by: Marcel Ribeiro-Dantas <mribeirodantas@seqera.io>
