### PR TITLE
Undeprecate countBy operator

### DIFF
--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -1481,10 +1481,9 @@ reduce
 ------
 
 The ``reduce`` operator applies a function of your choosing to every item emitted by a channel.
-Each time this function is invoked it takes two parameters: firstly the `i-th` emitted item
-and secondly the result of the previous invocation of the function itself. The result is
-passed on to the next function call, along with the `i+1 th` item, until all the items are
-processed.
+Each time this function is invoked it takes two parameters: firstly the accumulated value and
+secondly the `i-th` emitted item. The result is passed as the accumulated value to the next
+function call, along with the `i+1 th` item, until all the items are processed.
 
 Finally, the ``reduce`` operator emits the result of the last invocation of your function
 as the sole output.
@@ -1504,14 +1503,9 @@ It prints the following output::
     a: 10 b: 5
     result = 15
 
-.. tip::
-  A common use case for this operator is to use the first paramter as an `accumulator`
-  the second parameter as the `i-th` item to be processed.
+Optionally you can specify an initial value for the accumulator as shown below::
 
-Optionally you can specify a `seed` value in order to initialise the accumulator parameter
-as shown below::
-
-    myChannel.reduce( seedValue ) {  a, b -> ... }
+    myChannel.reduce( initialValue ) {  a, b -> ... }
 
 
 .. _operator-separate:

--- a/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
@@ -546,7 +546,6 @@ class OperatorImpl {
      * @param source The source channel
      * @return A {@code DataflowVariable} returning the a {@code Map} containing the counting values for each key
      */
-    @Deprecated
     DataflowWriteChannel<Map> countBy(final DataflowReadChannel source ) {
         countBy(source, { it })
     }
@@ -558,7 +557,6 @@ class OperatorImpl {
      * @param criteria
      * @return
      */
-    @Deprecated
     DataflowWriteChannel<Map> countBy(final DataflowReadChannel source, final Closure criteria ) {
 
         final target = new DataflowVariable()


### PR DESCRIPTION
The countBy operator is deprecated for some reason, but I think it adds enough value that it's worth keeping.

With `reduce`:
```groovy
channel.of( 'x', 'y', 'x', 'x', 'z', 'y' )
    | reduce([:]) { counts, v ->
      counts[v] = (counts[v] ?: 0) + 1
      counts
    }
```

With `countBy`:
```groovy
channel.of( 'x', 'y', 'x', 'x', 'z', 'y' )
    | countBy
```