### PR TITLE
initialize the plugin once it's defined

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
@@ -153,6 +153,7 @@ class PluginExtensionProvider implements ExtensionProvider {
                 throw new IllegalStateException("Extension '$realName' it isn't defined by plugin ${pluginId}")
             }
         }
+        ext.checkInit((Session)Global.session)
         return instance = this
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
@@ -153,6 +153,7 @@ class PluginExtensionProvider implements ExtensionProvider {
                 throw new IllegalStateException("Extension '$realName' it isn't defined by plugin ${pluginId}")
             }
         }
+        // initialise the plugin session
         ext.checkInit((Session)Global.session)
         return instance = this
     }

--- a/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
@@ -17,6 +17,8 @@
 
 package nextflow.plugin.extension
 
+import nextflow.plugin.hello.HelloExtension
+
 import java.nio.file.Path
 
 import nextflow.Channel
@@ -221,6 +223,17 @@ class PluginExtensionMethodsTest extends Dsl2Spec {
         "include { sayHello } from 'plugin/nf-test-plugin-hello'; channel.of( sayHello('es') )" | 'hola'
         "include { sayHello as hi } from 'plugin/nf-test-plugin-hello'; channel.of( hi() )"     | 'hi'
 
+    }
+
+    def 'should call init plugin in custom functions'() {
+        when:
+        def result = dsl_eval("""
+            include { sayHello } from 'plugin/nf-test-plugin-hello' 
+            sayHello()
+        """)
+
+        then:
+        true
     }
 
     def 'should throw function not found'() {

--- a/modules/nf-commons/src/testFixtures/groovy/nextflow/plugin/hello/HelloExtension.groovy
+++ b/modules/nf-commons/src/testFixtures/groovy/nextflow/plugin/hello/HelloExtension.groovy
@@ -40,6 +40,11 @@ import nextflow.plugin.extension.PluginExtensionPoint
 class HelloExtension extends PluginExtensionPoint {
 
     /*
+    * Flag to check if init was called
+     */
+    boolean initialized = false
+
+    /*
      * A session hold information about current execution of the script
      */
     private Session session
@@ -51,6 +56,7 @@ class HelloExtension extends PluginExtensionPoint {
     @Override
     protected void init(Session session) {
         this.session = session
+        this.initialized = true
     }
 
     /*
@@ -133,6 +139,7 @@ class HelloExtension extends PluginExtensionPoint {
      */
     @Function
     String sayHello(String lang='en'){
+        assert initialized, "PluginExtension was not initilized"
         // sayHello is the entrypoint where we can write all the logic or delegate to other classes, ...
         return functions.sayHello(lang)
     }


### PR DESCRIPTION
Currently, nextflow is calling the `init` method of the plugin in the first call of the Operator

This PR initializes the plugin once it's defined 

closes #3348 