### PR TITLE
Improve default value in cli help of `nextflow log -s`

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
@@ -52,7 +52,7 @@ class CliOptions {
     /**
      * the packages to trace
      */
-    @Parameter(names='-trace', description = 'Add processes execution tracing to log')
+    @Parameter(names='-trace', description = 'Enable trace level logging for the specified package name - multiple packages can be provided separating them with a comma e.g. \'-trace nextflow,io.seqera\'')
     List<String> trace
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
@@ -52,7 +52,7 @@ class CliOptions {
     /**
      * the packages to trace
      */
-    @Parameter(names='-trace', hidden = true)
+    @Parameter(names='-trace', description = 'Add processes execution tracing to log')
     List<String> trace
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLog.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLog.groovy
@@ -61,7 +61,7 @@ class CmdLog extends CmdBase implements CacheBase {
     static final public NAME = 'log'
 
     @Parameter(names = ['-s'], description='Character used to separate column values')
-    String sep = '\t'
+    String sep = 'TAB'
 
     @Parameter(names=['-f','-fields'], description = 'Comma separated list of fields to include in the printed log -- Use the `-l` option to show the list of available fields')
     String fields

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLog.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLog.groovy
@@ -61,7 +61,7 @@ class CmdLog extends CmdBase implements CacheBase {
     static final public NAME = 'log'
 
     @Parameter(names = ['-s'], description='Character used to separate column values')
-    String sep = 'TAB'
+    String sep = '\\t'
 
     @Parameter(names=['-f','-fields'], description = 'Comma separated list of fields to include in the printed log -- Use the `-l` option to show the list of available fields')
     String fields


### PR DESCRIPTION
I'm not sure TAB is the best, but we definitely have to think of something
better than \t, that shows up as blank space in the CLI help.

To make it more clear what I mean:

<img width="338" alt="Screenshot 2022-11-10 at 11 27 02" src="https://user-images.githubusercontent.com/1023197/201117631-a4d7b56b-b96a-4f4f-b834-7b67e8f7f2bb.png">
