### PR TITLE
use groovy stripIndent instead java version

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/util/GsBashLib.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/util/GsBashLib.groovy
@@ -54,7 +54,7 @@ class GsBashLib extends BashFunLib<GsBashLib> {
     }
 
     protected makeLib() {
-        def ret = '''
+        '''
         nxf_gs_download() {
             local source=$1
             local target=$2

--- a/plugins/nf-google/src/main/nextflow/cloud/google/util/GsBashLib.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/util/GsBashLib.groovy
@@ -54,7 +54,7 @@ class GsBashLib extends BashFunLib<GsBashLib> {
     }
 
     protected makeLib() {
-        '''
+        def ret = '''
         nxf_gs_download() {
             local source=$1
             local target=$2
@@ -84,7 +84,8 @@ class GsBashLib extends BashFunLib<GsBashLib> {
             local target=$2
             gsutil ${gs_opts[@]} cp -R "$name" "$target/$name"
         }
-        '''.stripIndent()
+        '''
+        "$ret".stripIndent()
     }
 
     @Override

--- a/plugins/nf-google/src/main/nextflow/cloud/google/util/GsBashLib.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/util/GsBashLib.groovy
@@ -84,8 +84,7 @@ class GsBashLib extends BashFunLib<GsBashLib> {
             local target=$2
             gsutil ${gs_opts[@]} cp -R "$name" "$target/$name"
         }
-        '''
-        "$ret".stripIndent()
+        '''.stripIndent(true)
     }
 
     @Override


### PR DESCRIPTION
it seems new versions of Java include their stripIndent implementation 
don't understand very well where is the problem but using GString force to use groovy version in all implementations

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>

closes #3375