### PR TITLE
Container cpu shares

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerBuilder.groovy
@@ -59,7 +59,7 @@ abstract class ContainerBuilder<V extends ContainerBuilder> {
 
     protected List<String> engineOptions = []
 
-    protected Float cpus
+    protected Integer cpus
 
     protected String cpuset
 
@@ -94,7 +94,7 @@ abstract class ContainerBuilder<V extends ContainerBuilder> {
         return (V)this
     }
 
-    V setCpus(Float value) {
+    V setCpus(Integer value) {
         this.cpus = value
         return (V)this
     }

--- a/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy
@@ -120,7 +120,7 @@ class DockerBuilder extends ContainerBuilder<DockerBuilder> {
         result << 'run -i '
 
         if( cpus && !legacy )
-            result << "--cpus ${String.format(Locale.ROOT, "%.1f", cpus)} "
+            result << "--cpu-shares ${cpus * 1024} "
 
         if( cpuset ) {
             if( legacy )

--- a/modules/nextflow/src/main/groovy/nextflow/container/PodmanBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/PodmanBuilder.groovy
@@ -115,7 +115,7 @@ class PodmanBuilder extends ContainerBuilder<PodmanBuilder> {
             result << '--privileged '
 
         if( cpus ) {
-            result << "--cpus ${String.format(Locale.ROOT, "%.1f", cpus)} "
+            result << "--cpu-shares ${cpus * 1024} "
         }
 
         if( memory ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -62,7 +62,7 @@ class TaskBean implements Serializable, Cloneable {
 
     String containerCpuset
 
-    Float containerCpus
+    Integer containerCpus
 
     MemoryUnit containerMemory
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
@@ -140,18 +140,18 @@ class DockerBuilderTest extends Specification {
         new DockerBuilder('fedora')
                 .setCpus(2)
                 .build()
-                .runCommand == 'docker run -i --cpus 2.0 -v "$PWD":"$PWD" -w "$PWD" fedora'
+                .runCommand == 'docker run -i --cpu-shares 2048 -v "$PWD":"$PWD" -w "$PWD" fedora'
 
         new DockerBuilder('fedora')
-                .setCpus(1.414)
+                .setCpus(1)
                 .build()
-                .runCommand == 'docker run -i --cpus 1.4 -v "$PWD":"$PWD" -w "$PWD" fedora'
+                .runCommand == 'docker run -i --cpu-shares 1024 -v "$PWD":"$PWD" -w "$PWD" fedora'
 
         new DockerBuilder('fedora')
-                .setCpus(2.5)
+                .setCpus(8)
                 .setCpuset('1,2')
                 .build()
-                .runCommand == 'docker run -i --cpus 2.5 --cpuset-cpus 1,2 -v "$PWD":"$PWD" -w "$PWD" fedora'
+                .runCommand == 'docker run -i --cpu-shares 8192 --cpuset-cpus 1,2 -v "$PWD":"$PWD" -w "$PWD" fedora'
 
         new DockerBuilder('fedora')
                 .params(legacy: true)

--- a/modules/nextflow/src/test/groovy/nextflow/container/PodmanBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/PodmanBuilderTest.groovy
@@ -222,7 +222,7 @@ class PodmanBuilderTest extends Specification {
         new PodmanBuilder('fedora')
                 .setCpus(3)
                 .build()
-                .runCommand == 'podman run -i -v "$PWD":"$PWD" -w "$PWD" --cpus 3.0 fedora'
+                .runCommand == 'podman run -i -v "$PWD":"$PWD" -w "$PWD" --cpu-shares 3072 fedora'
 
         new PodmanBuilder('fedora')
                 .setMemory(new MemoryUnit('100m'))
@@ -230,10 +230,10 @@ class PodmanBuilderTest extends Specification {
                 .runCommand == 'podman run -i -v "$PWD":"$PWD" -w "$PWD" --memory 100m fedora'
 
         new PodmanBuilder('fedora')
-                .setCpus(1.414)
+                .setCpus(1)
                 .setMemory(new MemoryUnit('400m'))
                 .build()
-                .runCommand == 'podman run -i -v "$PWD":"$PWD" -w "$PWD" --cpus 1.4 --memory 400m fedora'
+                .runCommand == 'podman run -i -v "$PWD":"$PWD" -w "$PWD" --cpu-shares 1024 --memory 400m fedora'
 
     }
 }


### PR DESCRIPTION
This PR implements the use of cpu-shares for container CPUs allocation instead of Docker `--cpus` option. 

This allows better utilization of CPUs resources and makes consistent with the semantic of cpus request with other schedulers such as AWS Batch and Kuberneters. 

See also [here](https://www.batey.info/cgroup-cpu-shares-for-kubernetes.html) and #3338 