### PR TITLE
include all operators and functions from a plugin

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -101,3 +101,6 @@ In the same way as operators, functions can be aliased::
 
     include { reverseString as anotherReverseMethod } from 'plugin/my-plugin'
 
+As of version `22.11.0` you can include all operatos and functions a plugin exports using the '_' expression
+
+    include { _ } from 'plugin/my-plugin'

--- a/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
@@ -124,6 +124,21 @@ class PluginExtensionProvider implements ExtensionProvider {
         final definedFactories= getDeclaredFactoryExtensionMethods0(ext.getClass())
         // find all functions defined in the plugin
         final definedFunctions= getDeclaredFunctionsExtensionMethods0(ext.getClass())
+        if( includedNames.get('_')){
+            def mapOp = definedOperators.inject([:],{map, op->
+                map[op] = op
+                map
+            }) as Map<String,String>
+            def mapFact = definedFactories.inject([:],{map, op->
+                map[op] = op
+                map
+            }) as Map<String,String>
+            def mapFunc = definedFunctions.inject([:],{map, op->
+                map[op] = op
+                map
+            }) as Map<String,String>
+            includedNames = mapOp.deepMerge(mapFact.deepMerge(mapFunc))
+        }
         for( Map.Entry<String,String> entry : includedNames ) {
             String realName = entry.key
             String aliasName = entry.value

--- a/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
@@ -498,4 +498,21 @@ class PluginExtensionMethodsTest extends Dsl2Spec {
 
     }
 
+    def 'should allows to include all functions'() {
+        given:
+        def SCRIPT_TEXT= '''
+        nextflow.enable.strict = true
+                
+        include { _ } from 'plugin/nf-test-plugin-hello' 
+        
+        channel.of( sayHello() ).goodbye() 
+        '''
+
+        when:
+        def result = dsl_eval(SCRIPT_TEXT)
+
+        then:
+        result.val == 'hi'
+        result.val == Channel.STOP
+    }
 }


### PR DESCRIPTION
This PR implements a shortcut to include all functions and operators from a plugin 

I couldn't find the way to use the `*` character so I use `_` 

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>