### PR TITLE
Store error to `task.error`

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -968,6 +968,7 @@ class TaskProcessor {
         ErrorStrategy errorStrategy = TERMINATE
         final message = []
         try {
+            task.error = error
             // -- do not recoverable error, just re-throw it
             if( error instanceof Error ) throw error
 


### PR DESCRIPTION
`task.error` appears to be always null, even on retry. This PR gives users access to e.g. `task.error.message` to inform retry strategy.

Signed-off-by: Scott Gigante <84813314+scottgigante-immunai@users.noreply.github.com>

cc @pditommaso 