### PR TITLE
Ignore Exit status for Runnables in Google Batch

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -165,7 +165,8 @@ class GoogleBatchTaskHandler extends TaskHandler {
             .setComputeResource(computeResource)
             .addRunnables(
                 Runnable.newBuilder()
-                    .setContainer(container)
+                        .setContainer(container)
+                        .setIgnoreExitStatus(true)
             )
             .addAllVolumes( launcher.getVolumes() )
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -165,8 +165,8 @@ class GoogleBatchTaskHandler extends TaskHandler {
             .setComputeResource(computeResource)
             .addRunnables(
                 Runnable.newBuilder()
-                        .setContainer(container)
-                        .setIgnoreExitStatus(true)
+                    .setContainer(container)
+                    .setIgnoreExitStatus(true)
             )
             .addAllVolumes( launcher.getVolumes() )
 


### PR DESCRIPTION
Ignore Exit status for runnables allows Errors to be ignored when specified in the workflow

Signed-off-by: Hatem Nawar <hnawar@google.com>