### PR TITLE
fix bug with FluxExecutor jobs output

### DIFF
--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -103,6 +103,8 @@ Resource requests and other job characteristics can be controlled via the follow
 * :ref:`process-queue`
 * :ref:`process-time`
 
+Additionally, to have Flux print all output to stderr and stdout, add `flux.terminalOutput` to be true.
+
 .. note:: Flux does not support specifying memory. 
 
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/FluxExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/FluxExecutorTest.groovy
@@ -89,6 +89,12 @@ class FluxExecutorTest extends Specification {
         task.config.clusterOptions = '--tasks-per-node=4 --cpus-per-node=4'
         then:
         executor.getSubmitCommandLine(task, Paths.get('/some/path/job.sh')) == ['flux', 'mini', 'submit', '--setattr=cwd=/work/path', '--job-name="nf-my_task"', '--output=/work/path/.command.log', '--time-limit=60', '--tasks-per-node=4', '--cpus-per-node=4', '/bin/bash', 'job.sh']
+
+        when:
+        task.config = new TaskConfig()
+        task.config.flux = [terminalOutput: true]
+        then:
+        executor.getSubmitCommandLine(task, Paths.get('/some/path/job.sh')) == ['flux', 'mini', 'submit', '--setattr=cwd=/work/path', '--job-name="nf-my_task"', '/bin/bash', 'job.sh']
     }
 
     def testWorkDirWithBlanks() {
@@ -144,7 +150,7 @@ class FluxExecutorTest extends Specification {
         def executor = [:] as FluxExecutor
         then:
         usr
-        executor.queueStatusCommand(null) == ['flux', 'jobs', '--suppress-header', '--format="{id.f58} {status_abbrev}"', '--since="-15m"', '--user', usr]
-        executor.queueStatusCommand('xxx') == ['flux', 'jobs', '--suppress-header', '--format="{id.f58} {status_abbrev}"', '--since="-15m"', '--queue', 'xxx', '--user', usr]
+        executor.queueStatusCommand(null) == ['sh', '-c', "flux jobs --suppress-header --format=\"{id.f58} {status_abbrev}\" --since=\"-15m\" --user=" + usr]
+        executor.queueStatusCommand('xxx') == ['sh', '-c', "flux jobs --suppress-header --format=\"{id.f58} {status_abbrev}\" --since=\"-15m\" --queue=xxx --user=" + usr]
     }
 }


### PR DESCRIPTION
This pull request fixes one bug, and adds a new parameter to the FluxExecutor to support printing of output to stderr/stdout.

- Fixes https://github.com/nextflow-io/nextflow/issues/3419

## Jobs Listing Bug
Currently, for some reason the jobs listing is passing tests, but in testing with a workflow there is an error warning printed to the terminal as reported in https://github.com/nextflow-io/nextflow/issues/3419 The tweak suggested by Paolo there seems to fix the issue - I'm able to run the workflow from the terminal or web UI and I no longer see the warning.

## Output

We started a discussion in https://github.com/nextflow-io/nextflow/discussions/3421#discussioncomment-4204810 about how to enforce the process to print to stderr/stdout. I woke up and realized it was a "this is simple stupid" issue - we needed to add a parameter to the FluxExecutor that would say "please print all output to the terminal." This means the default will still print to the default log, which is expected behavior, but work workflows that use Flux within the RESTFul API I can give instruction for a profile like:

```
profiles {
    flux {
        process.conda = "$baseDir/conda.yml"
        process.executor = 'flux'
        process.terminal_output = true
    }

```

and that seems to fix the issue. And I don't think it's so nuts to require this custom setting for a Flux RESTFul API intended workflow - we typically need to build a custom container base anyway, and we can figure out a more dynamic way down the line (e.g., providing the argument via the running command perhaps) if this isn't desired. For each job that is created for us by nextflow we get the output in the UI if there is output.

![image](https://user-images.githubusercontent.com/814322/203311924-0d6a29ef-e8a0-445c-8752-fc4a46058a50.png)

This was totally empty before! So I'm very happy - I can click a job in the table and see what the heck it was doing.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>