### PR TITLE
allow collect method to be chaining

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
@@ -17,6 +17,8 @@
 
 package nextflow
 
+import nextflow.extension.OpCall
+
 import static nextflow.util.CheckHelper.*
 
 import java.nio.file.FileSystem
@@ -624,6 +626,23 @@ class Channel  {
     static private void fetchSraFiles0(SraExplorer explorer) {
         def future = CompletableFuture.runAsync ({ explorer.apply() } as Runnable)
         fromPath0Future = future.exceptionally(Channel.&handlerException)
+    }
+
+    /**
+     * Issue: https://github.com/nextflow-io/nextflow/issues/3378
+     * as GroovyDefault implements a `collect` method by default for the script the user is not able
+     * to use the collect operator when chaining methods (i.e. channel.of('a') | collect | view )
+     *
+     * importing this method as static via ScriptParser tells to the compiler to use it instead default method
+     *
+     * The return of the method needs to be undefined (def) to avoid errors in compile time
+     *
+     * @param args
+     * @return
+     */
+    static def collect( Closure args=null ){
+        final result = OpCall.create("collect", args)
+        return result
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
@@ -118,6 +118,7 @@ class ScriptParser {
         importCustomizer.addImports( ValueObject.name )
         importCustomizer.addImport( 'channel', Channel.name )
         importCustomizer.addStaticStars( Nextflow.name )
+        importCustomizer.addStaticImport( Channel.name, "collect")
 
         config = new CompilerConfiguration()
         config.addCompilationCustomizers( importCustomizer )

--- a/modules/nextflow/src/test/groovy/FunctionalTests.groovy
+++ b/modules/nextflow/src/test/groovy/FunctionalTests.groovy
@@ -744,4 +744,22 @@ class FunctionalTests extends Specification {
         def abort = thrown(AbortRunException)
         runner.session.fault.report ==~ /(?s).*-- Check script '(.*?)' at line: 10.*/
     }
+
+    /**
+     * test chaining collect method
+     */
+    def 'test collect' () {
+
+        setup:
+        def script = '''
+            nextflow.enable.dsl=2
+            Channel.of('a','b') | collect { it.toUpperCase() }
+            '''
+        when:
+        def runner = new TestScriptRunner( [:] )
+
+        then:
+        runner.setScript(script).execute().value == ['A', 'B']
+
+    }
 }

--- a/modules/nextflow/src/test/groovy/FunctionalTests.groovy
+++ b/modules/nextflow/src/test/groovy/FunctionalTests.groovy
@@ -744,22 +744,4 @@ class FunctionalTests extends Specification {
         def abort = thrown(AbortRunException)
         runner.session.fault.report ==~ /(?s).*-- Check script '(.*?)' at line: 10.*/
     }
-
-    /**
-     * test chaining collect method
-     */
-    def 'test collect' () {
-
-        setup:
-        def script = '''
-            nextflow.enable.dsl=2
-            Channel.of('a','b') | collect { it.toUpperCase() }
-            '''
-        when:
-        def runner = new TestScriptRunner( [:] )
-
-        then:
-        runner.setScript(script).execute().value == ['A', 'B']
-
-    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/extension/ChannelCollectOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/ChannelCollectOpTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020-2022, Seqera Labs
+ * Copyright 2013-2019, Centre for Genomic Regulation (CRG)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.extension
+
+import groovyx.gpars.dataflow.DataflowVariable
+import nextflow.Channel
+import nextflow.exception.ScriptCompilationException
+import org.junit.Rule
+import spock.lang.Ignore
+import test.Dsl2Spec
+import test.OutputCapture
+
+/**
+ *
+ * @author Jorge Aguilera <jorge.aguilera@seqera.io>
+ */
+class ChannelCollectOpTest extends Dsl2Spec  {
+
+    @Rule
+    OutputCapture capture = new OutputCapture()
+
+
+    /**
+     * test chaining collect method
+     */
+
+    def 'test collect' () {
+
+        when:
+        def result = dsl_eval'''            
+            Channel.of('a','b') | collect { it.toUpperCase() } | view
+            '''
+        then:
+        result.val == ['A', 'B']
+    }
+
+}


### PR DESCRIPTION
as GroovyDefault implements a `collect` method by default for the script the user is not able  to use the collect operator when chaining methods (i.e. channel.of('a') | collect | view )

 importing this method as static via ScriptParser tells the compiler to use it instead default method
