### PR TITLE
testing fix for config variables

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
@@ -63,7 +63,7 @@ class FluxExecutor extends AbstractGridExecutor {
         result << '--job-name="' + getJobNameFor(task) + '"'
 
         // Only write output to file if user doesn't want written entirely to terminal
-        Boolean terminalOutput = task.config.navigate('flux.terminalOutput') as Boolean
+        Boolean terminalOutput = session.config.navigate('flux.terminalOutput') as Boolean
         if ( !terminalOutput ) {
             result << '--output=' + quote(task.workDir.resolve(TaskRun.CMD_LOG))  // -o OUTFILE
         }


### PR DESCRIPTION
This is a tiny change to ensure that the flux.terminalOutput is correctly passed all the way from the config to the executor! For some reason with task.config, it's not there, likely because it's not known to the task to be parsed?

This was all @pditommaso thank you for the help! Once this is in we are good to go for Nextflow with Flux I think.

 - This will close #3429 

Here is the fixed workflow (before this said the job didn't produce output):

![image](https://user-images.githubusercontent.com/814322/203851244-786ddc7d-4921-491c-a4cb-4d1e990f4327.png)


Signed-off-by: vsoch <vsoch@users.noreply.github.com>