### PR TITLE
Add support for custom conda channels

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -66,6 +66,8 @@ class CondaCache {
 
     private Path configCacheDir0
 
+    private List<String> channels = Collections.emptyList()
+
     @PackageScope String getCreateOptions() { createOptions }
 
     @PackageScope Duration getCreateTimeout() { createTimeout }
@@ -73,6 +75,8 @@ class CondaCache {
     @PackageScope Map<String,String> getEnv() { System.getenv() }
 
     @PackageScope Path getConfigCacheDir0() { configCacheDir0 }
+
+    @PackageScope List<String> getChannels() { channels }
 
     @PackageScope String getBinaryName() {
         if (useMamba)
@@ -111,7 +115,9 @@ class CondaCache {
 
         if( config.useMicromamba )
             useMicromamba = config.useMicromamba as boolean
-        
+
+        if( config.getChannels() )
+            channels = config.getChannels()
     }
 
     /**
@@ -278,7 +284,8 @@ class CondaCache {
         }
 
         else {
-            cmd = "${binaryName} create ${opts}--yes --quiet --prefix ${Escape.path(prefixPath)} $condaEnv"
+            final channelsOpt = channels.collect(it -> "-c $it ").join('')
+            cmd = "${binaryName} create ${opts}--yes --quiet --prefix ${Escape.path(prefixPath)} ${channelsOpt}$condaEnv"
         }
 
         try {

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaConfig.groovy
@@ -20,7 +20,8 @@ package nextflow.conda
 import groovy.transform.CompileStatic
 
 /**
- *
+ * Model Conda configuration
+ * 
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @CompileStatic
@@ -41,5 +42,20 @@ class CondaConfig extends LinkedHashMap {
         if( enabled == null )
             enabled = env.get('NXF_CONDA_ENABLED')
         return enabled?.toString() == 'true'
+    }
+
+    List<String> getChannels() {
+        final value = get('channels')
+        if( !value ) {
+            return Collections.<String>emptyList()
+        }
+        if( value instanceof List ) {
+            return value
+        }
+        if( value instanceof CharSequence ) {
+            return value.tokenize(',').collect(it -> it.trim())
+        }
+
+        throw new IllegalArgumentException("Unexected conda.channels value: $value")
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -243,7 +243,7 @@ class CondaCacheTest extends Specification {
         result == PREFIX
     }
 
-def 'should create conda env with options - using mamba' () {
+    def 'should create conda env with options - using mamba' () {
         given:
         def ENV = 'bwa=1.1.1'
         def PREFIX = Paths.get('/foo/bar')
@@ -257,6 +257,23 @@ def 'should create conda env with options - using mamba' () {
         1 * cache.isTextFilePath(ENV)
         0 * cache.makeAbsolute(_)
         1 * cache.runCommand("mamba create --this --that --mkdir --yes --quiet --prefix $PREFIX $ENV") >> null
+        result == PREFIX
+    }
+
+    def 'should create conda env with channels' () {
+        given:
+        def ENV = 'bwa=1.1.1'
+        def PREFIX = Paths.get('/foo/bar')
+        and:
+        def cache = Spy(new CondaCache(new CondaConfig([channels:['bioconda','defaults']])))
+
+        when:
+        def result = cache.createLocalCondaEnv0(ENV, PREFIX)
+        then:
+        1 * cache.isYamlFilePath(ENV)
+        1 * cache.isTextFilePath(ENV)
+        0 * cache.makeAbsolute(_)
+        1 * cache.runCommand("conda create --mkdir --yes --quiet --prefix /foo/bar -c bioconda -c defaults bwa=1.1.1") >> null
         result == PREFIX
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaConfigTest.groovy
@@ -45,4 +45,23 @@ class CondaConfigTest extends Specification {
         true        | [enabled: true]   | [NXF_CONDA_ENABLED: true]
     }
 
+
+    @Unroll
+    def 'should check channels options'() {
+        given:
+        def conda = new CondaConfig(CONFIG, [:])
+        expect:
+        conda.getChannels() == EXPECTED
+
+        where:
+        EXPECTED                | CONFIG
+        []                      | [:]
+        ['bioconda']            | [channels:'bioconda']
+        ['bioconda']            | [channels:['bioconda']]
+        and:
+        ['this','that','other'] | [channels:'this,that,other']
+        ['this','that','other'] | [channels:'this, that ,other']
+        and:
+        ['this','that','other'] | [channels:['this','that','other']]
+    }
 }

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -57,7 +57,7 @@ class WaveClient {
 
     private static Logger log = LoggerFactory.getLogger(WaveClient)
 
-    private static final List<String> DEFAULT_CONDA_CHANNELS = ['defaults', 'conda-forge']
+    private static final List<String> DEFAULT_CONDA_CHANNELS = ['conda-forge','defaults']
 
     final private HttpClient httpClient
 

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -57,6 +57,8 @@ class WaveClient {
 
     private static Logger log = LoggerFactory.getLogger(WaveClient)
 
+    private static final List<String> DEFAULT_CONDA_CHANNELS = ['defaults', 'conda-forge']
+
     final private HttpClient httpClient
 
     final private WaveConfig config
@@ -79,12 +81,15 @@ class WaveClient {
 
     private CookieManager cookieManager
 
+    private List<String> condaChannels
+
     WaveClient(Session session) {
         this.session = session
         this.config = new WaveConfig(session.config.wave as Map ?: Collections.emptyMap(), SysEnv.get())
         this.fusion = new FusionConfig(session.config.fusion as Map ?: Collections.emptyMap(), SysEnv.get())
         this.tower = new TowerConfig(session.config.tower as Map ?: Collections.emptyMap(), SysEnv.get())
         this.endpoint = config.endpoint()
+        this.condaChannels = session.getCondaConfig()?.getChannels() ?: DEFAULT_CONDA_CHANNELS
         log.debug "Wave server endpoint: ${endpoint}"
         this.packer = new Packer()
         // create cache
@@ -400,10 +405,11 @@ class WaveClient {
     }
 
     protected String condaRecipeToDockerFile(String recipe) {
+        def channelsOpts = condaChannels.collect(it -> "-c $it").join(' ')
         def result = """\
         FROM ${config.condaOpts().mambaImage}
         RUN \\
-           micromamba install -y -n base -c defaults -c conda-forge \\
+           micromamba install -y -n base $channelsOpts \\
            $recipe \\
            && micromamba clean -a -y
         """.stripIndent()


### PR DESCRIPTION
This PR adds the support for custom conda channels.  

The channels can be specified in the nextflow config e.g. 

```
conda {
  channels = ['bioconda','defaults']
}
```

They are used when creating the Conda environment via punctual packages specified via the `conda` directive e.g. 

```
process foo {
  conda 'samtools'
} 
```
 
Note, custom channels are ignored when the `conda` directive specified a Conda recipe yaml file 


Signed-off-by: Paolo Di Tommaso <paolo.ditommaso@gmail.com>