### PR TITLE
At TowerArchiver resolve envar paths relative to baseDir

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerArchiver.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerArchiver.groovy
@@ -149,7 +149,7 @@ class TowerArchiver {
 
     protected void archiveFile(String name) {
         if( name )
-            archiveFile(Path.of(name).toAbsolutePath())
+            archiveFile(baseDir.resolve(name))
     }
 
     protected void archiveFile(Path source) {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerArchiver.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerArchiver.groovy
@@ -17,6 +17,8 @@
 
 package io.seqera.tower.plugin
 
+import nextflow.exception.AbortOperationException
+
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
 import java.time.temporal.ChronoUnit
@@ -130,26 +132,41 @@ class TowerArchiver {
     }
 
     void archiveLogs() {
-        archiveFile(env.get('NXF_OUT_FILE'))
-        archiveFile(env.get('NXF_LOG_FILE'))
-        archiveFile(env.get('NXF_TML_FILE'))
-        archiveFile(env.get('TOWER_CONFIG_FILE'))
-        archiveFile(env.get('TOWER_REPORTS_FILE'))
+        // Nextflow log file are expected to be found at the working directory
+        // when running from Tower launcher the cache command, if needed, has
+        // copied them before starting the archive process
+
+        final work = env.get('NXF_WORK') ?: env.get('NXF_TEST_WORK')
+        if( !work ) {
+            log.error("Missing target work dir - Tower archive cannot be performed")
+            return
+        }
+        if( !work.startsWith('/') ) {
+            log.error("Invalid NXF_WORK work directory - it must start with a slash character - offending value: '${work}'")
+            return
+        }
+
+        final base = Path.of(work)
+        archiveFile(base, env.get('NXF_OUT_FILE'))
+        archiveFile(base, env.get('NXF_LOG_FILE'))
+        archiveFile(base, env.get('NXF_TML_FILE'))
+        archiveFile(base, env.get('TOWER_CONFIG_FILE'))
+        archiveFile(base, env.get('TOWER_REPORTS_FILE'))
     }
 
     void archiveTaskLogs(String workDir) {
         final base = Path.of(workDir)
-        archiveFile(base.resolve('.command.out'))
-        archiveFile(base.resolve('.command.err'))
-        archiveFile(base.resolve('.command.log'))
-        archiveFile(base.resolve('.command.run'))
-        archiveFile(base.resolve('.command.sh'))
-        archiveFile(base.resolve('.exitcode'))
+        archiveFile(base, '.command.out')
+        archiveFile(base, '.command.err')
+        archiveFile(base, '.command.log')
+        archiveFile(base, '.command.run')
+        archiveFile(base, '.command.sh')
+        archiveFile(base, '.exitcode')
     }
 
-    protected void archiveFile(String name) {
+    protected void archiveFile(Path base, String name) {
         if( name )
-            archiveFile(baseDir.resolve(name))
+            archiveFile(base.resolve(name))
     }
 
     protected void archiveFile(Path source) {


### PR DESCRIPTION
## Description

When archiving files defined in an environment variable, we should assume that they are relative paths to `baseDir` no to the current working directory.

## Example

Given `NXF_ARCHIVE_DIR="/scratch,s3://fusionfs/archived"` when running a normal pipeline with Tower we have for example this variable `NXF_OUT_FILE=nf-3rvDYTUlUhJ1Ge.txt` that [here](http://github.com/nextflow-io/nextflow/blob/1ed2640a8bba0b43cdb69bb9fdfa5ed3308395bf/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerArchiver.groovy#L133-L133) it ends resolved to this absolute path `/3rvDYTUlUhJ1Ge.txt` because the launcher is running at `/` folder. But then [here](http://github.com/nextflow-io/nextflow/blob/1ed2640a8bba0b43cdb69bb9fdfa5ed3308395bf/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerArchiver.groovy#L125-L125) it is discarded because `baseDir` is `/scratch` (extracted from `NXF_ARCHIVE_DIR`). Notice that both files (`/3rvDYTUlUhJ1Ge.txt` and `/scratch/3rvDYTUlUhJ1Ge.txt`) exists because the [saveCacheFiles](http://github.com/nextflow-io/nextflow/blob/1ed2640a8bba0b43cdb69bb9fdfa5ed3308395bf/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy#L102-L102) has copied them.
