### PR TITLE
Add possible values of `status` in `trace.txt` to the documentation

### DIFF
--- a/docs/tracing.rst
+++ b/docs/tracing.rst
@@ -200,7 +200,7 @@ native_id               Task ID given by the underlying execution system e.g. PO
 process                 Nextflow process name.
 tag                     User provided identifier associated this task.
 name                    Task name.
-status                  Task status.
+status                  Task status. Possible values are: ``NEW``, ``SUBMITTED``, ``RUNNING``, ``COMPLETED``, ``FAILED`` and ``ABORTED``.
 exit                    POSIX process exit status.
 module                  Environment module used to run the task.
 container               Docker image name used to execute the task.


### PR DESCRIPTION
The information is helpful when parsing the file with some sort of script. Information taken from: https://github.com/nextflow-io/nextflow/blob/fa400d5f3b5a32ac30117b85cc107f9edfa75e8d/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy#L127-L139