### PR TITLE
add sentence on bash options

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -63,6 +63,18 @@ scripts with multiple commands spanning multiple lines. For example::
       """
     }
 
+By default, the script block is executed with the `bash options <https://tldp.org/LDP/abs/html/options.html>`_ ``set -ue``.
+The user can add custom options directly to the process definition, for example::
+
+    process doMoreThings {
+    shell = ['/bin/bash', '-euo', 'pipefail']
+      """
+      blastp -db $db -query query.fa -outfmt 6 > blast_result
+      cat blast_result | head -n 10 | cut -f 2 > top_hits
+      blastdbcmd -db $db -entry_batch top_hits > sequences
+      """
+    }
+
 As explained in the script tutorial section, strings can be defined using single-quotes
 or double-quotes, and multi-line strings are defined by three single-quote or three double-quote characters.
 


### PR DESCRIPTION
Signed-off-by: Alexander Toenges <21218078+ATpoint@users.noreply.github.com>

Add a sentence on how to provide custom bash/shell options such as `pipefail` to the process definition.