### PR TITLE
Quote the logName in the Cloud Logging filter

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/logging/BatchLogging.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/logging/BatchLogging.groovy
@@ -63,7 +63,7 @@ class BatchLogging {
     @PackageScope List<String> fetchLogs(String uid) {
         try(Logging logging = opts.getService()) {
             // use logging here
-            final filter = "resource.type=generic_task AND logName=projects/${projectId}/logs/batch_task_logs AND labels.job_uid=$uid"
+            final filter = "resource.type=generic_task AND logName=\"projects/${projectId}/logs/batch_task_logs\" AND labels.job_uid=$uid"
             final entries = logging.listLogEntries(
                     Logging.EntryListOption.filter(filter),
                     Logging.EntryListOption.pageSize(1000) )


### PR DESCRIPTION
Quoting will allow special characters, in particular ":", to be parsed. This should prevent the unparseable filter exception in https://github.com/nextflow-io/nextflow/issues/3353.

Signed-off-by: Aaron Golden <aegolden@google.com>