### PR TITLE
Use workDir/tmp for collectFile output caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ temp
 plugins-prod
 sandbox
 wave-tests
+modules/*/bin
+plugins/*/bin

--- a/modules/nextflow/src/main/groovy/nextflow/extension/CollectFileOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/CollectFileOp.groovy
@@ -93,6 +93,7 @@ class CollectFileOp {
         // caching params
         collector.resumable = Global.session.resumeMode
         collector.cacheable = Global.session.cacheable && ( params?.cache?.toString() != 'false' )
+        collector.cacheBase = Global.session.workDir.resolve("tmp")
         collector.hashMode = HashMode.of(params?.cache) ?: HashMode.of(Global.session.config?.process?.cache) ?: HashMode.DEFAULT()
         collector.hashKeys = [
                 Global.session.uniqueId,


### PR DESCRIPTION
If we use ephemeral storage in $NXF_TEMP for caching the collectFile outputs, then the caching will always fail if the run is resumed on a new machine, or if the tmp directory is cleaned between runs.