### PR TITLE
Add readOnlyInputs option for CharliecloudBuilder

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -25,6 +25,7 @@ import groovy.util.logging.Slf4j
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
+ * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
  */
 @CompileStatic
 @Slf4j

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -171,7 +171,8 @@ class CharliecloudCache {
             return localPath
         }
 
-        final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
+        // final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
+        final file = new File("${localPath.parent.parent.parent}/.ch-pulling.lock")
         final wait = "Another Nextflow instance is pulling the image $imageUrl with Charliecloud -- please wait until the download completes"
         final err =  "Unable to acquire exclusive lock after $pullTimeout on file: $file"
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -26,6 +26,7 @@ import spock.lang.Unroll
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
+ * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
  */
 class CharliecloudBuilderTest extends Specification {
 
@@ -82,6 +83,16 @@ class CharliecloudBuilderTest extends Specification {
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:true).build().getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:false).build().getRunCommand('bwa --this --that file.fastq')
         then:
         cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }


### PR DESCRIPTION
This merge request is to add the `readOnlyInputs` option as discussed in the  **Charliecloud and shared cacheDir** #3367 issue.

With this modification:

- the default `readOnlyInputs` value is `false`
- if `readOnlyInputs` is `true`;
- the `-w` option is removed from the command
- the bound volumes are transformed to only mount the first folder of the path

For example, if I try to bind `/home/user/workdir/` to `/home/` the bound path will be `/home` to `/home`. By doing that, charliecloud doesn't try to `mkdir -p /home/user/workdir/` within the read-only container, the external path is bound at the `/home` directory level so all the subfolders are accessible with the user rights. If one tries to bind `/` I added an expection.

ps: Sorry for the code style, it's my first time coding in groovy

Signed-off-by: Laurent Modolo <laurent.modolo@ens-lyon.fr>