### PR TITLE
Update .gitignore to include vscode dot dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .nextflow*
 .node-nextflow*
 .devcontainer
+.vscode/*
 **/build/**
 build/**
 modules/**/build/


### PR DESCRIPTION
@pditommaso I know this is a bit silly, but it is quite useful to ignore the .vscode directories that get created by MS Visual Studio Code .. for those who use it for development purposes.

Signed-off-by: Marco De La Pierre <marco.delapierre@gmail.com>