### PR TITLE
Don't set realtime to `complete - start` by default

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -191,12 +191,6 @@ abstract class TaskHandler {
                 // elapsed time since submit until completion
                 if( submitTimeMillis )
                     record.duration = completeTimeMillis - submitTimeMillis
-                // elapsed time since start of the job until completion
-                // note: this may be override run time provided by the trace file (3rd line)
-                if( startTimeMillis ) {
-                    record.realtime = completeTimeMillis - startTimeMillis
-                    log.trace "task stats: ${task.name}; start: ${startTimeMillis}; complete: ${completeTimeMillis}; realtime: ${completeTimeMillis - startTimeMillis} [${record.realtime}]; "
-                }
             }
 
             def file = task.workDir?.resolve(TaskRun.CMD_TRACE)


### PR DESCRIPTION
The `realtime` trace metric is the runtime of the `.command.sh` script, and it is measured by the command wrapper. However, it is initially set to `complete - start`, presumably as a backup in case the `.command.trace` file can't be recovered.

This is a bad practice from a data science perspective, because then you don't know whether `realtime` is including extra things like staging time (consider the benchmarks we are running right now). Instead, Nextflow should leave `realtime` blank if it can't recover the trace file, and let the user decide how to deal with missing values. The user may choose to impute or ignore the missing values, or just use `complete - start` for consistency, but it should be their choice.