### PR TITLE
Update source comments related to overwrite in trace/report [ci skip]

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
@@ -71,7 +71,7 @@ class ReportObserver implements TraceObserver {
     private ResourcesAggregator aggregator
 
     /**
-     * Overwrite existing trace file instead of rolling it
+     * Overwrite existing trace file (required in some cases, as rolling filename has been deprecated)
      */
     boolean overwrite
 

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
@@ -70,7 +70,7 @@ class TraceFileObserver implements TraceObserver {
     String separator = '\t'
 
     /**
-     * Overwrite existing trace file instead of rolling it
+     * Overwrite existing trace file (required in some cases, as rolling filename has been deprecated)
      */
     boolean overwrite
 


### PR DESCRIPTION
Filename rolling has been deprecated, but comments in the source code were out of date. This PR fixes it.

Ref: https://github.com/nextflow-io/nextflow/issues/3186
