### PR TITLE
add support for AWS_SESSION_TOKEN

### DIFF
--- a/modules/nf-commons/src/main/nextflow/Global.groovy
+++ b/modules/nf-commons/src/main/nextflow/Global.groovy
@@ -98,6 +98,7 @@ class Global {
 
         String a
         String b
+        String c
 
         if( config && config.aws instanceof Map ) {
             a = ((Map)config.aws).accessKey
@@ -112,13 +113,14 @@ class Global {
 
         // as define by amazon doc
         // http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
-        if( env && (a=env.AWS_ACCESS_KEY_ID) && (b=env.AWS_SECRET_ACCESS_KEY) )  {
-            log.debug "Using AWS credentials defined by environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
-            return [a, b]
-        }
+        // supports AWS_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY, and AWS_SESSION_TOKEN
+        if( env && (a=(env.AWS_ACCESS_KEY_ID ?: env.AWS_ACCESS_KEY)) && (b=(env.AWS_SECRET_ACCESS_KEY ?: env.AWS_SECRET_KEY)) )  {
+            if ( env && (c=env.AWS_SESSION_TOKEN) ) {
+                log.debug "Using AWS credentials defined by environment variables AWS_ACCESS_KEY(_ID)?, AWS_SECRET(_ACCESS)?_KEY and AWS_SESSION_TOKEN"
+                return [a, b, c]
+            }
 
-        if( env && (a=env.AWS_ACCESS_KEY) && (b=env.AWS_SECRET_KEY) ) {
-            log.debug "Using AWS credentials defined by environment variables AWS_ACCESS_KEY and AWS_SECRET_KEY"
+            log.debug "Using AWS credentials defined by environment variables AWS_ACCESS_KEY(_ID)? and AWS_SECRET(_ACCESS)?_KEY"
             return [a, b]
         }
 

--- a/modules/nf-commons/src/test/nextflow/GlobalTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/GlobalTest.groovy
@@ -38,6 +38,7 @@ class GlobalTest extends Specification {
         Global.getAwsCredentials0([AWS_ACCESS_KEY: 'x', AWS_SECRET_KEY: '222'], null) == ['x','222']
         Global.getAwsCredentials0([AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999'], null) == ['q','999']
         Global.getAwsCredentials0([AWS_ACCESS_KEY: 'x', AWS_SECRET_KEY: '222',  AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999'], null) == ['q','999']
+        Global.getAwsCredentials0([AWS_ACCESS_KEY_ID: 'x', AWS_SECRET_ACCESS_KEY: '222',  AWS_SESSION_TOKEN: 'foobar',], null) == ['x','222', 'foobar']
 
         Global.getAwsCredentials0([AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999'], [aws:[accessKey: 'b', secretKey: '333']]) == ['b','333']
         Global.getAwsCredentials0(null, [aws:[accessKey: 'b', secretKey: '333']]) == ['b','333']


### PR DESCRIPTION
There's a few issues floating around about this:
- https://github.com/nextflow-io/nextflow/issues/1724
- https://github.com/nextflow-io/nextflow/issues/2839
- https://github.com/nextflow-io/nextflow/pull/1265

Figured I'd take a stab at implementing. Wrote a test, but also ran locally and verified that the session token actually works.

I did combine the `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` and `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` creds cases. Sure, technically, it means someone could supply an invalid config and it might work. But also, it unifies the session token logic.

I didn't add this to the config options, because who's putting an ephemeral token in their nextflow config??

Truthfully, I believe we're on the wrong path, and that we should just let the AWS Java SDK resolve credentials. It is opinionated in how it resolves credentials. If we delegated, we wouldn't have to account for every weird possible way of specifying aws creds. Perhaps there's a good reason not to though.

Anyway, let me know what you think. I'd love to have this in.