### PR TITLE
Implements commons config for AWS S3 client

### DIFF
--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -595,13 +595,17 @@ class FileHelper {
     /**
      * Acquire or create the file system for the given {@link URI}
      *
-     * @param uri A {@link URI} locating a file into a file system
-     * @param env An option environment specification that may be used to instantiate the underlying file system.
-     *          As defined by {@link FileSystemProvider#newFileSystem(java.net.URI, java.util.Map)}
-     * @return The corresponding {@link FileSystem} object
-     * @throws IllegalArgumentException if does not exist a valid provider for the given URI scheme
+     * @param uri
+     *      A {@link URI} locating a file into a file system
+     * @param config
+     *      A {@link Map} object representing the file system configuration. The structure of this object is entirely
+     *      delegate to the file system implementation
+     * @return
+     *      The corresponding {@link FileSystem} object
+     * @throws
+     *      IllegalArgumentException if does not exist a valid provider for the given URI scheme
      */
-    static FileSystem getOrCreateFileSystemFor( URI uri, Map env = null ) {
+    static FileSystem getOrCreateFileSystemFor( URI uri, Map config = null ) {
         assert uri
 
         /*
@@ -629,7 +633,7 @@ class FileHelper {
             catch( FileSystemNotFoundException e ) { fs=null }
             if( !fs ) {
                 log.debug "Creating a file system instance for provider: ${provider.class.simpleName}"
-                fs = provider.newFileSystem(uri, env ?: envFor(uri.scheme))
+                fs = provider.newFileSystem(uri, config!=null ? config : envFor(uri.scheme))
             }
             fs
         }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy
@@ -27,6 +27,7 @@ import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 import com.amazonaws.regions.InstanceMetadataRegionProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.regions.RegionUtils
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.batch.AWSBatch
 import com.amazonaws.services.batch.AWSBatchClient
 import com.amazonaws.services.batch.AWSBatchClientBuilder
@@ -104,9 +105,7 @@ class AmazonClientFactory {
             throw new AbortOperationException("Missing AWS security credentials -- Provide access/security keys pair or define an IAM instance profile (suggested)")
 
         // -- get the aws default region
-        region = config.region ?: fetchRegion()
-        if( !region )
-            throw new AbortOperationException('Missing AWS region -- Make sure to define in your system environment the variable `AWS_DEFAULT_REGION`')
+        region = config.region ?: fetchRegion() ?: Regions.DEFAULT_REGION.getName()
     }
 
     /**

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
@@ -82,6 +82,10 @@ class AwsConfig {
 
     AwsBatchConfig getBatchConfig() { batchConfig }
 
+    Map<String,?> getS3LegacyClientConfig() {
+        return s3Legacy.getAwsClientConfig()
+    }
+
     /**
      * Retrieve the AWS credentials from the given context. It look for AWS credential in the following order
      * 1) Nextflow config {@code aws.accessKey} and {@code aws.secretKey} pair
@@ -251,7 +255,7 @@ class AwsConfig {
         new AwsConfig( (Map)config.aws ?: Collections.emptyMap()  )
     }
 
-    static AwsConfig getConfig() {
+    static AwsConfig config() {
         getConfig0(Global.config)
     }
 }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
@@ -19,7 +19,6 @@ package nextflow.cloud.aws.fusion
 
 import groovy.transform.CompileStatic
 import nextflow.cloud.aws.config.AwsConfig
-import nextflow.Global
 import nextflow.fusion.FusionConfig
 import nextflow.fusion.FusionEnv
 import org.pf4j.Extension
@@ -38,7 +37,7 @@ class AwsFusionEnv implements FusionEnv {
             return Collections.<String,String>emptyMap()
 
         final result = new HashMap<String,String>()
-        final awsConfig = AwsConfig.getConfig()
+        final awsConfig = AwsConfig.config()
         final endpoint = awsConfig.s3Config.endpoint
         final creds = config.exportAwsAccessKeys() ? awsConfig.getCredentials() : Collections.<String>emptyList()
         if( creds ) {

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3PathFactory.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3PathFactory.groovy
@@ -3,9 +3,10 @@ package nextflow.cloud.aws.util
 import java.nio.file.Path
 
 import com.upplication.s3fs.S3Path
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.Global
 import nextflow.cloud.aws.batch.AwsBatchFileCopyStrategy
-import nextflow.cloud.aws.config.AwsConfig
 import nextflow.file.FileHelper
 import nextflow.file.FileSystemPathFactory
 /**
@@ -14,6 +15,7 @@ import nextflow.file.FileSystemPathFactory
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
+@CompileStatic
 class S3PathFactory extends FileSystemPathFactory {
 
     @Override
@@ -23,10 +25,14 @@ class S3PathFactory extends FileSystemPathFactory {
             final path = "s3:///${str.substring(5)}"
             // note: this URI constructor parse the path parameter and extract the `scheme` and `authority` components
             final uri = new URI(null,null, path,null,null)
-            final env = AwsConfig.getConfig().getFileSystemEnv()
-            return FileHelper.getOrCreateFileSystemFor(uri,env).provider().getPath(uri)
+            return FileHelper.getOrCreateFileSystemFor(uri,config()).provider().getPath(uri)
         }
         return null
+    }
+
+    private Map config() {
+        final result = Global.config?.get('aws') as Map
+        return result != null ? result : Collections.emptyMap()
     }
 
     @Override


### PR DESCRIPTION
This PR refactor the AWS S3 client used by Nextflow in order to use a common configuration and client instantiation strategy based on the [AwsConfig](https://github.com/nextflow-io/nextflow/blob/d25fdd9a6457d273c8d762ed8f7bb12c4b3b3ef3/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy#L35-L35) and [AmazonClientFactory](https://github.com/nextflow-io/nextflow/blob/d25fdd9a6457d273c8d762ed8f7bb12c4b3b3ef3/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy#L56-L56) classes. 


However, it introduces some changes that need to be reviewed carefully. The previous implementation was instantiating an S3 client without specifying any region. This was done on purpose to allow the same client instance to access buckets in different region. 

The implementation provided by this PR uses the `AmazonS3ClientBuilder` class with seems to require the region as mandatory. 

https://github.com/nextflow-io/nextflow/blob/d25fdd9a6457d273c8d762ed8f7bb12c4b3b3ef3/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy#L229-L242


As a workaround when no region is specified, the client factory uses the default region 

https://github.com/nextflow-io/nextflow/blob/d25fdd9a6457d273c8d762ed8f7bb12c4b3b3ef3/plugins/nf-amazon/src/main/nextflow/cloud/aws/AmazonClientFactory.groovy#L107-L108

But I'm not sure that this provides the same behavior as before. 


Also looking into the SDK code it looks it uses a magic region `us-east-1-regional`, see below 

```
   @Override
    @Deprecated
    public synchronized void setEndpoint(String endpoint) {
        if (ServiceUtils.isS3AccelerateEndpoint(endpoint)) {
            throw new IllegalStateException("To enable accelerate mode, please use AmazonS3ClientBuilder.withAccelerateModeEnabled(true)");
        } else {
            super.setEndpoint(endpoint);
            /*
             * Extract the region string from the endpoint if it's not known to be a
             * global S3 endpoint.
             */
            if (!ServiceUtils.isS3USStandardEndpoint(endpoint)) {
                clientRegion = AwsHostNameUtils.parseRegionName(this.endpoint.getHost(), S3_SERVICE_NAME);
            }
        }
    }

    /**
     * @deprecated use {@link AmazonS3ClientBuilder#setRegion(String)}
     */
    @Override
    @Deprecated
    public synchronized void setRegion(com.amazonaws.regions.Region region) {
        if (region.getName().equalsIgnoreCase("us-east-1")) {
            if (clientOptions.isRegionalUsEast1EndpointEnabled() || REGIONAL_ENDPOINTS_OPTION_RESOLVER.useRegionalMode()) {
                region = RegionUtils.getRegion("us-east-1-regional");
            }
        }

        super.setRegion(region);
        /*
         * We need to preserve the user provided region. This is because the
         * region might be mapped to a global s3 endpoint (e.g. when the client
         * is in accelerate mode), in which case we won't be able to extract the
         * region back from the endpoint during request signing phase.
         */
        clientRegion = region.getName();
    }
```

Query ChatGTP it says 

> The us-east-1 region is a standard region that is available for all AWS services, including S3. It is a general purpose region located in N. Virginia, USA.
>
>On the other hand, the us-east-1-regional is an S3 specific region, and it's only available for S3 usage. This means that you can't use us-east-1-regional as a region value for other AWS services.
>
>The us-east-1-regional region is a specialized region for S3, which offers lower latency and higher throughput for customers in the us-east-1 region. By default, data stored in the us-east-1-regional region is stored in the same geographical area as the us-east-1 region, meaning you are still getting the data stored in N.Virginia.
>
>With us-east-1-regional you can achieve faster performance by avoiding internet backbone congestion, as well as reducing cross-region data transfer costs when data is accessed by customers in the same region.
> 
>You can also confirm that us-east-1-regional is specific to S3 by trying to create a resource on other services such as EC2 or RDS with this region, it will throw an exception, saying that this region is not available.
> 
>You should note that us-east-1-regional is not exist as a predefined constant in the com.amazonaws.regions.Regions class. Instead, you should use us-east-1 and make sure your S3 bucket is located in this region, then you can access it with us-east-1-regional endpoint URL.


It should be verified the current implementation allows the access to any bucket irrespective the region specified 