### PR TITLE
Clarify named config scope nesting

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -960,22 +960,6 @@ to the same profile using a common prefix. For example::
 This configuration defines three different profiles: ``standard``, ``cluster``, and ``cloud``, that each set different process
 configuration strategies depending on the target runtime platform. The ``standard`` profile is used by default when no profile is specified. 
 
-In order to add attributes from a named config scope (``aws``, ``docker``, ``conda``, etc.) to a configuration profile, the named scope must be nested inside the profile, not at the profile name level. For example::
-
-    profiles {
-    // This defines a profile named aws, but not an AWS-scoped config. AWS-specific config will not be parsed at this level
-      aws {
-        process.memory = '2 GB'
-        timeline.enabled = true
-        
-    // This defines an AWS scope within the profile named aws
-        aws {
-          client {
-            maxConnections = 10
-          }
-        }
-      }
-    }
 
 .. tip::
     Multiple configuration profiles can be specified by separating the profile names

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -19,7 +19,7 @@ Since each configuration file can contain conflicting settings, the sources are 
 7. Values defined within the pipeline script itself (e.g. ``main.nf``)
 
 When more than one of these options for specifying configurations are used, they are merged, so that the settings in the
-first override the same settings that appearing in the second, and so on.
+first override the same settings appearing in the second, and so on.
 
 .. tip::
   If you want to ignore any default configuration files and use only a custom one, use ``-C <config file>``.
@@ -33,14 +33,14 @@ A Nextflow configuration file is a simple text file containing a set of properti
   name = value
 
 Please note, string values need to be wrapped in quotation characters while numbers and boolean values (``true``, ``false``) do not.
-Also note that values are typed. THis means that, for example, ``1`` is different from ``'1'`` — the first is interpreted
+Also note that values are typed. This means that, for example, ``1`` is different from ``'1'`` — the first is interpreted
 as the number one, while the latter is interpreted as a string value.
 
 
 Config variables
 ----------------
 
-Configuration properties can be used as variables in the configuration file, by using the usual
+Configuration properties can be used as variables in the configuration file by using the
 ``$propertyName`` or ``${expression}`` syntax.
 
 For example::
@@ -958,7 +958,7 @@ to the same profile using a common prefix. For example::
     }
 
 This configuration defines three different profiles: ``standard``, ``cluster``, and ``cloud``, that each set different process
-configuration strategies depending on the target runtime platform. The ``standard`` profile is used by default when no profile is specified by the user. 
+configuration strategies depending on the target runtime platform. The ``standard`` profile is used by default when no profile is specified. 
 
 In order to add attributes from a named config scope (``aws``, ``docker``, ``conda``, etc.) to a configuration profile, the named scope must be nested inside the profile, not at the profile name level. For example::
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -8,9 +8,7 @@ Configuration file
 ==================
 
 When a pipeline script is launched, Nextflow looks for configuration files in multiple locations.
-Since each configuration file can contain conflicting settings, the sources are ranked to decide which
-settings to are applied. All possible configuration sources are reported below, listed in order
-of priority:
+Since each configuration file can contain conflicting settings, the sources are ranked to determine which settings are applied. Possible configuration sources, in order of priority:
 
 1. Parameters specified on the command line (``--something value``)
 2. Parameters provided using the ``-params-file`` option
@@ -20,11 +18,11 @@ of priority:
 6. The config file ``$HOME/.nextflow/config``
 7. Values defined within the pipeline script itself (e.g. ``main.nf``)
 
-When more than one of these ways of specifying configurations are used, they are merged, so that the settings in the
-first override the same ones that may appear in the second one, and so on.
+When more than one of these options for specifying configurations are used, they are merged, so that the settings in the
+first override the same settings that appearing in the second, and so on.
 
 .. tip::
-  If you want to ignore any default configuration files and use only the custom one, use ``-C <config file>``.
+  If you want to ignore any default configuration files and use only a custom one, use ``-C <config file>``.
 
 
 Config syntax
@@ -35,14 +33,14 @@ A Nextflow configuration file is a simple text file containing a set of properti
   name = value
 
 Please note, string values need to be wrapped in quotation characters while numbers and boolean values (``true``, ``false``) do not.
-Also note that values are typed, meaning for example that, ``1`` is different from ``'1'``, since the first is interpreted
+Also note that values are typed. THis means that, for example, ``1`` is different from ``'1'`` — the first is interpreted
 as the number one, while the latter is interpreted as a string value.
 
 
 Config variables
 ----------------
 
-Configuration properties can be used as variables in the configuration file itself, by using the usual
+Configuration properties can be used as variables in the configuration file, by using the usual
 ``$propertyName`` or ``${expression}`` syntax.
 
 For example::
@@ -54,9 +52,9 @@ For example::
 Please note, the usual rules for :ref:`string-interpolation` are applied, thus a string containing a variable
 reference must be wrapped in double-quote chars instead of single-quote chars.
 
-The same mechanism allows you to access environment variables defined in the hosting system. Any variable whose name is
-not defined in the Nextflow configuration file(s) is supposed to be a reference to an environment variable with that name.
-So, in the above example the property ``customPath`` is defined as the current system ``PATH`` to which
+The same mechanism allows you to access environment variables defined in the hosting system. Any variable name
+not defined in the Nextflow configuration file(s) is interpreted to be a reference to an environment variable with that name.
+So, in the above example, the property ``customPath`` is defined as the current system ``PATH`` to which
 the string ``/my/app/folder`` is appended.
 
 
@@ -64,7 +62,7 @@ Config comments
 ---------------
 
 Configuration files use the same conventions for comments used by the Groovy or Java programming languages. Thus, use ``//`` to comment
-a single line or ``/*`` .. ``*/`` to comment a block on multiple lines.
+a single line, or ``/*`` .. ``*/`` to comment a block on multiple lines.
 
 
 Config include
@@ -85,8 +83,7 @@ Config scopes
 =============
 
 Configuration settings can be organized in different scopes by dot prefixing the property names with a scope
-identifier or grouping the properties in the same scope using the curly brackets notation. This is shown in the
-following example::
+identifier, or grouping the properties in the same scope using the curly brackets notation. For example::
 
    alpha.x  = 1
    alpha.y  = 'string value..'
@@ -102,7 +99,7 @@ following example::
 Scope `aws`
 -----------
 
-The ``aws`` scope allows you to configure the access to Amazon S3 storage. Use the attributes ``accessKey`` and ``secretKey``
+The ``aws`` scope allows you to configure access to Amazon S3 storage. Use the attributes ``accessKey`` and ``secretKey``
 to specify your bucket credentials. For example::
 
 
@@ -113,16 +110,16 @@ to specify your bucket credentials. For example::
         profile = '<AWS CONFIG PROFILE>' // optional
     }
 
-Click the following link to learn more about `AWS Security Credentials <http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html>`_.
+See `AWS Security Credentials <http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html>`_ for more information.
 
-Advanced client configuration options can be set by using the ``client`` attribute. The following properties can be used:
+Advanced client configuration options can be set using the ``client`` attribute. The following properties can be used:
 
 =========================== ================
 Name                        Description
 =========================== ================
 anonymous                   Allow the access of public S3 buckets without the need to provide AWS credentials. Any service that does not accept unsigned requests will return a service access error.
-s3Acl                       Allow the setting of a predefined bucket permissions also known as *canned ACL*. Permitted values are ``Private``, ``PublicRead``, ``PublicReadWrite``, ``AuthenticatedRead``, ``LogDeliveryWrite``, ``BucketOwnerRead``, ``BucketOwnerFullControl`` and ``AwsExecRead``. See `Amazon docs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl>`_ for details.
-connectionTimeout           The amount of time to wait (in milliseconds) when initially establishing a connection before giving up and timing out.
+s3Acl                       Allow the setting of predefined bucket permissions, also known as *canned ACL*. Permitted values are ``Private``, ``PublicRead``, ``PublicReadWrite``, ``AuthenticatedRead``, ``LogDeliveryWrite``, ``BucketOwnerRead``, ``BucketOwnerFullControl``, and ``AwsExecRead``. See `Amazon docs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl>`_ for details.
+connectionTimeout           The amount of time to wait (in milliseconds) when initially establishing a connection before timing out.
 endpoint                    The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.
 glacierAutoRetrieval        Enable auto retrieval of S3 objects stored with Glacier class store (EXPERIMENTAL. default: ``false``, requires version ``22.12.0-edge`` or later).
 glacierExpirationDays       The time, in days, between when an object is restored to the bucket and when it expires (EXPERIMENTAL. default: ``7``, requires version ``22.12.0-edge`` or later).
@@ -935,9 +932,9 @@ Config profiles
 ===============
 
 Configuration files can contain the definition of one or more *profiles*. A profile is a set of configuration attributes
-that can be activated/chosen when launching a pipeline execution by using the ``-profile`` command line option.
+that can be selected during pipeline execution by using the ``-profile`` command line option.
 
-Configuration profiles are defined by using the special scope ``profiles`` which group the attributes that belong
+Configuration profiles are defined using the special scope ``profiles``, which group the attributes that belong
 to the same profile using a common prefix. For example::
 
     profiles {
@@ -960,9 +957,25 @@ to the same profile using a common prefix. For example::
 
     }
 
-This configuration defines three different profiles: ``standard``, ``cluster`` and ``cloud`` that set different process
-configuration strategies depending on the target runtime platform. By convention the ``standard`` profile is implicitly used
-when no other profile is specified by the user.
+This configuration defines three different profiles: ``standard``, ``cluster``, and ``cloud``, that each set different process
+configuration strategies depending on the target runtime platform. The ``standard`` profile is used by default when no profile is specified by the user. 
+
+In order to add attributes from a named config scope (``aws``, ``docker``, ``conda``, etc.) to a configuration profile, the named scope must be nested inside the profile, not at the profile name level. For example::
+
+    profiles {
+    // This defines a profile named aws, but not an AWS-scoped config. AWS-specific config will not be parsed at this level
+      aws {
+        process.memory = '2 GB'
+        timeline.enabled = true
+        
+    // This defines an AWS scope within the profile named aws
+        aws {
+          client {
+            maxConnections = 10
+          }
+        }
+      }
+    }
 
 .. tip::
     Multiple configuration profiles can be specified by separating the profile names


### PR DESCRIPTION
-Add clarification and example of named config scope nesting inside a config profile.  -Minor language fixes.

Signed-off-by: Llewellyn vd Berg <113503285+llewellyn-sl@users.noreply.github.com>