### PR TITLE
Add note for revision vs commitID [ci skip] 

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -63,7 +63,7 @@ manifest                    Entries of the workflow manifest.
 |
 
 .. note:: 
-    When passing a git tag or branch name using the ``-r`` argument in your CLI command, the ``workflow.revision`` and the associated ``workflow.commitId`` is populated. When passing only the Git commit ID using ``-r``, no ``workflow.revision`` is returned. 
+    When passing a Git tag or branch name using the ``-r`` argument in your CLI command, the ``workflow.revision`` and the associated ``workflow.commitId`` are populated. When passing only the Git commit ID using ``-r``, no ``workflow.revision`` is returned. 
 
 .. _metadata-nextflow:
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -18,7 +18,7 @@ For example::
     println "Manifest's pipeline version: $workflow.manifest.version"
 
 .. tip::
-    To shortcut the access to multiple ``workflow`` properties you can use the Groovy
+    To shortcut access to multiple ``workflow`` properties, you can use the Groovy
     `with <http://docs.groovy-lang.org/latest/html/groovy-jdk/java/lang/Object.html#with(groovy.lang.Closure)>`_ method.
 
 The following table lists the properties that can be accessed on the ``workflow`` object:
@@ -62,6 +62,8 @@ manifest                    Entries of the workflow manifest.
 | Properties marked with a `*` are accessible only in the workflow completion and error handlers. See the `Completion handler`_ section for details.
 |
 
+.. note:: 
+    When passing a git tag or branch name using the ``-r`` argument in your CLI command, the ``workflow.revision`` and the associated ``workflow.commitId`` is populated. When passing only the Git commit ID using ``-r``, no ``workflow.revision`` is returned. 
 
 .. _metadata-nextflow:
 


### PR DESCRIPTION
Per FD#2725, added a note explaining the difference in behavior between passing a git tag or branch name vs. passing a commit ID using the `-r` argument. 

Signed-off-by: Llewellyn vd Berg <113503285+llewellyn-sl@users.noreply.github.com>