### PR TITLE
Fix submit command in error message for grid executors that pipe wrapper script

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -185,7 +185,11 @@ class GridTaskHandler extends TaskHandler {
             final exitStatus = process.waitFor()
 
             if( exitStatus ) {
-                throw new ProcessNonZeroExitStatusException("Failed to submit process to grid scheduler for execution", result, exitStatus, builder.command())
+                final command = pipeScript
+                    ? builder.command() << '<' << TaskRun.CMD_RUN
+                    : builder.command()
+
+                throw new ProcessNonZeroExitStatusException("Failed to submit process to grid scheduler for execution", result, exitStatus, command)
             }
 
             // -- return the process stdout

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -185,11 +185,7 @@ class GridTaskHandler extends TaskHandler {
             final exitStatus = process.waitFor()
 
             if( exitStatus ) {
-                final command = pipeScript
-                    ? builder.command() << '<' << TaskRun.CMD_RUN
-                    : builder.command()
-
-                throw new ProcessNonZeroExitStatusException("Failed to submit process to grid scheduler for execution", result, exitStatus, command)
+                throw new ProcessNonZeroExitStatusException("Failed to submit process to grid scheduler for execution", result, exitStatus, launchCmd0(builder,pipeScript))
             }
 
             // -- return the process stdout
@@ -202,6 +198,15 @@ class GridTaskHandler extends TaskHandler {
             process.err.closeQuietly()
             process.destroy()
         }
+    }
+
+    protected List<String> launchCmd0(ProcessBuilder builder, String pipeScript) {
+        if( !pipeScript )
+            return builder.command()
+        final result = new ArrayList(builder.command())
+        result.add('<')
+        result.add(TaskRun.CMD_RUN)
+        return result
     }
     
     /*

--- a/modules/nextflow/src/test/groovy/nextflow/executor/GridTaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/GridTaskHandlerTest.groovy
@@ -67,4 +67,17 @@ class GridTaskHandlerTest extends Specification {
         task.exitStatus == 10
 
     }
+
+    def 'should create launch command' () {
+        given:
+        def builder = new ProcessBuilder().command(CMD)
+        def exec = Spy(GridTaskHandler)
+        expect:
+        exec.launchCmd0(builder, PIPE) == EXPECTED
+
+        where:
+        CMD         | PIPE  | EXPECTED
+        ['qsub']    | null  | ['qsub']
+        ['qsub']    | 'xyz' | ['qsub', '<', '.command.run']
+    }
 }


### PR DESCRIPTION
Closes #3024 

Some grid executors pipe the wrapper script to their submit command (e.g. LSF). In this case, when a task fails and Nextflow prints an error message, the submit command is incorrect because it doesn't include the pipe. For example:
```
Caused by:
  Failed to submit process to grid scheduler for execution

Command executed:

  bsub

Command exit status:
  -

Command output:
  (empty)
```

The submit command in this case should be `bsub < .command.run`.

This PR changes the error message to append `< .command.run` to the command if the wrapper script was piped into the submit command.