### PR TITLE
Fix #3553 (breaking environment variable values containing `=`)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1497,7 +1497,7 @@ class TaskProcessor {
         final env = workDir.resolve(TaskRun.CMD_ENV).text
         final result = new HashMap(50)
         for(String line : env.readLines() ) {
-            def (k,v) = line.tokenize('=')
+            def (k, v) = line.split('=', limit=2);
             result.put(k,v)
         }
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1497,7 +1497,7 @@ class TaskProcessor {
         final env = workDir.resolve(TaskRun.CMD_ENV).text
         final result = new HashMap(50)
         for(String line : env.readLines() ) {
-            def (k, v) = line.split('=', limit=2);
+            def (k, v) = line.split('=', 2);
             result.put(k,v)
         }
         return result


### PR DESCRIPTION
The use of `tokenize` will separate all substrings separated by
the symbol (equal sign in this case). If an environment variable
contains an equal sign, `tokenize` will split in more than one
place and this will break the string that should be saved. Using
`split` with the `limit` parameter we fix this.

For more details, check https://github.com/nextflow-io/nextflow/issues/3553

