### PR TITLE
AWS config refactor using AWS credentials chain

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
@@ -72,8 +72,6 @@ class AwsConfig {
 
     String getRegion() { region }
 
-    String getAssumeRoleArn() { assumeRoleArn }
-
     AwsS3Config getS3Config() { s3config }
 
     AwsBatchConfig getBatchConfig() { batchConfig }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
@@ -46,17 +46,13 @@ class AwsConfig {
 
     private String profile
     
-    private String assumeRoleArn
-
     private AwsS3Legacy s3Legacy
 
     AwsConfig(Map config) {
-        final creds = getAwsCredentials(SysEnv.get(), config)
-        this.accessKey = creds?[0]
-        this.secretKey = creds?[1]
+        this.accessKey = config.accessKey
+        this.secretKey = config.secretKey
         this.profile = getAwsProfile0(SysEnv.get(), config)
         this.region = getAwsRegion(SysEnv.get(), config)
-        this.assumeRoleArn = config.assumeRoleArn as String
         this.batchConfig = new AwsBatchConfig((Map)config.batch ?: Collections.emptyMap())
         this.s3config = new AwsS3Config((Map)config.client ?: Collections.emptyMap())
         this.s3Legacy = new AwsS3Legacy((Map)config.client ?: Collections.emptyMap())
@@ -86,59 +82,6 @@ class AwsConfig {
         return s3Legacy.getAwsClientConfig()
     }
 
-    /**
-     * Retrieve the AWS credentials from the given context. It look for AWS credential in the following order
-     * 1) Nextflow config {@code aws.accessKey} and {@code aws.secretKey} pair
-     * 2) System env {@code AWS_ACCESS_KEY} and {@code AWS_SECRET_KEY} pair
-     * 3) System env {@code AWS_ACCESS_KEY_ID} and {@code AWS_SECRET_ACCESS_KEY} pair
-     *
-     *
-     * @param env The system environment map
-     * @param config The nextflow config object map
-     * @return A pair where the first element is the access key and the second the secret key or
-     *      {@code null} if the credentials are missing
-     */
-    static protected List<String> getAwsCredentials0(Map env, Map config, List<Path> files=List.of()) {
-
-        String a
-        String b
-
-        if( config instanceof Map ) {
-            a = config.accessKey
-            b = config.secretKey
-
-            if( a && b ) {
-                log.debug "Using AWS credentials defined in nextflow config file"
-                return List.of(a, b)
-            }
-
-        }
-
-        // as define by amazon doc
-        // http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
-        if( env && (a=env.AWS_ACCESS_KEY_ID) && (b=env.AWS_SECRET_ACCESS_KEY) )  {
-            log.debug "Using AWS credentials defined by environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
-            return List.of(a,b)
-        }
-
-        if( env && (a=env.AWS_ACCESS_KEY) && (b=env.AWS_SECRET_KEY) ) {
-            log.debug "Using AWS credentials defined by environment variables AWS_ACCESS_KEY and AWS_SECRET_KEY"
-            return List.of(a, b)
-        }
-
-        for( Path it : files ) {
-            final conf = new IniFile(it)
-            final profile = getAwsProfile0(env, config)
-            final section = conf.section(profile)
-            if( (a=section.aws_access_key_id) && (b=section.aws_secret_access_key) ) {
-                log.debug "Using AWS credential defined in `$profile` section in file: ${conf.file}"
-                return List.of(a,b)
-            }
-        }
-
-        return null
-    }
-
     static protected String getAwsProfile0(Map env, Map<String,Object> config) {
 
         final profile = config?.profile as String
@@ -151,16 +94,9 @@ class AwsConfig {
         if( env?.containsKey('AWS_DEFAULT_PROFILE'))
             return env.get('AWS_DEFAULT_PROFILE')
 
-        return 'default'
+        return null
     }
 
-    static protected List<String> getAwsCredentials(Map env, Map config) {
-
-        final home = Paths.get(System.properties.get('user.home') as String)
-        final files = [ home.resolve('.aws/credentials'), home.resolve('.aws/config') ]
-        return getAwsCredentials0(env, config, files)
-
-    }
 
     static protected String getAwsRegion(Map env, Map config) {
 
@@ -186,8 +122,8 @@ class AwsConfig {
             return null
         }
 
-        def profile = getAwsProfile0(env, config)
-        def ini = new IniFile(awsFile)
+        final profile = getAwsProfile0(env, config) ?: 'default'
+        final ini = new IniFile(awsFile)
         return ini.section(profile).region
     }
 

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
@@ -18,6 +18,7 @@
 package nextflow.cloud.aws.fusion
 
 import groovy.transform.CompileStatic
+import nextflow.SysEnv
 import nextflow.cloud.aws.config.AwsConfig
 import nextflow.fusion.FusionConfig
 import nextflow.fusion.FusionEnv
@@ -39,7 +40,7 @@ class AwsFusionEnv implements FusionEnv {
         final result = new HashMap<String,String>()
         final awsConfig = AwsConfig.config()
         final endpoint = awsConfig.s3Config.endpoint
-        final creds = config.exportAwsAccessKeys() ? awsConfig.getCredentials() : Collections.<String>emptyList()
+        final creds = config.exportAwsAccessKeys() ? awsCreds(awsConfig) : List.<String>of()
         if( creds ) {
             result.AWS_ACCESS_KEY_ID = creds[0]
             result.AWS_SECRET_ACCESS_KEY = creds[1]
@@ -47,5 +48,15 @@ class AwsFusionEnv implements FusionEnv {
         if( endpoint )
             result.AWS_S3_ENDPOINT = endpoint
         return result
+    }
+
+    protected List<String> awsCreds(AwsConfig awsConfig) {
+        final result = awsConfig.getCredentials()
+        if( result )
+            return result
+        if( SysEnv.get('AWS_ACCESS_KEY_ID') && SysEnv.get('AWS_SECRET_ACCESS_KEY') )
+            return List.<String>of(SysEnv.get('AWS_ACCESS_KEY_ID'), SysEnv.get('AWS_SECRET_ACCESS_KEY'))
+        else
+            return List.<String>of()
     }
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsConfigTest.groovy
@@ -28,68 +28,6 @@ import spock.lang.Unroll
  */
 class AwsConfigTest extends Specification {
 
-    @Unroll
-    def 'should fetch aws creds'() {
-        expect:
-        AwsConfig.getAwsCredentials0(ENV, CREDS) == EXPECTED
-
-        where:
-        ENV                                                     | CREDS                                 | EXPECTED
-        null                                                    | null                                  | null
-        [AWS_ACCESS_KEY: 'x', AWS_SECRET_KEY: '222']            | null                                  | ['x','222']
-        [AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999']  | null                                  | ['q','999']
-        [AWS_ACCESS_KEY: 'x', AWS_SECRET_KEY: '222',  AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999']     | null | ['q','999']
-        [AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999']  | [accessKey: 'b', secretKey: '333']    | ['b','333']
-        null                                                    | [accessKey: 'b', secretKey: '333']    | ['b','333']
-        null                                                    | [accessKey: 'b']                      | null
-        [AWS_ACCESS_KEY_ID: 'q', AWS_SECRET_ACCESS_KEY: '999']  | [accessKey: 'b', secretKey: '333']    | ['b','333']
-    }
-
-    def 'should lod creds from file'() {
-        given:
-        def file = Files.createTempFile('test','test')
-        file.text = '''
-            [default]
-            aws_access_key_id = aaa
-            aws_secret_access_key = bbbb
-            '''
-
-        expect:
-        AwsConfig.getAwsCredentials0(null, null, [file]) == ['aaa','bbbb']
-        and:
-        AwsConfig.getAwsCredentials0([AWS_ACCESS_KEY: 'x', AWS_SECRET_KEY: '222'], null, [file]) == ['x','222']
-
-        cleanup:
-        file?.delete()
-    }
-
-    def 'should load creds with a profile'() {
-
-        given:
-        def file = Files.createTempFile('test','test')
-        file.text = '''
-            [default]
-            aws_access_key_id = aaa
-            aws_secret_access_key = bbbb
-            
-            [foo]
-            aws_access_key_id = xxx
-            aws_secret_access_key = yyy
-
-            [bar]
-            aws_access_key_id = ppp
-            aws_secret_access_key = qqq
-            aws_session_token = www
-            '''
-
-        expect:
-        AwsConfig.getAwsCredentials0([AWS_PROFILE: 'foo'], null, [file]) == ['xxx','yyy']
-        and:
-        AwsConfig.getAwsCredentials0([AWS_DEFAULT_PROFILE: 'bar'], null, [file]) == ['ppp','qqq']
-
-        cleanup:
-        file?.delete()
-    }
 
     def 'should get aws region'() {
         expect:
@@ -134,36 +72,6 @@ class AwsConfigTest extends Specification {
 
         cleanup:
         file?.delete()
-    }
-
-    def 'should get aws credentials with file and profile from config' () {
-
-        given:
-        def file = Files.createTempFile('test','test')
-        file.text = '''
-            [default]
-            aws_access_key_id = aaa
-            aws_secret_access_key = bbbb
-            
-            [foo]
-            aws_access_key_id = xxx
-            aws_secret_access_key = yyy
-
-            [bar]
-            aws_access_key_id = ppp
-            aws_secret_access_key = qqq
-            aws_session_token = www
-            '''
-
-        expect:
-        AwsConfig.getAwsCredentials0([:], [profile:'foo'], [file]) == ['xxx','yyy']
-        AwsConfig.getAwsCredentials0([AWS_DEFAULT_PROFILE: 'bar'], [profile:'foo'], [file]) == ['xxx','yyy']
-        AwsConfig.getAwsCredentials0([AWS_DEFAULT_PROFILE: 'bar'], [:], [file]) == ['ppp','qqq']
-        AwsConfig.getAwsCredentials0([:], [:], [file]) == ['aaa','bbbb']
-
-        cleanup:
-        file?.delete()
-
     }
 
     def 'should get aws config' () {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsConfigTest.groovy
@@ -85,23 +85,19 @@ class AwsConfigTest extends Specification {
         config.secretKey == SECRET_KEY
         config.profile == PROFILE
         config.region == REGION
-        config.assumeRoleArn == ROLE
         config.credentials == (ACCESS_KEY && SECRET_KEY ? [ACCESS_KEY, SECRET_KEY] : [])
 
         cleanup:
         SysEnv.pop()
 
         where:
-        ENV                 | CONFIG                                                                | ACCESS_KEY          | SECRET_KEY    | REGION            | PROFILE       | ROLE
-        [:]                 | [accessKey: 'a', secretKey: 'b']                                      | 'a'                 | 'b'           | null              | 'default'     | null
-        [:]                 | [accessKey: 'x', secretKey: 'y', region: 'eu-region-x']               | 'x'                 | 'y'           | 'eu-region-x'     | 'default'     | null
-        [:]                 | [accessKey: 'p', secretKey: 'q', profile: 'hola']                     | 'p'                 | 'q'           | null              | 'hola'        | null
-        [:]                 | [accessKey: 'a', secretKey: 'b', assumeRoleArn: 'role-x']             | 'a'                 | 'b'           | null              | 'default'     | 'role-x'
+        ENV                 | CONFIG                                                                | ACCESS_KEY          | SECRET_KEY    | REGION            | PROFILE
+        [:]                 | [accessKey: 'a', secretKey: 'b']                                      | 'a'                 | 'b'           | null              | null
+        [:]                 | [accessKey: 'x', secretKey: 'y', region: 'eu-region-x']               | 'x'                 | 'y'           | 'eu-region-x'     | null
+        [:]                 | [accessKey: 'p', secretKey: 'q', profile: 'hola']                     | 'p'                 | 'q'           | null              | 'hola'
         and:
-        [AWS_ACCESS_KEY_ID: 'k1', AWS_SECRET_ACCESS_KEY: 's1']  | [accessKey: 'a', secretKey: 'b']  | 'a'        | 'b'           | null              | 'default'     | null
-        [AWS_ACCESS_KEY_ID: 'k1', AWS_SECRET_ACCESS_KEY: 's1']  | [:]                               | 'k1'              | 's1'          | null              | 'default'     | null
-        [AWS_DEFAULT_REGION: 'eu-xyz']                          | [:]                               | null              | null          | 'eu-xyz'          | 'default'     | null
-        [AWS_DEFAULT_PROFILE: 'my-profile']                     | [:]                               | null              | null          | null              | 'my-profile'  | null
+        [AWS_DEFAULT_REGION: 'eu-xyz']                          | [:]                               | null              | null          | 'eu-xyz'          | null
+        [AWS_DEFAULT_PROFILE: 'my-profile']                     | [:]                               | null              | null          | null              | 'my-profile'
 
     }
 


### PR DESCRIPTION
The goal of this PR is to refactor the AWS authentication logic, so that:
* The AWS credentials chain is [used by default](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)
* The `accessKey` and `secretKey` can be provided alternatively via nextflow.config file in the `aws` scope
* The AWS profile can be provided alternatively via nextflow.config file in the `aws` scope
 