### PR TITLE
Upgrade kryo to 5.4.0

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api "commons-codec:commons-codec:1.15"
     api "commons-io:commons-io:2.11.0"
     api "com.beust:jcommander:1.35"
-    api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
+    api("com.esotericsoftware:kryo:5.4.0")
     api('org.iq80.leveldb:leveldb:0.12')
     api('org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r')
     api ('javax.activation:activation:1.1.1')

--- a/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
@@ -271,7 +271,7 @@ class PathSerializer extends Serializer<Path> {
     }
 
     @Override
-    Path read(Kryo kryo, Input input, Class<Path> type) {
+    Path read(Kryo kryo, Input input, Class<? extends Path> type) {
         final scheme = input.readString()
         final path = input.readString()
         log.trace "Path de-serialization > scheme: $scheme; path: $path"
@@ -306,7 +306,7 @@ class GStringSerializer extends Serializer<GString> {
     }
 
     @Override
-    GString read(Kryo kryo, Input stream, Class<GString> type) {
+    GString read(Kryo kryo, Input stream, Class<? extends GString> type) {
         Object[] values = kryo.readObject(stream, OBJ_ARRAY_CLASS)
         String[] strings = kryo.readObject(stream, STR_ARRAY_CLASS)
         log.trace "GString de-serialize: values: ${values} - strings: ${strings}"
@@ -326,7 +326,7 @@ class URLSerializer extends Serializer<URL> {
     }
 
     @Override
-    URL read(Kryo kryo, Input input, Class<URL> type) {
+    URL read(Kryo kryo, Input input, Class<? extends URL> type) {
         log.trace "URL de-serialization"
         return new URL(input.readString())
     }
@@ -344,7 +344,7 @@ class UUIDSerializer extends Serializer<UUID> {
     }
 
     @Override
-    UUID read(Kryo kryo, Input input, Class<UUID> type) {
+    UUID read(Kryo kryo, Input input, Class<? extends UUID> type) {
         log.trace "UUID de-serialization"
         long mostBits = input.readLong()
         long leastBits = input.readLong()
@@ -364,7 +364,7 @@ class FileSerializer extends Serializer<File> {
     }
 
     @Override
-    File read(Kryo kryo, Input input, Class<File> type) {
+    File read(Kryo kryo, Input input, Class<? extends File> type) {
         log.trace "File de-serialization"
         return new File(input.readString())
     }
@@ -393,7 +393,7 @@ class PatternSerializer extends Serializer<Pattern> {
     }
 
     @Override
-    Pattern read(Kryo kryo, Input input, Class<Pattern> type) {
+    Pattern read(Kryo kryo, Input input, Class<? extends Pattern> type) {
 
         def len = input.readInt()
         def buffer = new byte[len]
@@ -418,7 +418,7 @@ class ArrayTupleSerializer extends Serializer<ArrayTuple> {
     }
 
     @Override
-    ArrayTuple read(Kryo kryo, Input input, Class<ArrayTuple> type) {
+    ArrayTuple read(Kryo kryo, Input input, Class<? extends ArrayTuple> type) {
         final len = input.readInt()
         def list = new ArrayList(len)
         for( int i=0; i<len; i++ ) {
@@ -439,7 +439,7 @@ class MapEntrySerializer extends Serializer<Map.Entry> {
     }
 
     @Override
-    Map.Entry read(Kryo kryo, Input input, Class<Map.Entry> type) {
+    Map.Entry read(Kryo kryo, Input input, Class<? extends Map.Entry> type) {
         def key = kryo.readClassAndObject(input)
         def val = kryo.readClassAndObject(input)
         new MapEntry(key,val)

--- a/modules/nextflow/src/main/java/de/javakaffee/kryoserializers/UnmodifiableCollectionsSerializer.java
+++ b/modules/nextflow/src/main/java/de/javakaffee/kryoserializers/UnmodifiableCollectionsSerializer.java
@@ -67,7 +67,7 @@ public class UnmodifiableCollectionsSerializer extends Serializer<Object> {
     }
 
     @Override
-    public Object read(final Kryo kryo, final Input input, final Class<Object> clazz) {
+    public Object read(final Kryo kryo, final Input input, final Class<? extends Object> clazz) {
         final int ordinal = input.readInt( true );
         final UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.values()[ordinal];
         final Object sourceCollection = kryo.readClassAndObject( input );

--- a/modules/nf-httpfs/src/main/nextflow/file/http/XPathSerializer.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XPathSerializer.groovy
@@ -42,7 +42,7 @@ class XPathSerializer extends Serializer<XPath> {
     }
 
     @Override
-    XPath read(Kryo kryo, Input input, Class<XPath> type) {
+    XPath read(Kryo kryo, Input input, Class<? extends XPath> type) {
         final uri = input.readString()
         log.trace "Path de-serialization > uri=$uri"
         (XPath) FileHelper.asPath(new URI(uri))

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/file/AzPathSerializer.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/file/AzPathSerializer.groovy
@@ -41,7 +41,7 @@ class AzPathSerializer extends Serializer<AzPath> implements SerializerRegistran
     }
 
     @Override
-    AzPath read(Kryo kryo, Input input, Class<AzPath> type) {
+    AzPath read(Kryo kryo, Input input, Class<? extends AzPath> type) {
         final path = input.readString()
         log.trace "Azure Blob storage path > path=$path"
         return (AzPath)FileHelper.asPath(path)

--- a/plugins/nf-google/src/main/nextflow/cloud/google/util/GsPathSerializer.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/util/GsPathSerializer.groovy
@@ -48,7 +48,7 @@ class GsPathSerializer extends Serializer<CloudStoragePath> implements Serialize
     }
 
     @Override
-    CloudStoragePath read(Kryo kryo, Input input, Class<CloudStoragePath> type) {
+    CloudStoragePath read(Kryo kryo, Input input, Class<? extends CloudStoragePath> type) {
         final path = input.readString()
         log.trace "Google CloudStoragePath de-serialization > path=$path"
         def uri = CloudStorageFileSystem.URI_SCHEME + '://' + path


### PR DESCRIPTION
Closes #2734 

I was able to successfully resume a pipeline on AWS Batch with an S3 file that contains spaces in the filename. I just upgraded kryo to 5.4.0 -- here are the [migration notes](https://github.com/EsotericSoftware/kryo/wiki/Migration-to-v5).

Only required a few code changes, however some of the CI tests are failing now. For example:
```console
$ ./gradlew :nextflow:test --tests=nextflow.util.KryoHelperTest.'testGString' --info
KryoHelperTest > testGString FAILED
    java.lang.IllegalArgumentException: Class is not registered: org.codehaus.groovy.runtime.GStringImpl
    Note: To register this class use: kryo.register(org.codehaus.groovy.runtime.GStringImpl.class);
        at com.esotericsoftware.kryo.Kryo.getRegistration(Kryo.java:579)
        at com.esotericsoftware.kryo.util.DefaultClassResolver.writeClass(DefaultClassResolver.java:112)
        at com.esotericsoftware.kryo.Kryo.writeClass(Kryo.java:613)
        at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:708)
        at nextflow.util.KryoHelper.serialize(SerializationHelper.groovy:167)
        at nextflow.util.KryoHelperTest.testGString(KryoHelperTest.groovy:81)
```

So it seems like some basic classes are not registered by default, but I'm not sure what the best solution is.

Also, this upgrade will break the `.nextflow` cache, so users will need to delete it.