### PR TITLE
Check for incorrect errorStrategies

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -812,6 +812,11 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
      *      The {@link ProcessConfig} instance itself.
      */
     ProcessConfig errorStrategy( strategy ) {
+        listOfStrategies = ['terminate', 'finish', 'ignore', 'retry']
+        if (!listOfStrategies.contains(strategy)) {
+            throw new IllegalArgumentException("Unrecognized error strategy: " + strategy + ". Available strategies are: " + listOfStrategies.join(', '))
+        }
+
         configProperties.put('errorStrategy', strategy)
         return this
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -813,8 +813,10 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
      */
     ProcessConfig errorStrategy( strategy ) {
         listOfStrategies = ['terminate', 'finish', 'ignore', 'retry']
-        if (!listOfStrategies.contains(strategy)) {
-            throw new IllegalArgumentException("Unrecognized error strategy: " + strategy + ". Available strategies are: " + listOfStrategies.join(', '))
+        if (strategy !instanceof Closure) {
+            if (!listOfStrategies.contains(strategy)) {
+                throw new IllegalArgumentException("Unrecognized error strategy: " + strategy + ". Available strategies are: " + listOfStrategies.join(', '))
+            }
         }
 
         configProperties.put('errorStrategy', strategy)

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -44,6 +44,8 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
 
     static final public transient LABEL_REGEXP = ~/[a-zA-Z]([a-zA-Z0-9_]*[a-zA-Z0-9]+)?/
 
+    private static final List<String> VALID_ERROR_STRATEGIES = ErrorStrategy.values().collect { it -> it.toString() }
+
     static final public List<String> DIRECTIVES = [
             'accelerator',
             'afterScript',
@@ -813,10 +815,9 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
      *      The {@link ProcessConfig} instance itself.
      */
     ProcessConfig errorStrategy( strategy ) {
-        listOfStrategies = ['terminate', 'finish', 'ignore', 'retry']
         if (strategy !instanceof Closure) {
-            if (!listOfStrategies.contains(strategy)) {
-                throw new IllegalArgumentException("Unrecognized error strategy: " + strategy + ". Available strategies are: " + listOfStrategies.join(', '))
+            if (strategy.toUpperCase() !in VALID_ERROR_STRATEGIES) {
+                throw new IllegalArgumentException("Unrecognized error strategy: ${strategy}. Available strategies are: ${VALID_ERROR_STRATEGIES.join(', ').toLowerCase()}")
             }
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -22,7 +22,6 @@ import java.nio.file.Files
 import nextflow.scm.ProviderConfig
 import spock.lang.Specification
 import spock.lang.Unroll
-import test.OutputCapture
 
 import nextflow.exception.IllegalDirectiveException
 import nextflow.processor.ErrorStrategy
@@ -761,6 +760,18 @@ class ProcessConfigTest extends Specification {
                 Unrecognized error strategy: terminated. Available strategies are: terminate, finish, ignore, retry
                 '''
                 .stripIndent().trim()
+
+        when:
+        def process3 = new ProcessConfig(Mock(BaseScript))
+        process1.errorStrategy ','
+
+        then:
+        def e3 = thrown(IllegalArgumentException)
+        e3.message ==
+                '''
+                Unrecognized error strategy: ,. Available strategies are: terminate, finish, ignore, retry
+                '''
+                        .stripIndent().trim()
     }
 
     def 'should not throw exception for valid error strategy or closure' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -763,7 +763,7 @@ class ProcessConfigTest extends Specification {
                 .stripIndent().trim()
     }
 
-    def 'should not throw exception for valid error strategy' () {
+    def 'should not throw exception for valid error strategy or closure' () {
         when:
         def process1 = new ProcessConfig(Mock(BaseScript))
         process1.errorStrategy 'retry'
@@ -777,5 +777,12 @@ class ProcessConfigTest extends Specification {
 
         then:
         def e2 = noExceptionThrown()
+
+        when:
+        def process3 = new ProcessConfig(Mock(BaseScript))
+        process3.errorStrategy { task.exitStatus==14 ? 'retry' : 'terminate' }
+
+        then:
+        def e3 = noExceptionThrown()
     }
 }


### PR DESCRIPTION
There are many situations that go silent in Nextflow, including when a non-existent (or typo) error strategy is provided. This Pull Request throws an exception whenever this happens, and includes unit tests for such situations. Because it's not possible to assess closure content at runtime, it's not possible to check for non-existent (or typo) error strategies when a closure is provided as `errorStrategy` so the check will not be performed in such circumstances.
