### PR TITLE
Use cgroup for memory trace metrics

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -214,11 +214,13 @@ class BashWrapperBuilder {
         binding.helpers_script = getHelpersScript()
 
         if( runWithContainer ) {
+            binding.container_enabled = 'true'
             binding.container_boxid = 'export NXF_BOXID="nxf-$(dd bs=18 count=1 if=/dev/urandom 2>/dev/null | base64 | tr +/ 0A)"'
             binding.container_helpers = containerBuilder.getScriptHelpers()
             binding.kill_cmd = containerBuilder.getKillCommand()
         }
         else {
+            binding.container_enabled = 'false'
             binding.container_boxid = null
             binding.container_helpers = null
             binding.kill_cmd = KILL_CMD

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -66,6 +66,14 @@ nxf_stat() {
 
     [ $NXF_DEBUG = 1 ] && echo -e "++ stat SUM=${sum[*]}"
 
+    ## use memory metrics from cgroup if available
+    if [ -e /sys/fs/cgroup ]; then
+        sum[2]=$(($(cat /sys/fs/cgroup/memory/memory.memsw.usage_in_bytes) / 1024))
+        sum[3]=$(($(cat /sys/fs/cgroup/memory/memory.usage_in_bytes) / 1024))
+        sum[4]=$(($(cat /sys/fs/cgroup/memory/memory.memsw.max_usage_in_bytes) / 1024))
+        sum[5]=$(($(cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes) / 1024))
+    fi
+
     ## calc peaks
     for i in {1..7}; do
         if [ ${sum[i]} -lt ${cpu_peak[i]} ]; then

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -67,7 +67,7 @@ nxf_stat() {
     [ $NXF_DEBUG = 1 ] && echo -e "++ stat SUM=${sum[*]}"
 
     ## use memory metrics from cgroup if available
-    if [ -e /sys/fs/cgroup ]; then
+    if [ {{container_enabled}} == true ]; then
         sum[2]=$(($(cat /sys/fs/cgroup/memory/memory.memsw.usage_in_bytes) / 1024))
         sum[3]=$(($(cat /sys/fs/cgroup/memory/memory.usage_in_bytes) / 1024))
         sum[4]=$(($(cat /sys/fs/cgroup/memory/memory.memsw.max_usage_in_bytes) / 1024))


### PR DESCRIPTION
Closes #3496 

Changes the `nxf_stat` function in the wrapper script to overwrite the memory-related trace metrics with the corresponding cgroup values if they are available. This way, if a task is running in a container, Nextflow will track the memory usage of the entire container instead of just the task (and its children).

Example:
```console
$ nextflow run hello -with-trace -with-docker ; cat trace.txt
task_id vmem    rss     peak_vmem       peak_rss
2       10.4 MB 10.7 MB 15.1 MB 15.1 MB
3       10 MB   9.7 MB  13.6 MB 13.6 MB
1       9.7 MB  9.9 MB  11.7 MB 11.7 MB
4       9.1 MB  9.3 MB  13.2 MB 13.2 MB
```

We might need to modify the precondition for using these metrics. I noticed that in my WSL environment, the `/sys/fs/cgroup` directory exists even without a container, so that would throw off my metrics for a non-containerized run.