### PR TITLE
Revert "Add readOnlyInputs option for CharliecloudBuilder"

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -25,7 +25,6 @@ import groovy.util.logging.Slf4j
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
- * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
  */
 @CompileStatic
 @Slf4j
@@ -47,9 +46,6 @@ class CharliecloudBuilder extends ContainerBuilder<CharliecloudBuilder> {
         if( params.containsKey('runOptions') )
             addRunOptions(params.runOptions.toString())
 
-        if( params.containsKey('readOnlyInputs') )
-            this.readOnlyInputs = params.readOnlyInputs?.toString() == 'true'
-
         return this
     }
 
@@ -62,9 +58,7 @@ class CharliecloudBuilder extends ContainerBuilder<CharliecloudBuilder> {
     CharliecloudBuilder build(StringBuilder result) {
         assert image
 
-        result << 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env '
-        if (!readOnlyInputs)
-            result << '-w '
+        result << 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env '
 
         appendEnv(result)
 
@@ -84,23 +78,9 @@ class CharliecloudBuilder extends ContainerBuilder<CharliecloudBuilder> {
         return this
     }
 
-    protected String getRoot(String path) {
-        def rootPath = path.split("/")
-
-        if (rootPath.size() >= 1)
-            rootPath = "/${rootPath[1]}"
-        else
-            throw new IllegalArgumentException("Not a valid working directory value: ${path}")
-
-        return rootPath
-    }
-    
     @Override
     protected String composeVolumePath(String path, boolean readOnly = false) {
-        def mountCmd = "-b ${escape(path)}"
-        if (readOnlyInputs)
-            mountCmd = "-b ${getRoot(escape(path))}"
-        return mountCmd
+        return "-b ${escape(path)}"
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -171,8 +171,7 @@ class CharliecloudCache {
             return localPath
         }
 
-        // final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
-        final file = new File("${localPath.parent.parent.parent}/.ch-pulling.lock")
+        final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
         final wait = "Another Nextflow instance is pulling the image $imageUrl with Charliecloud -- please wait until the download completes"
         final err =  "Unable to acquire exclusive lock after $pullTimeout on file: $file"
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -26,7 +26,6 @@ import spock.lang.Unroll
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
- * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
  */
 class CharliecloudBuilderTest extends Specification {
 
@@ -83,16 +82,6 @@ class CharliecloudBuilderTest extends Specification {
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
-        then:
-        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
-
-        when:
-        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:true).build().getRunCommand('bwa --this --that file.fastq')
-        then:
-        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
-
-        when:
-        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:false).build().getRunCommand('bwa --this --that file.fastq')
         then:
         cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }


### PR DESCRIPTION
It turns out unit tests were not running, and this PR #3477 causes the build to fail reverting it
 
Reverts nextflow-io/nextflow#3477