### PR TITLE
Reinstate exit code for Spack tests

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/spack/SpackCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/spack/SpackCache.groovy
@@ -299,7 +299,7 @@ class SpackCache {
     }
 
     @PackageScope
-    void runCommand( String cmd ) {
+    int runCommand( String cmd ) {
         log.trace """spack env create
                      command: $cmd
                      timeout: $createTimeout""".stripIndent()


### PR DESCRIPTION
Signed-off-by: Marco De La Pierre <marco.delapierre@gmail.com>

Hi @pditommaso , 

following this commit of yours:
https://github.com/nextflow-io/nextflow/commit/868374d3d591113a6fa3364d4e520d2ef3374aaf#diff-86b11d6f83a372628c1957303e638eccaa9583281cdb8657845b1222b6ff570a

I have re-pulled and retested, as I had done previously, and cannot find issues with these tests, they run successfully.

I believe the bugfix you applied in `SpackCacheTest` probably fixed the issue?
