### PR TITLE
Add readOnlyInputs option for CharliecloudBuilder

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -25,6 +25,7 @@ import groovy.util.logging.Slf4j
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
+ * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
  */
 @CompileStatic
 @Slf4j

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -96,7 +96,7 @@ class CharliecloudBuilder extends ContainerBuilder<CharliecloudBuilder> {
     }
     
     @Override
-    protected String composeVolumePath(String path, boolean readOnly = false) {
+    protected String composeVolumePath(String path, boolean readOnlyInputs = false) {
         def mountCmd = "-b ${escape(path)}"
         if (readOnlyInputs)
             mountCmd = "-b ${getRoot(escape(path))}"

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -85,12 +85,12 @@ class CharliecloudBuilder extends ContainerBuilder<CharliecloudBuilder> {
     }
 
     protected String getRoot(String path) {
-        def rootPath = path.split("/")
+        def rootPath = path.tokenize("/")
 
-        if (rootPath.size() >= 1)
-            rootPath = "/${rootPath[1]}"
+        if (rootPath.size() >= 1 && path[0] == '/')
+            rootPath = "/${rootPath[0]}"
         else
-            throw new IllegalArgumentException("Not a valid working directory value: ${path}")
+            throw new IllegalArgumentException("Not a valid working directory value (absolute path?): ${path}")
 
         return rootPath
     }

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -171,7 +171,8 @@ class CharliecloudCache {
             return localPath
         }
 
-        final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
+        // final file = new File("${localPath.parent.parent.parent}/.${localPath.name}.lock")
+        final file = new File("${localPath.parent.parent.parent}/.ch-pulling.lock")
         final wait = "Another Nextflow instance is pulling the image $imageUrl with Charliecloud -- please wait until the download completes"
         final err =  "Unable to acquire exclusive lock after $pullTimeout on file: $file"
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -26,6 +26,7 @@ import spock.lang.Unroll
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
+ * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
  */
 class CharliecloudBuilderTest extends Specification {
 
@@ -82,6 +83,16 @@ class CharliecloudBuilderTest extends Specification {
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:true).build().getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:false).build().getRunCommand('bwa --this --that file.fastq')
         then:
         cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -39,34 +39,34 @@ class CharliecloudBuilderTest extends Specification {
         expect:
         new CharliecloudBuilder('busybox')
                 .build()
-                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .params(runOptions: '-j')
                 .build()
-                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" -j busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" -j busybox --'
         
         new CharliecloudBuilder('busybox')
                 .params(temp: '/foo')
                 .build()
-                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b /foo:/tmp -b "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b /foo:/tmp -b "$PWD" busybox --'
 
         new CharliecloudBuilder('busybox')
                 .addEnv('X=1')
                 .addEnv(ALPHA:'aaa', BETA: 'bbb')
                 .build()
-                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env --set-env=X=1 --set-env=ALPHA=aaa --set-env=BETA=bbb -b "$PWD" busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w --set-env=X=1 --set-env=ALPHA=aaa --set-env=BETA=bbb -b "$PWD" busybox --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .build()
-                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b /foo/data/file1 -b "$PWD" ubuntu --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b /foo/data/file1 -b "$PWD" ubuntu --'
 
         new CharliecloudBuilder('ubuntu')
                 .addMount(path1)
                 .addMount(path2)
                 .build()
-                .runCommand == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b /foo/data/file1 -b /bar/data/file2 -b "$PWD" ubuntu --'
+                .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b /foo/data/file1 -b /bar/data/file2 -b "$PWD" ubuntu --'
     }
 
     def 'should get run command' () {
@@ -74,27 +74,27 @@ class CharliecloudBuilderTest extends Specification {
         when:
         def cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand()
         then:
-        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu --'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" ubuntu --'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- bwa --this --that file.fastq'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" ubuntu -- bwa --this --that file.fastq'
 
         when:
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
 
         when:
-        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:true).build().getRunCommand('bwa --this --that file.fastq')
+        cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').params(readOnlyInputs: 'true').build().getRunCommand('bwa --this --that file.fastq')
         then:
         cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
 
         when:
-        cmd = new CharliecloudBuilder('ubuntu').params(readOnlyInputs:false).build().getRunCommand('bwa --this --that file.fastq')
+        cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').params(readOnlyInputs: 'false').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-run --unset-env="*" -c "$PWD" -w --no-home --set-env -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }
 
     @Unroll

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -69,6 +69,7 @@ class CharliecloudBuilderTest extends Specification {
                 .runCommand == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b /foo/data/file1 -b /bar/data/file2 -b "$PWD" ubuntu --'
     }
 
+    def db_file = Paths.get('/home/db')
     def 'should get run command' () {
 
         when:
@@ -95,6 +96,27 @@ class CharliecloudBuilderTest extends Specification {
         cmd = new CharliecloudBuilder('ubuntu').params(entry:'/bin/sh').params(readOnlyInputs: 'false').build().getRunCommand('bwa --this --that file.fastq')
         then:
         cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('ubuntu')
+            .params(entry:'/bin/sh')
+            .addMount(db_file)
+            .addMount(db_file)
+            .params(readOnlyInputs: 'true')
+            .build().getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -b /home -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('ubuntu')
+            .params(entry:'/bin/sh')
+            .addMount(db_file)
+            .addMount(db_file)
+            .params(readOnlyInputs: 'false')
+            .build()
+            .getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$PWD" --no-home --set-env -w -b /home/db -b "$PWD" ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }
 
     @Unroll


### PR DESCRIPTION
This merge request is to add the `readOnlyInputs` option as discussed in the  **Charliecloud and shared cacheDir** #3367 issue  and following the  **Add readOnlyInputs option for CharliecloudBuilder** #3477 merge request

With this modification:

- the default `readOnlyInputs` value is `false`
- if `readOnlyInputs` is `true`;
- the `-w` option is removed from the command
- the bound volumes are transformed to only mount the first folder of the path

For example, if I try to bind `/home/user/workdir/` to `/home/` the bound path will be `/home` to `/home`. By doing that, charliecloud doesn't try to `mkdir -p /home/user/workdir/` within the read-only container, the external path is bound at the `/home` directory level so all the subfolders are accessible with the user rights. If one tries to bind `/` I added an expection.

Signed-off-by: Laurent Modolo [laurent.modolo@ens-lyon.fr](mailto:laurent.modolo@ens-lyon.fr)