### PR TITLE
Remove container tag from AWS Batch job definition

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -607,7 +607,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         if( !name ) return null
         if( !ContainerNameValidator.isValidImageName(name) ) throw new IllegalArgumentException("Invalid container image name: $name")
 
-        def result = name.replaceAll(/[^a-zA-Z0-9\-_]+/,'-')
+        def result = stripTag(name.trim()).replaceAll(/[^a-zA-Z0-9\-_]+/,'-')
         // Batch job definition length cannot exceed 128 characters
         // take first 40 chars + add a unique MD5 hash (32 chars)
         if( result.length()>125 ) {
@@ -616,6 +616,17 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         }
 
         return "nf-" + result
+    }
+
+    protected String stripTag(String name) {
+        final p = name.lastIndexOf(':')
+        if( p==-1 )
+            return name
+        final suffix = p<name.length() ? name.substring(p) : null
+        if( !suffix || suffix.contains('/') )
+            return name
+        else
+            return name.substring(0,p)
     }
 
     protected List<String> classicSubmitCli() {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -385,8 +385,8 @@ class AwsBatchTaskHandlerTest extends Specification {
         expect:
         handler.normalizeJobDefinitionName(null) == null
         handler.normalizeJobDefinitionName('foo') == 'nf-foo'
-        handler.normalizeJobDefinitionName('foo:1') == 'nf-foo-1'
-        handler.normalizeJobDefinitionName('docker.io/foo/bar:1') == 'nf-docker-io-foo-bar-1'
+        handler.normalizeJobDefinitionName('foo:1') == 'nf-foo'
+        handler.normalizeJobDefinitionName('docker.io/foo/bar:1') == 'nf-docker-io-foo-bar'
         and:
         handler.normalizeJobDefinitionName('docker.io/some-container-very-long-name-123456789/123456789/123456789/123456789/123456789/123456789/123456789/123456789/123456789/123456789/name:123') == 'nf-docker-io-some-container-very-long-name--35e0fa487af0f525a8c14e7866449d8e'
 
@@ -396,6 +396,21 @@ class AwsBatchTaskHandlerTest extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'should string tag' () {
+        given:
+        def handler = Spy(AwsBatchTaskHandler)
+
+        expect:
+        handler.stripTag(NAME) == EXPECTED
+
+        where:
+        NAME                | EXPECTED
+        'foo'               | 'foo'
+        'foo:1.0'           | 'foo'
+        'host:8080/foo'     | 'host:8080/foo'
+        'host:8080/foo:'    | 'host:8080/foo'
+        'host:8080/foo:2.0' | 'host:8080/foo'
+    }
 
     def 'should validate job validation method' () {
         given:


### PR DESCRIPTION
This commit strips the container tag segment from the name associated with the AWS Batch job definition created by nextflow.

The rationale of this change is reduce the proliferation of AWS batch jobs created by nextflow when using containers with the same name and different tags

Signed-off-by: Paolo Di Tommaso <paolo.ditommaso@gmail.com>