### PR TITLE
Log exception trace in Tower client

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -550,7 +550,7 @@ class TowerClient implements TraceObserver {
                     continue
                 }
                 else {
-                    log.trace("Got error $code - refreshTries=$refreshTries - currentRefresh=$currentRefresh")
+                    log.trace("Got HTTP code $code - refreshTries=$refreshTries - currentRefresh=$currentRefresh", e)
                 }
 
                 String msg


### PR DESCRIPTION
In some cases, an `IOException` might happen when sending a request to Tower even if the returned HTTP code is a successful code such as `200 OK`:
```
Feb-02 17:06:22.569 [main] TRACE io.seqera.tower.plugin.TowerClient - Got error 200 - refreshTries=0 - currentRefresh=null
```

This change logs the exception trace in order to have more debugging information.