### PR TITLE
Fix syntax highlighting in tests

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdCleanTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdCleanTest.groovy
@@ -69,7 +69,7 @@ class CmdCleanTest extends Specification {
     }
 
 
-    def 'non-empty folder (.command.file name) keep logs' () {
+    def 'non-empty folder [.command.file name] keep logs' () {
 
         given:
         def folder = Files.createTempDirectory('test')

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -195,7 +195,7 @@ class ConfigBuilderTest extends Specification {
         file?.delete()
     }
 
-    def 'CLI params should override the ones defined in the config file (2)' () {
+    def 'CLI params should override the ones defined in the config file [2]' () {
         setup:
         def file = Files.createTempFile('test',null)
         file.text = '''
@@ -2047,7 +2047,7 @@ class ConfigBuilderTest extends Specification {
         folder?.deleteDir()
     }
 
-    def 'should access top params from profile (2)' () {
+    def 'should access top params from profile [2]' () {
         given:
         def folder = Files.createTempDirectory('test')
         def file1 = folder.resolve('file1.conf')

--- a/modules/nextflow/src/test/groovy/nextflow/script/params/FileOutParamTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/FileOutParamTest.groovy
@@ -74,7 +74,7 @@ class FileOutParamTest extends Specification {
     }
 
 
-    def 'should return a name relative to the workDir (with string)' () {
+    def 'should return a name relative to the workDir [with string]' () {
 
         given:
         def param = [:] as FileOutParam

--- a/modules/nextflow/src/test/groovy/nextflow/util/SimpleHttpClientTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/SimpleHttpClientTest.groovy
@@ -82,7 +82,7 @@ class SimpleHttpClientTest extends Specification{
         thrown(UnknownHostException)
     }
 
-    def 'check isJson() method'() {
+    def 'check isJson method'() {
 
         when:
         def httpClient = new SimpleHttpClient()

--- a/modules/nf-commons/src/test/nextflow/extension/FilesExTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/extension/FilesExTest.groovy
@@ -317,7 +317,7 @@ class FilesExTest extends Specification {
 
     }
 
-    def 'test moveTo (directory) ' () {
+    def 'test moveTo directory' () {
 
         given:
         def sourceFolder =  Files.createTempDirectory('folderToCopy')


### PR DESCRIPTION
Some methods in the unit tests have string literal names with parentheses in the name. For some reason, this breaks the Groovy syntax highlighter (at least in VS Code and GitHub), so I found them with a regex and fixed them.