### PR TITLE
Add support for debuging a Fusion task launched from Tower

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionAwareTask.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionAwareTask.groovy
@@ -20,6 +20,9 @@ package nextflow.fusion
 import groovy.transform.CompileStatic
 import nextflow.executor.Executor
 import nextflow.processor.TaskRun
+
+import static nextflow.fusion.FusionConfig.FUSION_PATH
+
 /**
  * Implements commons logic to handle fusion based tasks.
  * This trait is expected to be used by a sub-class of {@link nextflow.processor.TaskHandler}
@@ -59,7 +62,7 @@ trait FusionAwareTask {
     List<String> fusionSubmitCli() {
         final fusion = fusionLauncher()
         final runFile = fusion.toContainerMount(task.workDir.resolve(TaskRun.CMD_RUN))
-        return ['/usr/bin/fusion', 'bash', runFile.toString() ]
+        return [FUSION_PATH, 'bash', runFile.toString() ]
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
@@ -30,6 +30,8 @@ class FusionConfig {
     final static public String DEFAULT_FUSION_AMD64_URL = 'https://fusionfs.seqera.io/releases/v2.0-amd64.json'
     final static public String DEFAULT_FUSION_ARM64_URL = 'https://fusionfs.seqera.io/releases/v2.0-arm64.json'
 
+    final static public String FUSION_PATH = '/usr/bin/fusion'
+
     final private Boolean enabled
     final private String containerConfigUrl
     final private Boolean exportAwsAccessKeys

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveDebugCmd.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveDebugCmd.groovy
@@ -74,9 +74,11 @@ class WaveDebugCmd {
         if ( image.startsWith("wave.seqera.io") ) {
             // Run a waved container
             cmd.runContainer(image, buildCommand(workDir))
-        } else {
+        }
+        else {
             // Wave it before running
-            cmd.runContainer([image] + buildCommand(workDir))
+            List<String> args = [image] + buildCommand(workDir)
+            cmd.runContainer(args)
         }
     }
 

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveDebugCmd.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveDebugCmd.groovy
@@ -61,7 +61,7 @@ class WaveDebugCmd {
                 final image = args.pop()
                 runRemoteTask(criteria, image)
             } catch (NoSuchElementException ignored) {
-                throw new AbortOperationException("Missing container image - usage: nextflow plugin nf-wave:debug <remote-task-path> <image>")
+                throw new AbortOperationException("Missing container image - usage: nextflow plugin nf-wave:debug-task <remote-task-path> <image>")
             }
             return
         }

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveRunCmd.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveRunCmd.groovy
@@ -39,12 +39,19 @@ class WaveRunCmd {
 
     private Map containerParams
 
+    private List<Path> containerMounts
+
     private Set<String> environment = new HashSet<>()
 
     WaveRunCmd(Session session) { this.session=session }
 
     WaveRunCmd withContainerParams(Map params) {
         this.containerParams = params
+        return this
+    }
+
+    WaveRunCmd withMounts(List<Path> path) {
+        this.containerMounts = path
         return this
     }
 
@@ -67,6 +74,7 @@ class WaveRunCmd {
         final containerBuilder = new DockerBuilder(image)
                 .addMountWorkDir(false)
                 .addRunOptions('--rm')
+                .addMounts(containerMounts)
                 .params(containerConfig)
                 .params(containerParams)
 

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/cli/WaveDebugCmdTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/cli/WaveDebugCmdTest.groovy
@@ -1,0 +1,8 @@
+package io.seqera.wave.plugin.cli
+
+/**
+ *
+ *  @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class WaveDebugCmdTest {
+}

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/cli/WaveDebugCmdTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/cli/WaveDebugCmdTest.groovy
@@ -1,8 +1,47 @@
+/*
+ * Copyright 2020-2022, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.seqera.wave.plugin.cli
+
+import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  *
- *  @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-class WaveDebugCmdTest {
+class WaveDebugCmdTest extends Specification {
+
+    @Unroll
+    def 'should check remote path' () {
+        expect:
+        WaveDebugCmd.isRemotePath(PATH) == EXPECTED
+        where:
+        PATH                | EXPECTED
+        null                | false
+        'foo'               | false
+        '/some/file'        | false
+        and:
+        's3://foo/bar'      | true
+        'gs://foo/bar'      | true
+        and:
+        'file:/foo/bar'     | false
+        'file://foo/bar'    | false
+        'file:///foo/bar'   | false
+    }
+
 }


### PR DESCRIPTION
Make it easier to debug a task that was launched from Tower. The way of using it is providing also the image container.

**Usage:**
``` 
nextflow plugin nf-wave:debug-task s3://<task-work-directory> <image>
```

If the image is a wave image (starting with `wave.seqera.io`) is it use as it is. But when the image is not a wave image then it is "waved" using given Nextflow configuration.

Example Nextflow config to use if you need to use credentials at `~/.aws/credentials`
```
$ cat nextflow.config 
wave {
  enabled = true
}

fusion {
  enabled = true
}

docker {
  userEmulation = true
}
```

Previous debug mode is still supported in the same way `nextflow plugin nf-wave:debug-task <task hash>` to debug tasks launched locally with Nextflow CLI.

**Example usage:**
![usage screenshot](https://user-images.githubusercontent.com/1315429/216809217-21dd19b4-2062-4280-8aae-2ecbc522a5e6.png)


