### PR TITLE
Automatically update year in the copyright notice at the bottom [ci skip]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 
 import sys, os
 import sphinx_rtd_theme
+import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -45,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Nextflow'
-copyright = u'2022, Seqera Labs, S.L'
+copyright = str(datetime.date.today().year) + u', Seqera Labs, S.L'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Every new year, the year in the copyright notice at the bottom must be manually updated. This PR fixes this by automatically setting the current year at every build.
