### PR TITLE
Remove deprecated code (part 2)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
@@ -168,6 +168,8 @@ class Channel  {
      */
     @Deprecated
     static DataflowWriteChannel from( Collection items ) {
+        log.warn("Channel.from() is deprecated -- use Channel.of() or Channel.fromList() instead")
+
         final result = from0(items)
         NodeMarker.addSourceNode('Channel.from', result)
         return result
@@ -195,6 +197,8 @@ class Channel  {
      */
     @Deprecated
     static DataflowWriteChannel from( Object... items ) {
+        log.warn("Channel.from() is deprecated -- use Channel.of() or Channel.fromList() instead")
+
         checkNoChannels('channel.from', items)
         for( Object it : items ) if(CH.isChannel(it))
             throw new IllegalArgumentException("channel.from argument is already a channel object")

--- a/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
@@ -998,7 +998,7 @@ class OperatorImpl {
      * For example:
      *
      * <pre>
-     *     Channel.from(...)
+     *     Channel.of(...)
      *            .tap { newChannelName }
      *            .map { ... }
      *  </pre>

--- a/modules/nextflow/src/test/groovy/nextflow/ChannelTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/ChannelTest.groovy
@@ -168,36 +168,6 @@ class ChannelTest extends Specification {
         result.val == Channel.STOP
     }
 
-    def testFrom() {
-        given:
-        DataflowQueue result
-
-        when:
-        result = Channel.from('hola')
-        then:
-        result.val == 'hola'
-        result.val == Channel.STOP
-
-        when:
-        result = Channel.from('alpha','delta')
-        then:
-        result.val == 'alpha'
-        result.val == 'delta'
-        result.val == Channel.STOP
-
-        when:
-        result = Channel.from(['alpha','delta'])
-        then:
-        result.val == 'alpha'
-        result.val == 'delta'
-        result.val == Channel.STOP
-
-        when:
-        result = Channel.from([])
-        then:
-        result.val == Channel.STOP
-    }
-
     def testSingleFile() {
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/dag/DAGTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/dag/DAGTest.groovy
@@ -303,8 +303,8 @@ class DAGTest extends Specification {
         dag.addDataflowBroadcastPair(ch1r, ch1)
         dag.addDataflowBroadcastPair(ch2r, ch2)
 
-        dag.addSourceNode( 'Channel.from', ch1r)
-        dag.addSourceNode( 'Channel.from', ch2r)
+        dag.addSourceNode( 'Channel.of', ch1r)
+        dag.addSourceNode( 'Channel.of', ch2r)
 
         dag.addOperatorNode( 'combine', [ch1r, ch2r], chC )
 

--- a/modules/nextflow/src/test/groovy/nextflow/extension/BranchOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/BranchOpTest.groovy
@@ -270,8 +270,8 @@ class BranchOpTest extends Dsl2Spec  {
                 bar: it>=5
             }
 
-            bra1 = Channel.from(1,2,3).branch(criteria)  
-            bra2 = Channel.from(6,7,8).branch(criteria)  
+            bra1 = Channel.of(1,2,3).branch(criteria)  
+            bra2 = Channel.of(6,7,8).branch(criteria)  
             
             bra1.foo.view { "foo:$it" }
             bra2.bar.view { "bar:$it" }

--- a/modules/nextflow/src/test/groovy/nextflow/extension/BufferOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/BufferOpTest.groovy
@@ -38,14 +38,14 @@ class BufferOpTest extends Specification {
     def testBufferClose() {
 
         when:
-        def r1 = Channel.from(1,2,3,1,2,3).buffer({ it == 2 })
+        def r1 = Channel.of(1,2,3,1,2,3).buffer({ it == 2 })
         then:
         r1.val == [1,2]
         r1.val == [3,1,2]
         r1.val == Channel.STOP
 
         when:
-        def r2 = Channel.from('a','b','c','a','b','z').buffer(~/b/)
+        def r2 = Channel.of('a','b','c','a','b','z').buffer(~/b/)
         then:
         r2.val == ['a','b']
         r2.val == ['c','a','b']
@@ -56,7 +56,7 @@ class BufferOpTest extends Specification {
     def testBufferWithCount() {
 
         when:
-        def r1 = Channel.from(1,2,3,1,2,3,1).buffer( size:2 )
+        def r1 = Channel.of(1,2,3,1,2,3,1).buffer( size:2 )
         then:
         r1.val == [1,2]
         r1.val == [3,1]
@@ -64,7 +64,7 @@ class BufferOpTest extends Specification {
         r1.val == Channel.STOP
 
         when:
-        r1 = Channel.from(1,2,3,1,2,3,1).buffer( size:2, remainder: true )
+        r1 = Channel.of(1,2,3,1,2,3,1).buffer( size:2, remainder: true )
         then:
         r1.val == [1,2]
         r1.val == [3,1]
@@ -74,14 +74,14 @@ class BufferOpTest extends Specification {
 
 
         when:
-        def r2 = Channel.from(1,2,3,4,5,1,2,3,4,5,1,2,9).buffer( size:3, skip:2 )
+        def r2 = Channel.of(1,2,3,4,5,1,2,3,4,5,1,2,9).buffer( size:3, skip:2 )
         then:
         r2.val == [3,4,5]
         r2.val == [3,4,5]
         r2.val == Channel.STOP
 
         when:
-        r2 = Channel.from(1,2,3,4,5,1,2,3,4,5,1,2,9).buffer( size:3, skip:2, remainder: true )
+        r2 = Channel.of(1,2,3,4,5,1,2,3,4,5,1,2,9).buffer( size:3, skip:2, remainder: true )
         then:
         r2.val == [3,4,5]
         r2.val == [3,4,5]
@@ -104,14 +104,14 @@ class BufferOpTest extends Specification {
     def testBufferOpenClose() {
 
         when:
-        def r1 = Channel.from(1,2,3,4,5,1,2,3,4,5,1,2).buffer( 2, 4 )
+        def r1 = Channel.of(1,2,3,4,5,1,2,3,4,5,1,2).buffer( 2, 4 )
         then:
         r1.val == [2,3,4]
         r1.val == [2,3,4]
         r1.val == Channel.STOP
 
         when:
-        def r2 = Channel.from('a','b','c','a','b','z').buffer(~/a/,~/b/)
+        def r2 = Channel.of('a','b','c','a','b','z').buffer(~/a/,~/b/)
         then:
         r2.val == ['a','b']
         r2.val == ['a','b']
@@ -123,7 +123,7 @@ class BufferOpTest extends Specification {
 
         when:
         def sum = 0
-        def r1 = Channel.from(1,2,3,1,2,3).buffer(remainder: true, { sum+=it; sum==7 })
+        def r1 = Channel.of(1,2,3,1,2,3).buffer(remainder: true, { sum+=it; sum==7 })
         then:
         r1.val == [1,2,3,1]
         r1.val == [2,3]

--- a/modules/nextflow/src/test/groovy/nextflow/extension/CollectOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/CollectOpTest.groovy
@@ -36,7 +36,7 @@ class CollectOpTest extends Specification {
     def 'should collect items into a list'() {
 
         when:
-        def source = Channel.from(1,2,3)
+        def source = Channel.of(1,2,3)
         def result = source.collect()
         then:
         result.val == [1,2,3]

--- a/modules/nextflow/src/test/groovy/nextflow/extension/CombineOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/CombineOpTest.groovy
@@ -58,8 +58,8 @@ class CombineOpTest extends Specification {
     def 'should combine channels' () {
 
         given:
-        def left = Channel.from('a','b','c')
-        def right = Channel.from(1,2,3)
+        def left = Channel.of('a','b','c')
+        def right = Channel.of(1,2,3)
         def op = new CombineOp(left, right)
 
         when:
@@ -80,8 +80,8 @@ class CombineOpTest extends Specification {
 
     def 'should combine by a value' () {
         given:
-        def left = Channel.from(['A', 10], ['A', 20], ['B', 30], ['B', 40])
-        def right = Channel.from(['A', 11], ['A', 22], ['B', 33])
+        def left = Channel.of(['A', 10], ['A', 20], ['B', 30], ['B', 40])
+        def right = Channel.of(['A', 11], ['A', 22], ['B', 33])
 
         when:
         def op = new CombineOp(left,right)
@@ -96,7 +96,7 @@ class CombineOpTest extends Specification {
     def 'should combine a channel with a list' () {
 
         given:
-        def left = Channel.from('a','b')
+        def left = Channel.of('a','b')
         def right = [1,2,3,4]
         def op = new CombineOp(left, right)
 
@@ -162,9 +162,9 @@ class CombineOpTest extends Specification {
     def 'should chain combine ops flat default' () {
 
         given:
-        def ch2 = Channel.from('a','b','c')
-        def ch3 = Channel.from('x','y')
-        def ch1 = Channel.from(1,2)
+        def ch2 = Channel.of('a','b','c')
+        def ch3 = Channel.of('x','y')
+        def ch1 = Channel.of(1,2)
 
         when:
         def result = new CombineOp(new CombineOp(ch1, ch2).apply(), ch3).apply()
@@ -191,9 +191,9 @@ class CombineOpTest extends Specification {
     def 'should chain combine ops flat true' () {
 
         given:
-        def ch1 = Channel.from(1,2)
-        def ch2 = Channel.from('a','b','c')
-        def ch3 = Channel.from('x','y')
+        def ch1 = Channel.of(1,2)
+        def ch2 = Channel.of('a','b','c')
+        def ch3 = Channel.of('x','y')
 
         when:
         def result = new CombineOp(new CombineOp(ch1, ch2).apply(), ch3).apply()
@@ -219,7 +219,7 @@ class CombineOpTest extends Specification {
     def 'should combine with tuples' () {
 
         when:
-        def left = Channel.from([1, 'x'], [2,'y'], [3, 'z'])
+        def left = Channel.of([1, 'x'], [2,'y'], [3, 'z'])
         def right = ['alpha','beta','gamma']
 
         def result = new CombineOp(left, right).apply()
@@ -245,7 +245,7 @@ class CombineOpTest extends Specification {
     def 'should combine with map' () {
 
         when:
-        def left = Channel.from([id:1, val:'x'], [id:2,val:'y'], [id:3, val:'z'])
+        def left = Channel.of([id:1, val:'x'], [id:2,val:'y'], [id:3, val:'z'])
         def right = ['alpha','beta','gamma']
         def result = left.combine(right)
         def all = (List) ToListOp.apply(result).val
@@ -271,7 +271,7 @@ class CombineOpTest extends Specification {
     def 'should combine items'() {
 
         when:
-        def left = Channel.from(1,2,3)
+        def left = Channel.of(1,2,3)
         def right = ['a','b']
         def result = left.combine(right).toSortedList().val.iterator()
         then:
@@ -283,8 +283,8 @@ class CombineOpTest extends Specification {
         result.next() == [3, 'b']
 
         when:
-        left = Channel.from(1,2)
-        right = Channel.from('a','b','c')
+        left = Channel.of(1,2)
+        right = Channel.of('a','b','c')
         result = left.combine(right).toSortedList().val.iterator()
         then:
         result.next() == [1, 'a']
@@ -299,9 +299,9 @@ class CombineOpTest extends Specification {
     def 'should chain combine'() {
 
         when:
-        def str1 = Channel.from('a','b','c')
-        def str2 = Channel.from('x','y')
-        def result = Channel.from(1,2).combine(str1).combine(str2).toSortedList().val.iterator()
+        def str1 = Channel.of('a','b','c')
+        def str2 = Channel.of('x','y')
+        def result = Channel.of(1,2).combine(str1).combine(str2).toSortedList().val.iterator()
         then:
         result.next() == [1,'a','x']
         result.next() == [1,'a','y']
@@ -317,9 +317,9 @@ class CombineOpTest extends Specification {
         result.next() == [2,'c','y']
 
         when:
-        str1 = Channel.from('a','b','c')
-        str2 = Channel.from('x','y')
-        result = Channel.from(1,2).combine(str1).combine(str2,flat:false).toSortedList().val.iterator()
+        str1 = Channel.of('a','b','c')
+        str2 = Channel.of('x','y')
+        result = Channel.of(1,2).combine(str1).combine(str2,flat:false).toSortedList().val.iterator()
         then:
         result.next() == [1,'a','x']
         result.next() == [1,'a','y']
@@ -338,8 +338,8 @@ class CombineOpTest extends Specification {
     def 'should combine by first element' () {
 
         given:
-        def left = Channel.from( ['A',1], ['A',2], ['B',1], ['B',2] )
-        def right = Channel.from( ['A',1], ['A',2], ['B',1], ['B',2] )
+        def left = Channel.of( ['A',1], ['A',2], ['B',1], ['B',2] )
+        def right = Channel.of( ['A',1], ['A',2], ['B',1], ['B',2] )
 
         when:
         def op = new CombineOp(left, right)

--- a/modules/nextflow/src/test/groovy/nextflow/extension/ConcatOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/ConcatOpTest.groovy
@@ -32,8 +32,8 @@ class ConcatOp2Test extends Dsl2Spec {
 
         when:
         def result = dsl_eval('''
-            c1 = Channel.from(1,2,3)
-            c2 = Channel.from('a','b','c')
+            c1 = Channel.of(1,2,3)
+            c2 = Channel.of('a','b','c')
             c1.concat(c2)
         ''')
         then:
@@ -50,7 +50,7 @@ class ConcatOp2Test extends Dsl2Spec {
         when:
         def result = dsl_eval('''
             ch1 = Channel.value(1)
-            ch2 = Channel.from(2,3)
+            ch2 = Channel.of(2,3)
             ch1.concat(ch2)        
         ''')
         then:

--- a/modules/nextflow/src/test/groovy/nextflow/extension/CountFastaOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/CountFastaOpTest.groovy
@@ -63,7 +63,7 @@ class CountFastaOpTest extends Specification {
                 .stripIndent()
 
         when:
-        def result = Channel.from( str, str2 ).countFasta()
+        def result = Channel.of( str, str2 ).countFasta()
         then:
         result.val == 8
 
@@ -112,7 +112,7 @@ class CountFastaOpTest extends Specification {
                 .stripIndent()
 
         when:
-        def result = Channel.from( file1, file2 ).countFasta()
+        def result = Channel.of( file1, file2 ).countFasta()
         then:
         result.val == 10
 

--- a/modules/nextflow/src/test/groovy/nextflow/extension/CountFastqOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/CountFastqOpTest.groovy
@@ -67,7 +67,7 @@ class CountFastqOpTest extends Specification {
 
 
         when:
-        def result = Channel.from( READS, READS2 ).countFastq()
+        def result = Channel.of( READS, READS2 ).countFastq()
         then:
         result.val == 7
 
@@ -123,7 +123,7 @@ class CountFastqOpTest extends Specification {
 
 
         when:
-        def result = Channel.from(file1, file2).countFastq()
+        def result = Channel.of(file1, file2).countFastq()
         then:
         result.val == 9
 

--- a/modules/nextflow/src/test/groovy/nextflow/extension/CountLinesOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/CountLinesOpTest.groovy
@@ -53,7 +53,7 @@ class CountLinesOpTest extends Specification {
             '''
                 .stripIndent().strip()
 
-        def result = Channel.from(str, str2, str3).countLines()
+        def result = Channel.of(str, str2, str3).countLines()
         then:
         result.val == 11
 

--- a/modules/nextflow/src/test/groovy/nextflow/extension/DataflowMergeExtensionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/DataflowMergeExtensionTest.groovy
@@ -43,9 +43,9 @@ class DataflowMergeExtensionTest extends Specification {
 
     def 'should merge with open array with custom closure'() {
         when:
-        def alpha = Channel.from(1, 3, 5);
-        def beta =  Channel.from(2, 4, 6);
-        def delta = Channel.from(7, 8, 1);
+        def alpha = Channel.of(1, 3, 5)
+        def beta =  Channel.of(2, 4, 6)
+        def delta = Channel.of(7, 8, 1)
         def result = alpha.merge( beta, delta ) { a,b,c -> [c,b,a] }
         then:
         result instanceof DataflowQueue
@@ -57,9 +57,9 @@ class DataflowMergeExtensionTest extends Specification {
 
     def 'should merge with open array' () {
         when:
-        def alpha = Channel.from(1, 3, 5);
-        def beta =  Channel.from(2, 4, 6);
-        def delta = Channel.from(7, 8, 1);
+        def alpha = Channel.of(1, 3, 5)
+        def beta =  Channel.of(2, 4, 6)
+        def delta = Channel.of(7, 8, 1)
         def result = alpha.merge( beta, delta )
         then:
         result instanceof DataflowQueue
@@ -72,8 +72,8 @@ class DataflowMergeExtensionTest extends Specification {
     def 'should merge with with default'() {
 
         when:
-        def left =  Channel.from(1, 3, 5);
-        def right = Channel.from(2, 4, 6);
+        def left =  Channel.of(1, 3, 5)
+        def right = Channel.of(2, 4, 6)
         def result = left.merge(right)
         then:
         result instanceof DataflowQueue
@@ -83,8 +83,8 @@ class DataflowMergeExtensionTest extends Specification {
         result.val == Channel.STOP
 
         when:
-        left  = Channel.from(1, 2, 3);
-        right = Channel.from(['a','b'], ['p','q'], ['x','z']);
+        left  = Channel.of(1, 2, 3)
+        right = Channel.of(['a','b'], ['p','q'], ['x','z'])
         result = left.merge(right)
         then:
         result instanceof DataflowQueue
@@ -94,8 +94,8 @@ class DataflowMergeExtensionTest extends Specification {
         result.val == Channel.STOP
 
         when:
-        left  = Channel.from('A','B','C');
-        right = Channel.from(['a',[1,2,3]], ['b',[3,4,5]], ['c',[6,7,8]]);
+        left  = Channel.of('A','B','C')
+        right = Channel.of(['a',[1,2,3]], ['b',[3,4,5]], ['c',[6,7,8]])
         result = left.merge(right)
         then:
         result instanceof DataflowQueue
@@ -109,9 +109,9 @@ class DataflowMergeExtensionTest extends Specification {
     def 'should merge with list'() {
 
         when:
-        def alpha = Channel.from(1, 3, 5);
-        def beta  = Channel.from(2, 4, 6);
-        def delta = Channel.from(7, 8, 1);
+        def alpha = Channel.of(1, 3, 5)
+        def beta  = Channel.of(2, 4, 6)
+        def delta = Channel.of(7, 8, 1)
         def result = alpha.merge( [beta, delta] ) { a,b,c -> [c,b,a] }
         then:
         result instanceof DataflowQueue
@@ -125,8 +125,8 @@ class DataflowMergeExtensionTest extends Specification {
     def 'should merge with queue'() {
 
         when:
-        def alpha = Channel.from(1, 3, 5);
-        def beta = Channel.from(2, 4, 6);
+        def alpha = Channel.of(1, 3, 5)
+        def beta = Channel.of(2, 4, 6)
 
         def result = alpha.merge(beta) { a,b -> [a, b+1] }
 

--- a/modules/nextflow/src/test/groovy/nextflow/extension/DataflowTapExtensionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/DataflowTapExtensionTest.groovy
@@ -41,7 +41,7 @@ class DataflowTapExtensionTest extends Specification {
     def 'should `tap` item to a new channel' () {
 
         when:
-        def result = Channel.from( 4,7,9 ) .tap { first }.map { it+1 }
+        def result = Channel.of( 4,7,9 ) .tap { first }.map { it+1 }
         then:
         session.binding.first.val == 4
         session.binding.first.val == 7
@@ -60,7 +60,7 @@ class DataflowTapExtensionTest extends Specification {
     def 'should `tap` item to more than one channel' () {
 
         when:
-        def result = Channel.from( 4,7,9 ) .tap { foo; bar }.map { it+1 }
+        def result = Channel.of( 4,7,9 ) .tap { foo; bar }.map { it+1 }
         then:
         session.binding.foo.val == 4
         session.binding.foo.val == 7
@@ -84,7 +84,7 @@ class DataflowTapExtensionTest extends Specification {
 
         when:
         def target = Channel.create()
-        def result = Channel.from( 8,2,5 ) .tap(target).map { it+1 }
+        def result = Channel.of( 8,2,5 ) .tap(target).map { it+1 }
         then:
         result instanceof DataflowQueue
         target instanceof DataflowQueue

--- a/modules/nextflow/src/test/groovy/nextflow/extension/DumpOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/DumpOpTest.groovy
@@ -43,7 +43,7 @@ class DumpOpTest extends Specification {
         new Session(dumpChannels: ['*'])
 
         when:
-        def result = Channel.from(1, 2, 3).dump()
+        def result = Channel.of(1, 2, 3).dump()
         then:
         result.val == 1
         result.val == 2
@@ -61,7 +61,7 @@ class DumpOpTest extends Specification {
         new Session(dumpChannels: ['*'])
 
         when:
-        def result = Channel.from(1, 2, 3).dump { it * it }
+        def result = Channel.of(1, 2, 3).dump { it * it }
         then:
         result.val == 1
         result.val == 2
@@ -79,7 +79,7 @@ class DumpOpTest extends Specification {
         new Session(dumpChannels: ['*'])
 
         when:
-        def result = Channel.from(1, 2, 3).dump(tag: 'foo')
+        def result = Channel.of(1, 2, 3).dump(tag: 'foo')
         then:
         result.val == 1
         result.val == 2

--- a/modules/nextflow/src/test/groovy/nextflow/extension/JoinOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/JoinOpTest.groovy
@@ -35,8 +35,8 @@ class JoinOpTest extends Specification {
 
     def 'should join entries' () {
         given:
-        def ch1 = Channel.from(['X', 1], ['Y', 2], ['Z', 3], ['P', 7])
-        def ch2 = Channel.from(['Z', 6], ['Y', 5], ['X', 4])
+        def ch1 = Channel.of(['X', 1], ['Y', 2], ['Z', 3], ['P', 7])
+        def ch2 = Channel.of(['Z', 6], ['Y', 5], ['X', 4])
 
         when:
         def op = new JoinOp(ch1, ch2)
@@ -52,8 +52,8 @@ class JoinOpTest extends Specification {
 
     def 'should join entries by index' () {
         given:
-        def ch1 = Channel.from([1, 'X'], [2, 'Y'], [3, 'Z'], [7, 'P'])
-        def ch2 = Channel.from([6, 'Z'], [5, 'Y'], [4, 'X'])
+        def ch1 = Channel.of([1, 'X'], [2, 'Y'], [3, 'Z'], [7, 'P'])
+        def ch2 = Channel.of([6, 'Z'], [5, 'Y'], [4, 'X'])
 
         when:
         def op = new JoinOp(ch1, ch2, [by:1])
@@ -67,8 +67,8 @@ class JoinOpTest extends Specification {
 
     def 'should join entries with composite index' () {
         given:
-        def ch1 = Channel.from([1, 'a','b', ['foo']], [2, 'p','q', ['bar']], [3, 'x','y', ['baz']], [7, 'P'])
-        def ch2 = Channel.from([5, 'p','q', [333]], [4, 'a','b', [444]], [6, 'x','y', [555]])
+        def ch1 = Channel.of([1, 'a','b', ['foo']], [2, 'p','q', ['bar']], [3, 'x','y', ['baz']], [7, 'P'])
+        def ch2 = Channel.of([5, 'p','q', [333]], [4, 'a','b', [444]], [6, 'x','y', [555]])
 
         when:
         def op = new JoinOp(ch1, ch2, [by:[1,2]])
@@ -84,8 +84,8 @@ class JoinOpTest extends Specification {
 
     def 'should join entries with remainder' () {
         given:
-        def ch1 = Channel.from(['X', 1], ['Y', 2], ['Z', 3], ['P', 7])
-        def ch2 = Channel.from(['Z', 6], ['Y', 5], ['X', 4], ['Q', ['foo','bar', [77,88,99]]])
+        def ch1 = Channel.of(['X', 1], ['Y', 2], ['Z', 3], ['P', 7])
+        def ch2 = Channel.of(['Z', 6], ['Y', 5], ['X', 4], ['Q', ['foo','bar', [77,88,99]]])
 
         when:
         def op = new JoinOp(ch1, ch2, [remainder: true])
@@ -102,8 +102,8 @@ class JoinOpTest extends Specification {
     def 'should join single item channels' () {
 
         given:
-        def ch1 = Channel.from( 1,2,3 )
-        def ch2 = Channel.from( 1,0,0,2,7,8,9,3 )
+        def ch1 = Channel.of( 1,2,3 )
+        def ch2 = Channel.of( 1,0,0,2,7,8,9,3 )
 
         when:
         def op = new JoinOp(ch1, ch2)
@@ -116,8 +116,8 @@ class JoinOpTest extends Specification {
     def 'should join single item channels with remainder' () {
 
         given:
-        def ch1 = Channel.from( 1,2,3 )
-        def ch2 = Channel.from( 1,0,0,2,7,8,9,3 )
+        def ch1 = Channel.of( 1,2,3 )
+        def ch2 = Channel.of( 1,0,0,2,7,8,9,3 )
 
         when:
         def op = new JoinOp(ch1, ch2, [remainder: true])
@@ -130,7 +130,7 @@ class JoinOpTest extends Specification {
     def 'should join empty channel and remainder' () {
 
         when:
-        def left = Channel.from(1,2,3)
+        def left = Channel.of(1,2,3)
         def right = Channel.empty()
         def result = left.join(right, remainder: true)
         then:
@@ -144,7 +144,7 @@ class JoinOpTest extends Specification {
     def 'should join empty channel with pairs and remainder' () {
 
         when:
-        def left = Channel.from(['X', 1], ['Y', 2], ['Z', 3])
+        def left = Channel.of(['X', 1], ['Y', 2], ['Z', 3])
         def right = Channel.empty()
         def result = left.join(right, remainder: true)
         then:
@@ -158,7 +158,7 @@ class JoinOpTest extends Specification {
 
         when:
         given:
-        def ch1 = Channel.from( 1,2,3 )
+        def ch1 = Channel.of( 1,2,3 )
         def ch2 = Channel.value(1)
 
         when:
@@ -172,8 +172,8 @@ class JoinOpTest extends Specification {
     def 'should join pair with singleton and remainder' () {
 
         when:
-        def left = Channel.from(['P', 0], ['X', 1], ['Y', 2], ['Z', 3])
-        def right = Channel.from('X', 'Y', 'Z', 'Q')
+        def left = Channel.of(['P', 0], ['X', 1], ['Y', 2], ['Z', 3])
+        def right = Channel.of('X', 'Y', 'Z', 'Q')
         def result = left.join(right)
         then:
         result.val == ['X', 1]
@@ -182,8 +182,8 @@ class JoinOpTest extends Specification {
         result.val == Channel.STOP
 
         when:
-        left = Channel.from(['P', 0], ['X', 1], ['Y', 2], ['Z', 3])
-        right = Channel.from('X', 'Y', 'Z', 'Q')
+        left = Channel.of(['P', 0], ['X', 1], ['Y', 2], ['Z', 3])
+        right = Channel.of('X', 'Y', 'Z', 'Q')
         result = left.join(right, remainder: true).toList().val.sort { it -> it[0] }
         then:
         result[2] == ['X', 1]

--- a/modules/nextflow/src/test/groovy/nextflow/extension/MixOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/MixOpTest.groovy
@@ -25,13 +25,13 @@ import test.Dsl2Spec
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Timeout(5)
-class MixOp2Test extends Dsl2Spec {
+class MixOpTest extends Dsl2Spec {
 
     def 'should mix channels'() {
         when:
         def result = dsl_eval('''
-            c1 = Channel.from( 1,2,3 )
-            c2 = Channel.from( 'a','b' )
+            c1 = Channel.of( 1,2,3 )
+            c2 = Channel.of( 'a','b' )
             c3 = Channel.value( 'z' )
             c1.mix(c2,c3)
             
@@ -51,7 +51,7 @@ class MixOp2Test extends Dsl2Spec {
     def 'should mix with value channels'() {
         when:
         def result = dsl_eval('''
-            Channel.value(1).mix( Channel.from([2,3])  )
+            Channel.value(1).mix( Channel.fromList([2,3])  )
             ''')
         then:
         result.toList().val.sort() == [1,2,3]

--- a/modules/nextflow/src/test/groovy/nextflow/extension/MultiMapOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/MultiMapOpTest.groovy
@@ -105,7 +105,7 @@ class MultiMapOpTest extends Dsl2Spec {
                 bar: it*it
             }
 
-            ch1 = Channel.from(1,2,3).multiMap(criteria)  
+            ch1 = Channel.of(1,2,3).multiMap(criteria)  
             
             ch1.foo.view { "foo:$it" }
             ch1.bar.view { "bar:$it" }

--- a/modules/nextflow/src/test/groovy/nextflow/extension/OperatorImplTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/OperatorImplTest.groovy
@@ -40,35 +40,35 @@ class OperatorImplTest extends Specification {
     def testFilter() {
 
         when:
-        def c1 = Channel.from(1,2,3,4,5).filter { it > 3 }
+        def c1 = Channel.of(1,2,3,4,5).filter { it > 3 }
         then:
         c1.val == 4
         c1.val == 5
         c1.val == Channel.STOP
 
         when:
-        def c2 = Channel.from('hola','hello','cioa','miao').filter { it =~ /^h.*/ }
+        def c2 = Channel.of('hola','hello','cioa','miao').filter { it =~ /^h.*/ }
         then:
         c2.val == 'hola'
         c2.val == 'hello'
         c2.val == Channel.STOP
 
         when:
-        def c3 = Channel.from('hola','hello','cioa','miao').filter { it ==~ /^h.*/ }
+        def c3 = Channel.of('hola','hello','cioa','miao').filter { it ==~ /^h.*/ }
         then:
         c3.val == 'hola'
         c3.val == 'hello'
         c3.val == Channel.STOP
 
         when:
-        def c4 = Channel.from('hola','hello','cioa','miao').filter( ~/^h.*/ )
+        def c4 = Channel.of('hola','hello','cioa','miao').filter( ~/^h.*/ )
         then:
         c4.val == 'hola'
         c4.val == 'hello'
         c4.val == Channel.STOP
 
         when:
-        def c5 = Channel.from('hola',1,'cioa',2,3).filter( Number )
+        def c5 = Channel.of('hola',1,'cioa',2,3).filter( Number )
         then:
         c5.val == 1
         c5.val == 2
@@ -76,9 +76,9 @@ class OperatorImplTest extends Specification {
         c5.val == Channel.STOP
 
         expect:
-        Channel.from(1,2,4,2,4,5,6,7,4).filter(1) .count().val == 1
-        Channel.from(1,2,4,2,4,5,6,7,4).filter(2) .count().val == 2
-        Channel.from(1,2,4,2,4,5,6,7,4).filter(4) .count().val == 3
+        Channel.of(1,2,4,2,4,5,6,7,4).filter(1) .count().val == 1
+        Channel.of(1,2,4,2,4,5,6,7,4).filter(2) .count().val == 2
+        Channel.of(1,2,4,2,4,5,6,7,4).filter(4) .count().val == 3
 
     }
 
@@ -101,7 +101,7 @@ class OperatorImplTest extends Specification {
 
         when:
         count = 0
-        channel = Channel.from(1,2,3,4)
+        channel = Channel.of(1,2,3,4)
         channel.subscribe { count++; }
         sleep(100)
         then:
@@ -115,7 +115,7 @@ class OperatorImplTest extends Specification {
         when:
         def count = 0
         def done = false
-        Channel.from(1,2,3).subscribe onNext:  { count++ }, onComplete: { done = true }
+        Channel.of(1,2,3).subscribe onNext:  { count++ }, onComplete: { done = true }
         sleep 100
         then:
         done
@@ -161,7 +161,7 @@ class OperatorImplTest extends Specification {
 
     def testMap() {
         when:
-        def result = Channel.from(1,2,3).map { "Hello $it" }
+        def result = Channel.of(1,2,3).map { "Hello $it" }
         then:
         result.val == 'Hello 1'
         result.val == 'Hello 2'
@@ -183,7 +183,7 @@ class OperatorImplTest extends Specification {
     def testMapParamExpanding () {
 
         when:
-        def result = Channel.from(1,2,3).map { [it, it] }.map { x, y -> x+y }
+        def result = Channel.of(1,2,3).map { [it, it] }.map { x, y -> x+y }
         then:
         result.val == 2
         result.val == 4
@@ -194,7 +194,7 @@ class OperatorImplTest extends Specification {
     def testSkip() {
 
         when:
-        def result = Channel.from(1,2,3).map { it == 2 ? Channel.VOID : "Hello $it" }
+        def result = Channel.of(1,2,3).map { it == 2 ? Channel.VOID : "Hello $it" }
         then:
         result.val == 'Hello 1'
         result.val == 'Hello 3'
@@ -206,7 +206,7 @@ class OperatorImplTest extends Specification {
     def testMapMany () {
 
         when:
-        def result = Channel.from(1,2,3).flatMap { it -> [it, it*2] }
+        def result = Channel.of(1,2,3).flatMap { it -> [it, it*2] }
         then:
         result.val == 1
         result.val == 2
@@ -237,7 +237,7 @@ class OperatorImplTest extends Specification {
     def testMapManyWithTuples () {
 
         when:
-        def result = Channel.from( [1,2], ['a','b'] ).flatMap { it -> [it, it.reverse()] }
+        def result = Channel.of( [1,2], ['a','b'] ).flatMap { it -> [it, it.reverse()] }
         then:
         result.val == [1,2]
         result.val == [2,1]
@@ -249,7 +249,7 @@ class OperatorImplTest extends Specification {
     def testMapManyDefault  () {
 
         when:
-        def result = Channel.from( [1,2], ['a',['b','c']] ).flatMap()
+        def result = Channel.of( [1,2], ['a',['b','c']] ).flatMap()
         then:
         result.val == 1
         result.val == 2
@@ -261,7 +261,7 @@ class OperatorImplTest extends Specification {
     def testMapManyWithHashArray () {
 
         when:
-        def result = Channel.from(1,2,3).flatMap { it -> [ k: it, v: it*2] }
+        def result = Channel.of(1,2,3).flatMap { it -> [ k: it, v: it*2] }
         then:
         result.val == new MapEntry('k',1)
         result.val == new MapEntry('v',2)
@@ -286,7 +286,7 @@ class OperatorImplTest extends Specification {
 
 
         when:
-        channel = Channel.from(1,2,3,4,5)
+        channel = Channel.of(1,2,3,4,5)
         result = channel.reduce { a, e -> a += e }
         then:
         result.getVal() == 15
@@ -306,7 +306,7 @@ class OperatorImplTest extends Specification {
         result.getVal() == null
 
         when:
-        result = Channel.from(6,5,4,3,2,1).reduce { a, e -> Channel.STOP }
+        result = Channel.of(6,5,4,3,2,1).reduce { a, e -> Channel.STOP }
         then:
         result.val == 6
 
@@ -330,7 +330,7 @@ class OperatorImplTest extends Specification {
         result.getVal() == 10
 
         when:
-        result = Channel.from(6,5,4,3,2,1).reduce(0) { a, e -> a < 3 ? a+1 : Channel.STOP }
+        result = Channel.of(6,5,4,3,2,1).reduce(0) { a, e -> a < 3 ? a+1 : Channel.STOP }
         then:
         result.val == 3
 
@@ -339,12 +339,12 @@ class OperatorImplTest extends Specification {
     def testFirst() {
 
         expect:
-        Channel.from(3,6,4,5,4,3,4).first().val == 3
+        Channel.of(3,6,4,5,4,3,4).first().val == 3
     }
 
     def testFirstWithCriteria() {
         expect:
-        Channel.from(3,6,4,5,4,3,4).first{ it>4 } .val == 6
+        Channel.of(3,6,4,5,4,3,4).first{ it>4 } .val == 6
     }
 
     def testFirstWithValue() {
@@ -360,10 +360,10 @@ class OperatorImplTest extends Specification {
     def testFirstWithCondition() {
 
         expect:
-        Channel.from(3,6,4,5,4,3,4).first { it % 2 == 0  } .val == 6
-        Channel.from( 'a', 'b', 'c', 1, 2 ).first( Number ) .val == 1
-        Channel.from( 'a', 'b', 1, 2, 'aaa', 'bbb' ).first( ~/aa.*/ ) .val == 'aaa'
-        Channel.from( 'a', 'b', 1, 2, 'aaa', 'bbb' ).first( 1 ) .val == 1
+        Channel.of(3,6,4,5,4,3,4).first { it % 2 == 0  } .val == 6
+        Channel.of( 'a', 'b', 'c', 1, 2 ).first( Number ) .val == 1
+        Channel.of( 'a', 'b', 1, 2, 'aaa', 'bbb' ).first( ~/aa.*/ ) .val == 'aaa'
+        Channel.of( 'a', 'b', 1, 2, 'aaa', 'bbb' ).first( 1 ) .val == 1
 
     }
 
@@ -371,7 +371,7 @@ class OperatorImplTest extends Specification {
     def testTake() {
 
         when:
-        def result = Channel.from(1,2,3,4,5,6).take(3)
+        def result = Channel.of(1,2,3,4,5,6).take(3)
         then:
         result.val == 1
         result.val == 2
@@ -379,18 +379,18 @@ class OperatorImplTest extends Specification {
         result.val == Channel.STOP
 
         when:
-        result = Channel.from(1).take(3)
+        result = Channel.of(1).take(3)
         then:
         result.val == 1
         result.val == Channel.STOP
 
         when:
-        result = Channel.from(1,2,3).take(0)
+        result = Channel.of(1,2,3).take(0)
         then:
         result.val == Channel.STOP
 
         when:
-        result = Channel.from(1,2,3).take(-1)
+        result = Channel.of(1,2,3).take(-1)
         then:
         result.val == 1
         result.val == 2
@@ -398,7 +398,7 @@ class OperatorImplTest extends Specification {
         result.val == Channel.STOP
 
         when:
-        result = Channel.from(1,2,3).take(3)
+        result = Channel.of(1,2,3).take(3)
         then:
         result.val == 1
         result.val == 2
@@ -410,7 +410,7 @@ class OperatorImplTest extends Specification {
     def testLast() {
 
         expect:
-        Channel.from(3,6,4,5,4,3,9).last().val == 9
+        Channel.of(3,6,4,5,4,3,9).last().val == 9
         Channel.value('x').last().val == 'x'
     }
 
@@ -419,9 +419,9 @@ class OperatorImplTest extends Specification {
 
     def testCount() {
         expect:
-        Channel.from(4,1,7,5).count().val == 4
-        Channel.from(4,1,7,1,1).count(1).val == 3
-        Channel.from('a','c','c','q','b').count ( ~/c/ ) .val == 2
+        Channel.of(4,1,7,5).count().val == 4
+        Channel.of(4,1,7,1,1).count(1).val == 3
+        Channel.of('a','c','c','q','b').count ( ~/c/ ) .val == 2
         Channel.value(5).count().val == 1
         Channel.value(5).count(5).val == 1
         Channel.value(5).count(6).val == 0
@@ -430,7 +430,7 @@ class OperatorImplTest extends Specification {
     def testToList() {
 
         when:
-        def channel = Channel.from(1,2,3)
+        def channel = Channel.of(1,2,3)
         then:
         channel.toList().val == [1,2,3]
 
@@ -454,7 +454,7 @@ class OperatorImplTest extends Specification {
     def testToSortedList() {
 
         when:
-        def channel = Channel.from(3,1,4,2)
+        def channel = Channel.of(3,1,4,2)
         then:
         channel.toSortedList().val == [1,2,3,4]
 
@@ -465,7 +465,7 @@ class OperatorImplTest extends Specification {
         channel.toSortedList().val == []
 
         when:
-        channel = Channel.from([1,'zeta'], [2,'gamma'], [3,'alpaha'], [4,'delta'])
+        channel = Channel.of([1,'zeta'], [2,'gamma'], [3,'alpaha'], [4,'delta'])
         then:
         channel.toSortedList { it[1] } .val == [[3,'alpaha'], [4,'delta'], [2,'gamma'], [1,'zeta'] ]
 
@@ -484,21 +484,21 @@ class OperatorImplTest extends Specification {
 
     def testUnique() {
         expect:
-        Channel.from(1,1,1,5,7,7,7,3,3).unique().toList().val == [1,5,7,3]
-        Channel.from(1,3,4,5).unique { it%2 } .toList().val == [1,4]
+        Channel.of(1,1,1,5,7,7,7,3,3).unique().toList().val == [1,5,7,3]
+        Channel.of(1,3,4,5).unique { it%2 } .toList().val == [1,4]
     }
 
     def testDistinct() {
         expect:
-        Channel.from(1,1,2,2,2,3,1,1,2,2,3).distinct().toList().val == [1,2,3,1,2,3]
-        Channel.from(1,1,2,2,2,3,1,1,2,4,6).distinct { it%2 } .toList().val == [1,2,3,2]
+        Channel.of(1,1,2,2,2,3,1,1,2,2,3).distinct().toList().val == [1,2,3,1,2,3]
+        Channel.of(1,1,2,2,2,3,1,1,2,4,6).distinct { it%2 } .toList().val == [1,2,3,2]
     }
 
 
     def testFlatten() {
 
         when:
-        def r1 = Channel.from(1,2,3).flatten()
+        def r1 = Channel.of(1,2,3).flatten()
         then:
         r1.val == 1
         r1.val == 2
@@ -506,7 +506,7 @@ class OperatorImplTest extends Specification {
         r1.val == Channel.STOP
 
         when:
-        def r2 = Channel.from([1,'a'], [2,'b']).flatten()
+        def r2 = Channel.of([1,'a'], [2,'b']).flatten()
         then:
         r2.val == 1
         r2.val == 'a'
@@ -515,7 +515,7 @@ class OperatorImplTest extends Specification {
         r2.val == Channel.STOP
 
         when:
-        def r3 = Channel.from( [1,2] as Integer[], [3,4] as Integer[] ).flatten()
+        def r3 = Channel.of( [1,2] as Integer[], [3,4] as Integer[] ).flatten()
         then:
         r3.val == 1
         r3.val == 2
@@ -524,7 +524,7 @@ class OperatorImplTest extends Specification {
         r3.val == Channel.STOP
 
         when:
-        def r4 = Channel.from( [1,[2,3]], 4, [5,[6]] ).flatten()
+        def r4 = Channel.of( [1,[2,3]], 4, [5,[6]] ).flatten()
         then:
         r4.val == 1
         r4.val == 2
@@ -553,7 +553,7 @@ class OperatorImplTest extends Specification {
     def testCollate() {
 
         when:
-        def r1 = Channel.from(1,2,3,1,2,3,1).collate( 2, false )
+        def r1 = Channel.of(1,2,3,1,2,3,1).collate( 2, false )
         then:
         r1.val == [1,2]
         r1.val == [3,1]
@@ -561,7 +561,7 @@ class OperatorImplTest extends Specification {
         r1.val == Channel.STOP
 
         when:
-        def r2 = Channel.from(1,2,3,1,2,3,1).collate( 3 )
+        def r2 = Channel.of(1,2,3,1,2,3,1).collate( 3 )
         then:
         r2.val == [1,2,3]
         r2.val == [1,2,3]
@@ -573,14 +573,14 @@ class OperatorImplTest extends Specification {
     def testCollateWithStep() {
 
         when:
-        def r1 = Channel.from(1,2,3,4).collate( 3, 1, false )
+        def r1 = Channel.of(1,2,3,4).collate( 3, 1, false )
         then:
         r1.val == [1,2,3]
         r1.val == [2,3,4]
         r1.val == Channel.STOP
 
         when:
-        def r2 = Channel.from(1,2,3,4).collate( 3, 1, true )
+        def r2 = Channel.of(1,2,3,4).collate( 3, 1, true )
         then:
         r2.val == [1,2,3]
         r2.val == [2,3,4]
@@ -589,7 +589,7 @@ class OperatorImplTest extends Specification {
         r2.val == Channel.STOP
 
         when:
-        def r3 = Channel.from(1,2,3,4).collate( 3, 1  )
+        def r3 = Channel.of(1,2,3,4).collate( 3, 1  )
         then:
         r3.val == [1,2,3]
         r3.val == [2,3,4]
@@ -598,19 +598,19 @@ class OperatorImplTest extends Specification {
         r3.val == Channel.STOP
 
         when:
-        def r4 = Channel.from(1,2,3,4).collate( 4,4 )
+        def r4 = Channel.of(1,2,3,4).collate( 4,4 )
         then:
         r4.val == [1,2,3,4]
         r4.val == Channel.STOP
 
         when:
-        def r5 = Channel.from(1,2,3,4).collate( 6,6 )
+        def r5 = Channel.of(1,2,3,4).collate( 6,6 )
         then:
         r5.val == [1,2,3,4]
         r5.val == Channel.STOP
 
         when:
-        def r6 = Channel.from(1,2,3,4).collate( 6,6,false )
+        def r6 = Channel.of(1,2,3,4).collate( 6,6,false )
         then:
         r6.val == Channel.STOP
 
@@ -666,8 +666,8 @@ class OperatorImplTest extends Specification {
 
     def testMix() {
         when:
-        def c1 = Channel.from( 1,2,3 )
-        def c2 = Channel.from( 'a','b' )
+        def c1 = Channel.of( 1,2,3 )
+        def c2 = Channel.of( 'a','b' )
         def c3 = Channel.value( 'z' )
         def result = c1.mix(c2,c3).toList().val
 
@@ -684,7 +684,7 @@ class OperatorImplTest extends Specification {
 
     def testMixWithSingleton() {
         when:
-        def result = Channel.value(1).mix( Channel.from([2,3])  )
+        def result = Channel.value(1).mix( Channel.of(2,3)  )
         then:
         result.toList().val.sort() == [1,2,3]
     }
@@ -733,8 +733,8 @@ class OperatorImplTest extends Specification {
     def testCross() {
 
         setup:
-        def ch1 = Channel.from(  [1, 'x'], [2,'y'], [3,'z'] )
-        def ch2 = Channel.from( [1,11], [1,13], [2,21],[2,22], [2,23], [4,1], [4,2]  )
+        def ch1 = Channel.of( [1, 'x'], [2,'y'], [3,'z'] )
+        def ch2 = Channel.of( [1,11], [1,13], [2,21],[2,22], [2,23], [4,1], [4,2]  )
 
         when:
         def result = ch1.cross(ch2)
@@ -753,7 +753,7 @@ class OperatorImplTest extends Specification {
 
         setup:
         def ch1 = Channel.create()
-        def ch2 = Channel.from ( ['PF00006', 'PF00006_mafft.aln'], ['PF00006', 'PF00006_clustalo.aln'])
+        def ch2 = Channel.of ( ['PF00006', 'PF00006_mafft.aln'], ['PF00006', 'PF00006_clustalo.aln'])
 
         when:
         Thread.start {  sleep 100;   ch1 << ['PF00006', 'PF00006.sp_lib'] << Channel.STOP }
@@ -770,7 +770,7 @@ class OperatorImplTest extends Specification {
     def testCross3() {
 
         setup:
-        def ch1 = Channel.from([['PF00006', 'PF00006.sp_lib'] ])
+        def ch1 = Channel.of(['PF00006', 'PF00006.sp_lib'])
         def ch2 = Channel.create ( )
 
         when:
@@ -788,8 +788,8 @@ class OperatorImplTest extends Specification {
     def testConcat() {
 
         when:
-        def c1 = Channel.from(1,2,3)
-        def c2 = Channel.from('a','b','c')
+        def c1 = Channel.of(1,2,3)
+        def c2 = Channel.of('a','b','c')
         def all = c1.concat(c2)
         then:
         all.val == 1
@@ -802,7 +802,7 @@ class OperatorImplTest extends Specification {
 
         when:
         def d1 = Channel.create()
-        def d2 = Channel.from('a','b','c')
+        def d2 = Channel.of('a','b','c')
         def d3 = Channel.create()
         def result = d1.concat(d2,d3)
 
@@ -823,7 +823,7 @@ class OperatorImplTest extends Specification {
 
     def testContactWithSingleton() {
         when:
-        def result = Channel.value(1).concat( Channel.from(2,3) )
+        def result = Channel.value(1).concat( Channel.of(2,3) )
         then:
         result.val == 1
         result.val == 2
@@ -1014,7 +1014,7 @@ class OperatorImplTest extends Specification {
         def result
 
         when:
-        result = Channel.from(1,2,3).ifEmpty(100)
+        result = Channel.of(1,2,3).ifEmpty(100)
         then:
         result.val == 1
         result.val == 2
@@ -1065,7 +1065,7 @@ class OperatorImplTest extends Specification {
         def session = new Session()
 
         when:
-        Channel.from(10,20,30)
+        Channel.of(10,20,30)
                 .map { it +2 }
                 .set { result }
 
@@ -1090,14 +1090,14 @@ class OperatorImplTest extends Specification {
     def 'should emit channel items until the condition is verified' () {
 
         when:
-        def result = Channel.from(1,2,3,4).until { it == 3 }
+        def result = Channel.of(1,2,3,4).until { it == 3 }
         then:
         result.val == 1
         result.val == 2
         result.val == Channel.STOP
 
         when:
-        result = Channel.from(1,2,3).until { it == 5 }
+        result = Channel.of(1,2,3).until { it == 5 }
         then:
         result.val == 1
         result.val == 2
@@ -1126,7 +1126,7 @@ class OperatorImplTest extends Specification {
         def session = new Session()
 
         when:
-        Channel.from(1,2,3).set { result }
+        Channel.of(1,2,3).set { result }
 
         then:
         session.binding.result.val == 1

--- a/modules/nextflow/src/test/groovy/nextflow/extension/RandomSampleTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/RandomSampleTest.groovy
@@ -34,7 +34,7 @@ class RandomSampleTest extends Specification {
     def 'should produce random sample' () {
 
         given:
-        def ch = Channel.from('A'..'Z')
+        def ch = Channel.of('A'..'Z')
         def sampler = new RandomSampleOp(ch, 10)
 
         when:
@@ -49,7 +49,7 @@ class RandomSampleTest extends Specification {
     def 'should produce random sample given a short channel' () {
 
         given:
-        def ch = Channel.from('A'..'J')
+        def ch = Channel.of('A'..'J')
         def sampler = new RandomSampleOp(ch, 20)
 
         when:
@@ -63,7 +63,7 @@ class RandomSampleTest extends Specification {
     def 'should produce random sample given a channel emitting the same number of items as the buffer' () {
 
         given:
-        def ch = Channel.from('A'..'J')
+        def ch = Channel.of('A'..'J')
         def sampler = new RandomSampleOp(ch, 10)
 
         when:
@@ -77,8 +77,8 @@ class RandomSampleTest extends Specification {
     def 'should always produce the same sequence' () {
         given:
         def testSeq = 'A'..'J'
-        def ch1 = Channel.from(testSeq)
-        def ch2 = Channel.from(testSeq)
+        def ch1 = Channel.of(testSeq)
+        def ch2 = Channel.of(testSeq)
         def seed  = 23
         def firstSampler = new RandomSampleOp(ch1, 10, seed)
         def secondSampler = new RandomSampleOp(ch2, 10, seed)

--- a/modules/nextflow/src/test/groovy/nextflow/extension/SetOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/SetOpTest.groovy
@@ -30,7 +30,7 @@ class SetOpTest extends Dsl2Spec {
     def 'should set a channel in the global context' () {
         when:
         def result = dsl_eval(/
-            Channel.from(1,2,3) | set { foo }
+            Channel.of(1,2,3) | set { foo }
             foo | map { it *2 }
         /)
         then:
@@ -50,7 +50,7 @@ class SetOpTest extends Dsl2Spec {
     def 'should invoke set with dot notation' () {
         when:
         def result = dsl_eval(/
-            Channel.from(1,2,3).set { foo } 
+            Channel.of(1,2,3).set { foo } 
             foo.map { it *2 }
         /)
         then:

--- a/modules/nextflow/src/test/groovy/nextflow/extension/SplitFastaOperatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/SplitFastaOperatorTest.groovy
@@ -70,7 +70,7 @@ class SplitFastaOperatorTest extends Specification {
     def 'should split fasta in sequences'() {
 
         given:
-        def sequences = Channel.from(fasta1).splitFasta()
+        def sequences = Channel.of(fasta1).splitFasta()
 
         expect:
         with(sequences) {
@@ -86,7 +86,7 @@ class SplitFastaOperatorTest extends Specification {
     def 'should split fasta in records' () {
 
         given:
-        def records = Channel.from(fasta1, fasta2).splitFasta(record:[id:true])
+        def records = Channel.of(fasta1, fasta2).splitFasta(record:[id:true])
         expect:
         records.val == [id:'1aboA']
         records.val == [id:'1ycsB']
@@ -117,7 +117,7 @@ class SplitFastaOperatorTest extends Specification {
 
         given:
         def target = Channel.create()
-        Channel.from(fasta1,fasta2).splitFasta(record:[id:true], into: target)
+        Channel.of(fasta1,fasta2).splitFasta(record:[id:true], into: target)
 
         expect:
         target.val == [id:'1aboA']
@@ -153,7 +153,7 @@ class SplitFastaOperatorTest extends Specification {
         def target = Channel.create()
 
         when:
-        Channel.from(F1,F3).splitFasta(by:2, into: target)
+        Channel.of(F1,F3).splitFasta(by:2, into: target)
         then:
         target.val == '>1\nAAA\n>2\nBBB\n'
         target.val == '>3\nCCC\n'
@@ -194,7 +194,7 @@ class SplitFastaOperatorTest extends Specification {
         def target = Channel.create()
 
         when:
-        Channel.from(F1,F3).splitFasta(by:2, limit:4, into: target)
+        Channel.of(F1,F3).splitFasta(by:2, limit:4, into: target)
         then:
         target.val == '>1\nAAA\n>2\nBBB\n'
         target.val == '>3\nCCC\n>4\nDDD\n'

--- a/modules/nextflow/src/test/groovy/nextflow/extension/SplitFastqOp2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/SplitFastqOp2Test.groovy
@@ -77,7 +77,7 @@ class SplitFastqOp2Test extends Dsl2Spec {
 
         when:
         channel = dsl_eval("""
-            Channel.from([['sample_id', file("$file1"), file("$file2")]]).splitFastq(by:1, pe:true)
+            Channel.of(['sample_id', file("$file1"), file("$file2")]).splitFastq(by:1, pe:true)
         """)
 
         result = channel.val

--- a/modules/nextflow/src/test/groovy/nextflow/extension/SplitFastqOperatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/SplitFastqOperatorTest.groovy
@@ -78,7 +78,7 @@ class SplitFastqOperatorTest extends Specification {
     def 'should split a fastq' () {
 
         when:
-        def target = Channel.from(READS).splitFastq(by:2)
+        def target = Channel.of(READS).splitFastq(by:2)
         then:
         target.val == '''
             @SRR636272.19519409/1
@@ -113,7 +113,7 @@ class SplitFastqOperatorTest extends Specification {
         def folder = Files.createTempDirectory('test')
 
         when:
-        def target = Channel.from(READS).splitFastq(by:2, compress:true, file:folder)
+        def target = Channel.of(READS).splitFastq(by:2, compress:true, file:folder)
         then:
         gunzip(target.val) == '''
             @SRR636272.19519409/1
@@ -148,7 +148,7 @@ class SplitFastqOperatorTest extends Specification {
     def 'should split read pairs' () {
 
         when:
-        def result = Channel.from([['sample_id',READS,READS2]]).splitFastq(by:1, elem:[1,2]).toList().val
+        def result = Channel.of(['sample_id',READS,READS2]).splitFastq(by:1, elem:[1,2]).toList().val
 
         then:
         result.size() ==4
@@ -218,7 +218,7 @@ class SplitFastqOperatorTest extends Specification {
         def result
 
         when:
-        channel = Channel.from([['sample_id',file1,file2]]).splitFastq(by:1, pe:true)
+        channel = Channel.of(['sample_id',file1,file2]).splitFastq(by:1, pe:true)
         result = channel.val
         then:
         result[0] == 'sample_id'

--- a/modules/nextflow/src/test/groovy/nextflow/extension/SplitTextOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/SplitTextOpTest.groovy
@@ -13,14 +13,14 @@ class SplitTextOpTest extends Specification {
     def 'should split text' () {
 
         when:
-        def result = Channel.from('foo\nbar').splitText()
+        def result = Channel.of('foo\nbar').splitText()
         then:
         result.val == 'foo\n'
         result.val == 'bar\n'
         result.val == Channel.STOP
 
         when:
-        result = Channel.from('foo\nbar\nbaz').splitText(by:2)
+        result = Channel.of('foo\nbar\nbaz').splitText(by:2)
         then:
         result.val == 'foo\nbar\n'
         result.val == 'baz\n'
@@ -30,14 +30,14 @@ class SplitTextOpTest extends Specification {
     def 'should split text and invoke closure' () {
 
         when:
-        def result = Channel.from('foo\nbar').splitText { it.trim().reverse() }
+        def result = Channel.of('foo\nbar').splitText { it.trim().reverse() }
         then:
         result.val == 'oof'
         result.val == 'rab'
         result.val == Channel.STOP
 
         when:
-        result = Channel.from('aa\nbb\ncc\ndd').splitText(by:2) { it.trim() }
+        result = Channel.of('aa\nbb\ncc\ndd').splitText(by:2) { it.trim() }
         then:
         result.val == 'aa\nbb'
         result.val == 'cc\ndd'

--- a/modules/nextflow/src/test/groovy/nextflow/extension/TransposeOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/TransposeOpTest.groovy
@@ -31,7 +31,7 @@ class TransposeOpTest extends Specification {
     def 'should transpose tuple' () {
 
         given:
-        def ch = Channel.from(['a',[1,2,3],'p','q'], ['b',[4,5,6],'x','y'])
+        def ch = Channel.of(['a',[1,2,3],'p','q'], ['b',[4,5,6],'x','y'])
 
         when:
         def result = new TransposeOp(ch).apply()
@@ -51,7 +51,7 @@ class TransposeOpTest extends Specification {
     def 'should transpose multiple tuples' () {
 
         given:
-        def ch = Channel.from(['a',[1,2,3],['p','q']], ['b',[4,5,6],['x','y']])
+        def ch = Channel.of(['a',[1,2,3],['p','q']], ['b',[4,5,6],['x','y']])
 
         when:
         def result = new TransposeOp(ch).apply()
@@ -69,7 +69,7 @@ class TransposeOpTest extends Specification {
     def 'should transpose multiple tuples with remainder' () {
 
         given:
-        def ch = Channel.from(['a',[1,2,3],['p','q']], ['b',[4,5],['x','y','z']])
+        def ch = Channel.of(['a',[1,2,3],['p','q']], ['b',[4,5],['x','y','z']])
 
         when:
         def result = new TransposeOp(ch, [remainder:true]).apply()
@@ -89,7 +89,7 @@ class TransposeOpTest extends Specification {
     def 'should transpose tuple by 1' () {
 
         given:
-        def ch = Channel.from(['a',[1,2,3],['p','q']], ['b',[4,5,6],['x','y']])
+        def ch = Channel.of(['a',[1,2,3],['p','q']], ['b',[4,5,6],['x','y']])
 
         when:
         def result = new TransposeOp(ch, [by:1]).apply()
@@ -137,7 +137,7 @@ class TransposeOpTest extends Specification {
     def 'should transpose tuple 3' () {
 
         given:
-        def ch = Channel.from(['a','b'], ['c','d'], ['e','f'])
+        def ch = Channel.of(['a','b'], ['c','d'], ['e','f'])
 
         when:
         def result = new TransposeOp(ch).apply()
@@ -153,7 +153,7 @@ class TransposeOpTest extends Specification {
     def 'should transpose values' () {
 
         given:
-        def ch = Channel.from('a','b','c','d')
+        def ch = Channel.of('a','b','c','d')
 
         when:
         def result = new TransposeOp(ch).apply()

--- a/modules/nextflow/src/test/groovy/nextflow/extension/ViewOperatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/ViewOperatorTest.groovy
@@ -43,7 +43,7 @@ class ViewOperatorTest extends Specification{
     def 'should print channel items'() {
 
         when:
-        def result = Channel.from(1,2,3).view()
+        def result = Channel.of(1,2,3).view()
         then:
         result.val == 1
         result.val == 2
@@ -56,7 +56,7 @@ class ViewOperatorTest extends Specification{
     def 'should print channel items applying the closure formatting rule'() {
 
         when:
-        def result = Channel.from(1,2,3).view { "~ $it " }
+        def result = Channel.of(1,2,3).view { "~ $it " }
         then:
         result.val == 1
         result.val == 2
@@ -70,7 +70,7 @@ class ViewOperatorTest extends Specification{
     def 'should print channel items without appending the newline character'() {
 
         when:
-        def result = Channel.from(1,2,3).view(newLine:false) { " ~ $it" }
+        def result = Channel.of(1,2,3).view(newLine:false) { " ~ $it" }
         then:
         result.val == 1
         result.val == 2

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
@@ -59,7 +59,7 @@ class ScriptIncludesTest extends Dsl2Spec {
                 "echo 'hello'"
         }
         workflow {
-            foo(Channel.from(new Foo(id: "hello_world")))
+            foo(Channel.of(new Foo(id: "hello_world")))
         }
         """
 
@@ -205,7 +205,7 @@ class ScriptIncludesTest extends Dsl2Spec {
         include { foo } from "$MODULE" 
         workflow {
            emit:
-           channel.from( foo() ).flatMap { foo(it, it*2) } 
+           channel.fromList( foo() ).flatMap { foo(it, it*2) } 
         }
         """
 
@@ -242,7 +242,7 @@ class ScriptIncludesTest extends Dsl2Spec {
         include { foo } from "$MODULE" 
         workflow {
            emit:
-           channel.from( foo(1, 2, 3) ) 
+           channel.of( foo(1, 2, 3) ) 
         }
         """
 
@@ -463,7 +463,7 @@ class ScriptIncludesTest extends Dsl2Spec {
 
         SCRIPT.text = """
         include { foo } from "$MODULE" 
-        hello_ch = Channel.from('world')
+        hello_ch = Channel.of('world')
         
         workflow {
             main: foo(hello_ch)
@@ -504,7 +504,7 @@ class ScriptIncludesTest extends Dsl2Spec {
         include { foo } from './module.nf'
 
         workflow {
-          main: ch1 = Channel.from('world')
+          main: ch1 = Channel.of('world')
                 ch2 = Channel.value(['x', '/some/file'])
                 foo(ch1, ch2)
           emit: foo.out  

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptPipesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptPipesTest.groovy
@@ -30,7 +30,7 @@ class ScriptPipesTest extends Dsl2Spec {
         } 
 
         workflow {
-            main: Channel.from('Hello') | map { it.reverse() } | (foo & bar)
+            main: Channel.of('Hello') | map { it.reverse() } | (foo & bar)
             emit:
                 foo.out
                 bar.out
@@ -66,7 +66,7 @@ class ScriptPipesTest extends Dsl2Spec {
         } 
 
         workflow {
-            emit: Channel.from('Hola') | foo | map { it.reverse() } | bar
+            emit: Channel.of('Hola') | foo | map { it.reverse() } | bar
         }
         '''
 
@@ -105,7 +105,7 @@ class ScriptPipesTest extends Dsl2Spec {
         // the multiple output channels 
         // to the `bar` process receiving multiple inputs
         workflow {
-            emit: Channel.from('hello') | foo | bar 
+            emit: Channel.of('hello') | foo | bar 
         }
         '''
 
@@ -136,7 +136,7 @@ class ScriptPipesTest extends Dsl2Spec {
         // pipe the multiple output channels 
         // to the `concat` operator
         workflow {
-            emit: Channel.from('hola') | foo | concat 
+            emit: Channel.of('hola') | foo | concat 
         }
         '''
 
@@ -216,7 +216,7 @@ class ScriptPipesTest extends Dsl2Spec {
         }     
         
         workflow {
-            emit: Channel.from(1,2,3) | square | collect 
+            emit: Channel.of(1,2,3) | square | collect 
         }
         '''
 
@@ -232,7 +232,7 @@ class ScriptPipesTest extends Dsl2Spec {
     def 'should pipe branch output to concat operator' () {
         given:
         def SCRIPT ='''   
-        Channel.from(10,20,30) | branch { foo: it <=10; bar: true } | concat 
+        Channel.of(10,20,30) | branch { foo: it <=10; bar: true } | concat 
         '''
 
         when:
@@ -255,7 +255,7 @@ class ScriptPipesTest extends Dsl2Spec {
         }
 
         workflow {
-           emit: Channel.from(10,20) | branch { foo: it <=10; bar: true } | foo 
+           emit: Channel.of(10,20) | branch { foo: it <=10; bar: true } | foo 
         }
         '''
 
@@ -329,7 +329,7 @@ class ScriptPipesTest extends Dsl2Spec {
         }
         
         def init(str='hi'){
-            Channel.from(str)
+            Channel.of(str)
         }
         
         workflow {
@@ -357,7 +357,7 @@ class ScriptPipesTest extends Dsl2Spec {
         }
         
         def init(str='hi'){
-            Channel.from(str)
+            Channel.of(str)
         }
         
         workflow {
@@ -385,7 +385,7 @@ class ScriptPipesTest extends Dsl2Spec {
         }
         
         def init(str='hi'){
-            Channel.from(str)
+            Channel.of(str)
         }
 
         def bar(ch1=null) {            

--- a/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
@@ -438,7 +438,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec {
         }
         workflow{
             main:
-                Channel.from('hi') | sayHello
+                Channel.of('hi') | sayHello
             emit:
                 sayHello.out
         }
@@ -484,7 +484,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec {
         }
         workflow{
             main:
-                Channel.from('hi') | foo
+                Channel.of('hi') | foo
             emit:
                 foo.out
         }


### PR DESCRIPTION
Second batch of changes from #3344 . This PR removes the use of `Channel.from` from all tests, since the method is deprecated. I didn't remove the method outright, but I did add a warning to match the documentation.