### PR TITLE
Remove deprecated code (part 3)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -397,15 +397,15 @@ class TaskProcessor {
         if ( !taskBody )
             throw new IllegalStateException("Missing task body for process `$name`")
 
-        // -- check that input set defines at least two elements
-        def invalidInputSet = config.getInputs().find { it instanceof TupleInParam && it.inner.size()<2 }
-        if( invalidInputSet )
-            checkWarn "Input `set` must define at least two component -- Check process `$name`"
+        // -- check that input tuple defines at least two elements
+        def invalidInputTuple = config.getInputs().find { it instanceof TupleInParam && it.inner.size()<2 }
+        if( invalidInputTuple )
+            checkWarn "Input `tuple` must define at least two elements -- Check process `$name`"
 
-        // -- check that output set defines at least two elements
-        def invalidOutputSet = config.getOutputs().find { it instanceof TupleOutParam && it.inner.size()<2 }
-        if( invalidOutputSet )
-            checkWarn "Output `set` must define at least two component -- Check process `$name`"
+        // -- check that output tuple defines at least two elements
+        def invalidOutputTuple = config.getOutputs().find { it instanceof TupleOutParam && it.inner.size()<2 }
+        if( invalidOutputTuple )
+            checkWarn "Output `tuple` must define at least two elements -- Check process `$name`"
 
         /**
          * Verify if this process run only one time
@@ -589,7 +589,7 @@ class TaskProcessor {
         currentTask.set(task)
 
         // -- validate input lengths
-        validateInputSets(values)
+        validateInputTuples(values)
 
         // -- map the inputs to a map and use to delegate closure values interpolation
         final secondPass = [:]
@@ -619,13 +619,13 @@ class TaskProcessor {
     }
 
     @Memoized
-    private List<TupleInParam> getDeclaredInputSet() {
+    private List<TupleInParam> getDeclaredInputTuple() {
         getConfig().getInputs().ofType(TupleInParam)
     }
 
-    protected void validateInputSets( List values ) {
+    protected void validateInputTuples( List values ) {
 
-        def declaredSets = getDeclaredInputSet()
+        def declaredSets = getDeclaredInputTuple()
         for( int i=0; i<declaredSets.size(); i++ ) {
             final param = declaredSets[i]
             final entry = values[param.index]
@@ -633,7 +633,7 @@ class TaskProcessor {
             final actual = entry instanceof Collection ? entry.size() : (entry instanceof Map ? entry.size() : 1)
 
             if( actual != expected ) {
-                final msg = "Input tuple does not match input set cardinality declared by process `$name` -- offending value: $entry"
+                final msg = "Input tuple does not match tuple declaration in process `$name` -- offending value: $entry"
                 checkWarn(msg, [firstOnly: true, cacheKey: this])
             }
         }

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -91,13 +91,9 @@ abstract class BaseScript extends Script implements ExecutionContext {
     }
 
     protected process( String name, Closure<BodyDef> body ) {
-        if( NF.isDsl2() ) {
-            def process = new ProcessDef(this,body,name)
-            meta.addDefinition(process)
-        }
-        else {
-            throw new UnsupportedOperationException("DSL1 is not supported anymore")
-        }
+        log.info "BaseScript.process ${name}"
+        def process = new ProcessDef(this,body,name)
+        meta.addDefinition(process)
     }
 
     /**
@@ -160,22 +156,6 @@ abstract class BaseScript extends Script implements ExecutionContext {
         if( !entryFlow ) {
             if( meta.getLocalWorkflowNames() )
                 log.warn "No entry workflow specified"
-            if( meta.getLocalProcessNames() ) {
-                final msg = """\
-                        =============================================================================
-                        =                                WARNING                                    =
-                        = You are running this script using DSL2 syntax, however it does not        = 
-                        = contain any 'workflow' definition so there's nothing for Nextflow to run. =
-                        =                                                                           =
-                        = If this script was written using Nextflow DSL1 syntax, please add the     = 
-                        = setting 'nextflow.enable.dsl=1' to the nextflow.config file or use the    =
-                        = command-line option '-dsl1' when running the pipeline.                    =
-                        =                                                                           =
-                        = More details at this link: https://www.nextflow.io/docs/latest/dsl2.html  =
-                        =============================================================================
-                        """.stripIndent()
-                throw new AbortOperationException(msg)
-            }
             return result
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -57,28 +57,6 @@ class IncludeDef {
     @PackageScope Map addedParams
     private Session session
 
-    @Deprecated
-    IncludeDef( String module ) {
-        final msg = "Anonymous module inclusion is deprecated -- Replace `include '${module}'` with `include { MODULE_NAME } from '${module}'`"
-        if( NF.isDsl2() )
-            throw new DeprecationException(msg)
-        log.warn msg
-        this.path = module
-        this.modules = new ArrayList<>(1)
-        this.modules << new Module(null,null)
-    }
-
-    IncludeDef(TokenVar token, String alias=null) {
-        def component = token.name; if(alias) component += " as $alias"
-        def msg = "Unwrapped module inclusion is deprecated -- Replace `include $component from './MODULE/PATH'` with `include { $component } from './MODULE/PATH'`"
-        if( NF.isDsl2() )
-            throw new DeprecationException(msg)
-        log.warn msg
-
-        this.modules = new ArrayList<>(1)
-        this.modules << new Module(token.name, alias)
-    }
-
     protected IncludeDef(List<Module> modules) {
         this.modules = new ArrayList<>(modules)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -49,22 +49,20 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             'afterScript',
             'beforeScript',
             'cache',
-            'conda',
-            'cpus',
-            'container',
-            'containerOptions',
             'cleanup',
             'clusterOptions',
+            'conda',
+            'container',
+            'containerOptions',
+            'cpus',
             'debug',
             'disk',
-            'echo', // deprecated
             'errorStrategy',
             'executor',
             'ext',
             'fair',
-            'machineType',
-            'queue',
             'label',
+            'machineType',
             'maxErrors',
             'maxForks',
             'maxRetries',
@@ -73,24 +71,24 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             'penv',
             'pod',
             'publishDir',
+            'queue',
+            'resourceLabels',
             'scratch',
+            'secret',
             'shell',
             'spack',
+            'stageInMode',
+            'stageOutMode',
             'storeDir',
             'tag',
             'time',
             // input-output qualifiers
             'file',
-            'set',
             'val',
             'each',
             'env',
-            'secret',
             'stdin',
-            'stdout',
-            'stageInMode',
-            'stageOutMode',
-            'resourceLabels'
+            'stdout'
     ]
 
     /**
@@ -535,12 +533,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
         new EachInParam(this).bind(obj)
     }
 
-    InParam _in_set( Object... obj ) {
-        final msg = "Input of type `set` is deprecated -- Use `tuple` instead"
-        if( NF.isDsl2() ) throw new DeprecationException(msg)
-        new TupleInParam(this).bind(obj)
-    }
-
     InParam _in_tuple( Object... obj ) {
         new TupleInParam(this).bind(obj)
     }
@@ -603,12 +595,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
                     .setOptions(opts)
                     .bind(obj)
         }
-    }
-
-    OutParam _out_set( Object... obj ) {
-        final msg = "Output of type `set` is deprecated -- Use `tuple` instead"
-        if( NF.isDsl2() ) throw new DeprecationException(msg)
-        new TupleOutParam(this) .bind(obj)
     }
 
     OutParam _out_tuple( Object... obj ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptBinding.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptBinding.groovy
@@ -186,12 +186,7 @@ class ScriptBinding extends WorkflowBinding {
 
     @Override
     void setVariable( String name, Object value ) {
-        if( name == 'channel' ) {
-            final msg = 'The use of the identifier `channel` as variable name is discouraged and will be deprecated in a future version'
-            if( NF.isDsl2() ) throw new DeprecationException(msg)
-            log.warn(msg)
-        }
-        if( name != 'args' && name != 'params' )
+        if( name !in ['args', 'channel', 'params'] )
             super.setVariable(name, value)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -98,8 +98,6 @@ class ScriptMeta {
     /** The module components included in the script */
     private Map<String,ComponentDef> imports = new HashMap<>(10)
 
-    private List<String> dsl1ProcessNames
-
     /** Whenever it's a module script or the main script */
     private boolean module
 
@@ -166,25 +164,6 @@ class ScriptMeta {
                 throw new DuplicateModuleFunctionException(msg)
             log.warn(msg)
         }
-    }
-
-    /*
-     * This method invocation is made by the NF AST transformer to pass
-     * the process names declared in the workflow script. This is only required
-     * for DSL1 script.
-     *
-     * When using DSL2 process names can be discovered during
-     * the script execution since, the process declaration is de-coupled by the
-     * process invocations.
-     */
-    @PackageScope
-    void setDsl1ProcessNames(List<String> names) {
-        this.dsl1ProcessNames = names
-    }
-
-    @PackageScope
-    List<String> getDsl1ProcessNames() {
-        dsl1ProcessNames ?: Collections.<String>emptyList()
     }
 
     @PackageScope
@@ -265,9 +244,6 @@ class ScriptMeta {
     }
 
     Set<String> getProcessNames() {
-        if( NF.dsl1 )
-            return new HashSet<String>(getDsl1ProcessNames())
-
         def result = new HashSet(definitions.size() + imports.size())
         // local definitions
         for( def item : definitions.values() ) {
@@ -283,9 +259,6 @@ class ScriptMeta {
     }
 
     Set<String> getLocalProcessNames() {
-        if( NF.dsl1 )
-            return new HashSet<String>(getDsl1ProcessNames())
-
         def result = new HashSet(definitions.size() + imports.size())
         // local definitions
         for( def item : definitions.values() ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptTokens.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptTokens.groovy
@@ -37,10 +37,10 @@ class TokenVar {
 }
 
 /**
- *  A token used by the DSL to identify a 'file' declaration in a 'set' parameter, for example:
+ *  A token used by the DSL to identify a 'file' declaration in a 'tuple' parameter, for example:
  *      <pre>
  *      input:
- *      set( file('name'), ... )
+ *      tuple( file('name'), ... )
  *      </pre>
  *
  */
@@ -50,10 +50,10 @@ class TokenFileCall {
 }
 
 /**
- *  A token used by the DSL to identify a 'path' declaration in a 'set' parameter, for example:
+ *  A token used by the DSL to identify a 'path' declaration in a 'tuple' parameter, for example:
  *      <pre>
  *      input:
- *      set( path('name'), ... )
+ *      tuple( path('name'), ... )
  *      </pre>
  *
  */
@@ -100,7 +100,7 @@ class TokenStdoutCall { }
  * Token used by the DSL to identify a environment variable declaration, like this
  *     <pre>
  *     input:
- *     set( env(X), ... )
+ *     tuple( env(X), ... )
  *     <pre>
  */
 @ToString
@@ -115,10 +115,10 @@ class TokenEnvCall {
  * This class is used to identify a 'val' when used like in this example:
  * <pre>
  *  input:
- *  set ( val(x), ...  )
+ *  tuple ( val(x), ...  )
  *
  *  output:
- *  set( val(y), ...  )
+ *  tuple( val(y), ...  )
  *
  * </pre>
  *

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/BaseInParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/BaseInParam.groovy
@@ -81,23 +81,9 @@ abstract class BaseInParam extends BaseParam implements InParam {
             return CH.getReadChannel(value)
         }
 
-        if( NF.isDsl2() ) {
-            final result = CH.value()
-            result.bind(value)
-            return result
-        }
-
-        // wrap any collections with a DataflowQueue
-        if( value instanceof Collection ) {
-            return CH.emitAndClose(CH.queue(), value)
-        }
-
-        // wrap any array with a DataflowQueue
-        if ( value && value.class.isArray() ) {
-            return CH.emitAndClose(CH.queue(), value as Collection)
-        }
-
-        value!=null ? CH.value(value) : CH.value() 
+        final result = CH.value()
+        result.bind(value)
+        return result
     }
 
 
@@ -170,13 +156,6 @@ abstract class BaseInParam extends BaseParam implements InParam {
         throw new IllegalArgumentException(message)
     }
 
-    BaseInParam from( def obj ) {
-        if( NF.isDsl2() )
-            throw new ScriptRuntimeException("Process clause `from` should not be provided when using DSL 2")
-        setFrom(obj)
-        return this
-    }
-
     void setFrom( obj ) {
         checkFromNotNull(obj)
         fromObject = obj
@@ -188,22 +167,6 @@ abstract class BaseInParam extends BaseParam implements InParam {
         if( CH.isChannel(inChannel) )
             return inChannel
         throw new IllegalStateException("Missing input channel")
-    }
-
-    BaseInParam from( Object... obj ) {
-
-        def normalize = obj.collect {
-            if( it instanceof DataflowReadChannel )
-                throw new IllegalArgumentException("Multiple channels are not allowed on 'from' input declaration")
-
-            if( it instanceof Closure )
-                return it.call()
-            else
-                it
-        }
-
-        fromObject = normalize as List
-        return this
     }
 
     def decodeInputs( List inputs ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/BaseOutParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/BaseOutParam.groovy
@@ -63,10 +63,8 @@ abstract class BaseOutParam extends BaseParam implements OutParam {
 
     void lazyInit() {
 
-        if( intoObj instanceof TokenVar[] ) {
-            if( NF.dsl2 )
-                throw new IllegalArgumentException("Not a valid output channel argument: $intoObj")
-            for( def it : intoObj ) { lazyInitImpl(it) }
+        if( intoObj instanceof TokenVar || intoObj instanceof TokenVar[] ) {
+            throw new IllegalArgumentException("Not a valid output channel argument: $intoObj")
         }
         else if( intoObj != null ) {
             lazyInitImpl(intoObj)
@@ -84,14 +82,9 @@ abstract class BaseOutParam extends BaseParam implements OutParam {
 
     @PackageScope
     void lazyInitImpl( def target ) {
-        def channel = null
-        if( target instanceof TokenVar ) {
-            assert !NF.dsl2
-            channel = outputValToChannel(target.name)
-        }
-        else if( target != null ) {
-            channel = outputValToChannel(target)
-        }
+        def channel = (target != null)
+            ? outputValToChannel(target)
+            : null
 
         if( channel ) {
             outChannels.add(channel)
@@ -157,20 +150,6 @@ abstract class BaseOutParam extends BaseParam implements OutParam {
         return this
     }
 
-    BaseOutParam into( def value ) {
-        if( NF.dsl2 )
-            throw new ScriptRuntimeException("Process clause `into` should not be provided when using DSL 2")
-        this.intoObj = value
-        return this
-    }
-
-    BaseOutParam into( TokenVar... vars ) {
-        if( NF.dsl2 )
-            throw new ScriptRuntimeException("Process clause `into` should not be provided when using DSL 2")
-        intoObj = vars
-        return this
-    }
-
     void setInto( Object obj ) {
         intoObj = obj
     }
@@ -178,12 +157,6 @@ abstract class BaseOutParam extends BaseParam implements OutParam {
     DataflowWriteChannel getOutChannel() {
         init()
         return outChannels ? outChannels.get(0) : null
-    }
-
-    @Deprecated
-    List<DataflowWriteChannel> getOutChannels() {
-        init()
-        return outChannels
     }
 
     String getName() {

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/FileInParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/FileInParam.groovy
@@ -56,13 +56,6 @@ class FileInParam extends BaseInParam implements PathQualifier {
             return this
         }
 
-        // the ability to pass a closure as file name has been replaced by
-        // lazy gstring -- this should be deprecated
-        if( obj instanceof Closure && !NF.dsl2 ) {
-            filePattern = obj
-            return this
-        }
-
         throw new IllegalArgumentException()
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/InParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/InParam.groovy
@@ -32,10 +32,6 @@ interface InParam extends Cloneable {
 
     Object getRawChannel()
 
-    InParam from( Object value )
-
-    InParam from( Object... values )
-
     short index
 
     short mapIndex

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/OutParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/OutParam.groovy
@@ -33,17 +33,6 @@ interface OutParam extends Cloneable {
     String getName()
 
     /**
-     * Defines the channel to which bind the output(s) in the script context
-     *
-     * @param value It can be a string representing a channel variable name in the script context. If
-     *      the variable does not exist it creates a {@code DataflowVariable} in the script with that name.
-     *      If the specified {@code value} is a {@code DataflowWriteChannel} object, use this object
-     *      as the output channel
-     * @return
-     */
-    OutParam into( def value )
-
-    /**
      * @return The output channel instance
      */
     DataflowWriteChannel getOutChannel()

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/TupleInParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/TupleInParam.groovy
@@ -36,7 +36,7 @@ class TupleInParam extends BaseInParam {
 
     protected List<BaseInParam> inner = []
 
-    @Override String getTypeName() { 'set' }
+    @Override String getTypeName() { 'tuple' }
 
     @Override
     TupleInParam clone() {

--- a/modules/nextflow/src/test/groovy/nextflow/ast/NextflowDSLImplTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/ast/NextflowDSLImplTest.groovy
@@ -1,23 +1,32 @@
 package nextflow.ast
 
+import nextflow.Session
 import nextflow.script.BaseScript
 import nextflow.script.ScriptMeta
+import nextflow.script.ScriptParser
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
-import test.BaseSpec
+import test.Dsl2Spec
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-class NextflowDSLImplTest extends BaseSpec {
+class NextflowDSLImplTest extends Dsl2Spec {
+
+    def createCompilerConfig() {
+        def config = new CompilerConfiguration()
+        config.setScriptBaseClass(BaseScript.class.name)
+        config.addCompilationCustomizers( new ASTTransformationCustomizer(NextflowDSL))
+
+        return config
+    }
+
 
     def 'should fetch method names' () {
 
         given:
-        def config = new CompilerConfiguration()
-        config.setScriptBaseClass(BaseScript.class.name)
-        config.addCompilationCustomizers( new ASTTransformationCustomizer(NextflowDSL))
+        def config = createCompilerConfig()
 
         def SCRIPT = '''
             def foo() { 
@@ -35,8 +44,8 @@ class NextflowDSLImplTest extends BaseSpec {
             process alpha {
               /hello/
             }
-
         '''
+
         when:
         new GroovyShell(config).parse(SCRIPT)
         then:
@@ -45,12 +54,9 @@ class NextflowDSLImplTest extends BaseSpec {
 
     def 'should not allow duplicate processes' () {
         given:
-        def config = new CompilerConfiguration()
-        config.setScriptBaseClass(BaseScript.class.name)
-        config.addCompilationCustomizers( new ASTTransformationCustomizer(NextflowDSL))
+        def config = createCompilerConfig()
 
         def SCRIPT = '''
-                    
             process alpha {
               /hello/
             }
@@ -58,7 +64,6 @@ class NextflowDSLImplTest extends BaseSpec {
             process alpha {
               /world/
             }
-
         '''
 
         when:
@@ -71,12 +76,9 @@ class NextflowDSLImplTest extends BaseSpec {
 
     def 'should not allow duplicate workflow' () {
         given:
-        def config = new CompilerConfiguration()
-        config.setScriptBaseClass(BaseScript.class.name)
-        config.addCompilationCustomizers( new ASTTransformationCustomizer(NextflowDSL))
+        def config = createCompilerConfig()
 
         def SCRIPT = '''
-                    
             workflow alpha {
               /hello/
             }
@@ -84,7 +86,6 @@ class NextflowDSLImplTest extends BaseSpec {
             workflow alpha {
               /world/
             }
-
         '''
 
         when:
@@ -97,29 +98,24 @@ class NextflowDSLImplTest extends BaseSpec {
     def 'should throw illegal name exception' () {
 
         given:
-        def config = new CompilerConfiguration()
-        config.setScriptBaseClass(BaseScript.class.name)
-        config.addCompilationCustomizers( new ASTTransformationCustomizer(NextflowDSL))
+        def config = createCompilerConfig()
 
         when:
         def SCRIPT = '''
             workflow 'foo:bar' {
               /hello/
             }
-
         '''
         new GroovyShell(config).parse(SCRIPT)
         then:
         def e = thrown(MultipleCompilationErrorsException)
         e.message.contains 'Process and workflow names cannot contain colon character'
 
-
         when:
         SCRIPT = '''
             process 'foo:bar' {
               /hello/
             }
-
         '''
         new GroovyShell(config).parse(SCRIPT)
         then:
@@ -129,12 +125,9 @@ class NextflowDSLImplTest extends BaseSpec {
 
     def 'should set process name in the script meta' () {
         given:
-        def config = new CompilerConfiguration()
-        config.setScriptBaseClass(BaseScript.class.name)
-        config.addCompilationCustomizers( new ASTTransformationCustomizer(NextflowDSL))
+        def parser = new ScriptParser(new Session())
 
         def SCRIPT = '''
-                    
             process alpha {
               /hello/
             }
@@ -142,14 +135,12 @@ class NextflowDSLImplTest extends BaseSpec {
             process beta {
               /world/
             }
-
         '''
 
         when:
-        def script = new GroovyShell(config).parse(SCRIPT)
+        parser.runScript(SCRIPT)
         then:
-        ScriptMeta.get(script).getDsl1ProcessNames() == ['alpha', 'beta']
-        ScriptMeta.get(script).getProcessNames() == ['alpha', 'beta'] as Set
+        ScriptMeta.get(parser.getScript()).getProcessNames() == ['alpha', 'beta'] as Set
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/IncludeDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/IncludeDefTest.groovy
@@ -168,6 +168,7 @@ class IncludeDefTest extends Specification {
         }
     }
 
+    @Unroll
     def 'should add includes' () {
         given:
         def binding = new ScriptBinding([params: [foo:1, bar:2]])
@@ -186,14 +187,12 @@ class IncludeDefTest extends Specification {
 
 
         where:
-        INCLUDE                                         | PATH          | NAME      | ALIAS     | PARAMS
-        "include 'some/path'"                           | 'some/path'   | null      | null      | null
-        "include ALPHA from 'modules/path'"             | 'modules/path'| 'ALPHA'   | null      | null
-        "include ALPHA as BRAVO from 'modules/x'"       | 'modules/x'   | 'ALPHA'   | 'BRAVO'   | null
-        "include 'modules/1' params(a:1, b:2)"          | 'modules/1'   | null      | null      | [a:1, b:2]
-        "include DELTA from 'abc' params(x:1)"          | 'abc'         | 'DELTA'   | null      | [x:1]
-        "include GAMMA as FOO from 'm1' params(p:2)"    | 'm1'          | 'GAMMA'   | 'FOO'     | [p:2]
-        "include GAMMA as FOO from 'm1' params([:])"    | 'm1'          | 'GAMMA'   | 'FOO'     | [:]
+        INCLUDE                                          | PATH          | NAME      | ALIAS     | PARAMS
+        "include { ALPHA } from 'modules/path'"          | 'modules/path'| 'ALPHA'   | null      | null
+        "include { ALPHA as BRAVO } from 'modules/x'"    | 'modules/x'   | 'ALPHA'   | 'BRAVO'   | null
+        "include { DELTA } from 'abc' params(x:1)"       | 'abc'         | 'DELTA'   | null      | [x:1]
+        "include { GAMMA as FOO } from 'm1' params(p:2)" | 'm1'          | 'GAMMA'   | 'FOO'     | [p:2]
+        "include { GAMMA as FOO } from 'm1' params([:])" | 'm1'          | 'GAMMA'   | 'FOO'     | [:]
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -180,7 +180,7 @@ class ProcessConfigTest extends Specification {
 
         when:
         config._in_file([infile:'filename.fa'])
-        config._in_val('x') .from(1)
+        config._in_val('x').setFrom(1)
         config._in_stdin()
 
         then:
@@ -209,9 +209,9 @@ class ProcessConfigTest extends Specification {
 
         when:
         config._out_stdout()
-        config._out_file(new TokenVar('file1')).into('ch1')
-        config._out_file(new TokenVar('file2')).into('ch2')
-        config._out_file(new TokenVar('file3')).into('ch3')
+        config._out_file(new TokenVar('file1')).setInto('ch1')
+        config._out_file(new TokenVar('file2')).setInto('ch2')
+        config._out_file(new TokenVar('file3')).setInto('ch3')
 
         then:
         config.outputs.size() == 4

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
@@ -1157,8 +1157,8 @@ class ScriptIncludesTest extends Dsl2Spec {
         def runner = new MockScriptRunner()
         def result = runner.setScript(SCRIPT).execute()
         then:
-        def e = thrown(DeprecationException)
-        e.message == "Unwrapped module inclusion is deprecated -- Replace `include foo from './MODULE/PATH'` with `include { foo } from './MODULE/PATH'`"
+        def e = thrown(ScriptCompilationException)
+        e.message.contains "Invalid include statement -- the correct syntax is `include { ... } from '...'`"
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptMetaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptMetaTest.groovy
@@ -108,8 +108,8 @@ class ScriptMetaTest extends Dsl2Spec {
         meta1.getComponent('my_process') instanceof ProcessDef
         meta1.getComponent('my_process').name == 'my_process'
 
-//        then:
-//        meta1.getProcessNames() == ['proc1','proc2','my_process'] as Set
+        then:
+        meta1.getProcessNames() == ['proc1','proc2','my_process'] as Set
     }
 
 


### PR DESCRIPTION
Third batch of changes from #3344 . This PR removes some deprecated code related to DSL syntax:
- remove DSL1 process name definitions
- remove old module include syntax
- remove from / into syntax for process inputs/outputs
- remove old process named args syntax
- remove set qualifier for process inputs/outputs