### PR TITLE
Edit `fair` directive

### DIFF
--- a/docs/process.rst
+++ b/docs/process.rst
@@ -1737,8 +1737,8 @@ This can be defined in the ``nextflow.config`` file as shown below::
 fair
 ----
 
-When using the ``fair`` directive the sequence of the outputs of a process executions is guaranteed
-to match the sequence of the input values irrespective. For example::
+When using the ``fair`` directive, the sequence of the outputs of a process is guaranteed
+to match the sequence of the input values. For example::
 
     process foo {
       fair true
@@ -1757,7 +1757,7 @@ to match the sequence of the input values irrespective. For example::
        channel.of('A','B','C','D') | foo | view
     }
 
-The above example produces the following output::
+The above example produces::
 
     [1, A]
     [2, B]


### PR DESCRIPTION
I initially opened this edit to add the `fair` directive, only to find it already present in the edit view. Is there a reason it is not shown on the doc site? What's the usual lag time between merge and publish?