### PR TITLE
Updates to S3 Glacier auto retrieval

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -123,7 +123,7 @@ connectionTimeout           The amount of time to wait (in milliseconds) when in
 endpoint                    The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.
 glacierAutoRetrieval        Enable auto retrieval of S3 objects stored with Glacier class store (EXPERIMENTAL. default: ``false``, requires version ``22.12.0-edge`` or later).
 glacierExpirationDays       The time, in days, between when an object is restored to the bucket and when it expires (EXPERIMENTAL. default: ``7``, requires version ``22.12.0-edge`` or later).
-glacierRetrievalTier        The retrieval tier to use when restoring objects from Glacier, one of [``EXPEDITED``, ``STANDARD``, ``BULK``] (EXPERIMENTAL. requires version ``23.03.0-edge`` or later).
+glacierRetrievalTier        The retrieval tier to use when restoring objects from Glacier, one of [``Expedited``, ``Standard``, ``Bulk``] (EXPERIMENTAL. requires version ``23.03.0-edge`` or later).
 maxConnections              The maximum number of allowed open HTTP connections.
 maxErrorRetry               The maximum number of retry attempts for failed retryable requests.
 protocol                    The protocol (i.e. HTTP or HTTPS) to use when connecting to AWS.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -123,6 +123,7 @@ connectionTimeout           The amount of time to wait (in milliseconds) when in
 endpoint                    The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.
 glacierAutoRetrieval        Enable auto retrieval of S3 objects stored with Glacier class store (EXPERIMENTAL. default: ``false``, requires version ``22.12.0-edge`` or later).
 glacierExpirationDays       The time, in days, between when an object is restored to the bucket and when it expires (EXPERIMENTAL. default: ``7``, requires version ``22.12.0-edge`` or later).
+glacierRetrievalTier        The retrieval tier to use when restoring objects from Glacier, one of [``EXPEDITED``, ``STANDARD``, ``BULK``] (EXPERIMENTAL. requires version ``23.03.0-edge`` or later).
 maxConnections              The maximum number of allowed open HTTP connections.
 maxErrorRetry               The maximum number of retry attempts for failed retryable requests.
 protocol                    The protocol (i.e. HTTP or HTTPS) to use when connecting to AWS.

--- a/plugins/nf-amazon/src/main/com/upplication/s3fs/S3FileSystemProvider.java
+++ b/plugins/nf-amazon/src/main/com/upplication/s3fs/S3FileSystemProvider.java
@@ -951,6 +951,7 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
 		client.setUploadMaxThreads(props.getProperty("upload_max_threads"));
 		client.setGlacierAutoRetrieval(props.getProperty("glacier_auto_retrieval"));
 		client.setGlacierExpirationDays(props.getProperty("glacier_expiration_days"));
+		client.setGlacierRetrievalTier(props.getProperty("glacier_retrieval_tier"));
 
 		if (uri.getHost() != null) {
 			client.setEndpoint(uri.getHost());


### PR DESCRIPTION
Based on discussions with Michael Kroell about the Glacier auto retrieval. See this [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/batch-ops-initiate-restore-object.html) for context.

- Don't specify expiration days if storage class is intelligent tiering (otherwise the restore will fail)
- Add glacierRetrievalTier config option (Standard, Expedited, Bulk)