### PR TITLE
Add Fusion support to Condor executor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/CondorExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/CondorExecutor.groovy
@@ -16,9 +16,11 @@
  */
 
 package nextflow.executor
+
 import java.nio.file.Path
 
 import groovy.transform.InheritConstructors
+import nextflow.fusion.FusionHelper
 import nextflow.processor.TaskRun
 /**
  * HTCondor executor
@@ -90,7 +92,9 @@ class CondorExecutor extends AbstractGridExecutor {
 
     @Override
     List<String> getSubmitCommandLine(TaskRun task, Path scriptFile) {
-        return ['condor_submit', '--terse', CMD_CONDOR]
+        return pipeLauncherScript()
+                ? List.of('condor_submit', '-terse')
+                : List.of('condor_submit', '-terse', CMD_CONDOR)
     }
 
     @Override
@@ -147,6 +151,15 @@ class CondorExecutor extends AbstractGridExecutor {
         return result
     }
 
+    @Override
+    protected boolean pipeLauncherScript() {
+        return isFusionEnabled()
+    }
+
+    @Override
+    boolean isFusionEnabled() {
+        return FusionHelper.isFusionEnabled(session)
+    }
 
     @InheritConstructors
     static class CondorWrapperBuilder extends BashWrapperBuilder {

--- a/modules/nextflow/src/test/groovy/nextflow/executor/CondorExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/CondorExecutorTest.groovy
@@ -16,6 +16,7 @@
  */
 
 package nextflow.executor
+
 import java.nio.file.Files
 
 import nextflow.Session
@@ -25,6 +26,8 @@ import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import spock.lang.Specification
+import spock.lang.Unroll
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -131,14 +134,23 @@ class CondorExecutorTest extends Specification {
 
     }
 
-
+    @Unroll
     def 'should return launch command line' () {
 
         given:
-        def executor = [:] as CondorExecutor
+        def session = Mock(Session) { getConfig() >> [:] }
+        def exec = Spy(CondorExecutor) { getSession() >> session }
 
-        expect:
-        executor.getSubmitCommandLine( Mock(TaskRun), null) == ['condor_submit', '--terse', '.command.condor']
+        when:
+        def result = exec.getSubmitCommandLine(Mock(TaskRun), null)
+        then:
+        exec.pipeLauncherScript() >> PIPE
+        result == EXPECTED
+
+        where:
+        PIPE      | EXPECTED
+        false     | ['condor_submit', '-terse', '.command.condor']
+        true      | ['condor_submit', '-terse']
 
     }
 


### PR DESCRIPTION
@JosephLalli this PR is ready for you to test. Here is the quickstart to build and test locally:

```bash
# build
git clone -b fusion-condor git@github.com:nextflow-io/nextflow.git
cd nextflow
make compile

# test
../launch.sh run main.nf ...
```

Just keep in mind that we haven't tested Fusion on MinIO-based S3 compatible storage yet, so that part might not work.