### PR TITLE
Named arguments for processes and workflows

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -516,8 +516,10 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
 
     /// input parameters
 
-    InParam _in_val( obj ) {
-        new ValueInParam(this).bind(obj)
+    InParam _in_val( Map opts=null, Object obj ) {
+        new ValueInParam(this)
+                .setOptions(opts)
+                .bind(obj)
     }
 
     InParam _in_file( obj ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/BaseInParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/BaseInParam.groovy
@@ -27,6 +27,7 @@ import nextflow.exception.ScriptRuntimeException
 import nextflow.extension.CH
 import nextflow.script.ProcessConfig
 import nextflow.script.TokenVar
+import nextflow.util.ConfigHelper
 /**
  * Model a process generic input parameter
  *
@@ -46,6 +47,8 @@ abstract class BaseInParam extends BaseParam implements InParam {
      * The channel to which the input value is bound
      */
     private inChannel
+
+    String channelTakeName
 
     /**
      * @return The input channel instance used by this parameter to receive the process inputs
@@ -234,6 +237,21 @@ abstract class BaseInParam extends BaseParam implements InParam {
         }
 
         return value
+    }
+
+    BaseInParam setTake( value ) {
+        if( isNestedParam() )
+            throw new IllegalArgumentException("Input `take` option is not allowed in tuple components")
+        if( !value )
+            throw new IllegalArgumentException("Missing input `take` name")
+        if( !ConfigHelper.isValidIdentifier(value) ) {
+            final msg = "Input take '$value' is not a valid name -- Make sure it starts with an alphabetic or underscore character and it does not contain any blank, dot or other special characters"
+            if( NF.strictMode )
+                throw new IllegalArgumentException(msg)
+            log.warn(msg)
+        }
+        this.channelTakeName = value
+        return this
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/InParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/InParam.groovy
@@ -42,4 +42,6 @@ interface InParam extends Cloneable {
 
     def decodeInputs( List values )
 
+    String getChannelTakeName()
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptDslTest.groovy
@@ -359,7 +359,7 @@ class ScriptDslTest extends Dsl2Spec {
 
         then:
         def err = thrown(ScriptRuntimeException)
-        err.message == 'Process `bar` declares 1 input channel but 0 were specified'
+        err.message == 'Process `bar` was invoked with 0 positional argument(s) but 1 were expected'
     }
 
     def 'should report error accessing undefined out/a' () {
@@ -451,7 +451,7 @@ class ScriptDslTest extends Dsl2Spec {
 
         then:
         def err = thrown(ScriptRuntimeException)
-        err.message == "Process `bar` declares 1 input channel but 0 were specified"
+        err.message == "Process `bar` was invoked with 0 positional argument(s) but 1 were expected"
     }
 
     def 'should report error accessing undefined out/e' () {

--- a/tests/process-named-inputs.nf
+++ b/tests/process-named-inputs.nf
@@ -1,0 +1,32 @@
+#!/usr/bin/env nextflow
+
+process foo {
+  input:
+    val bar
+    val baz
+  output: 
+    stdout
+
+  script:
+    """
+    echo $bar
+    echo $baz
+    """
+}
+
+
+workflow foo_wrapper {
+  take:
+    bar
+    baz
+  main:
+    foo(bar: bar, baz: baz)
+  emit:
+    foo.out
+}
+
+
+workflow {
+  foo_wrapper(bar: 'bar', baz: 'baz')
+    | view
+}


### PR DESCRIPTION
Closes #2257 #3507 

Adds a `take` option for process inputs that is similar to the `emit` option for outputs. Processes and workflows can now be invoked with named arguments, using the same syntax as native Groovy functions.

Additionally, you don't have to specify the `take` option in the input declaration if the process input has a simple name. For inputs with e.g. GStrings, closures, tuples, the `take` option must be explicit.

It works by interpreting the first process / workflow argument as the named arguments map if it is a map. We have to do this because the invocation happens through `WorkflowBinding.invokeMethod()` rather than an actual function definition. So there will be a problem if you call a process and the first argument is a map, but you meant for that argument to be for the first process input (i.e. as a value channel).

One way that we could avoid this problem is to refactor the NextflowDSL AST transformation to convert process and workflow definitions into actual function definitions, so that the process/workflow inputs are defined as native function arguments.