### PR TITLE
Change access rights of submitRateLimit

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -109,7 +109,7 @@ class TaskPollingMonitor implements TaskMonitor {
     /**
      * Define rate limit for task submission
      */
-    private RateLimiter submitRateLimit
+    protected RateLimiter submitRateLimit
 
     /**
      * Create the task polling monitor with the provided named parameters object.


### PR DESCRIPTION
In my CWS plugin, I overwrite the `submitPendingTasks` method. However, the submitRateLimit is not accessible. Please merge this to give me access.