### PR TITLE
Make GroupKey.target accessible

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/GroupKey.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/GroupKey.groovy
@@ -53,6 +53,8 @@ class GroupKey implements CacheFunnel {
 
     int getGroupSize() { size }
 
+    Object getGroupTarget() { target }
+
     /**
      * Delegate any method invocation to the target key object
      *


### PR DESCRIPTION
For my CWS Plugin I need to access the target attribute. I implemented a method similar to the `getGroupSize`.