### PR TITLE
Make GroupKey cloneable

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/GroupKey.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/GroupKey.groovy
@@ -31,7 +31,7 @@ import org.codehaus.groovy.runtime.InvokerHelper
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-class GroupKey implements CacheFunnel {
+class GroupKey implements CacheFunnel, Cloneable {
 
     private final Object target
 


### PR DESCRIPTION
See discussions in #3104 and #2660

When modifying maps, it is generally better to copy the map, e.g. `metadata + [id: 'foo']`. However, if the map contains a GroupKey, it won't work. This PR simply makes GroupKey cloneable so that you don't have to remove and re-add the group key to clone a map.