### PR TITLE
Support maps for combine, join, and groupTuple operators

### DIFF
--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -794,13 +794,44 @@ according to these rules:
 * For any other value, the value itself is used as a key.
 
 
+.. _operator-groupmap:
+
+groupMap
+----------
+
+The ``groupMap`` operator collects maps of values emitted by the source channel, grouping together the
+elements that share the same key, and emitting a new map object for each distinct key collected. It is
+nearly identical to the ``groupTuple`` operator, except that it operates on maps instead of tuples. As such,
+the ``by`` parameter should specify string keys instead of integer indices.
+
+For example::
+
+    Channel.of(
+            [group: 1, name: 'A'],
+            [group: 1, name: 'B'],
+            [group: 2, name: 'C'],
+            [group: 3, name: 'B'],
+            [group: 1, name: 'C'],
+            [group: 2, name: 'A'],
+            [group: 3, name: 'D']
+        )
+        .groupMap(by: 'group')
+        .view()
+
+It prints::
+
+    [group: 1, name: [A, B, C]]
+    [group: 2, name: [C, A]]
+    [group: 3, name: [B, D]]
+
+
 .. _operator-grouptuple:
 
 groupTuple
 ----------
 
-The ``groupTuple`` operator collects tuples (or lists) of values emitted by the source channel grouping together the
-elements that share the same key. Finally it emits a new tuple object for each distinct key collected.
+The ``groupTuple`` operator collects tuples (or lists) of values emitted by the source channel, grouping together the
+elements that share the same key, and emitting a new tuple object for each distinct key collected.
 
 In other words, the operator transforms a sequence of tuple like *(K, V, W, ..)* into a new channel emitting a sequence of
 *(K, list(V), list(W), ..)*

--- a/modules/nextflow/src/main/groovy/nextflow/extension/AbstractGroupOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/AbstractGroupOp.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.extension
+
+import groovy.util.logging.Slf4j
+import groovyx.gpars.dataflow.DataflowReadChannel
+import groovyx.gpars.dataflow.DataflowWriteChannel
+import nextflow.Channel
+import nextflow.util.ArrayBag
+import nextflow.util.CacheHelper
+import nextflow.util.CheckHelper
+/**
+ * Abstract class for grouping operators.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@Slf4j
+abstract class AbstractGroupOp {
+
+    static protected Map PARAM_TYPES = [
+        sort: [Boolean, 'true', 'natural', 'deep', 'hash', Closure, Comparator],
+        size: Integer,
+        remainder: Boolean
+    ]
+
+    protected DataflowReadChannel source
+
+    protected int size
+
+    protected boolean remainder
+
+    protected sort
+
+    protected Comparator comparator
+
+    protected DataflowWriteChannel target
+
+    AbstractGroupOp(Map params, DataflowReadChannel source) {
+        this.source = source
+        size = params?.size ?: 0
+        remainder = params?.remainder ?: false
+        sort = params?.sort
+        comparator = createComparator()
+    }
+
+    /**
+     * Get the expected size of a key that contains a GroupKey.
+     *
+     * @param key
+     */
+    static protected int sizeBy(List key)  {
+        if( key.size()==1 && key[0] instanceof GroupKey ) {
+            final groupKey = (GroupKey)key[0]
+            final size = groupKey.getGroupSize()
+            log.debug "groupMap dynamic size: key=${groupKey} size=${size}"
+            return size
+        }
+        else
+            return 0
+    }
+
+    /**
+     * Create the comparator to be used depending the #sort property
+     */
+    private Comparator createComparator() {
+
+        /*
+         * comparator logic used to sort tuple elements
+         */
+        switch(sort) {
+            case null:
+                return null
+
+            case true:
+            case 'true':
+            case 'natural':
+                return { o1,o2 -> o1<=>o2 } as Comparator
+
+            case 'hash':
+                return { o1, o2 ->
+                    def h1 = CacheHelper.hasher(o1).hash()
+                    def h2 = CacheHelper.hasher(o2).hash()
+                    return h1.asLong() <=> h2.asLong()
+                } as Comparator
+
+            case 'deep':
+                return { o1, o2 ->
+                    def h1 = CacheHelper.hasher(o1, CacheHelper.HashMode.DEEP).hash()
+                    def h2 = CacheHelper.hasher(o2, CacheHelper.HashMode.DEEP).hash()
+                    return h1.asLong() <=> h2.asLong()
+                } as Comparator
+
+            case Comparator:
+                return sort as Comparator
+
+            case Closure:
+                final closure = (Closure)sort
+                if( closure.getMaximumNumberOfParameters()==2 )
+                    return sort as Comparator
+
+                else if( closure.getMaximumNumberOfParameters()==1 )
+                    return { o1, o2 ->
+                        def v1 = closure.call(o1)
+                        def v2 = closure.call(o2)
+                        return v1 <=> v2
+                    } as Comparator
+
+                else
+                    throw new IllegalArgumentException("Invalid groupMap option - The sort closure should have 1 or 2 arguments")
+
+            default:
+                throw new IllegalArgumentException("Not a valid sort argument: ${sort}")
+        }
+
+    }
+
+    /**
+     * Invoke the operator
+     */
+    DataflowWriteChannel apply() {
+
+        if( target == null )
+            target = CH.create()
+
+        // apply the operator to the source channel
+        DataflowHelper.subscribeImpl(source, getHandlers())
+
+        // return the target channel
+        return target
+    }
+
+    abstract protected Map getHandlers()
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
@@ -226,9 +226,12 @@ class OperatorImpl {
         return result
     }
 
-    DataflowWriteChannel groupTuple( final DataflowReadChannel source, final Map params=null ) {
-        def result = new GroupTupleOp(params, source).apply()
-        return result
+    DataflowWriteChannel groupMap( DataflowReadChannel source, Map params=null ) {
+        new GroupMapOp(params, source).apply()
+    }
+
+    DataflowWriteChannel groupTuple( DataflowReadChannel source, Map params=null ) {
+        new GroupTupleOp(params, source).apply()
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/extension/GroupMapOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/GroupMapOpTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.extension
+
+import nextflow.Channel
+import nextflow.Session
+import spock.lang.Specification
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+class GroupMapOpTest extends Specification {
+
+    def setup() {
+        new Session()
+    }
+
+    def 'should group items using dynamic group size' () {
+        given:
+        def k1 = new GroupKey('k1', 2)
+        def k2 = new GroupKey('k2', 3)
+        def k3 = new GroupKey('k3', 4)
+
+        def items = [
+            [group: k1, name: 'a'],
+            [group: k1, name: 'b'],
+            [group: k2, name: 'x'],
+            [group: k3, name: 'q'],
+            [group: k1, name: 'd'],
+            [group: k1, name: 'c'],
+            [group: k2, name: 'y'],
+            [group: k1, name: 'f'],
+            [group: k2, name: 'z']
+        ]
+
+        when:
+        // here the size is defined as operator argument
+        def result = items.channel().groupMap(by: 'group', size: 2)
+        then:
+        result.val == [group: k1, name: ['a', 'b']]
+        result.val == [group: k1, name: ['d', 'c']]
+        result.val == [group: k2, name: ['x', 'y']]
+        result.val == Channel.STOP
+
+        when:
+        // here the size is inferred by the key itself
+        result = items.channel().groupMap(by: 'group')
+        then:
+        result.val == [group: k1, name: ['a', 'b']]
+        result.val == [group: k1, name: ['d', 'c']]
+        result.val == [group: k2, name: ['x', 'y', 'z']]
+        result.val == Channel.STOP
+
+        when:
+        result = items.channel().groupMap(by: 'group', remainder: true)
+        then:
+        result.val == [group: k1, name: ['a', 'b']]
+        result.val == [group: k1, name: ['d', 'c']]
+        result.val == [group: k2, name: ['x', 'y', 'z']]
+        result.val == [group: k3, name: ['q']]
+        result.val == [group: k1, name: ['f']]
+        result.val == Channel.STOP
+    }
+}

--- a/modules/nextflow/src/test/groovy/nextflow/extension/GroupTupleOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/GroupTupleOpTest.groovy
@@ -18,10 +18,8 @@
 package nextflow.extension
 
 import nextflow.Channel
-
-import spock.lang.Specification
-
 import nextflow.Session
+import spock.lang.Specification
 
 /**
  *
@@ -101,8 +99,7 @@ class GroupTupleOpTest extends Specification {
         0       | []
     }
 
-
-    def 'should group items using dyn group size' () {
+    def 'should group items using dynamic group size' () {
         given:
         def k1 = new GroupKey("k1", 2)
         def k2 = new GroupKey('k2', 3)
@@ -129,7 +126,6 @@ class GroupTupleOpTest extends Specification {
         result.val == [k1, ['d', 'c'] ]
         result.val == [k2, ['x', 'y', 'z'] ]
         result.val == Channel.STOP
-
 
         when:
         result = tuples.channel().groupTuple(remainder: true)


### PR DESCRIPTION
Closes #3108 

Certain operators are designed to work with tuples but don't support maps. To encourage the use of maps in Nextflow pipelines, these operators should be extended (or duplicated) to also support maps.

TODO:
- [ ] combine
- [ ] join
- [x] groupTuple