### PR TITLE
Kuberun: add plugins to config

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdKubeRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdKubeRun.groovy
@@ -94,7 +94,7 @@ class CmdKubeRun extends CmdRun {
             headImage = podImage
         }
         checkRunName()
-        final driver = new K8sDriverLauncher(cmd: this, runName: runName, headImage: headImage, background: background(), headCpus: headCpus, headMemory: headMemory, headPreScript: headPreScript) 
+        final driver = new K8sDriverLauncher(cmd: this, runName: runName, headImage: headImage, background: background(), headCpus: headCpus, headMemory: headMemory, headPreScript: headPreScript, plugins: plugins)
         driver.run(pipeline, scriptArgs)
         final status = driver.shutdown()
         System.exit(status)

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -363,7 +363,7 @@ class K8sDriverLauncher {
 
         if ( plugins ) {
             LinkedList<String> plugins = config.plugins ?: []
-            plugins.addAll(this.plugins.tokenize(','))
+            plugins.addAll( this.plugins.tokenize(',') )
             config.plugins = plugins
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -127,6 +127,11 @@ class K8sDriverLauncher {
     private List<String> args
 
     /**
+     * Plugins to run the workflow
+     */
+    private String plugins
+
+    /**
      * Launcher entry point. Set-up the environment and create a pod that run the Nextflow
      * application (which in turns executed each task as a pod)
      *
@@ -355,6 +360,10 @@ class K8sDriverLauncher {
             k8s.workDir = cmd.workDir
         else if( !k8s.isSet('workDir') && config.workDir )
             k8s.workDir = config.workDir
+
+        LinkedList<String> plugins = config.plugins ?: []
+        plugins.addAll(this.plugins.tokenize(','))
+        config.plugins = plugins
 
         // -- some cleanup
         if( !k8s.pod )

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -361,9 +361,11 @@ class K8sDriverLauncher {
         else if( !k8s.isSet('workDir') && config.workDir )
             k8s.workDir = config.workDir
 
-        LinkedList<String> plugins = config.plugins ?: []
-        plugins.addAll(this.plugins.tokenize(','))
-        config.plugins = plugins
+        if ( plugins ) {
+            LinkedList<String> plugins = config.plugins ?: []
+            plugins.addAll(this.plugins.tokenize(','))
+            config.plugins = plugins
+        }
 
         // -- some cleanup
         if( !k8s.pod )

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sDriverLauncherTest.groovy
@@ -562,6 +562,17 @@ class K8sDriverLauncherTest extends Specification {
 
     }
 
+    def 'should add the plugin into the config' () {
+        given:
+        def cmd = new CmdKubeRun()
+        cmd.launcher = new Launcher(options: new CliOptions())
+
+        when:
+        def l = new K8sDriverLauncher(cmd: cmd, plugins: 'nf-cws@1.0.0', runName: 'bar')
+        then:
+        l.makeConfig( "/bar").get('plugins') == [ 'nf-cws@1.0.0' ]
+    }
+
     def 'should make config - deprecated' () {
 
         given:


### PR DESCRIPTION
Using `kuberun` with `-plugins xy` does not yet hand this over to the head-pod. This is implemented in this PR. It would be nice to have this, especially for CWS.