### PR TITLE
Add initial task graph and metadata json file

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -254,6 +254,7 @@ Name                Description
 enabled             When ``true`` turns on the generation of the DAG file (default: ``false``).
 file                Graph file name (default: ``dag-<timestamp>.dot``).
 overwrite           When ``true`` overwrites any existing DAG file with the same name.
+type                Can be ``abstract`` to render the abstract DAG or ``concrete`` to render the concrete (task) DAG (default: ``abstract``).
 ================== ================
 
 The above options can be used by prefixing them with the ``dag`` scope or surrounding them by curly

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -40,6 +40,7 @@ import nextflow.conda.CondaConfig
 import nextflow.config.Manifest
 import nextflow.container.ContainerConfig
 import nextflow.dag.DAG
+import nextflow.dag.ConcreteDAG
 import nextflow.exception.AbortOperationException
 import nextflow.exception.AbortSignalException
 import nextflow.exception.IllegalConfigException
@@ -193,6 +194,8 @@ class Session implements ISession {
 
     private DAG dag
 
+    private ConcreteDAG concreteDag
+
     private CacheDB cache
 
     private Barrier processesBarrier = new Barrier()
@@ -345,6 +348,7 @@ class Session implements ISession {
 
         // -- DAG object
         this.dag = new DAG()
+        this.concreteDag = new ConcreteDAG()
 
         // -- init work dir
         this.workDir = ((config.workDir ?: 'work') as Path).complete()
@@ -800,6 +804,8 @@ class Session implements ISession {
 
     DAG getDag() { this.dag }
 
+    ConcreteDAG getConcreteDAG() { this.concreteDag }
+
     ExecutorService getExecService() { execService }
 
     /**
@@ -1007,6 +1013,9 @@ class Session implements ISession {
         // save the completed task in the cache DB
         final trace = handler.safeTraceRecord()
         cache.putTaskAsync(handler, trace)
+
+        // save the task meta file to the task directory
+        handler.writeMetaFile()
 
         // notify the event to the observers
         for( int i=0; i<observers.size(); i++ ) {

--- a/modules/nextflow/src/main/groovy/nextflow/dag/ConcreteDAG.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/ConcreteDAG.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.dag
+
+import java.nio.file.Path
+import java.util.regex.Pattern
+
+import groovy.transform.MapConstructor
+import groovy.transform.ToString
+import groovy.util.logging.Slf4j
+import nextflow.processor.TaskRun
+/**
+ * Model the conrete (task) graph of a pipeline execution.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@Slf4j
+class ConcreteDAG {
+
+    Map<String,Node> nodes = new HashMap<>(100)
+
+    /**
+     * Create a new node for a task
+     *
+     * @param task
+     * @param hash
+     */
+    synchronized void addTaskNode( TaskRun task, String hash ) {
+        final label = "[${hash.substring(0,2)}/${hash.substring(2,8)}] ${task.name}"
+        final preds = task.getInputFilesMap().values()
+            .collect { p -> getPredecessorHash(p) }
+            .findAll { h -> h != null }
+
+        nodes[hash] = new Node(
+            index: nodes.size(),
+            label: label,
+            predecessors: preds
+        )
+    }
+
+    static public String getPredecessorHash(Path path) {
+        final pattern = Pattern.compile('.*/([a-z0-9]{2}/[a-z0-9]{30})')
+        final matcher = pattern.matcher(path.toString())
+
+        matcher.find() ? matcher.group(1).replace('/', '') : null
+    }
+
+    @MapConstructor
+    @ToString(includeNames = true, includes = 'label', includePackage=false)
+    protected class Node {
+
+        int index
+
+        String label
+
+        List<String> predecessors
+
+        String getSlug() { "t${index}" }
+
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/dag/CytoscapeHtmlRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/CytoscapeHtmlRenderer.groovy
@@ -29,7 +29,7 @@ import java.nio.file.Path
 class CytoscapeHtmlRenderer implements DagRenderer {
 
     @Override
-    void renderDocument(DAG dag, Path file) {
+    void renderAbstractGraph(DAG dag, Path file) {
         String tmplPage = readTemplate()
         String network = CytoscapeJsRenderer.renderNetwork(dag)
         file.text = tmplPage.replaceAll(~/\/\* REPLACE_WITH_NETWORK_DATA \*\//, network)

--- a/modules/nextflow/src/main/groovy/nextflow/dag/CytoscapeJsRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/CytoscapeJsRenderer.groovy
@@ -29,7 +29,7 @@ import java.nio.file.Path
 class CytoscapeJsRenderer implements DagRenderer {
 
     @Override
-    void renderDocument(DAG dag, Path file) {
+    void renderAbstractGraph(DAG dag, Path file) {
         file.text = renderNetwork(dag)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/dag/DAG.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/DAG.groovy
@@ -41,7 +41,7 @@ import nextflow.script.params.OutputsList
 import nextflow.script.params.TupleInParam
 import nextflow.script.params.TupleOutParam
 /**
- * Model a direct acyclic graph of the pipeline execution.
+ * Model the abstract graph of a pipeline execution.
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */

--- a/modules/nextflow/src/main/groovy/nextflow/dag/DagRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/DagRenderer.groovy
@@ -24,10 +24,19 @@ import java.nio.file.Path
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Mike Smoot <mes@aescon.com>
  */
-interface DagRenderer {
+trait DagRenderer {
 
     /**
-     * Render the dag to the specified file.
+     * Render an abstract (process/operator) DAG.
      */
-    void renderDocument(DAG dag, Path file);
+    void renderAbstractGraph(DAG dag, Path file) {
+        throw new UnsupportedOperationException("Abstract graph rendering is not supported for this file format")
+    }
+
+    /**
+     * Render a concrete (task) DAG.
+     */
+    void renderConcreteGraph(ConcreteDAG dag, Path file) {
+        throw new UnsupportedOperationException("Concrete graph rendering is not supported for this file format")
+    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/dag/DotRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/DotRenderer.groovy
@@ -46,7 +46,7 @@ class DotRenderer implements DagRenderer {
     static String normalise(String str) { str.replaceAll(/[^0-9_A-Za-z]/,'') }
 
     @Override
-    void renderDocument(DAG dag, Path file) {
+    void renderAbstractGraph(DAG dag, Path file) {
         file.text = renderNetwork(dag)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/dag/GexfRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/GexfRenderer.groovy
@@ -41,7 +41,7 @@ class GexfRenderer implements DagRenderer {
     }
 
     @Override
-    void renderDocument(DAG dag, Path file) {
+    void renderAbstractGraph(DAG dag, Path file) {
         final Charset charset = Charset.defaultCharset()
         Writer bw = Files.newBufferedWriter(file, charset) 
         final XMLOutputFactory xof = XMLOutputFactory.newFactory()

--- a/modules/nextflow/src/main/groovy/nextflow/dag/GraphVizRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/GraphVizRenderer.groovy
@@ -42,7 +42,7 @@ class GraphvizRenderer implements DagRenderer {
      * See http://www.graphviz.org for more info.
      */
     @Override
-    void renderDocument(DAG dag, Path target) {
+    void renderAbstractGraph(DAG dag, Path target) {
         def result = Files.createTempFile('nxf-',".$format")
         def temp = Files.createTempFile('nxf-','.dot')
         // save the DAG as `dot` to a temp file

--- a/modules/nextflow/src/main/groovy/nextflow/dag/MermaidRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/MermaidRenderer.groovy
@@ -27,11 +27,7 @@ import java.nio.file.Path
 class MermaidRenderer implements DagRenderer {
 
     @Override
-    void renderDocument(DAG dag, Path file) {
-        file.text = renderNetwork(dag)
-    }
-
-    String renderNetwork(DAG dag) {
+    void renderAbstractGraph(DAG dag, Path file) {
         def lines = []
         lines << "flowchart TD"
 
@@ -45,7 +41,7 @@ class MermaidRenderer implements DagRenderer {
 
         lines << ""
 
-        return lines.join('\n')
+        file.text = lines.join('\n')
     }
 
     private String renderVertex(DAG.Vertex vertex) {
@@ -75,5 +71,26 @@ class MermaidRenderer implements DagRenderer {
         String label = edge.label ? "|${edge.label}|" : ""
 
         return "${edge.from.name} -->${label} ${edge.to.name}"
+    }
+
+    @Override
+    void renderConcreteGraph(ConcreteDAG graph, Path file) {
+        def lines = []
+        lines << "flowchart TD"
+
+        graph.nodes.values().each { node ->
+            lines << "    ${node.getSlug()}[\"${node.label}\"]"
+
+            node.predecessors.each { key ->
+                final pred = graph.nodes[key]
+
+                if( pred )
+                    lines << "    ${pred.getSlug()} --> ${node.getSlug()}"
+            }
+        }
+
+        lines << ""
+
+        file.text = lines.join('\n')
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/dag/NodeMarker.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/NodeMarker.groovy
@@ -22,6 +22,7 @@ import groovyx.gpars.dataflow.operator.DataflowProcessor
 import nextflow.Global
 import nextflow.Session
 import nextflow.processor.TaskProcessor
+import nextflow.processor.TaskRun
 import nextflow.script.params.InputsList
 import nextflow.script.params.OutputsList
 /**
@@ -41,7 +42,7 @@ class NodeMarker {
     static private Session getSession() { Global.session as Session }
 
     /**
-     *  Creates a new vertex in the DAG representing a computing `process`
+     * Creates a vertex in the abstract DAG representing a computing `process`
      *
      * @param label The label associated to the process
      * @param inputs The list of inputs entering in the process
@@ -53,7 +54,7 @@ class NodeMarker {
     }
 
     /**
-     * Creates a new DAG vertex representing a dataflow operator
+     * Creates a vertex in the abstract DAG representing a dataflow operator
      *
      * @param label The operator label
      * @param inputs The operator input(s). It can be either a single channel or a list of channels.
@@ -67,7 +68,7 @@ class NodeMarker {
     }
 
     /**
-     * Creates a vertex in the DAG representing a dataflow channel source.
+     * Creates a vertex in the abstract DAG representing a dataflow channel source.
      *
      * @param label The node description
      * @param source Either a dataflow channel or a list of channel.
@@ -86,6 +87,17 @@ class NodeMarker {
     static void addDataflowBroadcastPair(readChannel, broadcastChannel)  {
         if( session && session.dag && !session.aborted )
             session.dag.addDataflowBroadcastPair(readChannel, broadcastChannel)
+    }
+
+    /**
+     * Creates a vertex in the concrete DAG representing a task
+     *
+     * @param task
+     * @param hash
+     */
+    static void addTaskNode( TaskRun task, String hash ) {
+        if( session?.concreteDAG && !session.aborted )
+            session.concreteDAG.addTaskNode( task, hash )
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -21,7 +21,11 @@ import static nextflow.processor.TaskStatus.*
 
 import java.nio.file.NoSuchFileException
 
+import groovy.json.JsonBuilder
 import groovy.util.logging.Slf4j
+import nextflow.dag.ConcreteDAG
+import nextflow.extension.FilesEx
+import nextflow.script.params.FileOutParam
 import nextflow.trace.TraceRecord
 /**
  * Actions to handle the underlying job running the user task.
@@ -212,6 +216,31 @@ abstract class TaskHandler {
         }
 
         return record
+    }
+
+    void writeMetaFile() {
+        final record = [
+            hash: task.hash.toString(),
+            inputs: task.getInputFilesMap().collect { name, path ->
+                [
+                    name: name,
+                    path: path.toString(),
+                    predecessor: ConcreteDAG.getPredecessorHash(path)
+                ]
+            },
+            outputs: task.getOutputsByType(FileOutParam).values().flatten().collect { path ->
+                final file = path.toFile()
+
+                [
+                    name: path.name,
+                    path: path.toString(),
+                    size: file.size(),
+                    checksum: file.isFile() ? FilesEx.getChecksum(path) : null
+                ]
+            }
+        ]
+
+        task.workDir.resolve(TaskRun.CMD_META).text = new JsonBuilder(record).toString()
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -524,7 +524,7 @@ class TaskProcessor {
         def invoke = new InvokeTaskAdapter(this, opInputs.size())
         session.allOperators << (operator = new DataflowOperator(group, params, invoke))
 
-        // notify the creation of a new vertex the execution DAG
+        // notify the creation of a new process in the abstract DAG
         NodeMarker.addProcessNode(this, config.getInputs(), config.getOutputs())
 
         // fix issue #41
@@ -756,8 +756,11 @@ class TaskProcessor {
 
                 log.trace "[${safeTaskName(task)}] Cacheable folder=${resumeDir?.toUriString()} -- exists=$exists; try=$tries; shouldTryCache=$shouldTryCache; entry=$entry"
                 def cached = shouldTryCache && exists && checkCachedOutput(task.clone(), resumeDir, hash, entry)
-                if( cached )
+                if( cached ) {
+                    // add cached task to the task graph
+                    NodeMarker.addTaskNode(task, hash.toString())
                     break
+                }
             }
             catch (Throwable t) {
                 log.warn1("[${safeTaskName(task)}] Unable to resume cached task -- See log file for details", causedBy: t)
@@ -779,6 +782,9 @@ class TaskProcessor {
             finally {
                 lock.release()
             }
+
+            // add submitted task to the task graph
+            NodeMarker.addTaskNode(task, hash.toString())
 
             // submit task for execution
             submitTask( task, hash, workDir )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -543,6 +543,7 @@ class TaskRun implements Cloneable {
     static final public String CMD_RUN = '.command.run'
     static final public String CMD_TRACE = '.command.trace'
     static final public String CMD_ENV = '.command.env'
+    static final public String CMD_META = '.command.meta.json'
 
 
     String toString( ) {

--- a/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
@@ -93,6 +93,7 @@ class DefaultObserverFactory implements TraceObserverFactory {
         if( !fileName ) fileName = GraphObserver.DEF_FILE_NAME
         def traceFile = (fileName as Path).complete()
         def observer = new GraphObserver(traceFile)
+        config.navigate('dag.type') { observer.dagType = it ?: 'abstract' }
         config.navigate('dag.overwrite')  { observer.overwrite = it }
         result << observer
     }

--- a/modules/nextflow/src/test/groovy/nextflow/dag/DotRendererTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/dag/DotRendererTest.groovy
@@ -55,7 +55,7 @@ class DotRendererTest extends Specification {
         dag.normalize()
 
         when:
-        new DotRenderer('TheGraph').renderDocument(dag, file)
+        new DotRenderer('TheGraph').renderAbstractGraph(dag, file)
         then:
         file.text ==
             '''

--- a/modules/nextflow/src/test/groovy/nextflow/dag/GexfRendererTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/dag/GexfRendererTest.groovy
@@ -47,7 +47,7 @@ class GexfRendererTest extends Specification {
 
             dag.normalize()
         when:
-                new GexfRenderer('TheGraph').renderDocument(dag, file.toPath())
+                new GexfRenderer('TheGraph').renderAbstractGraph(dag, file.toPath())
         then:
                 def graph = new XmlSlurper().parse(file);
                 assert graph.name() == 'gexf'

--- a/modules/nextflow/src/test/groovy/nextflow/dag/MermaidRendererTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/dag/MermaidRendererTest.groovy
@@ -47,7 +47,7 @@ class MermaidRendererTest extends Specification {
         dag.normalize()
 
         when:
-        new MermaidRenderer().renderDocument(dag, file)
+        new MermaidRenderer().renderAbstractGraph(dag, file)
         then:
         file.text ==
             '''

--- a/modules/nf-commons/src/main/nextflow/extension/FilesEx.groovy
+++ b/modules/nf-commons/src/main/nextflow/extension/FilesEx.groovy
@@ -35,6 +35,7 @@ import java.nio.file.attribute.FileAttribute
 import java.nio.file.attribute.FileTime
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
+import java.security.MessageDigest
 
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
@@ -1599,5 +1600,12 @@ class FilesEx {
 
     static String getScheme(Path path) {
         path.getFileSystem().provider().getScheme()
+    }
+
+    static String getChecksum(Path path) {
+        final data = Files.readAllBytes(path)
+        final hash = MessageDigest.getInstance("MD5").digest(data)
+
+        new BigInteger(1, hash).toString(16)
     }
 }


### PR DESCRIPTION
Redo of #3463 . Includes the following changes:

- `ConcreteDAG` class which tracks the concrete task DAG as the pipeline is executed
- `dag.type` config option which allows the user to render the task DAG instead of the regular DAG (currently only supported for Mermaid format)
- `.command.meta.json` file which is written on task completion and contains the task hash, input files, and output files

To test the DAG rendering, launch a pipeline with the following extra config:
```groovy
dag.enabled = true
dag.type = 'concrete'
dag.file = 'pipeline.mmd'
dag.overwrite = true
```

To test the task metadata file, simply launch a pipeline normally and inspect the task directories for `.command.meta.json` files.

Here is an example meta file from `rnaseq-nf`:
```json
{
    "hash": "4fb5c35e186526f64ee5a5cc2720e824",
    "inputs": [
        {
            "name": "ggal_gut",
            "path": "/work/ab/bc682dd08c72ded3c25640d3cb05ef/ggal_gut",
            "predecessor": "abbc682dd08c72ded3c25640d3cb05ef"
        },
        {
            "name": "fastqc_ggal_gut_logs",
            "path": "/work/c0/6030412e5508bc9c2f2d7b053eb882/fastqc_ggal_gut_logs",
            "predecessor": "c06030412e5508bc9c2f2d7b053eb882"
        },
        {
            "name": "multiqc",
            "path": "/.nextflow/assets/nextflow-io/rnaseq-nf/multiqc",
            "predecessor": null
        }
    ],
    "outputs": [
        {
            "name": "multiqc_report.html",
            "path": "/work/4f/b5c35e186526f64ee5a5cc2720e824/multiqc_report.html",
            "size": 1204127,
            "checksum": "a41d49c28135c51b7c92fb70cac70a66"
        }
    ]
}
```