### PR TITLE
added termination trap in nxf_trace to call cleanup function

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -217,6 +217,7 @@ nxf_trace_linux() {
 }
 
 nxf_trace() {
+    trap on_term TERM INT
     local trace_file=.command.trace
     touch $trace_file
     if [[ $(uname) = Darwin ]]; then


### PR DESCRIPTION
To completed address #3606, the trace version of the script needs to trap TERM/INT signals and invoke on_term.
