### PR TITLE
Reorder plugins-info.txt to match build order

### DIFF
--- a/modules/nextflow/src/main/resources/META-INF/plugins-info.txt
+++ b/modules/nextflow/src/main/resources/META-INF/plugins-info.txt
@@ -1,8 +1,8 @@
 nf-amazon@1.16.1
-nf-wave@0.8.1
-nf-console@1.0.5
-nf-google@1.7.2
 nf-azure@1.0.0
-nf-tower@1.5.11
+nf-wave@0.8.1
 nf-ga4gh@1.0.4
 nf-codecommit@0.1.3
+nf-tower@1.5.11
+nf-console@1.0.5
+nf-google@1.7.2


### PR DESCRIPTION
I don't know why, but `make compile` always reorders the list of plugins in `plugins-info.txt` and I always have to revert it. So I just reordered this file to match the way that `make compile` orders it.