### PR TITLE
Convert large tables to definition lists

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -14,9 +14,7 @@ You can provide your AWS access keys using the standard AWS variables shown belo
 
 If `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not defined in the environment, Nextflow will attempt to retrieve credentials from your `~/.aws/credentials` or `~/.aws/config` files. The `default` profile can be overridden via the environmental variable `AWS_PROFILE` (or `AWS_DEFAULT_PROFILE`).
 
-Alternatively AWS credentials can be specified in the Nextflow configuration file.
-
-See {ref}`AWS configuration<config-aws>` for more details.
+Alternatively AWS credentials can be specified in the Nextflow configuration file. See {ref}`AWS configuration<config-aws>` for more details.
 
 :::{note}
 Credentials can also be provided by using an IAM Instance Role. The benefit of this approach is that it spares you from managing/distributing AWS keys explicitly. Read the [IAM Roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) documentation and [this blog post](https://aws.amazon.com/blogs/security/granting-permission-to-launch-ec2-instances-with-iam-roles-passrole-permission/) for more details.
@@ -298,7 +296,7 @@ aws-cli/1.19.79 Python/3.8.5 Linux/4.14.231-173.361.amzn2.x86_64 botocore/1.20.7
 The `aws` tool will be placed in a directory named `bin` in the main installation folder. Modifying this directory structure after the tool is installed will cause it to not work properly.
 :::
 
-To configure Nextflow to use this installation, specify the `cliPath` option in the {ref}`AWS Batch<config-aws-batch>` configuration as shown below:
+To configure Nextflow to use this installation, specify the `aws.batch.cliPath` option in the Nextflow configuration as shown below:
 
 ```groovy
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
@@ -485,4 +483,4 @@ This [AWS page](https://aws.amazon.com/premiumsupport/knowledge-center/batch-job
 
 ## Advanced configuration
 
-Read {ref}`AWS Batch configuration<config-aws-batch>` section to learn more about advanced Batch configuration options.
+Read the {ref}`AWS configuration<config-aws>` section to learn more about advanced configuration options.

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -208,7 +208,7 @@ azure {
 }
 ```
 
-The above example defines the configuration for two node pools. The first will provision 10 compute nodes of type `Standard_D2_v2`, the second 5 nodes of type `Standard_E2_v3`. See the [Advanced settings](#advanced-settings) below for the complete list of available configuration options.
+The above example defines the configuration for two node pools. The first will provision 10 compute nodes of type `Standard_D2_v2`, the second 5 nodes of type `Standard_E2_v3`. See the {ref}`Azure configuration <config-azure>` section for the complete list of available configuration options.
 
 ### Requirements on pre-existing named pools
 
@@ -290,7 +290,7 @@ By default, Nextflow creates pool nodes based on CentOS 8, but this behavior can
 
 In the above snippet, replace `<name>` with the name of your Azure node pool.
 
-See the [Advanced settings](#advanced-settings) below and the [Azure Batch nodes](https://docs.microsoft.com/en-us/azure/batch/batch-linux-nodes) documentation for more details.
+See the {ref}`Azure configuration <config-azure>` section and the [Azure Batch nodes](https://docs.microsoft.com/en-us/azure/batch/batch-linux-nodes) documentation for more details.
 
 ### Private container registry
 
@@ -314,7 +314,7 @@ When using containers hosted in a private registry, the registry name must also 
 
 ## Active Directory Authentication
 
-As of version ``22.11.0-edge``, [Service Principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) credentials can optionally be used instead of Shared Keys for Azure Batch and Storage accounts. 
+As of version ``22.11.0-edge``, [Service Principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) credentials can optionally be used instead of Shared Keys for Azure Batch and Storage accounts.
 
 The Service Principal should have the at least the following role assignments:
 
@@ -346,47 +346,3 @@ azure {
     }
 }
 ```
-
-## Advanced settings
-
-The following configuration options are available:
-
-| Name                                           | Description                                                                                                                                                                                                                           |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `azure.activeDirectory.servicePrincipalId`     | The service principal client ID                                                                                                                                                                                                       |
-| `azure.activeDirectory.servicePrincipalSecret` | The service principal client secret                                                                                                                                                                                                   |
-| `azure.activeDirectory.tenantId`               | The Azure tenant ID                                                                                                                                                                                                                   |
-| `azure.storage.accountName`                    | The blob storage account name                                                                                                                                                                                                         |
-| `azure.storage.accountKey`                     | The blob storage account key                                                                                                                                                                                                          |
-| `azure.storage.sasToken`                       | The blob storage shared access signature token. This can be provided as an alternative to the `accountKey` setting.                                                                                                                   |
-| `azure.storage.tokenDuration`                  | The duration of the shared access signature token created by Nextflow when the `sasToken` option is *not* specified (default: `48h`).                                                                                                 |
-| `azure.batch.accountName`                      | The batch service account name.                                                                                                                                                                                                       |
-| `azure.batch.accountKey`                       | The batch service account key.                                                                                                                                                                                                        |
-| `azure.batch.endpoint`                         | The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.                                                                                                                                                        |
-| `azure.batch.location`                         | The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.                                                                                                              |
-| `azure.batch.autoPoolMode`                     | Enable the automatic creation of batch pools depending on the pipeline resources demand (default: `true`).                                                                                                                            |
-| `azure.batch.allowPoolCreation`                | Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: `false`).                                                                                                                         |
-| `azure.batch.deleteJobsOnCompletion`           | Enable the automatic deletion of jobs created by the pipeline execution (default: `true`).                                                                                                                                            |
-| `azure.batch.deletePoolsOnCompletion`          | Enable the automatic deletion of compute node pools upon pipeline completion (default: `false`).                                                                                                                                      |
-| `azure.batch.copyToolInstallMode`              | Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).                              |
-| `azure.batch.pools.<name>.publisher`           | Specify the publisher of virtual machine type used by the pool identified with `<name>` (default: `microsoft-azure-batch`, requires `nf-azure@0.11.0`).                                                                               |
-| `azure.batch.pools.<name>.offer`               | Specify the offer type of the virtual machine type used by the pool identified with `<name>` (default: `centos-container`, requires `nf-azure@0.11.0`).                                                                               |
-| `azure.batch.pools.<name>.sku`                 | Specify the ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.centos 8`, requires `nf-azure@0.11.0`).                                                                           |
-| `azure.batch.pools.<name>.vmType`              | Specify the virtual machine type used by the pool identified with `<name>`.                                                                                                                                                           |
-| `azure.batch.pools.<name>.vmCount`             | Specify the number of virtual machines provisioned by the pool identified with `<name>`.                                                                                                                                              |
-| `azure.batch.pools.<name>.maxVmCount`          | Specify the max of virtual machine when using auto scale option.                                                                                                                                                                      |
-| `azure.batch.pools.<name>.autoScale`           | Enable autoscaling feature for the pool identified with `<name>`.                                                                                                                                                                     |
-| `azure.batch.pools.<name>.fileShareRootPath`   | If mounting File Shares, this is the internal root mounting point. Must be `/mnt/resource/batch/tasks/fsmounts` for CentOS nodes or `/mnt/batch/tasks/fsmounts` for Ubuntu nodes (default is for CentOS, requires `nf-azure@0.11.0`). |
-| `azure.batch.pools.<name>.scaleFormula`        | Specify the scale formula for the pool identified with `<name>`. See Azure Batch [scaling documentation](https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling) for details.                                           |
-| `azure.batch.pools.<name>.scaleInterval`       | Specify the interval at which to automatically adjust the Pool size according to the autoscale formula. The minimum and maximum value are 5 minutes and 168 hours respectively (default: `10 mins`).                                  |
-| `azure.batch.pools.<name>.schedulePolicy`      | Specify the scheduling policy for the pool identified with `<name>`. It can be either `spread` or `pack` (default: `spread`).                                                                                                         |
-| `azure.batch.pools.<name>.privileged`          | Enable the task to run with elevated access. Ignored if `runAs` is set (default: `false`).                                                                                                                                            |
-| `azure.batch.pools.<name>.runAs`               | Specify the username under which the task is run. The user must already exist on each node of the pool.                                                                                                                               |
-| `azure.batch.pools.<name>.virtualNetwork`      | Specify the subnet ID of a virtual network in which to create the pool (requires version `23.03.0-edge` or later).
-| `azure.registry.server`                        | Specify the container registry from which to pull the Docker images (default: `docker.io`, requires `nf-azure@0.9.8`).                                                                                                                |
-| `azure.registry.userName`                      | Specify the username to connect to a private container registry (requires `nf-azure@0.9.8`).                                                                                                                                          |
-| `azure.registry.password`                      | Specify the password to connect to a private container registry (requires `nf-azure@0.9.8`).                                                                                                                                          |
-| `azure.retryPolicy.delay`                      | Delay when retrying failed API requests (default: `500ms`).                                                                                                                                                                           |
-| `azure.retryPolicy.maxDelay`                   | Max delay when retrying failed API requests (default: `60s`).                                                                                                                                                                         |
-| `azure.retryPolicy.jitter`                     | Jitter value when retrying failed API requests (default: `0.25`).                                                                                                                                                                     |
-| `azure.retryPolicy.maxAttempts`                | Max attempts when retrying failed API requests (default: `10`).                                                                                                                                                                       |

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -346,3 +346,7 @@ azure {
     }
 }
 ```
+
+## Advanced configuration
+
+Read the {ref}`Azure configuration<config-azure>` section to learn more about advanced configuration options.

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -60,7 +60,7 @@ See also: {ref}`process-multiple-input-channels`.
 
 (channel-factory)=
 
-## Channel factory
+## Channel factories
 
 Channels may be created explicitly using the following channel factory methods.
 
@@ -193,6 +193,12 @@ The first line returns a channel emitting the files ending with the suffix `.fa`
 As in Linux Bash, the `*` wildcard does not catch hidden files (i.e. files whose name starts with a `.` character).
 :::
 
+Multiple paths or glob patterns can be specified using a list:
+
+```groovy
+Channel.fromPath( ['/some/path/*.fq', '/other/path/*.fastq'] )
+```
+
 In order to include hidden files, you need to start your pattern with a period character or specify the `hidden: true` option. For example:
 
 ```groovy
@@ -205,32 +211,37 @@ The first example returns all hidden files in the specified path. The second one
 
 By default a [glob][glob] pattern only looks for regular file paths that match the specified criteria, i.e. it won't return directory paths.
 
-You may use the parameter `type` specifying the value `file`, `dir` or `any` in order to define what kind of paths you want. For example:
+You can use the `type` option specifying the value `file`, `dir` or `any` in order to define what kind of paths you want. For example:
 
 ```groovy
 myFileChannel = Channel.fromPath( '/path/*b', type: 'dir' )
 myFileChannel = Channel.fromPath( '/path/a*', type: 'any' )
 ```
 
-The first example will return all *directory* paths ending with the `b` suffix, while the second will return any file and directory starting with a `a` prefix.
+The first example will return all *directory* paths ending with the `b` suffix, while the second will return any file or directory starting with a `a` prefix.
 
-| Name          | Description                                                                                                                                |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| glob          | When `true` interprets characters `*`, `?`, `[]` and `{}` as glob wildcards, otherwise handles them as normal characters (default: `true`) |
-| type          | Type of paths returned, either `file`, `dir` or `any` (default: `file`)                                                                    |
-| hidden        | When `true` includes hidden files in the resulting paths (default: `false`)                                                                |
-| maxDepth      | Maximum number of directory levels to visit (default: `no limit`)                                                                          |
-| followLinks   | When `true` it follows symbolic links during directories tree traversal, otherwise they are managed as files (default: `true`)             |
-| relative      | When `true` returned paths are relative to the top-most common directory (default: `false`)                                                |
-| checkIfExists | When `true` throws an exception of the specified path do not exist in the file system (default: `false`)                                   |
+Available options:
 
-:::{note}
-Multiple paths or glob patterns can be specified using a list:
+`checkIfExists`
+: When `true` throws an exception of the specified path do not exist in the file system (default: `false`)
 
-```groovy
-Channel.fromPath( ['/some/path/*.fq', '/other/path/*.fastq'] )
-```
-:::
+`followLinks`
+: When `true` it follows symbolic links during directories tree traversal, otherwise they are managed as files (default: `true`)
+
+`glob`
+: When `true` interprets characters `*`, `?`, `[]` and `{}` as glob wildcards, otherwise handles them as normal characters (default: `true`)
+
+`hidden`
+: When `true` includes hidden files in the resulting paths (default: `false`)
+
+`maxDepth`
+: Maximum number of directory levels to visit (default: no limit)
+
+`relative`
+: When `true` returned paths are relative to the top-most common directory (default: `false`)
+
+`type`
+: Type of paths returned, either `file`, `dir` or `any` (default: `file`)
 
 (channel-filepairs)=
 
@@ -259,6 +270,12 @@ It will produce an output similar to the following:
 The glob pattern must contain at least one `*` wildcard character.
 :::
 
+Multiple glob patterns can be specified using a list:
+
+```groovy
+Channel.fromFilePairs( ['/some/data/SRR*_{1,2}.fastq', '/other/data/QFF*_{1,2}.fastq'] )
+```
+
 Alternatively, it is possible to implement a custom file pair grouping strategy providing a closure which, given the current file as parameter, returns the grouping key. For example:
 
 ```groovy
@@ -267,25 +284,28 @@ Channel
     .view { ext, files -> "Files with the extension $ext are $files" }
 ```
 
-Table of optional parameters available:
+Available options:
 
-| Name          | Description                                                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| type          | Type of paths returned, either `file`, `dir` or `any` (default: `file`)                                                        |
-| hidden        | When `true` includes hidden files in the resulting paths (default: `false`)                                                    |
-| maxDepth      | Maximum number of directory levels to visit (default: `no limit`)                                                              |
-| followLinks   | When `true` it follows symbolic links during directories tree traversal, otherwise they are managed as files (default: `true`) |
-| size          | Defines the number of files each emitted item is expected to hold (default: 2). Set to `-1` for any.                           |
-| flat          | When `true` the matching files are produced as sole elements in the emitted tuples (default: `false`).                         |
-| checkIfExists | When `true` throws an exception of the specified path do not exist in the file system (default: `false`)                       |
+`checkIfExists`
+: When `true` throws an exception of the specified path do not exist in the file system (default: `false`)
 
-:::{note}
-Multiple glob patterns can be specified using a list:
+`followLinks`
+: When `true` it follows symbolic links during directories tree traversal, otherwise they are managed as files (default: `true`)
 
-```groovy
-Channel.fromFilePairs( ['/some/data/SRR*_{1,2}.fastq', '/other/data/QFF*_{1,2}.fastq'] )
-```
-:::
+`flat`
+: When `true` the matching files are produced as sole elements in the emitted tuples (default: `false`).
+
+`hidden`
+: When `true` includes hidden files in the resulting paths (default: `false`)
+
+`maxDepth`
+: Maximum number of directory levels to visit (default: no limit)
+
+`size`
+: Defines the number of files each emitted item is expected to hold (default: 2). Set to `-1` for any.
+
+`type`
+: Type of paths returned, either `file`, `dir` or `any` (default: `file`)
 
 (channel-fromsra)=
 
@@ -334,23 +354,33 @@ Channel
 Each read pair is implicitly managed and returned as a list of files.
 :::
 
-:::{tip}
 This method uses the NCBI [ESearch](https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch) API behind the scenes, therefore it allows the use of any query term supported by this API.
-:::
 
-Table of optional parameters available:
+To access the ESearch API, you must provide your [NCBI API keys](https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities) through one of the following ways:
 
-| Name     | Description                                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| apiKey   | NCBI user API key.                                                                                                     |
-| cache    | Enable/disable the caching API requests (default: `true`).                                                             |
-| max      | Maximum number of entries that can be retried (default: unlimited) .                                                   |
-| protocol | Allow choosing the protocol for the resulting remote URLs. Available choices: `ftp`, `http`, `https` (default: `ftp`). |
+- The `apiKey` option:
+  ```groovy
+  Channel.fromSRA(ids, apiKey:'0123456789abcdef')
+  ```
 
-To access the NCBI search service the [NCBI API keys](https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities) should be provided either:
+- The `NCBI_API_KEY` variable in your environment:
+  ```bash
+  export NCBI_API_KEY=0123456789abcdef
+  ```
 
-- Using the `apiKey` optional parameter e.g. `Channel.fromSRA(ids, apiKey:'0123456789abcdef')`.
-- Exporting the `NCBI_API_KEY` variable in your environment e.g. `export NCBI_API_KEY=0123456789abcdef`.
+Available options:
+
+`apiKey`
+: NCBI user API key.
+
+`cache`
+: Enable/disable the caching API requests (default: `true`).
+
+`max`
+: Maximum number of entries that can be retried (default: unlimited) .
+
+`protocol`
+: Allow choosing the protocol for the resulting remote URLs. Available choices: `ftp`, `http`, `https` (default: `ftp`).
 
 (channel-of)=
 
@@ -429,11 +459,9 @@ Channel
 
 By default it watches only for new files created in the specified folder. Optionally, it is possible to provide a second argument that specifies what event(s) to watch. The supported events are:
 
-| Name     | Description                     |
-| -------- | ------------------------------- |
-| `create` | A new file is created (default) |
-| `modify` | A file is modified              |
-| `delete` | A file is deleted               |
+- `create`: A new file is created (default)
+- `modify`: A file is modified
+- `delete`: A file is deleted
 
 You can specify more than one of these events by using a comma separated string as shown below:
 
@@ -444,7 +472,7 @@ Channel
 ```
 
 :::{warning}
-The `watchPath` factory waits endlessly for files that match the specified pattern and event(s), which means that it will cause your pipeline to run forever. Consider using the `until` operator to close the channel when a certain condition is met (e.g. receiving a file named `DONE`).
+The `watchPath` factory waits endlessly for files that match the specified pattern and event(s), which means that it will cause your pipeline to run forever. Consider using the `take` or `until` operator to close the channel when a certain condition is met (e.g. after receiving 10 files, receiving a file named `DONE`).
 :::
 
 See also: [fromPath](#frompath) factory method.

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,6 +86,12 @@ The `apptainer` scope controls how [Apptainer](https://apptainer.org) containers
 
 The following settings are available:
 
+`apptainer.autoMounts`
+: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Apptainer installation (default: `false`).
+
+`apptainer.cacheDir`
+: The directory where remote Apptainer images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
+
 `apptainer.enabled`
 : Set this flag to `true` to enable Apptainer execution (default: `false`).
 
@@ -95,23 +101,17 @@ The following settings are available:
 `apptainer.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.
 
-`apptainer.runOptions`
-: This attribute can be used to provide any extra command line options supported by `apptainer exec`.
-
 `apptainer.noHttps`
 : Set this flag to `true` to pull the Apptainer image with http protocol (default: `false`).
-
-`apptainer.autoMounts`
-: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Apptainer installation (default: `false`).
-
-`apptainer.cacheDir`
-: The directory where remote Apptainer images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
 
 `apptainer.pullTimeout`
 : The amount of time the Apptainer pull can last, exceeding which the process is terminated (default: `20 min`).
 
 `apptainer.registry`
 : The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+`apptainer.runOptions`
+: This attribute can be used to provide any extra command line options supported by `apptainer exec`.
 
 Read the {ref}`container-apptainer` page to learn more about how to use Apptainer containers with Nextflow.
 
@@ -217,20 +217,20 @@ The following settings are available:
 `aws.client.userAgent`
 : The HTTP user agent header passed with all HTTP requests.
 
-`aws.client.uploadMaxThreads`
-: The maximum number of threads used for multipart upload.
-
 `aws.client.uploadChunkSize`
 : The size of a single part in a multipart upload (default: `100 MB`).
-
-`aws.client.uploadStorageClass`
-: The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).
 
 `aws.client.uploadMaxAttempts`
 : The maximum number of upload attempts after which a multipart upload returns an error (default: `5`).
 
+`aws.client.uploadMaxThreads`
+: The maximum number of threads used for multipart upload.
+
 `aws.client.uploadRetrySleep`
 : The time to wait after a failed upload attempt to retry the part upload (default: `500ms`).
+
+`aws.client.uploadStorageClass`
+: The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).
 
 (config-aws-batch)=
 
@@ -239,6 +239,9 @@ Advanced Batch configuration options can be set by using the `batch` attribute. 
 `aws.batch.cliPath`
 : The path where the AWS command line tool is installed in the host AMI.
 
+`aws.batch.delayBetweenAttempts`
+: Delay between download attempts from S3 (default: `10 sec`).
+
 `aws.batch.jobRole`
 : The AWS Job Role ARN that needs to be used to execute the Batch Job.
 
@@ -246,21 +249,15 @@ Advanced Batch configuration options can be set by using the `batch` attribute. 
 : *Requires version `22.09.0-edge` or later*
 : The name of the logs group used by Batch Jobs (default: `/aws/batch`).
 
-`aws.batch.volumes`
-: One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. `/host/path:/mount/path[:ro|rw]`. Multiple mounts can be specified separating them with a comma or using a list object.
-
-`aws.batch.delayBetweenAttempts`
-: Delay between download attempts from S3 (default: `10 sec`).
-
 `aws.batch.maxParallelTransfers`
 : Max parallel upload/download transfer operations *per job* (default: `4`).
-
-`aws.batch.maxTransferAttempts`
-: Max number of downloads attempts from S3 (default: `1`).
 
 `aws.batch.maxSpotAttempts`
 : *Requires version `22.04.0` or later*
 : Max number of execution attempts of a job interrupted by a EC2 spot reclaim event (default: `5`)
+
+`aws.batch.maxTransferAttempts`
+: Max number of downloads attempts from S3 (default: `1`).
 
 `aws.batch.retryMode`
 : The retry mode configuration setting, to accommodate rate-limiting on [AWS services](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html) (default: `standard`)
@@ -272,6 +269,9 @@ Advanced Batch configuration options can be set by using the `batch` attribute. 
 `aws.batch.shareIdentifier`
 : *Requires `22.09.0-edge` or later*
 : The share identifier for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/)
+
+`aws.batch.volumes`
+: One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. `/host/path:/mount/path[:ro|rw]`. Multiple mounts can be specified separating them with a comma or using a list object.
 
 (config-azure)=
 
@@ -290,35 +290,20 @@ The following settings are available:
 `azure.activeDirectory.tenantId`
 : The Azure tenant ID
 
-`azure.storage.accountName`
-: The blob storage account name
-
-`azure.storage.accountKey`
-: The blob storage account key
-
-`azure.storage.sasToken`
-: The blob storage shared access signature token. This can be provided as an alternative to the `accountKey` setting.
-
-`azure.storage.tokenDuration`
-: The duration of the shared access signature token created by Nextflow when the `sasToken` option is *not* specified (default: `48h`).
-
 `azure.batch.accountName`
 : The batch service account name.
 
 `azure.batch.accountKey`
 : The batch service account key.
 
-`azure.batch.endpoint`
-: The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.
-
-`azure.batch.location`
-: The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
+`azure.batch.allowPoolCreation`
+: Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: `false`).
 
 `azure.batch.autoPoolMode`
 : Enable the automatic creation of batch pools depending on the pipeline resources demand (default: `true`).
 
-`azure.batch.allowPoolCreation`
-: Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: `false`).
+`azure.batch.copyToolInstallMode`
+: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
 
 `azure.batch.deleteJobsOnCompletion`
 : Enable the automatic deletion of jobs created by the pipeline execution (default: `true`).
@@ -326,29 +311,11 @@ The following settings are available:
 `azure.batch.deletePoolsOnCompletion`
 : Enable the automatic deletion of compute node pools upon pipeline completion (default: `false`).
 
-`azure.batch.copyToolInstallMode`
-: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
+`azure.batch.endpoint`
+: The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.
 
-`azure.batch.pools.<name>.publisher`
-: *Requires `nf-azure@0.11.0`*
-: Specify the publisher of virtual machine type used by the pool identified with `<name>` (default: `microsoft-azure-batch`).
-
-`azure.batch.pools.<name>.offer`
-: *Requires `nf-azure@0.11.0`*
-: Specify the offer type of the virtual machine type used by the pool identified with `<name>` (default: `centos-container`).
-
-`azure.batch.pools.<name>.sku`
-: *Requires `nf-azure@0.11.0`*
-: Specify the ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.centos 8`).
-
-`azure.batch.pools.<name>.vmType`
-: Specify the virtual machine type used by the pool identified with `<name>`.
-
-`azure.batch.pools.<name>.vmCount`
-: Specify the number of virtual machines provisioned by the pool identified with `<name>`.
-
-`azure.batch.pools.<name>.maxVmCount`
-: Specify the max of virtual machine when using auto scale option.
+`azure.batch.location`
+: The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
 
 `azure.batch.pools.<name>.autoScale`
 : Enable autoscaling feature for the pool identified with `<name>`.
@@ -356,6 +323,23 @@ The following settings are available:
 `azure.batch.pools.<name>.fileShareRootPath`
 : *Requires `nf-azure@0.11.0`*
 : If mounting File Shares, this is the internal root mounting point. Must be `/mnt/resource/batch/tasks/fsmounts` for CentOS nodes or `/mnt/batch/tasks/fsmounts` for Ubuntu nodes (default is for CentOS).
+
+`azure.batch.pools.<name>.maxVmCount`
+: Specify the max of virtual machine when using auto scale option.
+
+`azure.batch.pools.<name>.offer`
+: *Requires `nf-azure@0.11.0`*
+: Specify the offer type of the virtual machine type used by the pool identified with `<name>` (default: `centos-container`).
+
+`azure.batch.pools.<name>.privileged`
+: Enable the task to run with elevated access. Ignored if `runAs` is set (default: `false`).
+
+`azure.batch.pools.<name>.publisher`
+: *Requires `nf-azure@0.11.0`*
+: Specify the publisher of virtual machine type used by the pool identified with `<name>` (default: `microsoft-azure-batch`).
+
+`azure.batch.pools.<name>.runAs`
+: Specify the username under which the task is run. The user must already exist on each node of the pool.
 
 `azure.batch.pools.<name>.scaleFormula`
 : Specify the scale formula for the pool identified with `<name>`. See Azure Batch [scaling documentation](https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling) for details.
@@ -366,15 +350,19 @@ The following settings are available:
 `azure.batch.pools.<name>.schedulePolicy`
 : Specify the scheduling policy for the pool identified with `<name>`. It can be either `spread` or `pack` (default: `spread`).
 
-`azure.batch.pools.<name>.privileged`
-: Enable the task to run with elevated access. Ignored if `runAs` is set (default: `false`).
-
-`azure.batch.pools.<name>.runAs`
-: Specify the username under which the task is run. The user must already exist on each node of the pool.
+`azure.batch.pools.<name>.sku`
+: *Requires `nf-azure@0.11.0`*
+: Specify the ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.centos 8`).
 
 `azure.batch.pools.<name>.virtualNetwork`
 : *Requires Nextflow `23.03.0-edge` or later*
 : Specify the subnet ID of a virtual network in which to create the pool.
+
+`azure.batch.pools.<name>.vmCount`
+: Specify the number of virtual machines provisioned by the pool identified with `<name>`.
+
+`azure.batch.pools.<name>.vmType`
+: Specify the virtual machine type used by the pool identified with `<name>`.
 
 `azure.registry.server`
 : *Requires `nf-azure@0.9.8`*
@@ -391,14 +379,26 @@ The following settings are available:
 `azure.retryPolicy.delay`
 : Delay when retrying failed API requests (default: `500ms`).
 
-`azure.retryPolicy.maxDelay`
-: Max delay when retrying failed API requests (default: `60s`).
-
 `azure.retryPolicy.jitter`
 : Jitter value when retrying failed API requests (default: `0.25`).
 
 `azure.retryPolicy.maxAttempts`
 : Max attempts when retrying failed API requests (default: `10`).
+
+`azure.retryPolicy.maxDelay`
+: Max delay when retrying failed API requests (default: `60s`).
+
+`azure.storage.accountName`
+: The blob storage account name
+
+`azure.storage.accountKey`
+: The blob storage account key
+
+`azure.storage.sasToken`
+: The blob storage shared access signature token. This can be provided as an alternative to the `accountKey` setting.
+
+`azure.storage.tokenDuration`
+: The duration of the shared access signature token created by Nextflow when the `sasToken` option is *not* specified (default: `48h`).
 
 (config-charliecloud)=
 
@@ -408,23 +408,23 @@ The `charliecloud` scope controls how [Charliecloud](https://hpc.github.io/charl
 
 The following settings are available:
 
+`charliecloud.cacheDir`
+: The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
+
 `charliecloud.enabled`
 : Set this flag to `true` to enable Charliecloud execution (default: `false`).
 
 `charliecloud.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.
 
-`charliecloud.temp`
-: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
+`charliecloud.pullTimeout`
+: The amount of time the Charliecloud pull can last, exceeding which the process is terminated (default: `20 min`).
 
 `charliecloud.runOptions`
 : This attribute can be used to provide any extra command line options supported by the `ch-run` command.
 
-`charliecloud.cacheDir`
-: The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
-
-`charliecloud.pullTimeout`
-: The amount of time the Charliecloud pull can last, exceeding which the process is terminated (default: `20 min`).
+`charliecloud.temp`
+: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
 
 Read the {ref}`container-charliecloud` page to learn more about how to use Charliecloud containers with Nextflow.
 
@@ -484,38 +484,38 @@ The following settings are available:
 `docker.enabled`
 : Set this flag to `true` to enable Docker execution (default: `false`).
 
+`docker.engineOptions`
+: This attribute can be used to provide any option supported by the Docker engine i.e. `docker [OPTIONS]`.
+
 `docker.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.
-
-`docker.legacy`
-: Uses command line options removed since version 1.10.x (default: `false`).
-
-`docker.sudo`
-: Executes Docker run command as `sudo` (default: `false`).
-
-`docker.tty`
-: Allocates a pseudo-tty (default: `false`).
-
-`docker.temp`
-: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
-
-`docker.remove`
-: Clean-up the container after the execution (default: `true`). For details see: <https://docs.docker.com/engine/reference/run/#clean-up---rm> .
-
-`docker.runOptions`
-: This attribute can be used to provide any extra command line options supported by the `docker run` command. For details see: <https://docs.docker.com/engine/reference/run/> .
-
-`docker.registry`
-: The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
 
 `docker.fixOwnership`
 : Fixes ownership of files created by the docker container.
 
-`docker.engineOptions`
-: This attribute can be used to provide any option supported by the Docker engine i.e. `docker [OPTIONS]`.
+`docker.legacy`
+: Uses command line options removed since version 1.10.x (default: `false`).
 
 `docker.mountFlags`
-: Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`
+: Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`.
+
+`docker.registry`
+: The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+`docker.remove`
+: Clean-up the container after the execution (default: `true`). See the [Docker documentation](https://docs.docker.com/engine/reference/run/#clean-up---rm) for details.
+
+`docker.runOptions`
+: This attribute can be used to provide any extra command line options supported by the `docker run` command. See the [Docker documentation](https://docs.docker.com/engine/reference/run/) for details.
+
+`docker.sudo`
+: Executes Docker run command as `sudo` (default: `false`).
+
+`docker.temp`
+: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
+
+`docker.tty`
+: Allocates a pseudo-tty (default: `false`).
 
 Read the {ref}`container-docker` page to learn more about how to use Docker containers with Nextflow.
 
@@ -553,32 +553,26 @@ The `executor` scope controls various executor behaviors.
 
 The following settings are available:
 
-`executor.name`
-: The name of the executor to be used (default: `local`).
-
-`executor.queueSize`
-: The number of tasks the executor will handle in a parallel manner. Default varies for each executor (see below).
-
-`executor.submitRateLimit`
-: Determines the max rate of job submission per time unit, for example `'10sec'` (10 jobs per second) or `'50/2min'` (50 jobs every 2 minutes) (default: unlimited).
-
-`executor.pollInterval`
-: Determines how often to check for process termination. Default varies for each executor (see below).
+`executor.cpus`
+: The maximum number of CPUs made available by the underlying system. Used only by the `local` executor.
 
 `executor.dumpInterval`
 : Determines how often to log the executor status (default: `5min`).
 
-`executor.queueGlobalStatu`
-: Determines how job status is retrieved. When `false` only the queue associated with the job execution is queried. When `true` the job status is queried globally i.e. irrespective of the submission queue (default: `false`, requires version `23.01.0-edge` or later).
-
-`executor.queueStatInterva`
-: Determines how often to fetch the queue status from the scheduler (default: `1min`). Used only by grid executors.
-
 `executor.exitReadTimeout`
 : Determines how long to wait before returning an error status when a process is terminated but the `.exitcode` file does not exist or is empty (default: `270 sec`). Used only by grid executors.
 
+`executor.jobName`
+: Determines the name of jobs submitted to the underlying cluster executor e.g. `executor.jobName = { "$task.name - $task.hash" }`. Make sure the resulting job name matches the validation constraints of the underlying batch scheduler.
+
 `executor.killBatchSize`
 : Determines the number of jobs that can be killed in a single command execution (default: `100`).
+
+`executor.memory`
+: The maximum amount of memory made available by the underlying system. Used only by the `local` executor.
+
+`executor.name`
+: The name of the executor to be used (default: `local`).
 
 `executor.perJobMemLimit`
 : Specifies Platform LSF *per-job* memory limit mode. See {ref}`lsf-executor`.
@@ -586,22 +580,22 @@ The following settings are available:
 `executor.perTaskReserve`
 : Specifies Platform LSF *per-task* memory reserve mode. See {ref}`lsf-executor`.
 
-`executor.jobName`
-: Determines the name of jobs submitted to the underlying cluster executor e.g. `executor.jobName = { "$task.name - $task.hash" }`. Make sure the resulting job name matches the validation constraints of the underlying batch scheduler.
+`executor.pollInterval`
+: Determines how often to check for process termination. Default varies for each executor (see below).
 
-`executor.cpus`
-: The maximum number of CPUs made available by the underlying system. Used only by the `local` executor.
+`executor.queueGlobalStatus`
+: *Requires version `23.01.0-edge` or later*
+: Determines how job status is retrieved. When `false` only the queue associated with the job execution is queried. When `true` the job status is queried globally i.e. irrespective of the submission queue (default: `false`).
 
-`executor.memory`
-: The maximum amount of memory made available by the underlying system. Used only by the `local` executor.
+`executor.queueSize`
+: The number of tasks the executor will handle in a parallel manner. Default varies for each executor (see below).
+
+`executor.queueStatInterval`
+: Determines how often to fetch the queue status from the scheduler (default: `1min`). Used only by grid executors.
 
 `executor.retry.delay`
 : *Requires `22.03.0-edge` or later*
 : Delay when retrying failed job submissions (default: `500ms`). Used only by grid executors.
-
-`executor.retry.maxDelay`
-: *Requires `22.03.0-edge` or later*
-: Max delay when retrying failed job submissions (default: `30s`). Used only by grid executors.
 
 `executor.retry.jitter`
 : *Requires `22.03.0-edge` or later*
@@ -611,9 +605,16 @@ The following settings are available:
 : *Requires `22.03.0-edge` or later*
 : Max attempts when retrying failed job submissions (default: `3`). Used only by grid executors.
 
+`executor.retry.maxDelay`
+: *Requires `22.03.0-edge` or later*
+: Max delay when retrying failed job submissions (default: `30s`). Used only by grid executors.
+
 `executor.retry.reason`
 : *Requires `22.03.0-edge` or later*
 : Regex pattern that when verified cause a failed submit operation to be re-tried (default: `Socket timed out`). Used only by grid executors.
+
+`executor.submitRateLimit`
+: Determines the max rate of job submission per time unit, for example `'10sec'` (10 jobs per second) or `'50/2min'` (50 jobs every 2 minutes) (default: unlimited).
 
 Some executor settings have different default values depending on the executor.
 
@@ -672,26 +673,39 @@ The following settings are available:
 `k8s.autoMountHostPaths`
 : Automatically mounts host paths in the job pods. Only for development purpose when using a single node cluster (default: `false`).
 
+`k8s.computeResourceType`
+: *Requires version `22.05.0-edge` or later*
+: Define whether use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`).
+
 `k8s.context`
 : Defines the Kubernetes [configuration context name](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to use.
 
-`k8s.namespace`
-: Defines the Kubernetes namespace to use (default: `default`).
+`k8s.fetchNodeName`
+: *Requires version `22.05.0-edge` or later*
+: If you trace the hostname, activate this option (default: `false`).
 
-`k8s.serviceAccount`
-: Defines the Kubernetes [service account name](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to use.
+`k8s.httpConnectTimeout`
+: *Requires version `22.10.0` or later*
+: Defines the Kubernetes client request HTTP connection timeout e.g. `'60s'`.
+
+`k8s.httpReadTimeout`
+: *Requires version `22.10.0` or later*
+: Defines the Kubernetes client request HTTP connection read timeout e.g. `'60s'`.
 
 `k8s.launchDir`
 : Defines the path where the workflow is launched and the user data is stored. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/<user-name>`).
 
-`k8s.workDir`
-: Defines the path where the workflow temporary data is stored. This must be a path in a shared K8s persistent volume (default:`<user-dir>/work`).
+`k8s.maxErrorRetry`
+: Defines the Kubernetes API max request retries (default: 4).
 
-`k8s.projectDir`
-: Defines the path where Nextflow projects are downloaded. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/projects`).
+`k8s.namespace`
+: Defines the Kubernetes namespace to use (default: `default`).
 
 `k8s.pod`
 : Allows the definition of one or more pod configuration options such as environment variables, config maps, secrets, etc. It allows the same settings as the {ref}`process-pod` process directive.
+
+`k8s.projectDir`
+: Defines the path where Nextflow projects are downloaded. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/projects`).
 
 `k8s.pullPolicy`
 : Defines the strategy to be used to pull the container image e.g. `pullPolicy: 'Always'`.
@@ -702,6 +716,9 @@ The following settings are available:
 `k8s.securityContext`
 : Defines the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for all pods.
 
+`k8s.serviceAccount`
+: Defines the Kubernetes [service account name](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to use.
+
 `k8s.storageClaimName`
 : The name of the persistent volume claim where store workflow result data.
 
@@ -709,29 +726,13 @@ The following settings are available:
 : The path location used to mount the persistent volume claim (default: `/workspace`).
 
 `k8s.storageSubPath`
-: The path in the persistent volume to be mounted (default: root).
-
-`k8s.computeResourceType`
-: *Requires version `22.05.0-edge` or later*
-: Define whether use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`).
-
-`k8s.fetchNodeName`
-: *Requires version `22.05.0-edge` or later*
-: If you trace the hostname, activate this option (default: `false`).
+: The path in the persistent volume to be mounted (default: `/`).
 
 `k8s.volumeClaims`
-: (deprecated)
+: *DEPRECATED*
 
-`k8s.maxErrorRetry`
-: Defines the Kubernetes API max request retries (default is set to 4)
-
-`k8s.httpReadTimeout`
-: *Requires version `22.10.0` or later*
-: Defines the Kubernetes client request HTTP connection read timeout e.g. `'60s'`.
-
-`k8s.httpConnectTimeout`
-: *Requires version `22.10.0` or later*
-: Defines the Kubernetes client request HTTP connection timeout e.g. `'60s'`.
+`k8s.workDir`
+: Defines the path where the workflow temporary data is stored. This must be a path in a shared K8s persistent volume (default:`<user-dir>/work`).
 
 See the {ref}`k8s-page` page for more details.
 
@@ -742,6 +743,9 @@ See the {ref}`k8s-page` page for more details.
 The `mail` scope controls the mail server used to send email notifications.
 
 The following settings are available:
+
+`mail.debug`
+: When `true` enables Java Mail logging for debugging purpose.
 
 `mail.from`
 : Default email sender address.
@@ -758,17 +762,14 @@ The following settings are available:
 `mail.smtp.password`
 : User password to connect to the mail server.
 
-`mail.smtp.proxy.hos`
+`mail.smtp.proxy.host`
 : Host name of an HTTP web proxy server that will be used for connections to the mail server.
 
-`mail.smtp.proxy.por`
+`mail.smtp.proxy.port`
 : Port number for the HTTP web proxy server.
 
 `mail.smtp.*`
 : Any SMTP configuration property supported by the [Java Mail API](https://javaee.github.io/javamail/), which Nextflow uses to send emails. See the table of available properties [here](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#properties).
-
-`mail.debug`
-: When `true` enables Java Mail logging for debugging purpose.
 
 For example, the following snippet shows how to configure Nextflow to send emails through the [AWS Simple Email Service](https://aws.amazon.com/ses/):
 
@@ -802,44 +803,44 @@ The `manifest` scope allows you to define some meta-data information needed when
 
 The following settings are available:
 
-`manifes.author`
+`manifest.author`
 : Project author name (use a comma to separate multiple names).
 
-`manifes.defaultBranch`
+`manifest.defaultBranch`
 : Git repository default branch (default: `master`).
 
-`manifes.description`
+`manifest.description`
 : Free text describing the workflow project.
 
-`manifes.doi`
+`manifest.doi`
 : Project related publication DOI identifier.
 
-`manifes.homePage`
+`manifest.homePage`
 : Project home page URL.
 
-`manifes.mainScript`
+`manifest.mainScript`
 : Project main script (default: `main.nf`).
 
-`manifes.name`
+`manifest.name`
 : Project short name.
 
-`manifes.nextflowVersion`
+`manifest.nextflowVersion`
 : Minimum required Nextflow version.
 
   This setting may be useful to ensure that a specific version is used:
 
   ```groovy
-  nextflowVersion = '1.2.3'        // exact match
-  nextflowVersion = '1.2+'         // 1.2 or later (excluding 2 and later)
-  nextflowVersion = '>=1.2'        // 1.2 or later
-  nextflowVersion = '>=1.2, <=1.5' // any version in the 1.2 .. 1.5 range
-  nextflowVersion = '!>=1.2'       // with ! prefix, stop execution if current version does not match required version.
+  manifest.nextflowVersion = '1.2.3'        // exact match
+  manifest.nextflowVersion = '1.2+'         // 1.2 or later (excluding 2 and later)
+  manifest.nextflowVersion = '>=1.2'        // 1.2 or later
+  manifest.nextflowVersion = '>=1.2, <=1.5' // any version in the 1.2 .. 1.5 range
+  manifest.nextflowVersion = '!>=1.2'       // with ! prefix, stop execution if current version does not match required version.
   ```
 
-`manifes.recurseSubmodules`
+`manifest.recurseSubmodules`
 : Set this flag to `true` to pull submodules recursively from the Git repository.
 
-`manifes.version`
+`manifest.version`
 : Project version number.
 
 The above options can also be specified in a `manifest` block, for example:
@@ -861,11 +862,11 @@ Read the {ref}`sharing-page` page to learn how to publish your pipeline to GitHu
 
 The `notification` scope allows you to define the automatic sending of a notification email message when the workflow execution terminates.
 
+`notification.binding`
+: An associative array modelling the variables in the template file.
+
 `notification.enabled`
 : Enables the sending of a notification message when the workflow execution completes.
-
-`notification.to`
-: Recipient address for the notification email. Multiple addresses can be specified separating them with a comma.
 
 `notification.from`
 : Sender address for the notification email message.
@@ -873,8 +874,8 @@ The `notification` scope allows you to define the automatic sending of a notific
 `notification.template`
 : Path of a template file which provides the content of the notification message.
 
-`notification.binding`
-: An associative array modelling the variables in the template file.
+`notification.to`
+: Recipient address for the notification email. Multiple addresses can be specified separating them with a comma.
 
 The notification message is sent my using the STMP server defined in the configuration {ref}`mail scope<config-mail>`.
 
@@ -907,11 +908,17 @@ The following settings are available:
 `podman.enabled`
 : Set this flag to `true` to enable Podman execution (default: `false`).
 
+`podman.engineOptions`
+: This attribute can be used to provide any option supported by the Podman engine i.e. `podman [OPTIONS]`.
+
 `podman.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.
 
-`podman.temp`
-: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
+`podman.mountFlags`
+: Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`.
+
+`podman.registry`
+: The registry from where container images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
 
 `podman.remove`
 : Clean-up the container after the execution (default: `true`).
@@ -919,14 +926,8 @@ The following settings are available:
 `podman.runOptions`
 : This attribute can be used to provide any extra command line options supported by the `podman run` command.
 
-`podman.registry`
-: The registry from where container images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
-
-`podman.engineOptions`
-: This attribute can be used to provide any option supported by the Podman engine i.e. `podman [OPTIONS]`.
-
-`podman.mountFlags`
-: Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`
+`podman.temp`
+: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
 
 Read the {ref}`container-podman` page to learn more about how to use Podman containers with Nextflow.
 
@@ -1065,11 +1066,11 @@ The following settings are available:
 `sarus.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.
 
-`sarus.tty`
-: Allocates a pseudo-tty (default: `false`).
-
 `sarus.runOptions`
 : This attribute can be used to provide any extra command line options supported by the `sarus run` command. For details see the [Sarus user guide](https://sarus.readthedocs.io/en/stable/user/user_guide.html).
+
+`sarus.tty`
+: Allocates a pseudo-tty (default: `false`).
 
 Read the {ref}`container-sarus` page to learn more about how to use Sarus containers with Nextflow.
 
@@ -1094,6 +1095,12 @@ The `singularity` scope controls how [Singularity](https://sylabs.io/singularity
 
 The following settings are available:
 
+`singularity.autoMounts`
+: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Singularity installation (default: `false`).
+
+`singularity.cacheDir`
+: The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
+
 `singularity.enabled`
 : Set this flag to `true` to enable Singularity execution (default: `false`).
 
@@ -1103,23 +1110,17 @@ The following settings are available:
 `singularity.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.
 
-`singularity.runOptions`
-: This attribute can be used to provide any extra command line options supported by `singularity exec`.
-
 `singularity.noHttps`
 : Set this flag to `true` to pull the Singularity image with http protocol (default: `false`).
-
-`singularity.autoMounts`
-: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Singularity installation (default: `false`).
-
-`singularity.cacheDir`
-: The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
 
 `singularity.pullTimeout`
 : The amount of time the Singularity pull can last, exceeding which the process is terminated (default: `20 min`).
 
 `singularity.registry`
 : The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+`singularity.runOptions`
+: This attribute can be used to provide any extra command line options supported by `singularity exec`.
 
 Read the {ref}`container-singularity` page to learn more about how to use Singularity containers with Nextflow.
 
@@ -1134,14 +1135,14 @@ The following settings are available:
 `spack.cacheDir`
 : Defines the path where Spack environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all compute nodes.
 
+`spack.createTimeout`
+: Defines the amount of time the Spack environment creation can last. The creation process is terminated when the timeout is exceeded (default: `60 min`).
+
 `spack.noChecksum`
 : Disables checksum verification for source tarballs (unsafe). Useful when requesting a package version not yet encoded in the corresponding Spack recipe (default: `false`).
 
 `spack.parallelBuilds`
 : Sets number of parallel package builds (Spack default: coincides with number of available CPU cores).
-
-`spack.createTimeout`
-: Defines the amount of time the Spack environment creation can last. The creation process is terminated when the timeout is exceeded (default: `60 min`).
 
 Nextflow does not allow for fine-grained configuration of the Spack package manager. Instead, this has to be performed directly on the host Spack installation. For more information see the [Spack documentation](https://spack.readthedocs.io).
 
@@ -1170,13 +1171,13 @@ The `tower` scope controls the settings for the [Nextflow Tower](https://tower.n
 
 The following settings are available:
 
-`tower.enabled`
-: When `true` Nextflow sends the workflow tracing and execution metrics to the Nextflow Tower service (default: `false`).
-
 `tower.accessToken`
 : The unique access token specific to your account on an instance of Tower.
 
   Your `accessToken` can be obtained from your Tower instance in the `Tokens page <https://tower.nf/tokens>`.
+
+`tower.enabled`
+: When `true` Nextflow sends the workflow tracing and execution metrics to the Nextflow Tower service (default: `false`).
 
 `tower.endpoint`
 : The endpoint of your Tower deployment (default: `https://tower.nf`).
@@ -1203,14 +1204,14 @@ The following settings are available:
 `trace.file`
 : Trace file name (default: `trace-<timestamp>.txt`).
 
-`trace.sep`
-: Character used to separate values in each row (default: `\t`).
+`trace.overwrite`
+: When `true` overwrites any existing trace file with the same name.
 
 `trace.raw`
 : When `true` turns on raw number report generation i.e. date and time are reported as milliseconds and memory as number of bytes.
 
-`trace.overwrite`
-: When `true` overwrites any existing trace file with the same name.
+`trace.sep`
+: Character used to separate values in each row (default: `\t`).
 
 The above options can also be specified in a `trace` block, for example:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,6 +78,43 @@ beta {
 }
 ```
 
+(config-apptainer)=
+
+### Scope `apptainer`
+
+The `apptainer` scope controls how [Apptainer](https://apptainer.org) containers are executed by Nextflow.
+
+The following settings are available:
+
+`apptainer.enabled`
+: Set this flag to `true` to enable Apptainer execution (default: `false`).
+
+`apptainer.engineOptions`
+: This attribute can be used to provide any option supported by the Apptainer engine i.e. `apptainer [OPTIONS]`.
+
+`apptainer.envWhitelist`
+: Comma separated list of environment variable names to be included in the container environment.
+
+`apptainer.runOptions`
+: This attribute can be used to provide any extra command line options supported by `apptainer exec`.
+
+`apptainer.noHttps`
+: Set this flag to `true` to pull the Apptainer image with http protocol (default: `false`).
+
+`apptainer.autoMounts`
+: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Apptainer installation (default: `false`).
+
+`apptainer.cacheDir`
+: The directory where remote Apptainer images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
+
+`apptainer.pullTimeout`
+: The amount of time the Apptainer pull can last, exceeding which the process is terminated (default: `20 min`).
+
+`apptainer.registry`
+: The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+Read the {ref}`container-apptainer` page to learn more about how to use Apptainer containers with Nextflow.
+
 (config-aws)=
 
 ### Scope `aws`
@@ -95,7 +132,20 @@ aws {
 
 See [AWS Security Credentials](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html) for more information.
 
-Advanced client configuration options can be set using the `client` attribute. The following options are available:
+Advanced client configuration options can be set using the `client` attribute. For example:
+
+```groovy
+aws {
+    client {
+        maxConnections = 20
+        connectionTimeout = 10000
+        uploadStorageClass = 'INTELLIGENT_TIERING'
+        storageEncryption = 'AES256'
+    }
+}
+```
+
+The following settings are available:
 
 `aws.client.anonymous`
 : Allow the access of public S3 buckets without the need to provide AWS credentials. Any service that does not accept unsigned requests will return a service access error.
@@ -182,22 +232,9 @@ Advanced client configuration options can be set using the `client` attribute. T
 `aws.client.uploadRetrySleep`
 : The time to wait after a failed upload attempt to retry the part upload (default: `500ms`).
 
-For example:
-
-```groovy
-aws {
-    client {
-        maxConnections = 20
-        connectionTimeout = 10000
-        uploadStorageClass = 'INTELLIGENT_TIERING'
-        storageEncryption = 'AES256'
-    }
-}
-```
-
 (config-aws-batch)=
 
-Advanced Batch configuration options can be set by using the `batch` attribute. The following options are available:
+Advanced Batch configuration options can be set by using the `batch` attribute. The following settings are available:
 
 `aws.batch.cliPath`
 : The path where the AWS command line tool is installed in the host AMI.
@@ -241,6 +278,8 @@ Advanced Batch configuration options can be set by using the `batch` attribute. 
 ### Scope `azure`
 
 The `azure` scope allows you to configure the interactions with {ref}`azure-page`.
+
+The following settings are available:
 
 `azure.activeDirectory.servicePrincipalId`
 : The service principal client ID
@@ -365,121 +404,126 @@ The `azure` scope allows you to configure the interactions with {ref}`azure-page
 
 ### Scope `charliecloud`
 
-The `charliecloud` configuration scope controls how [Charliecloud](https://hpc.github.io/charliecloud/) containers are executed by Nextflow.
+The `charliecloud` scope controls how [Charliecloud](https://hpc.github.io/charliecloud/) containers are executed by Nextflow.
 
 The following settings are available:
 
-| Name         | Description                                                                                                                                                           |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled      | Turn this flag to `true` to enable Charliecloud execution (default: `false`).                                                                                         |
-| envWhitelist | Comma separated list of environment variable names to be included in the container environment.                                                                       |
-| temp         | Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created. |
-| runOptions   | This attribute can be used to provide any extra command line options supported by the `ch-run` command.                                                               |
-| cacheDir     | The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.                 |
-| pullTimeout  | The amount of time the Charliecloud pull can last, exceeding which the process is terminated (default: `20 min`).                                                     |
+`charliecloud.enabled`
+: Set this flag to `true` to enable Charliecloud execution (default: `false`).
 
-The above options can be used by prefixing them with the `charliecloud` scope or surrounding them by curly brackets, as shown below:
+`charliecloud.envWhitelist`
+: Comma separated list of environment variable names to be included in the container environment.
 
-```groovy
-process.container = 'nextflow/examples'
+`charliecloud.temp`
+: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
 
-charliecloud {
-    enabled = true
-}
-```
+`charliecloud.runOptions`
+: This attribute can be used to provide any extra command line options supported by the `ch-run` command.
 
-Read {ref}`container-charliecloud` page to learn more about how to use Charliecloud containers with Nextflow.
+`charliecloud.cacheDir`
+: The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
 
-(config-cloud)=
+`charliecloud.pullTimeout`
+: The amount of time the Charliecloud pull can last, exceeding which the process is terminated (default: `20 min`).
 
-### Scope `cloud`
-
-:::{note}
-The `cloud` configuration scope is no longer used. See the platform-specific cloud executors instead.
-:::
+Read the {ref}`container-charliecloud` page to learn more about how to use Charliecloud containers with Nextflow.
 
 (config-conda)=
 
 ### Scope `conda`
 
-The `conda` scope allows for the definition of the configuration settings that control the creation of a Conda environment by the Conda package manager.
+The `conda` scope controls the creation of a Conda environment by the Conda package manager.
 
 The following settings are available:
 
-| Name          | Description                                                                                                                                                                                                                                 |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| cacheDir      | Defines the path where Conda environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all compute nodes.                                                                        |
-| createOptions | Defines any extra command line options supported by the `conda create` command. For details [Conda documentation](https://docs.conda.io/projects/conda/en/latest/commands/create.html).                                                     |
-| createTimeout | Defines the amount of time the Conda environment creation can last. The creation process is terminated when the timeout is exceeded (default: `20 min`).                                                                                    |
-| useMamba      | Uses the `mamba` binary instead of `conda` to create the Conda environments. For details [Mamba documentation](https://github.com/mamba-org/mamba).                                                                                         |
-| useMicromamba | uses the `micromamba` binary instead of `conda` to create the Conda environments (requires version `22.05.0-edge` or later). For details see [Micromamba documentation](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html). |
+`conda.cacheDir`
+: Defines the path where Conda environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all compute nodes.
+
+`conda.createOptions`
+: Defines any extra command line options supported by the `conda create` command. For details see the [Conda documentation](https://docs.conda.io/projects/conda/en/latest/commands/create.html).
+
+`conda.createTimeout`
+: Defines the amount of time the Conda environment creation can last. The creation process is terminated when the timeout is exceeded (default: `20 min`).
+
+`conda.useMamba`
+: Uses the `mamba` binary instead of `conda` to create the Conda environments. For details see the [Mamba documentation](https://github.com/mamba-org/mamba).
+
+`conda.useMicromamba`
+: *Requires version `22.05.0-edge` or later*
+: uses the `micromamba` binary instead of `conda` to create the Conda environments. For details see the [Micromamba documentation](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html).
+
+Read the {ref}`conda-page` page to learn more about how to use Conda environments with Nextflow.
 
 (config-dag)=
 
 ### Scope `dag`
 
-The `dag` scope allows you to control the layout of the execution graph diagram generated by Nextflow.
+The `dag` scope controls the layout of the execution graph diagram generated by Nextflow.
 
 The following settings are available:
 
-| Name      | Description                                                                                |
-| --------- | ------------------------------------------------------------------------------------------ |
-| enabled   | When `true` turns on the generation of the DAG file (default: `false`).                    |
-| file      | Graph file name (default: `dag-<timestamp>.dot`).                                          |
-| overwrite | When `true` overwrites any existing DAG file with the same name.                           |
+`dag.enabled`
+: When `true` turns on the generation of the DAG file (default: `false`).
 
-The above options can be used by prefixing them with the `dag` scope or surrounding them by curly brackets. For example:
+`dag.file`
+: Graph file name (default: `dag-<timestamp>.dot`).
 
-```groovy
-dag {
-    enabled = true
-    file = 'pipeline_dag.html'
-}
-```
+`dag.overwrite`
+: When `true` overwrites any existing DAG file with the same name.
 
-To learn more about the execution graph that can be generated by Nextflow read {ref}`dag-visualisation` documentation page.
+Read the {ref}`dag-visualisation` page to learn more about the execution graph that can be generated by Nextflow.
 
 (config-docker)=
 
 ### Scope `docker`
 
-The `docker` configuration scope controls how [Docker](https://www.docker.com) containers are executed by Nextflow.
+The `docker` scope controls how [Docker](https://www.docker.com) containers are executed by Nextflow.
 
 The following settings are available:
 
-| Name          | Description                                                                                                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| enabled       | Turn this flag to `true` to enable Docker execution (default: `false`).                                                                                                        |
-| envWhitelist  | Comma separated list of environment variable names to be included in the container environment.                                                                                |
-| legacy        | Uses command line options removed since version 1.10.x (default: `false`).                                                                                                     |
-| sudo          | Executes Docker run command as `sudo` (default: `false`).                                                                                                                      |
-| tty           | Allocates a pseudo-tty (default: `false`).                                                                                                                                     |
-| temp          | Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.          |
-| remove        | Clean-up the container after the execution (default: `true`). For details see: <https://docs.docker.com/engine/reference/run/#clean-up---rm> .                                 |
-| runOptions    | This attribute can be used to provide any extra command line options supported by the `docker run` command. For details see: <https://docs.docker.com/engine/reference/run/> . |
-| registry      | The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.       |
-| fixOwnership  | Fixes ownership of files created by the docker container.                                                                                                                      |
-| engineOptions | This attribute can be used to provide any option supported by the Docker engine i.e. `docker [OPTIONS]`.                                                                       |
-| mountFlags    | Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`                                                                                                        |
+`docker.enabled`
+: Set this flag to `true` to enable Docker execution (default: `false`).
 
-The above options can be used by prefixing them with the `docker` scope or surrounding them by curly brackets, as shown below:
+`docker.envWhitelist`
+: Comma separated list of environment variable names to be included in the container environment.
 
-```groovy
-process.container = 'nextflow/examples'
+`docker.legacy`
+: Uses command line options removed since version 1.10.x (default: `false`).
 
-docker {
-    enabled = true
-    temp = 'auto'
-}
-```
+`docker.sudo`
+: Executes Docker run command as `sudo` (default: `false`).
 
-Read {ref}`container-docker` page to learn more about how to use Docker containers with Nextflow.
+`docker.tty`
+: Allocates a pseudo-tty (default: `false`).
+
+`docker.temp`
+: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
+
+`docker.remove`
+: Clean-up the container after the execution (default: `true`). For details see: <https://docs.docker.com/engine/reference/run/#clean-up---rm> .
+
+`docker.runOptions`
+: This attribute can be used to provide any extra command line options supported by the `docker run` command. For details see: <https://docs.docker.com/engine/reference/run/> .
+
+`docker.registry`
+: The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+`docker.fixOwnership`
+: Fixes ownership of files created by the docker container.
+
+`docker.engineOptions`
+: This attribute can be used to provide any option supported by the Docker engine i.e. `docker [OPTIONS]`.
+
+`docker.mountFlags`
+: Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`
+
+Read the {ref}`container-docker` page to learn more about how to use Docker containers with Nextflow.
 
 (config-env)=
 
 ### Scope `env`
 
-The `env` scope allows the definition one or more variable that will be exported in the environment where the workflow tasks will be executed.
+The `env` scope allows the definition one or more variables that will be exported into the environment where workflow tasks are executed.
 
 Simply prefix your variable names with the `env` scope or surround them by curly brackets, as shown below:
 
@@ -505,29 +549,71 @@ The `env` scope provides environment variables to *tasks*, not Nextflow itself. 
 
 ### Scope `executor`
 
-The `executor` configuration scope allows you to set the optional executor settings, listed in the following table.
+The `executor` scope controls various executor behaviors.
 
-| Name              | Description                                                                                                                                                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name              | The name of the executor to be used (default: `local`).                                                                                                                                                                                  |
-| queueSize         | The number of tasks the executor will handle in a parallel manner. Default varies for each executor (see below).                                                                                                                         |
-| submitRateLimit   | Determines the max rate of job submission per time unit, for example `'10sec'` (10 jobs per second) or `'50/2min'` (50 jobs every 2 minutes) (default: unlimited).                                                                       |
-| pollInterval      | Determines how often to check for process termination. Default varies for each executor (see below).                                                                                                                                     |
-| dumpInterval      | Determines how often to log the executor status (default: `5min`).                                                                                                                                                                       |
-| queueGlobalStatus | Determines how job status is retrieved. When `false` only the queue associated with the job execution is queried. When `true` the job status is queried globally i.e. irrespective of the submission queue (default: `false`, requires version `23.01.0-edge` or later). |
-| queueStatInterval | Determines how often to fetch the queue status from the scheduler (default: `1min`). Used only by grid executors.                                                                                                                        |
-| exitReadTimeout   | Determines how long to wait before returning an error status when a process is terminated but the `.exitcode` file does not exist or is empty (default: `270 sec`). Used only by grid executors.                                         |
-| killBatchSize     | Determines the number of jobs that can be killed in a single command execution (default: `100`).                                                                                                                                         |
-| perJobMemLimit    | Specifies Platform LSF *per-job* memory limit mode. See {ref}`lsf-executor`.                                                                                                                                                             |
-| perTaskReserve    | Specifies Platform LSF *per-task* memory reserve mode. See {ref}`lsf-executor`.                                                                                                                                                          |
-| jobName           | Determines the name of jobs submitted to the underlying cluster executor e.g. `executor.jobName = { "$task.name - $task.hash" }`. Make sure the resulting job name matches the validation constraints of the underlying batch scheduler. |
-| cpus              | The maximum number of CPUs made available by the underlying system. Used only by the `local` executor.                                                                                                                                   |
-| memory            | The maximum amount of memory made available by the underlying system. Used only by the `local` executor.                                                                                                                                 |
-| retry.delay       | Delay when retrying failed job submissions (default: `500ms`). NOTE: used only by grid executors (requires `22.03.0-edge` or later).                                                                                                     |
-| retry.maxDelay    | Max delay when retrying failed job submissions (default: `30s`). NOTE: used only by grid executors (requires `22.03.0-edge` or later).                                                                                                   |
-| retry.jitter      | Jitter value when retrying failed job submissions (default: `0.25`). NOTE: used only by grid executors (requires `22.03.0-edge` or later).                                                                                               |
-| retry.maxAttempts | Max attempts when retrying failed job submissions (default: `3`). NOTE: used only by grid executors (requires `22.03.0-edge` or later).                                                                                                  |
-| retry.reason      | Regex pattern that when verified cause a failed submit operation to be re-tried (default: `Socket timed out`). NOTE: used only by grid executors (requires `22.03.0-edge` or later).                                                     |
+The following settings are available:
+
+`executor.name`
+: The name of the executor to be used (default: `local`).
+
+`executor.queueSize`
+: The number of tasks the executor will handle in a parallel manner. Default varies for each executor (see below).
+
+`executor.submitRateLimit`
+: Determines the max rate of job submission per time unit, for example `'10sec'` (10 jobs per second) or `'50/2min'` (50 jobs every 2 minutes) (default: unlimited).
+
+`executor.pollInterval`
+: Determines how often to check for process termination. Default varies for each executor (see below).
+
+`executor.dumpInterval`
+: Determines how often to log the executor status (default: `5min`).
+
+`executor.queueGlobalStatu`
+: Determines how job status is retrieved. When `false` only the queue associated with the job execution is queried. When `true` the job status is queried globally i.e. irrespective of the submission queue (default: `false`, requires version `23.01.0-edge` or later).
+
+`executor.queueStatInterva`
+: Determines how often to fetch the queue status from the scheduler (default: `1min`). Used only by grid executors.
+
+`executor.exitReadTimeout`
+: Determines how long to wait before returning an error status when a process is terminated but the `.exitcode` file does not exist or is empty (default: `270 sec`). Used only by grid executors.
+
+`executor.killBatchSize`
+: Determines the number of jobs that can be killed in a single command execution (default: `100`).
+
+`executor.perJobMemLimit`
+: Specifies Platform LSF *per-job* memory limit mode. See {ref}`lsf-executor`.
+
+`executor.perTaskReserve`
+: Specifies Platform LSF *per-task* memory reserve mode. See {ref}`lsf-executor`.
+
+`executor.jobName`
+: Determines the name of jobs submitted to the underlying cluster executor e.g. `executor.jobName = { "$task.name - $task.hash" }`. Make sure the resulting job name matches the validation constraints of the underlying batch scheduler.
+
+`executor.cpus`
+: The maximum number of CPUs made available by the underlying system. Used only by the `local` executor.
+
+`executor.memory`
+: The maximum amount of memory made available by the underlying system. Used only by the `local` executor.
+
+`executor.retry.delay`
+: *Requires `22.03.0-edge` or later*
+: Delay when retrying failed job submissions (default: `500ms`). Used only by grid executors.
+
+`executor.retry.maxDelay`
+: *Requires `22.03.0-edge` or later*
+: Max delay when retrying failed job submissions (default: `30s`). Used only by grid executors.
+
+`executor.retry.jitter`
+: *Requires `22.03.0-edge` or later*
+: Jitter value when retrying failed job submissions (default: `0.25`). Used only by grid executors.
+
+`executor.retry.maxAttempt`
+: *Requires `22.03.0-edge` or later*
+: Max attempts when retrying failed job submissions (default: `3`). Used only by grid executors.
+
+`executor.retry.reason`
+: *Requires `22.03.0-edge` or later*
+: Regex pattern that when verified cause a failed submit operation to be re-tried (default: `Socket timed out`). Used only by grid executors.
 
 Some executor settings have different default values depending on the executor.
 
@@ -579,56 +665,110 @@ executor.$local.memory = '32 GB'
 
 ### Scope `k8s`
 
-The `k8s` scope allows the definition of the configuration settings that control the deployment and execution of workflow applications in a Kubernetes cluster.
+The `k8s` scope controls the deployment and execution of workflow applications in a Kubernetes cluster.
 
 The following settings are available:
 
-| Name                | Description                                                                                                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| autoMountHostPaths  | Automatically mounts host paths in the job pods. Only for development purpose when using a single node cluster (default: `false`).                                                                |
-| context             | Defines the Kubernetes [configuration context name](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to use.                                      |
-| namespace           | Defines the Kubernetes namespace to use (default: `default`).                                                                                                                                     |
-| serviceAccount      | Defines the Kubernetes [service account name](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to use.                                                        |
-| launchDir           | Defines the path where the workflow is launched and the user data is stored. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/<user-name>`.             |
-| workDir             | Defines the path where the workflow temporary data is stored. This must be a path in a shared K8s persistent volume (default:`<user-dir>/work`).                                                  |
-| projectDir          | Defines the path where Nextflow projects are downloaded. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/projects`).                                   |
-| pod                 | Allows the definition of one or more pod configuration options such as environment variables, config maps, secrets, etc. It allows the same settings as the {ref}`process-pod` process directive. |
-| pullPolicy          | Defines the strategy to be used to pull the container image e.g. `pullPolicy: 'Always'`.                                                                                                          |
-| runAsUser           | Defines the user ID to be used to run the containers. Shortcut for the `securityContext` option.                                                                                                  |
-| securityContext     | Defines the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for all pods.                                                                          |
-| storageClaimName    | The name of the persistent volume claim where store workflow result data.                                                                                                                         |
-| storageMountPath    | The path location used to mount the persistent volume claim (default: `/workspace`).                                                                                                              |
-| storageSubPath      | The path in the persistent volume to be mounted (default: root).                                                                                                                                  |
-| computeResourceType | Define whether use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`, requires version `22.05.0-edge` or later).                                                |
-| fetchNodeName       | If you trace the hostname, activate this option (default: `false`, requires version `22.05.0-edge` or later).                                                                                     |
-| volumeClaims        | (deprecated)                                                                                                                                                                                      |
-| maxErrorRetry       | Defines the Kubernetes API max request retries (default is set to 4)                                                                                                                              |
-| httpReadTimeout     | Defines the Kubernetes client request HTTP connection read timeout e.g. `'60s'` (requires version `22.10.0` or later).                                                                            |
-| httpConnectTimeout  | Defines the Kubernetes client request HTTP connection timeout e.g. `'60s'` (requires version `22.10.0` or later).                                                                                 |
+`k8s.autoMountHostPaths`
+: Automatically mounts host paths in the job pods. Only for development purpose when using a single node cluster (default: `false`).
 
-See the {ref}`k8s-page` documentation for more details.
+`k8s.context`
+: Defines the Kubernetes [configuration context name](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to use.
+
+`k8s.namespace`
+: Defines the Kubernetes namespace to use (default: `default`).
+
+`k8s.serviceAccount`
+: Defines the Kubernetes [service account name](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to use.
+
+`k8s.launchDir`
+: Defines the path where the workflow is launched and the user data is stored. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/<user-name>`).
+
+`k8s.workDir`
+: Defines the path where the workflow temporary data is stored. This must be a path in a shared K8s persistent volume (default:`<user-dir>/work`).
+
+`k8s.projectDir`
+: Defines the path where Nextflow projects are downloaded. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/projects`).
+
+`k8s.pod`
+: Allows the definition of one or more pod configuration options such as environment variables, config maps, secrets, etc. It allows the same settings as the {ref}`process-pod` process directive.
+
+`k8s.pullPolicy`
+: Defines the strategy to be used to pull the container image e.g. `pullPolicy: 'Always'`.
+
+`k8s.runAsUser`
+: Defines the user ID to be used to run the containers. Shortcut for the `securityContext` option.
+
+`k8s.securityContext`
+: Defines the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for all pods.
+
+`k8s.storageClaimName`
+: The name of the persistent volume claim where store workflow result data.
+
+`k8s.storageMountPath`
+: The path location used to mount the persistent volume claim (default: `/workspace`).
+
+`k8s.storageSubPath`
+: The path in the persistent volume to be mounted (default: root).
+
+`k8s.computeResourceType`
+: *Requires version `22.05.0-edge` or later*
+: Define whether use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`).
+
+`k8s.fetchNodeName`
+: *Requires version `22.05.0-edge` or later*
+: If you trace the hostname, activate this option (default: `false`).
+
+`k8s.volumeClaims`
+: (deprecated)
+
+`k8s.maxErrorRetry`
+: Defines the Kubernetes API max request retries (default is set to 4)
+
+`k8s.httpReadTimeout`
+: *Requires version `22.10.0` or later*
+: Defines the Kubernetes client request HTTP connection read timeout e.g. `'60s'`.
+
+`k8s.httpConnectTimeout`
+: *Requires version `22.10.0` or later*
+: Defines the Kubernetes client request HTTP connection timeout e.g. `'60s'`.
+
+See the {ref}`k8s-page` page for more details.
 
 (config-mail)=
 
 ### Scope `mail`
 
-The `mail` scope allows you to define the mail server configuration settings needed to send email messages.
+The `mail` scope controls the mail server used to send email notifications.
 
-| Name            | Description                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| from            | Default email sender address.                                                               |
-| smtp.host       | Host name of the mail server.                                                               |
-| smtp.port       | Port number of the mail server.                                                             |
-| smtp.user       | User name to connect to the mail server.                                                    |
-| smtp.password   | User password to connect to the mail server.                                                |
-| smtp.proxy.host | Host name of an HTTP web proxy server that will be used for connections to the mail server. |
-| smtp.proxy.port | Port number for the HTTP web proxy server.                                                  |
-| smtp.\*         | Any SMTP configuration property supported by the Java Mail API (see link below).            |
-| debug           | When `true` enables Java Mail logging for debugging purpose.                                |
+The following settings are available:
 
-:::{note}
-Nextflow relies on the [Java Mail API](https://javaee.github.io/javamail/) to send email messages. Advanced mail configuration can be provided by using any SMTP configuration property supported by the Java Mail API. See the [table of available properties at this link](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#properties).
-:::
+`mail.from`
+: Default email sender address.
+
+`mail.smtp.host`
+: Host name of the mail server.
+
+`mail.smtp.port`
+: Port number of the mail server.
+
+`mail.smtp.user`
+: User name to connect to the mail server.
+
+`mail.smtp.password`
+: User password to connect to the mail server.
+
+`mail.smtp.proxy.hos`
+: Host name of an HTTP web proxy server that will be used for connections to the mail server.
+
+`mail.smtp.proxy.por`
+: Port number for the HTTP web proxy server.
+
+`mail.smtp.*`
+: Any SMTP configuration property supported by the [Java Mail API](https://javaee.github.io/javamail/), which Nextflow uses to send emails. See the table of available properties [here](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#properties).
+
+`mail.debug`
+: When `true` enables Java Mail logging for debugging purpose.
 
 For example, the following snippet shows how to configure Nextflow to send emails through the [AWS Simple Email Service](https://aws.amazon.com/ses/):
 
@@ -658,24 +798,51 @@ mail {
 
 ### Scope `manifest`
 
-The `manifest` configuration scope allows you to define some meta-data information needed when publishing your pipeline project on GitHub, BitBucket or GitLab, or when running your pipeline.
+The `manifest` scope allows you to define some meta-data information needed when publishing or running your pipeline.
 
 The following settings are available:
 
-| Name              | Description                                                                     |
-| ----------------- | ------------------------------------------------------------------------------- |
-| author            | Project author name (use a comma to separate multiple names).                   |
-| defaultBranch     | Git repository default branch (default: `master`).                              |
-| recurseSubmodules | Turn this flag to `true` to pull submodules recursively from the Git repository |
-| description       | Free text describing the workflow project.                                      |
-| doi               | Project related publication DOI identifier.                                     |
-| homePage          | Project home page URL.                                                          |
-| mainScript        | Project main script (default: `main.nf`).                                       |
-| name              | Project short name.                                                             |
-| nextflowVersion   | Minimum required Nextflow version.                                              |
-| version           | Project version number.                                                         |
+`manifes.author`
+: Project author name (use a comma to separate multiple names).
 
-The above options can be used by prefixing them with the `manifest` scope or surrounding them by curly brackets. For example:
+`manifes.defaultBranch`
+: Git repository default branch (default: `master`).
+
+`manifes.description`
+: Free text describing the workflow project.
+
+`manifes.doi`
+: Project related publication DOI identifier.
+
+`manifes.homePage`
+: Project home page URL.
+
+`manifes.mainScript`
+: Project main script (default: `main.nf`).
+
+`manifes.name`
+: Project short name.
+
+`manifes.nextflowVersion`
+: Minimum required Nextflow version.
+
+  This setting may be useful to ensure that a specific version is used:
+
+  ```groovy
+  nextflowVersion = '1.2.3'        // exact match
+  nextflowVersion = '1.2+'         // 1.2 or later (excluding 2 and later)
+  nextflowVersion = '>=1.2'        // 1.2 or later
+  nextflowVersion = '>=1.2, <=1.5' // any version in the 1.2 .. 1.5 range
+  nextflowVersion = '!>=1.2'       // with ! prefix, stop execution if current version does not match required version.
+  ```
+
+`manifes.recurseSubmodules`
+: Set this flag to `true` to pull submodules recursively from the Git repository.
+
+`manifes.version`
+: Project version number.
+
+The above options can also be specified in a `manifest` block, for example:
 
 ```groovy
 manifest {
@@ -686,19 +853,7 @@ manifest {
 }
 ```
 
-To learn how to publish your pipeline on GitHub, BitBucket or GitLab code repositories read {ref}`sharing-page` documentation page.
-
-#### Nextflow version
-
-The `nextflowVersion` setting allows you to specify a minimum required version to run the pipeline. This may be useful to ensure that a specific version is used:
-
-```groovy
-nextflowVersion = '1.2.3'        // exact match
-nextflowVersion = '1.2+'         // 1.2 or later (excluding 2 and later)
-nextflowVersion = '>=1.2'        // 1.2 or later
-nextflowVersion = '>=1.2, <=1.5' // any version in the 1.2 .. 1.5 range
-nextflowVersion = '!>=1.2'       // with ! prefix, stop execution if current version does not match required version.
-```
+Read the {ref}`sharing-page` page to learn how to publish your pipeline to GitHub, BitBucket or GitLab.
 
 (config-notification)=
 
@@ -706,13 +861,20 @@ nextflowVersion = '!>=1.2'       // with ! prefix, stop execution if current ver
 
 The `notification` scope allows you to define the automatic sending of a notification email message when the workflow execution terminates.
 
-| Name     | Description                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------- |
-| enabled  | Enables the sending of a notification message when the workflow execution completes.                            |
-| to       | Recipient address for the notification email. Multiple addresses can be specified separating them with a comma. |
-| from     | Sender address for the notification email message.                                                              |
-| template | Path of a template file which provides the content of the notification message.                                 |
-| binding  | An associative array modelling the variables in the template file.                                              |
+`notification.enabled`
+: Enables the sending of a notification message when the workflow execution completes.
+
+`notification.to`
+: Recipient address for the notification email. Multiple addresses can be specified separating them with a comma.
+
+`notification.from`
+: Sender address for the notification email message.
+
+`notification.template`
+: Path of a template file which provides the content of the notification message.
+
+`notification.binding`
+: An associative array modelling the variables in the template file.
 
 The notification message is sent my using the STMP server defined in the configuration {ref}`mail scope<config-mail>`.
 
@@ -738,41 +900,43 @@ params {
 
 ### Scope `podman`
 
-The `podman` configuration scope controls how [Podman](https://podman.io/) containers are executed by Nextflow.
+The `podman` scope controls how [Podman](https://podman.io/) containers are executed by Nextflow.
 
 The following settings are available:
 
-| Name          | Description                                                                                                                                                                 |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled       | Turn this flag to `true` to enable Podman execution (default: `false`).                                                                                                     |
-| envWhitelist  | Comma separated list of environment variable names to be included in the container environment.                                                                             |
-| temp          | Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.       |
-| remove        | Clean-up the container after the execution (default: `true`).                                                                                                               |
-| runOptions    | This attribute can be used to provide any extra command line options supported by the `podman run` command.                                                                 |
-| registry      | The registry from where container images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`. |
-| engineOptions | This attribute can be used to provide any option supported by the Podman engine i.e. `podman [OPTIONS]`.                                                                    |
-| mountFlags    | Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`                                                                                                     |
+`podman.enabled`
+: Set this flag to `true` to enable Podman execution (default: `false`).
 
-The above options can be used by prefixing them with the `podman` scope or surrounding them by curly brackets, as shown below:
+`podman.envWhitelist`
+: Comma separated list of environment variable names to be included in the container environment.
 
-```groovy
-process.container = 'nextflow/examples'
+`podman.temp`
+: Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
 
-podman {
-    enabled = true
-    temp = 'auto'
-}
-```
+`podman.remove`
+: Clean-up the container after the execution (default: `true`).
 
-Read {ref}`container-podman` page to learn more about how to use Podman containers with Nextflow.
+`podman.runOptions`
+: This attribute can be used to provide any extra command line options supported by the `podman run` command.
+
+`podman.registry`
+: The registry from where container images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+`podman.engineOptions`
+: This attribute can be used to provide any option supported by the Podman engine i.e. `podman [OPTIONS]`.
+
+`podman.mountFlags`
+: Add the specified flags to the volume mounts e.g. `mountFlags = 'ro,Z'`
+
+Read the {ref}`container-podman` page to learn more about how to use Podman containers with Nextflow.
 
 (config-process)=
 
 ### Scope `process`
 
-The `process` configuration scope allows you to provide the default configuration for the processes in your pipeline.
+The `process` scope allows you to specify default {ref}`directives <process-directives>` for processes in your pipeline.
 
-You can specify here any property described in the {ref}`process directive<process-directives>` and the executor sections. For examples:
+For example:
 
 ```groovy
 process {
@@ -782,7 +946,7 @@ process {
 }
 ```
 
-By using this configuration all processes in your pipeline will be executed through the SGE cluster, with the specified settings.
+By using this configuration, all processes in your pipeline will be executed through the SGE cluster, with the specified settings.
 
 (config-process-selectors)=
 
@@ -874,175 +1038,181 @@ Using the above configuration snippet, all workflow processes use 4 cpus if not 
 
 ### Scope `report`
 
-The `report` scope allows you to define configuration setting of the workflow {ref}`execution-report`.
+The `report` scope allows you to configure the workflow {ref}`execution-report`.
 
-| Name      | Description                                                                         |
-| --------- | ----------------------------------------------------------------------------------- |
-| enabled   | If `true` it create the workflow execution report.                                  |
-| file      | The path of the created execution report file (default: `report-<timestamp>.html`). |
-| overwrite | When `true` overwrites any existing report file with the same name.                 |
+The following settings are available:
+
+`report.enabled`
+: If `true` it create the workflow execution report.
+
+`report.file`
+: The path of the created execution report file (default: `report-<timestamp>.html`).
+
+`report.overwrite`
+: When `true` overwrites any existing report file with the same name.
 
 (config-sarus)=
 
 ### Scope `sarus`
 
-The ``sarus`` configuration scope controls how [Sarus](https://sarus.readthedocs.io) containers are executed by Nextflow.
+The ``sarus`` scope controls how [Sarus](https://sarus.readthedocs.io) containers are executed by Nextflow.
 
 The following settings are available:
 
-| Name         | Description                                                                                                                                                                                                     |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled      | Turn this flag to `true` to enable Sarus execution (default: `false`).                                                                                                                                          |
-| envWhitelist | Comma separated list of environment variable names to be included in the container environment.                                                                                                                 |
-| tty          | Allocates a pseudo-tty (default: `false`).                                                                                                                                                                      |
-| runOptions   | This attribute can be used to provide any extra command line options supported by the `sarus run` command. For details see the [Sarus user guide](https://sarus.readthedocs.io/en/stable/user/user_guide.html). |
+`sarus.enabled`
+: Set this flag to `true` to enable Sarus execution (default: `false`).
 
-Read {ref}`container-sarus` page to learn more about how to use Sarus containers with Nextflow.
+`sarus.envWhitelist`
+: Comma separated list of environment variable names to be included in the container environment.
+
+`sarus.tty`
+: Allocates a pseudo-tty (default: `false`).
+
+`sarus.runOptions`
+: This attribute can be used to provide any extra command line options supported by the `sarus run` command. For details see the [Sarus user guide](https://sarus.readthedocs.io/en/stable/user/user_guide.html).
+
+Read the {ref}`container-sarus` page to learn more about how to use Sarus containers with Nextflow.
 
 (config-shifter)=
 
 ### Scope `shifter`
 
-The `shifter` configuration scope controls how [Shifter](https://docs.nersc.gov/programming/shifter/overview/) containers are executed by Nextflow.
+The `shifter` scope controls how [Shifter](https://docs.nersc.gov/programming/shifter/overview/) containers are executed by Nextflow.
 
 The following settings are available:
 
-| Name    | Description                                                              |
-| ------- | ------------------------------------------------------------------------ |
-| enabled | Turn this flag to `true` to enable Shifter execution (default: `false`). |
+`shifter.enabled`
+: Set this flag to `true` to enable Shifter execution (default: `false`).
 
-Read {ref}`container-shifter` page to learn more about how to use Shifter containers with Nextflow.
+Read the {ref}`container-shifter` page to learn more about how to use Shifter containers with Nextflow.
 
 (config-singularity)=
 
 ### Scope `singularity`
 
-The `singularity` configuration scope controls how [Singularity](https://sylabs.io/singularity/) containers are executed by Nextflow.
+The `singularity` scope controls how [Singularity](https://sylabs.io/singularity/) containers are executed by Nextflow.
 
 The following settings are available:
 
-| Name          | Description                                                                                                                                                                              |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled       | Turn this flag to `true` to enable Singularity execution (default: `false`).                                                                                                             |
-| engineOptions | This attribute can be used to provide any option supported by the Singularity engine i.e. `singularity [OPTIONS]`.                                                                       |
-| envWhitelist  | Comma separated list of environment variable names to be included in the container environment.                                                                                          |
-| runOptions    | This attribute can be used to provide any extra command line options supported by the `singularity exec`.                                                                                |
-| noHttps       | Turn this flag to `true` to pull the Singularity image with http protocol (default: `false`).                                                                                            |
-| autoMounts    | When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Singularity installation (default: `false`). |
-| cacheDir      | The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.                                     |
-| pullTimeout   | The amount of time the Singularity pull can last, exceeding which the process is terminated (default: `20 min`).                                                                         |
-| registry      | The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.                 |
+`singularity.enabled`
+: Set this flag to `true` to enable Singularity execution (default: `false`).
 
-Read {ref}`container-singularity` page to learn more about how to use Singularity containers with Nextflow.
+`singularity.engineOptions`
+: This attribute can be used to provide any option supported by the Singularity engine i.e. `singularity [OPTIONS]`.
+
+`singularity.envWhitelist`
+: Comma separated list of environment variable names to be included in the container environment.
+
+`singularity.runOptions`
+: This attribute can be used to provide any extra command line options supported by `singularity exec`.
+
+`singularity.noHttps`
+: Set this flag to `true` to pull the Singularity image with http protocol (default: `false`).
+
+`singularity.autoMounts`
+: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Singularity installation (default: `false`).
+
+`singularity.cacheDir`
+: The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
+
+`singularity.pullTimeout`
+: The amount of time the Singularity pull can last, exceeding which the process is terminated (default: `20 min`).
+
+`singularity.registry`
+: The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+Read the {ref}`container-singularity` page to learn more about how to use Singularity containers with Nextflow.
 
 (config-spack)=
 
 ### Scope `spack`
 
-The `spack` scope allows for the definition of the configuration settings that control the creation of a Spack environment by the Spack package manager.
+The `spack` scope controls the creation of a Spack environment by the Spack package manager.
 
 The following settings are available:
 
-| Name           | Description                                                                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| cacheDir       | Defines the path where Spack environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all compute nodes.        |
-| noChecksum     | Disables checksum verification for source tarballs (unsafe). Useful when requesting a package version not yet encoded in the corresponding Spack recipe (default: `false`). |
-| parallelBuilds | Sets number of parallel package builds (Spack default: coincides with number of available CPU cores).                                                                       |
-| createTimeout  | Defines the amount of time the Spack environment creation can last. The creation process is terminated when the timeout is exceeded (default: `60 min`).                    |
+`spack.cacheDir`
+: Defines the path where Spack environments are stored. When using a compute cluster make sure to provide a shared file system path accessible from all compute nodes.
 
-Nextflow does not allow for fine-grained configuration of the Spack package manager.
-Instead, this has to be performed directly on the host Spack installation.
-For more information see the [Spack documentation](https://spack.readthedocs.io).
+`spack.noChecksum`
+: Disables checksum verification for source tarballs (unsafe). Useful when requesting a package version not yet encoded in the corresponding Spack recipe (default: `false`).
 
-(config-apptainer)=
+`spack.parallelBuilds`
+: Sets number of parallel package builds (Spack default: coincides with number of available CPU cores).
 
-### Scope `apptainer`
+`spack.createTimeout`
+: Defines the amount of time the Spack environment creation can last. The creation process is terminated when the timeout is exceeded (default: `60 min`).
 
-The `apptainer` configuration scope controls how [Apptainer](https://apptainer.org) containers are executed by Nextflow.
-
-The following settings are available:
-
-| Name          | Description      |
-| ------------- | ---------------- |
-| enabled       | Turn this flag to `true` to enable Apptainer execution (default: `false`). |
-| engineOptions | This attribute can be used to provide any option supported by the Apptainer engine i.e. `apptainer [OPTIONS]`. |
-| envWhitelist  | Comma separated list of environment variable names to be included in the container environment. |
-| runOptions    | This attribute can be used to provide any extra command line options supported by the `apptainer exec`. |
-| noHttps       | Turn this flag to `true` to pull the Apptainer image with http protocol (default: `false`). |
-| autoMounts    | When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature enabled in your Apptainer installation (default: `false`). |
-| cacheDir      | The directory where remote Apptainer images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes. |
-| pullTimeout   | The amount of time the Apptainer pull can last, exceeding which the process is terminated (default: `20 min`). |
-| registry      | The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`. |
-| ------------- | ---------------- |
-
-Read {ref}`container-apptainer` page to learn more about how to use Apptainer containers with Nextflow.
+Nextflow does not allow for fine-grained configuration of the Spack package manager. Instead, this has to be performed directly on the host Spack installation. For more information see the [Spack documentation](https://spack.readthedocs.io).
 
 (config-timeline)=
 
 ### Scope `timeline`
 
-The `timeline` scope allows you to enable/disable the processes execution timeline report generated by Nextflow.
+The `timeline` scope controls the execution timeline report generated by Nextflow.
 
 The following settings are available:
 
-| Name      | Description                                                                         |
-| --------- | ----------------------------------------------------------------------------------- |
-| enabled   | When `true` turns on the generation of the timeline report file (default: `false`). |
-| file      | Timeline file name (default: `timeline-<timestamp>.html`).                          |
-| overwrite | When `true` overwrites any existing timeline file with the same name.               |
+`timeline.enabled`
+: When `true` enables the generation of the timeline report file (default: `false`).
+
+`timeline.file`
+: Timeline file name (default: `timeline-<timestamp>.html`).
+
+`timeline.overwrite`
+: When `true` overwrites any existing timeline file with the same name.
 
 (config-tower)=
 
 ### Scope `tower`
 
-The `tower` configuration scope controls the settings for the [Nextflow Tower](https://tower.nf) monitoring and tracing service.
+The `tower` scope controls the settings for the [Nextflow Tower](https://tower.nf) monitoring and tracing service.
 
 The following settings are available:
 
-| Name        | Description                                                                                                             |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| enabled     | When `true` Nextflow sends the workflow tracing and execution metrics to the Nextflow Tower service (default: `false`). |
-| accessToken | The unique access token specific to your account on an instance of Tower.                                               |
-| endpoint    | The endpoint of your Tower deployment (default: `https://tower.nf`).                                                    |
-| workspaceId | The ID of the Tower workspace where the run should be added (default: the launching user personal workspace).           |
+`tower.enabled`
+: When `true` Nextflow sends the workflow tracing and execution metrics to the Nextflow Tower service (default: `false`).
 
-The above options can be used by prefixing them with the `tower` scope or surrounding them by curly
-brackets, as shown below:
+`tower.accessToken`
+: The unique access token specific to your account on an instance of Tower.
 
-```groovy
-tower {
-  enabled = true
-  accessToken = '<YOUR TOKEN>'
-  workspaceId = '<YOUR WORKSPACE ID>'
-}
-```
+  Your `accessToken` can be obtained from your Tower instance in the `Tokens page <https://tower.nf/tokens>`.
 
-:::{tip}
-Your `accessToken` can be obtained from your Tower instance in the `Tokens page <https://tower.nf/tokens>`.
-:::
+`tower.endpoint`
+: The endpoint of your Tower deployment (default: `https://tower.nf`).
 
-:::{tip}
-The Tower workspace ID can also be specified using the environment variable `TOWER_WORKSPACE_ID` (config file has priority over the environment variable).
-:::
+`tower.workspaceId`
+: The ID of the Tower workspace where the run should be added (default: the launching user personal workspace).
+
+  The Tower workspace ID can also be specified using the environment variable `TOWER_WORKSPACE_ID` (config file has priority over the environment variable).
 
 (config-trace)=
 
 ### Scope `trace`
 
-The `trace` scope allows you to control the layout of the execution trace file generated by Nextflow.
+The `trace` scope controls the layout of the execution trace file generated by Nextflow.
 
 The following settings are available:
 
-| Name      | Description                                                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| enabled   | When `true` turns on the generation of the execution trace report file (default: `false`).                                      |
-| fields    | Comma separated list of fields to be included in the report. The available fields are listed at {ref}`this page <trace-fields>` |
-| file      | Trace file name (default: `trace-<timestamp>.txt`).                                                                             |
-| sep       | Character used to separate values in each row (default: `\t`).                                                                  |
-| raw       | When `true` turns on raw number report generation i.e. date and time are reported as milliseconds and memory as number of bytes |
-| overwrite | When `true` overwrites any existing trace file with the same name.                                                              |
+`trace.enabled`
+: When `true` turns on the generation of the execution trace report file (default: `false`).
 
-The above options can be used by prefixing them with the `trace` scope or surrounding them by curly brackets. For example:
+`trace.fields`
+: Comma separated list of fields to be included in the report. The available fields are listed at {ref}`this page <trace-fields>`.
+
+`trace.file`
+: Trace file name (default: `trace-<timestamp>.txt`).
+
+`trace.sep`
+: Character used to separate values in each row (default: `\t`).
+
+`trace.raw`
+: When `true` turns on raw number report generation i.e. date and time are reported as milliseconds and memory as number of bytes.
+
+`trace.overwrite`
+: When `true` overwrites any existing trace file with the same name.
+
+The above options can also be specified in a `trace` block, for example:
 
 ```groovy
 trace {
@@ -1052,20 +1222,21 @@ trace {
 }
 ```
 
-To learn more about the execution report that can be generated by Nextflow read {ref}`trace-report` documentation page.
+Read the {ref}`trace-report` page to learn more about the execution report that can be generated by Nextflow.
 
 (config-weblog)=
 
 ### Scope `weblog`
 
-The `weblog` scope allows you to send detailed {ref}`trace scope<trace-fields>` information as HTTP POST request to a webserver, shipped as a JSON object.
+The `weblog` scope allows you to send detailed {ref}`trace <trace-fields>` information as HTTP POST requests to a webserver, shipped as a JSON object.
 
 Detailed information about the JSON fields can be found in the {ref}`weblog description<weblog-service>`.
 
-| Name    | Description                                                           |
-| ------- | --------------------------------------------------------------------- |
-| enabled | If `true` it will send HTTP POST requests to a given url.             |
-| url     | The url where to send HTTP POST requests (default: `http:localhost`). |
+`weblog.enabled`
+: If `true` it will send HTTP POST requests to a given url.
+
+`weblog.url`
+: The url where to send HTTP POST requests (default: `http:localhost`).
 
 (config-miscellaneous)=
 
@@ -1073,15 +1244,12 @@ Detailed information about the JSON fields can be found in the {ref}`weblog desc
 
 There are additional variables that can be defined within a configuration file that do not have a dedicated scope.
 
-These are defined alongside other scopes, but the option is assigned as typically variable.
+`cleanup`
+: If `true`, on a successful completion of a run all files in *work* directory are automatically deleted.
 
-| Name    | Description                                                                                             |
-| ------- | ------------------------------------------------------------------------------------------------------- |
-| cleanup | If `true`, on a successful completion of a run all files in *work* directory are automatically deleted. |
-
-:::{warning}
-The use of the `cleanup` option will prevent the use of the *resume* feature on subsequent executions of that pipeline run. Also, be aware that deleting all scratch files can take a lot of time, especially when using a shared file system or remote cloud storage.
-:::
+  :::{warning}
+  The use of the `cleanup` option will prevent the use of the *resume* feature on subsequent executions of that pipeline run. Also, be aware that deleting all scratch files can take a lot of time, especially when using a shared file system or remote cloud storage.
+  :::
 
 (config-profiles)=
 
@@ -1150,42 +1318,127 @@ In the above example, the `process.cpus` attribute is not correctly applied beca
 
 The following environment variables control the configuration of the Nextflow runtime and the underlying Java virtual machine.
 
-| Name                          | Description                                                                                                                                                                                                            |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| NXF_ANSI_LOG                  | Enables/disables ANSI console output (default `true` when ANSI terminal is detected).                                                                                                                                  |
-| NXF_ANSI_SUMMARY              | Enables/disables ANSI completion summary: `true\|false` (default: print summary if execution last more than 1 minute).                                                                                                 |
-| NXF_ASSETS                    | Defines the directory where downloaded pipeline repositories are stored (default: `$NXF_HOME/assets`)                                                                                                                  |
-| NXF_CHARLIECLOUD_CACHEDIR     | Directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.                                                                    |
-| NXF_CLASSPATH                 | Allows the extension of the Java runtime classpath with extra JAR files or class folders.                                                                                                                              |
-| NXF_CLOUD_DRIVER              | Defines the default cloud driver to be used if not specified in the config file or as command line option, either `aws` or `google`.                                                                                   |
-| NXF_CONDA_CACHEDIR            | Directory where Conda environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.                                                                            |
-| NXF_CONDA_ENABLED             | Enable the use of Conda recipes defined by using the :ref:process-conda directive. (default: `false`, requires version `22.08.0-edge` or later).                                                                       |
-| NXF_DEBUG                     | Defines scripts debugging level: `1` dump task environment variables in the task log file; `2` enables command script execution tracing; `3` enables command wrapper execution tracing.                                |
-| NXF_DEFAULT_DSL               | Defines the DSL version that should be used in not specified otherwise in the script of config file (default: `2`, requires version `22.03.0-edge` or later)                                                           |
-| NXF_DISABLE_JOBS_CANCELLATION | Disables the cancellation of child jobs on workflow execution termination (requires version `21.12.0-edge` or later).                                                                                                  |
-| NXF_ENABLE_SECRETS            | Enable Nextflow secrets features (default: `true`, requires version `21.09.0-edge` or later)                                                                                                                           |
-| NXF_ENABLE_STRICT             | Enable Nextflow *strict* execution mode (default: `false`, requires version `22.05.0-edge` or later)                                                                                                                   |
-| NXF_EXECUTOR                  | Defines the default process executor e.g. `sge`                                                                                                                                                                        |
-| NXF_GRAB                      | Provides extra runtime dependencies downloaded from a Maven repository service \[DEPRECATED\]                                                                                                                          |
-| NXF_HOME                      | Nextflow home directory (default: `$HOME/.nextflow`).                                                                                                                                                                  |
-| NXF_JAVA_HOME                 | Defines the path location of the Java VM installation used to run Nextflow. This variable overrides the `JAVA_HOME` variable if defined.                                                                               |
-| NXF_JVM_ARGS                  | Allows the setting Java VM options. This is similar to `NXF_OPTS` however it's only applied the JVM running Nextflow and not to any java pre-launching commands (requires `21.12.1-edge` or later).                    |
-| NXF_OFFLINE                   | When `true` disables the project automatic download and update from remote repositories (default: `false`).                                                                                                            |
-| NXF_OPTS                      | Provides extra options for the Java and Nextflow runtime. It must be a blank separated list of `-Dkey[=value]` properties.                                                                                             |
-| NXF_ORG                       | Default `organization` prefix when looking for a hosted repository (default: `nextflow-io`).                                                                                                                           |
-| NXF_PARAMS_FILE               | Defines the path location of the pipeline parameters file (requires version `20.10.0` or later).                                                                                                                       |
-| NXF_PID_FILE                  | Name of the file where the process PID is saved when Nextflow is launched in background.                                                                                                                               |
-| NXF_SCM_FILE                  | Defines the path location of the SCM config file (requires version `20.10.0` or later).                                                                                                                                |
-| NXF_SINGULARITY_CACHEDIR      | Directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.                                                                     |
-| NXF_SINGULARITY_LIBRARYDIR    | Directory where remote Singularity images are retrieved. It should be a directory accessible to all compute nodes (requires: `21.09.0-edge` or later).                                                                 |
-| NXF_SPACK_CACHEDIR            | Directory where Spack environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.                                                                            |
-| NXF_SPACK_ENABLED             | Enable the use of Spack recipes defined by using the :ref:process-spack directive. (default: `false`, requires version `23.02.0-edge` or later).                                                                       |
-| NXF_TEMP                      | Directory where temporary files are stored                                                                                                                                                                             |
-| NXF_VER                       | Defines what version of Nextflow to use.                                                                                                                                                                               |
-| NXF_WORK                      | Directory where working files are stored (usually your *scratch* directory)                                                                                                                                            |
-| JAVA_HOME                     | Defines the path location of the Java VM installation used to run Nextflow.                                                                                                                                            |
-| JAVA_CMD                      | Defines the path location of the Java binary command used to launch Nextflow.                                                                                                                                          |
-| HTTP_PROXY                    | Defines the HTTP proxy server. As of version `21.06.0-edge`, proxy authentication is supported providing the credentials in the proxy URL e.g. `http://user:password@proxy-host.com:port`.                             |
-| HTTPS_PROXY                   | Defines the HTTPS proxy server. As of version `21.06.0-edge`, proxy authentication is supported providing the credentials in the proxy URL e.g. `https://user:password@proxy-host.com:port`.                           |
-| FTP_PROXY                     | Defines the FTP proxy server. Proxy authentication is supported providing the credentials in the proxy URL e.g. `ftp://user:password@proxy-host.com:port`. FTP proxy support requires version `21.06.0-edge` or later. |
-| NO_PROXY                      | Defines one or more host names that should not use the proxy server. Separate multiple names using a comma character.                                                                                                  |
+`NXF_ANSI_LOG`
+: Enables/disables ANSI console output (default `true` when ANSI terminal is detected).
+
+`NXF_ANSI_SUMMARY`
+: Enables/disables ANSI completion summary: `true\|false` (default: print summary if execution last more than 1 minute).
+
+`NXF_ASSETS`
+: Defines the directory where downloaded pipeline repositories are stored (default: `$NXF_HOME/assets`)
+
+`NXF_CHARLIECLOUD_CACHEDIR`
+: Directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
+
+`NXF_CLASSPATH`
+: Allows the extension of the Java runtime classpath with extra JAR files or class folders.
+
+`NXF_CLOUD_DRIVER`
+: Defines the default cloud driver to be used if not specified in the config file or as command line option, either `aws` or `google`.
+
+`NXF_CONDA_CACHEDIR`
+: Directory where Conda environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
+
+`NXF_CONDA_ENABLED`
+: *Requires version `22.08.0-edge` or later*
+: Enable the use of Conda recipes defined by using the {ref}`process-conda` directive. (default: `false`).
+
+`NXF_DEBUG`
+: Defines scripts debugging level: `1` dump task environment variables in the task log file; `2` enables command script execution tracing; `3` enables command wrapper execution tracing.
+
+`NXF_DEFAULT_DSL`
+: *Requires version `22.03.0-edge` or later*
+: Defines the DSL version that should be used in not specified otherwise in the script of config file (default: `2`)
+
+`NXF_DISABLE_JOBS_CANCELLATION`
+: *Requires version `21.12.0-edge` or later*
+: Disables the cancellation of child jobs on workflow execution termination.
+
+`NXF_ENABLE_SECRETS`
+: *Requires version `21.09.0-edge` or later*
+: Enable Nextflow secrets features (default: `true`)
+
+`NXF_ENABLE_STRICT`
+: *Requires version `22.05.0-edge` or later*
+: Enable Nextflow *strict* execution mode (default: `false`)
+
+`NXF_EXECUTOR`
+: Defines the default process executor e.g. `sge`
+
+`NXF_GRAB`
+: *DEPRECATED*
+: Provides extra runtime dependencies downloaded from a Maven repository service
+
+`NXF_HOME`
+: Nextflow home directory (default: `$HOME/.nextflow`).
+
+`NXF_JAVA_HOME`
+: Defines the path location of the Java VM installation used to run Nextflow. This variable overrides the `JAVA_HOME` variable if defined.
+
+`NXF_JVM_ARGS`
+: *Requires version `21.12.1-edge` or later*
+: Allows the setting Java VM options. This is similar to `NXF_OPTS` however it's only applied the JVM running Nextflow and not to any java pre-launching commands.
+
+`NXF_OFFLINE`
+: When `true` disables the project automatic download and update from remote repositories (default: `false`).
+
+`NXF_OPTS`
+: Provides extra options for the Java and Nextflow runtime. It must be a blank separated list of `-Dkey[=value]` properties.
+
+`NXF_ORG`
+: Default `organization` prefix when looking for a hosted repository (default: `nextflow-io`).
+
+`NXF_PARAMS_FILE`
+: *Requires version `20.10.0` or later*
+: Defines the path location of the pipeline parameters file .
+
+`NXF_PID_FILE`
+: Name of the file where the process PID is saved when Nextflow is launched in background.
+
+`NXF_SCM_FILE`
+: *Requires version `20.10.0` or later*
+: Defines the path location of the SCM config file .
+
+`NXF_SINGULARITY_CACHEDIR`
+: Directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
+
+`NXF_SINGULARITY_LIBRARYDIR`
+: *Requires version `21.09.0-edge` or later*
+: Directory where remote Singularity images are retrieved. It should be a directory accessible to all compute nodes.
+
+`NXF_SPACK_CACHEDIR`
+: Directory where Spack environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
+
+`NXF_SPACK_ENABLED`
+: *Requires version `23.02.0-edge` or later*
+: Enable the use of Spack recipes defined by using the {ref}`process-spack` directive. (default: `false`).
+
+`NXF_TEMP`
+: Directory where temporary files are stored
+
+`NXF_VER`
+: Defines what version of Nextflow to use.
+
+`NXF_WORK`
+: Directory where working files are stored (usually your *scratch* directory)
+
+`JAVA_HOME`
+: Defines the path location of the Java VM installation used to run Nextflow.
+
+`JAVA_CMD`
+: Defines the path location of the Java binary command used to launch Nextflow.
+
+`HTTP_PROXY`
+: Defines the HTTP proxy server.
+: *New in version `21.06.0-edge`:* proxy authentication is supported providing the credentials in the proxy URL e.g. `http://user:password@proxy-host.com:port`.
+
+`HTTPS_PROXY`
+: Defines the HTTPS proxy server.
+: *New in version `21.06.0-edge`:* proxy authentication is supported providing the credentials in the proxy URL e.g. `https://user:password@proxy-host.com:port`.
+
+`FTP_PROXY`
+: *Requires version `21.06.0-edge` or later*
+: Defines the FTP proxy server. Proxy authentication is supported providing the credentials in the proxy URL e.g. `ftp://user:password@proxy-host.com:port`.
+
+`NO_PROXY`
+: Defines one or more host names that should not use the proxy server. Separate multiple names using a comma character.

--- a/docs/config.md
+++ b/docs/config.md
@@ -95,37 +95,92 @@ aws {
 
 See [AWS Security Credentials](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html) for more information.
 
-Advanced client configuration options can be set using the `client` attribute. The following properties can be used:
+Advanced client configuration options can be set using the `client` attribute. The following options are available:
 
-| Name                     | Description                                                                                                                                                                                                                                                                                                                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| anonymous                | Allow the access of public S3 buckets without the need to provide AWS credentials. Any service that does not accept unsigned requests will return a service access error.                                                                                                                                                                                                    |
-| s3Acl                    | Allow the setting of predefined bucket permissions, also known as *canned ACL*. Permitted values are `Private`, `PublicRead`, `PublicReadWrite`, `AuthenticatedRead`, `LogDeliveryWrite`, `BucketOwnerRead`, `BucketOwnerFullControl`, and `AwsExecRead`. See [Amazon docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) for details. |
-| connectionTimeout        | The amount of time to wait (in milliseconds) when initially establishing a connection before timing out.                                                                                                                                                                                                                                                                     |
-| endpoint                 | The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.                                                                                                                                                                                                                                                                                                                |
-| glacierAutoRetrieval     | Enable auto retrieval of S3 objects stored with Glacier class store (EXPERIMENTAL. default: `false`, requires version `22.12.0-edge` or later).                                                                                                                                                                                                                              |
-| glacierExpirationDays    | The time, in days, between when an object is restored to the bucket and when it expires (EXPERIMENTAL. default: `7`, requires version `22.12.0-edge` or later).                                                                                                                                                                                                              |
-| glacierRetrievalTier     | The retrieval tier to use when restoring objects from Glacier, one of [`Expedited`, `Standard`, `Bulk`] (EXPERIMENTAL. requires version `23.03.0-edge` or later).                                                                                                                                                                                                            |
-| maxConnections           | The maximum number of allowed open HTTP connections.                                                                                                                                                                                                                                                                                                                         |
-| maxErrorRetry            | The maximum number of retry attempts for failed retryable requests.                                                                                                                                                                                                                                                                                                          |
-| protocol                 | The protocol (i.e. HTTP or HTTPS) to use when connecting to AWS.                                                                                                                                                                                                                                                                                                             |
-| proxyHost                | The proxy host to connect through.                                                                                                                                                                                                                                                                                                                                           |
-| proxyPort                | The port on the proxy host to connect through.                                                                                                                                                                                                                                                                                                                               |
-| proxyUsername            | The user name to use when connecting through a proxy.                                                                                                                                                                                                                                                                                                                        |
-| proxyPassword            | The password to use when connecting through a proxy.                                                                                                                                                                                                                                                                                                                         |
-| s3PathStyleAccess        | Enable the use of path-based access model that is used to specify the address of an object in S3-compatible storage systems.                                                                                                                                                                                                                                                 |
-| signerOverride           | The name of the signature algorithm to use for signing requests made by the client.                                                                                                                                                                                                                                                                                          |
-| socketSendBufferSizeHint | The Size hint (in bytes) for the low level TCP send buffer.                                                                                                                                                                                                                                                                                                                  |
-| socketRecvBufferSizeHint | The Size hint (in bytes) for the low level TCP receive buffer.                                                                                                                                                                                                                                                                                                               |
-| socketTimeout            | The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out.                                                                                                                                                                                                                             |
-| storageEncryption        | The S3 server side encryption to be used when saving objects on S3, either `AES256` or `aws:kms` values are allowed.                                                                                                                                                                                                                                                         |
-| storageKmsKeyId          | The AWS KMS key Id to be used to encrypt files stored in the target S3 bucket (requires version `22.05.0-edge` or later).                                                                                                                                                                                                                                                    |
-| userAgent                | The HTTP user agent header passed with all HTTP requests.                                                                                                                                                                                                                                                                                                                    |
-| uploadMaxThreads         | The maximum number of threads used for multipart upload.                                                                                                                                                                                                                                                                                                                     |
-| uploadChunkSize          | The size of a single part in a multipart upload (default: `100 MB`).                                                                                                                                                                                                                                                                                                         |
-| uploadStorageClass       | The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).                                                                                                                                                                                                                             |
-| uploadMaxAttempts        | The maximum number of upload attempts after which a multipart upload returns an error (default: `5`).                                                                                                                                                                                                                                                                        |
-| uploadRetrySleep         | The time to wait after a failed upload attempt to retry the part upload (default: `500ms`).                                                                                                                                                                                                                                                                                  |
+`aws.client.anonymous`
+: Allow the access of public S3 buckets without the need to provide AWS credentials. Any service that does not accept unsigned requests will return a service access error.
+
+`aws.client.s3Acl`
+: Allow the setting of predefined bucket permissions, also known as *canned ACL*. Permitted values are `Private`, `PublicRead`, `PublicReadWrite`, `AuthenticatedRead`, `LogDeliveryWrite`, `BucketOwnerRead`, `BucketOwnerFullControl`, and `AwsExecRead`. See [Amazon docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) for details.
+
+`aws.client.connectionTimeout`
+: The amount of time to wait (in milliseconds) when initially establishing a connection before timing out.
+
+`aws.client.endpoint`
+: The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.
+
+`aws.client.glacierAutoRetrieval`
+: *EXPERIMENTAL. Requires version `22.12.0-edge` or later*
+: Enable auto retrieval of S3 objects stored with Glacier class store (default: `false`).
+
+`aws.client.glacierExpirationDays`
+: *EXPERIMENTAL. Requires version `22.12.0-edge` or later*
+: The time, in days, between when an object is restored to the bucket and when it expires (default: `7`).
+
+`aws.client.glacierRetrievalTier`
+: *EXPERIMENTAL. Requires version `23.03.0-edge` or later*
+: The retrieval tier to use when restoring objects from Glacier, one of [`Expedited`, `Standard`, `Bulk`].
+
+`aws.client.maxConnections`
+: The maximum number of allowed open HTTP connections.
+
+`aws.client.maxErrorRetry`
+: The maximum number of retry attempts for failed retryable requests.
+
+`aws.client.protocol`
+: The protocol (i.e. HTTP or HTTPS) to use when connecting to AWS.
+
+`aws.client.proxyHost`
+: The proxy host to connect through.
+
+`aws.client.proxyPort`
+: The port on the proxy host to connect through.
+
+`aws.client.proxyUsername`
+: The user name to use when connecting through a proxy.
+
+`aws.client.proxyPassword`
+: The password to use when connecting through a proxy.
+
+`aws.client.s3PathStyleAccess`
+: Enable the use of path-based access model that is used to specify the address of an object in S3-compatible storage systems.
+
+`aws.client.signerOverride`
+: The name of the signature algorithm to use for signing requests made by the client.
+
+`aws.client.socketSendBufferSizeHint`
+: The Size hint (in bytes) for the low level TCP send buffer.
+
+`aws.client.socketRecvBufferSizeHint`
+: The Size hint (in bytes) for the low level TCP receive buffer.
+
+`aws.client.socketTimeout`
+: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out.
+
+`aws.client.storageEncryption`
+: The S3 server side encryption to be used when saving objects on S3, either `AES256` or `aws:kms` values are allowed.
+
+`aws.client.storageKmsKeyId`
+: *Requires version `22.05.0-edge` or later*
+: The AWS KMS key Id to be used to encrypt files stored in the target S3 bucket ().
+
+`aws.client.userAgent`
+: The HTTP user agent header passed with all HTTP requests.
+
+`aws.client.uploadMaxThreads`
+: The maximum number of threads used for multipart upload.
+
+`aws.client.uploadChunkSize`
+: The size of a single part in a multipart upload (default: `100 MB`).
+
+`aws.client.uploadStorageClass`
+: The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).
+
+`aws.client.uploadMaxAttempts`
+: The maximum number of upload attempts after which a multipart upload returns an error (default: `5`).
+
+`aws.client.uploadRetrySleep`
+: The time to wait after a failed upload attempt to retry the part upload (default: `500ms`).
 
 For example:
 
@@ -142,21 +197,169 @@ aws {
 
 (config-aws-batch)=
 
-Advanced Batch configuration options can be set by using the `batch` attribute. The following properties can be used (required version `19.07.0` or later):
+Advanced Batch configuration options can be set by using the `batch` attribute. The following options are available:
 
-| Name                 | Description                                                                                                                                                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| cliPath              | The path where the AWS command line tool is installed in the host AMI.                                                                                                                                                             |
-| jobRole              | The AWS Job Role ARN that needs to be used to execute the Batch Job.                                                                                                                                                               |
-| logsGroup            | The name of the logs group used by Batch Jobs (default: `/aws/batch`, requires `22.09.0-edge` or later).                                                                                                                           |
-| volumes              | One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. `/host/path:/mount/path[:ro|rw]`. Multiple mounts can be specified separating them with a comma or using a list object. |
-| delayBetweenAttempts | Delay between download attempts from S3 (default `10 sec`).                                                                                                                                                                        |
-| maxParallelTransfers | Max parallel upload/download transfer operations *per job* (default: `4`).                                                                                                                                                         |
-| maxTransferAttempts  | Max number of downloads attempts from S3 (default: `1`).                                                                                                                                                                           |
-| maxSpotAttempts      | Max number of execution attempts of a job interrupted by a EC2 spot reclaim event (default: `5`, requires `22.04.0` or later)                                                                                                      |
-| retryMode            | The retry mode configuration setting, to accommodate rate-limiting on [AWS services](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html) (default: `standard`)                                            |
-| schedulingPriority   | The scheduling priority for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/) (default: `0`, requires `23.01.0-edge` or later)         |
-| shareIdentifier      | The share identifier for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/) (requires `22.09.0-edge` or later)                          |
+`aws.batch.cliPath`
+: The path where the AWS command line tool is installed in the host AMI.
+
+`aws.batch.jobRole`
+: The AWS Job Role ARN that needs to be used to execute the Batch Job.
+
+`aws.batch.logsGroup`
+: *Requires version `22.09.0-edge` or later*
+: The name of the logs group used by Batch Jobs (default: `/aws/batch`).
+
+`aws.batch.volumes`
+: One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. `/host/path:/mount/path[:ro|rw]`. Multiple mounts can be specified separating them with a comma or using a list object.
+
+`aws.batch.delayBetweenAttempts`
+: Delay between download attempts from S3 (default: `10 sec`).
+
+`aws.batch.maxParallelTransfers`
+: Max parallel upload/download transfer operations *per job* (default: `4`).
+
+`aws.batch.maxTransferAttempts`
+: Max number of downloads attempts from S3 (default: `1`).
+
+`aws.batch.maxSpotAttempts`
+: *Requires version `22.04.0` or later*
+: Max number of execution attempts of a job interrupted by a EC2 spot reclaim event (default: `5`)
+
+`aws.batch.retryMode`
+: The retry mode configuration setting, to accommodate rate-limiting on [AWS services](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html) (default: `standard`)
+
+`aws.batch.schedulingPriority`
+: *Requires `23.01.0-edge` or later*
+: The scheduling priority for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/) (default: `0`)
+
+`aws.batch.shareIdentifier`
+: *Requires `22.09.0-edge` or later*
+: The share identifier for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/)
+
+(config-azure)=
+
+### Scope `azure`
+
+The `azure` scope allows you to configure the interactions with {ref}`azure-page`.
+
+`azure.activeDirectory.servicePrincipalId`
+: The service principal client ID
+
+`azure.activeDirectory.servicePrincipalSecret`
+: The service principal client secret
+
+`azure.activeDirectory.tenantId`
+: The Azure tenant ID
+
+`azure.storage.accountName`
+: The blob storage account name
+
+`azure.storage.accountKey`
+: The blob storage account key
+
+`azure.storage.sasToken`
+: The blob storage shared access signature token. This can be provided as an alternative to the `accountKey` setting.
+
+`azure.storage.tokenDuration`
+: The duration of the shared access signature token created by Nextflow when the `sasToken` option is *not* specified (default: `48h`).
+
+`azure.batch.accountName`
+: The batch service account name.
+
+`azure.batch.accountKey`
+: The batch service account key.
+
+`azure.batch.endpoint`
+: The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.
+
+`azure.batch.location`
+: The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
+
+`azure.batch.autoPoolMode`
+: Enable the automatic creation of batch pools depending on the pipeline resources demand (default: `true`).
+
+`azure.batch.allowPoolCreation`
+: Enable the automatic creation of batch pools specified in the Nextflow configuration file (default: `false`).
+
+`azure.batch.deleteJobsOnCompletion`
+: Enable the automatic deletion of jobs created by the pipeline execution (default: `true`).
+
+`azure.batch.deletePoolsOnCompletion`
+: Enable the automatic deletion of compute node pools upon pipeline completion (default: `false`).
+
+`azure.batch.copyToolInstallMode`
+: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
+
+`azure.batch.pools.<name>.publisher`
+: *Requires `nf-azure@0.11.0`*
+: Specify the publisher of virtual machine type used by the pool identified with `<name>` (default: `microsoft-azure-batch`).
+
+`azure.batch.pools.<name>.offer`
+: *Requires `nf-azure@0.11.0`*
+: Specify the offer type of the virtual machine type used by the pool identified with `<name>` (default: `centos-container`).
+
+`azure.batch.pools.<name>.sku`
+: *Requires `nf-azure@0.11.0`*
+: Specify the ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.centos 8`).
+
+`azure.batch.pools.<name>.vmType`
+: Specify the virtual machine type used by the pool identified with `<name>`.
+
+`azure.batch.pools.<name>.vmCount`
+: Specify the number of virtual machines provisioned by the pool identified with `<name>`.
+
+`azure.batch.pools.<name>.maxVmCount`
+: Specify the max of virtual machine when using auto scale option.
+
+`azure.batch.pools.<name>.autoScale`
+: Enable autoscaling feature for the pool identified with `<name>`.
+
+`azure.batch.pools.<name>.fileShareRootPath`
+: *Requires `nf-azure@0.11.0`*
+: If mounting File Shares, this is the internal root mounting point. Must be `/mnt/resource/batch/tasks/fsmounts` for CentOS nodes or `/mnt/batch/tasks/fsmounts` for Ubuntu nodes (default is for CentOS).
+
+`azure.batch.pools.<name>.scaleFormula`
+: Specify the scale formula for the pool identified with `<name>`. See Azure Batch [scaling documentation](https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling) for details.
+
+`azure.batch.pools.<name>.scaleInterval`
+: Specify the interval at which to automatically adjust the Pool size according to the autoscale formula. The minimum and maximum value are 5 minutes and 168 hours respectively (default: `10 mins`).
+
+`azure.batch.pools.<name>.schedulePolicy`
+: Specify the scheduling policy for the pool identified with `<name>`. It can be either `spread` or `pack` (default: `spread`).
+
+`azure.batch.pools.<name>.privileged`
+: Enable the task to run with elevated access. Ignored if `runAs` is set (default: `false`).
+
+`azure.batch.pools.<name>.runAs`
+: Specify the username under which the task is run. The user must already exist on each node of the pool.
+
+`azure.batch.pools.<name>.virtualNetwork`
+: *Requires Nextflow `23.03.0-edge` or later*
+: Specify the subnet ID of a virtual network in which to create the pool.
+
+`azure.registry.server`
+: *Requires `nf-azure@0.9.8`*
+: Specify the container registry from which to pull the Docker images (default: `docker.io`).
+
+`azure.registry.userName`
+: *Requires `nf-azure@0.9.8`*
+: Specify the username to connect to a private container registry.
+
+`azure.registry.password`
+: *Requires `nf-azure@0.9.8`*
+: Specify the password to connect to a private container registry.
+
+`azure.retryPolicy.delay`
+: Delay when retrying failed API requests (default: `500ms`).
+
+`azure.retryPolicy.maxDelay`
+: Max delay when retrying failed API requests (default: `60s`).
+
+`azure.retryPolicy.jitter`
+: Jitter value when retrying failed API requests (default: `0.25`).
+
+`azure.retryPolicy.maxAttempts`
+: Max attempts when retrying failed API requests (default: `10`).
 
 (config-charliecloud)=
 
@@ -911,7 +1114,7 @@ profiles {
 ```
 
 This configuration defines three different profiles: `standard`, `cluster`, and `cloud`, that each set different process
-configuration strategies depending on the target runtime platform. The `standard` profile is used by default when no profile is specified. 
+configuration strategies depending on the target runtime platform. The `standard` profile is used by default when no profile is specified.
 
 :::{tip}
 Multiple configuration profiles can be specified by separating the profile names with a comma, for example:

--- a/docs/config.md
+++ b/docs/config.md
@@ -119,33 +119,80 @@ Read the {ref}`container-apptainer` page to learn more about how to use Apptaine
 
 ### Scope `aws`
 
-The `aws` scope allows you to configure access to Amazon S3 storage. Use the attributes `accessKey` and `secretKey` to specify your bucket credentials. For example:
+The `aws` scope controls the interactions with AWS, including AWS Batch and S3. For example:
 
 ```groovy
 aws {
     accessKey = '<YOUR S3 ACCESS KEY>'
     secretKey = '<YOUR S3 SECRET KEY>'
-    region = '<AWS REGION IDENTIFIER>'
-    profile = '<AWS CONFIG PROFILE>' // optional
-}
-```
+    region = 'us-east-1'
 
-See [AWS Security Credentials](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html) for more information.
-
-Advanced client configuration options can be set using the `client` attribute. For example:
-
-```groovy
-aws {
     client {
         maxConnections = 20
         connectionTimeout = 10000
         uploadStorageClass = 'INTELLIGENT_TIERING'
         storageEncryption = 'AES256'
     }
+    batch {
+        cliPath = '/home/ec2-user/miniconda/bin/aws'
+        maxTransferAttempts = 3
+        delayBetweenAttempts = '5 sec'
+    }
 }
 ```
 
+Read the {ref}`aws-page` and {ref}`amazons3-page` pages for more information.
+
 The following settings are available:
+
+`aws.accessKey`
+: AWS account access key
+
+`aws.profile`
+: AWS profile from `~/.aws/credentials`
+
+`aws.region`
+: AWS region (e.g. `us-east-1`)
+
+`aws.secretKey`
+: AWS account secret key
+
+`aws.batch.cliPath`
+: The path where the AWS command line tool is installed in the host AMI.
+
+`aws.batch.delayBetweenAttempts`
+: Delay between download attempts from S3 (default: `10 sec`).
+
+`aws.batch.jobRole`
+: The AWS Job Role ARN that needs to be used to execute the Batch Job.
+
+`aws.batch.logsGroup`
+: *Requires version `22.09.0-edge` or later*
+: The name of the logs group used by Batch Jobs (default: `/aws/batch`).
+
+`aws.batch.maxParallelTransfers`
+: Max parallel upload/download transfer operations *per job* (default: `4`).
+
+`aws.batch.maxSpotAttempts`
+: *Requires version `22.04.0` or later*
+: Max number of execution attempts of a job interrupted by a EC2 spot reclaim event (default: `5`)
+
+`aws.batch.maxTransferAttempts`
+: Max number of downloads attempts from S3 (default: `1`).
+
+`aws.batch.retryMode`
+: The retry mode configuration setting, to accommodate rate-limiting on [AWS services](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html) (default: `standard`)
+
+`aws.batch.schedulingPriority`
+: *Requires `23.01.0-edge` or later*
+: The scheduling priority for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/) (default: `0`)
+
+`aws.batch.shareIdentifier`
+: *Requires `22.09.0-edge` or later*
+: The share identifier for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/)
+
+`aws.batch.volumes`
+: One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. `/host/path:/mount/path[:ro|rw]`. Multiple mounts can be specified separating them with a comma or using a list object.
 
 `aws.client.anonymous`
 : Allow the access of public S3 buckets without the need to provide AWS credentials. Any service that does not accept unsigned requests will return a service access error.
@@ -232,52 +279,13 @@ The following settings are available:
 `aws.client.uploadStorageClass`
 : The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).
 
-(config-aws-batch)=
-
-Advanced Batch configuration options can be set by using the `batch` attribute. The following settings are available:
-
-`aws.batch.cliPath`
-: The path where the AWS command line tool is installed in the host AMI.
-
-`aws.batch.delayBetweenAttempts`
-: Delay between download attempts from S3 (default: `10 sec`).
-
-`aws.batch.jobRole`
-: The AWS Job Role ARN that needs to be used to execute the Batch Job.
-
-`aws.batch.logsGroup`
-: *Requires version `22.09.0-edge` or later*
-: The name of the logs group used by Batch Jobs (default: `/aws/batch`).
-
-`aws.batch.maxParallelTransfers`
-: Max parallel upload/download transfer operations *per job* (default: `4`).
-
-`aws.batch.maxSpotAttempts`
-: *Requires version `22.04.0` or later*
-: Max number of execution attempts of a job interrupted by a EC2 spot reclaim event (default: `5`)
-
-`aws.batch.maxTransferAttempts`
-: Max number of downloads attempts from S3 (default: `1`).
-
-`aws.batch.retryMode`
-: The retry mode configuration setting, to accommodate rate-limiting on [AWS services](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html) (default: `standard`)
-
-`aws.batch.schedulingPriority`
-: *Requires `23.01.0-edge` or later*
-: The scheduling priority for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/) (default: `0`)
-
-`aws.batch.shareIdentifier`
-: *Requires `22.09.0-edge` or later*
-: The share identifier for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/)
-
-`aws.batch.volumes`
-: One or more container mounts. Mounts can be specified as simple e.g. `/some/path` or canonical format e.g. `/host/path:/mount/path[:ro|rw]`. Multiple mounts can be specified separating them with a comma or using a list object.
-
 (config-azure)=
 
 ### Scope `azure`
 
-The `azure` scope allows you to configure the interactions with {ref}`azure-page`.
+The `azure` scope allows you to configure the interactions with Azure, including Azure Batch and Azure Blob Storage.
+
+Read the {ref}`azure-page` page for more information.
 
 The following settings are available:
 
@@ -661,6 +669,119 @@ executor.$sge.pollInterval = '30sec'
 executor.$local.cpus = 8
 executor.$local.memory = '32 GB'
 ```
+
+(config-google)=
+
+### Scope `google`
+
+The `google` scope allows you to configure the interactions with Google Cloud, including Google Cloud Batch, Google Life Sciences, and Google Cloud Storage.
+
+Read the {ref}`google-page` page for more information.
+
+The following settings are available:
+
+`google.enableRequesterPaysBuckets`
+: When `true` uses the given Google Cloud project ID as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`).
+
+`google.location`
+: The Google Cloud location where jobs are executed (default: `us-central1`).
+
+`google.project`
+: The Google Cloud project ID to use for pipeline execution
+
+`google.region`
+: *Available only for Google Life Sciences*
+: The Google Cloud region where jobs are executed. Multiple regions can be provided as a comma-separated list. Cannot be used with the `google.zone` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
+
+`google.zone`
+: *Available only for Google Life Sciences*
+: The Google Cloud zone where jobs are executed. Multiple zones can be provided as a comma-separated list. Cannot be used with the `google.region` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
+
+`google.batch.allowedLocations`
+: *Requires version `22.12.0-edge` or later*
+: Define the set of allowed locations for VMs to be provisioned. See [Google documentation](https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#locationpolicy) for details (default: no restriction).
+
+`google.batch.bootDiskSize`
+: Set the size of the virtual machine boot disk, e.g `50.GB` (default: none).
+
+`google.batch.cpuPlatform`
+: Set the minimum CPU Platform, e.g. `'Intel Skylake'`. See [Specifying a minimum CPU Platform for VM instances](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications) (default: none).
+
+`google.batch.network`
+: Set network name to attach the VM's network interface to. The value will be prefixed with `global/networks/` unless it contains a `/`, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used.
+
+`google.batch.serviceAccountEmail`
+: Define the Google service account email to use for the pipeline execution. If not specified, the default Compute Engine service account for the project will be used.
+
+`google.batch.spot`
+: When `true` enables the usage of *spot* virtual machines or `false` otherwise (default: `false`).
+
+`google.batch.subnetwork`
+: Define the name of the subnetwork to attach the instance to must be specified here, when the specified network is configured for custom subnet creation. The value is prefixed with `regions/subnetworks/` unless it contains a `/`, in which case it is assumed to be a fully specified subnetwork resource URL.
+
+`google.batch.usePrivateAddress`
+: When `true` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: `false`).
+
+`google.lifeSciences.bootDiskSize`
+: Set the size of the virtual machine boot disk e.g `50.GB` (default: none).
+
+`google.lifeSciences.copyImage`
+: The container image run to copy input and output files. It must include the `gsutil` tool (default: `google/cloud-sdk:alpine`).
+
+`google.lifeSciences.cpuPlatform`
+: Set the minimum CPU Platform e.g. `'Intel Skylake'`. See [Specifying a minimum CPU Platform for VM instances](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications) (default: none).
+
+`google.lifeSciences.debug`
+: When `true` copies the `/google` debug directory in that task bucket directory (default: `false`).
+
+`google.lifeSciences.keepAliveOnFailure`
+: *Requires version `21.06.0-edge` or later*
+: When `true` and a task complete with an unexpected exit status the associated compute node is kept up for 1 hour. This options implies `sshDaemon=true` (default: `false`).
+
+`google.lifeSciences.network`
+: *Requires version `21.03.0-edge` or later*
+: Set network name to attach the VM's network interface to. The value will be prefixed with `global/networks/` unless it contains a `/`, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used.
+
+`google.lifeSciences.preemptible`
+: When `true` enables the usage of *preemptible* virtual machines or `false` otherwise (default: `true`).
+
+`google.lifeSciences.serviceAccountEmail`
+: *Requires version `20.05.0-edge` or later*
+: Define the Google service account email to use for the pipeline execution. If not specified, the default Compute Engine service account for the project will be used.
+
+`google.lifeSciences.subnetwork`
+: *Requires version `21.03.0-edge` or later*
+: Define the name of the subnetwork to attach the instance to must be specified here, when the specified network is configured for custom subnet creation. The value is prefixed with `regions/subnetworks/` unless it contains a `/`, in which case it is assumed to be a fully specified subnetwork resource URL.
+
+`google.lifeSciences.sshDaemon`
+: When `true` runs SSH daemon in the VM carrying out the job to which it's possible to connect for debugging purposes (default: `false`).
+
+`google.lifeSciences.sshImage`
+: The container image used to run the SSH daemon (default: `gcr.io/cloud-genomics-pipelines/tools`).
+
+`google.lifeSciences.usePrivateAddress`
+: *Requires version `20.03.0-edge` or later*
+: When `true` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: `false`).
+
+`google.storage.delayBetweenAttempts`
+: *Requires version `21.06.0-edge` or later*
+: Delay between download attempts from Google Storage (default `10 sec`).
+
+`google.storage.downloadMaxComponents`
+: *Requires version `21.06.0-edge` or later*
+: Defines the value for the option `GSUtil:sliced_object_download_max_components` used by `gsutil` for transfer input and output data (default: `8`).
+
+`google.storage.maxParallelTransfers`
+: *Requires version `21.06.0-edge` or later*
+: Max parallel upload/download transfer operations *per job* (default: `4`).
+
+`google.storage.maxTransferAttempts`
+: *Requires version `21.06.0-edge` or later*
+: Max number of downloads attempts from Google Storage (default: `1`).
+
+`google.storage.parallelThreadCount`
+: *Requires version `21.06.0-edge` or later*
+: Defines the value for the option `GSUtil:parallel_thread_count` used by `gsutil` for transfer input and output data (default: `1`).
 
 (config-k8s)=
 

--- a/docs/google.md
+++ b/docs/google.md
@@ -66,7 +66,7 @@ when done, make sure to use the latest edge release running the snippet in the p
 
 ### Configuration
 
-Make sure to have defined in your environment the `GOOGLE_APPLICATION_CREDENTIALS` variable. See the section [Credentials](#credentials) for details.
+Make sure to have defined in your environment the `GOOGLE_APPLICATION_CREDENTIALS` variable. See the [Credentials](#credentials) section for details.
 
 :::{note}
 Make sure your Google account is allowed to access the Google Cloud Batch service by checking the [APIs & Services](https://console.cloud.google.com/apis/dashboard) dashboard.
@@ -74,10 +74,9 @@ Make sure your Google account is allowed to access the Google Cloud Batch servic
 
 Create or edit the file `nextflow.config` in your project root directory. The config must specify the following parameters:
 
-- Google Cloud Batch as Nextflow executor i.e. `process.executor = 'google-batch'`.
-- The Docker container image to be used to run pipeline tasks e.g. `process.container = 'biocontainers/salmon:0.8.2--1'`.
-- The Google Cloud `project` ID to run in e.g. `google.project = 'rare-lattice-222412'`.
-- The Google location e.g. `google.location = 'us-central1'`.
+- Google Cloud Batch as Nextflow executor
+- The Docker container image(s) for pipeline tasks
+- The Google Cloud project ID and location
 
 Example:
 
@@ -93,33 +92,13 @@ google {
 }
 ```
 
-:::{note}
-Make sure to specify the project ID, not the project name.
-:::
+Notes:
 
-:::{note}
-Make sure to specify a location where Google Batch is available. Refer to the [Google Batch documentation](https://cloud.google.com/batch/docs/get-started#locations) for region availability.
-:::
+- A container image must be specified to execute processes. You can use a different Docker image for each process using one or more {ref}`config-process-selectors`.
+- Make sure to specify the project ID, not the project name.
+- Make sure to specify a location where Google Batch is available. Refer to the [Google Batch documentation](https://cloud.google.com/batch/docs/get-started#locations) for region availability.
 
-:::{Note}
-A container image must be specified to deploy the process execution. You can use a different Docker image for each process using one or more {ref}`config-process-selectors`.
-:::
-
-The following configuration options are available:
-
-| Name                                | Description                                                                                                                                                                                                                                                                                                       |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `google.project`                    | The Google Project Id to use for the pipeline execution.                                                                                                                                                                                                                                                          |
-| `google.location`                   | The Google *location* where the job executions are deployed (default: `us-central1`).                                                                                                                                                                                                                             |
-| `google.enableRequesterPaysBuckets` | When `true` uses the configured Google project id as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`).     |
-| `google.batch.allowedLocations`     | Define the set of allowed locations for VMs to be provisioned. See [Google documentation](https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#locationpolicy) for details (default: no restriction. Requires version `22.12.0-edge` or later).                                          |
-| `google.batch.bootDiskSize`         | Set the size of the virtual machine boot disk, e.g `50.GB` (default: none).                                                                                                                                                                                                                                       |
-| `google.batch.cpuPlatform`          | Set the minimum CPU Platform, e.g. `'Intel Skylake'`. See [Specifying a minimum CPU Platform for VM instances](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications) (default: none).                                                                                          |
-| `google.batch.spot`                 | When `true` enables the usage of *spot* virtual machines or `false` otherwise (default: `false`).                                                                                                                                                                                                                 |
-| `google.batch.usePrivateAddress`    | When `true` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: `false`).       |
-| `google.batch.network`              | Set network name to attach the VM's network interface to. The value will be prefixed with global/networks/ unless it contains a /, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used.                                                  |
-| `google.batch.serviceAccountEmail`  | Define the Google service account email to use for the pipeline execution. If not specified, the default Compute Engine service account for the project will be used.                                                                                                                                             |
-| `google.batch.subnetwork`           | Define the name of the subnetwork to attach the instance to must be specified here, when the specified network is configured for custom subnet creation. The value is prefixed with `regions/subnetworks/` unless it contains a `/`, in which case it is assumed to be a fully specified subnetwork resource URL. |
+Read the {ref}`Google configuration<config-google>` section to learn more about advanced configuration options.
 
 ### Process definition
 
@@ -272,9 +251,9 @@ Make sure to enable the Cloud Life Sciences API beforehand. To learn how to enab
 Create a `nextflow.config` file in the project root directory. The config must specify the following parameters:
 
 - Google Life Sciences as Nextflow executor
-- The Docker container image(s) to run pipeline tasks
-- The Google Cloud `project` ID
-- The Google Cloud `region` or `zone` where the Compute Engine VMs will be started.
+- The Docker container image(s) for pipeline tasks
+- The Google Cloud project ID
+- The Google Cloud region or zone where the Compute Engine VMs will be executed.
   You need to specify one or the other, *not* both. Multiple regions or zones can be specified as a comma-separated list, e.g. `google.zone = 'us-central1-f,us-central-1-b'`.
 
 Example:
@@ -291,40 +270,12 @@ google {
 }
 ```
 
-:::{warning}
-Make sure to specify the project ID, not the project name.
-:::
+Notes:
+- A container image must be specified to execute processes. You can use a different Docker image for each process using one or more {ref}`config-process-selectors`.
+- Make sure to specify the project ID, not the project name.
+- Make sure to specify a location where Google Life Sciences is available. Refer to the [Google Cloud documentation](https://cloud.google.com/life-sciences/docs/concepts/locations) for details.
 
-:::{note}
-You can use a different Docker image for each process using one or more {ref}`config-process-selectors`.
-:::
-
-The following configuration options are available:
-
-| Name                                      | Description                                                                                                                                                                                                                                                                                                                                                 |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `google.project`                          | The Google Project Id to use for the pipeline execution.                                                                                                                                                                                                                                                                                                    |
-| `google.region`                           | The Google *region* where the computation is executed in Compute Engine VMs. Multiple regions can be provided separating them by a comma. Do not specify if a zone is provided. See [available Compute Engine regions and zones](https://cloud.google.com/compute/docs/regions-zones/)                                                                    |
-| `google.zone`                             | The Google *zone* where the computation is executed in Compute Engine VMs. Multiple zones can be provided separating them by a comma. Do not specify if a region is provided. See [available Compute Engine regions and zones](https://cloud.google.com/compute/docs/regions-zones/)                                                                      |
-| `google.location`                         | The Google *location* where the job executions are deployed to Cloud Life Sciences API. See [available Cloud Life Sciences API locations](https://cloud.google.com/life-sciences/docs/concepts/locations) (default: the same as the region or the zone specified).                                                                                         |
-| `google.enableRequesterPaysBuckets`       | When `true` uses the configured Google project id as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`)                                                |
-| `google.lifeSciences.bootDiskSize`        | Set the size of the virtual machine boot disk e.g `50.GB` (default: none).                                                                                                                                                                                                                                                                                  |
-| `google.lifeSciences.copyImage`           | The container image run to copy input and output files. It must include the `gsutil` tool (default: `google/cloud-sdk:alpine`).                                                                                                                                                                                                                             |
-| `google.lifeSciences.cpuPlatform`         | Set the minimum CPU Platform e.g. `'Intel Skylake'`. See [Specifying a minimum CPU Platform for VM instances](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications) (default: none).                                                                                                                                     |
-| `google.lifeSciences.debug`               | When `true` copies the `/google` debug directory in that task bucket directory (default: `false`)                                                                                                                                                                                                                                                           |
-| `google.lifeSciences.preemptible`         | When `true` enables the usage of *preemptible* virtual machines or `false` otherwise (default: `true`)                                                                                                                                                                                                                                                      |
-| `google.lifeSciences.usePrivateAddress`   | When `true` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: `false`). Requires version `20.03.0-edge` or later.       |
-| `google.lifeSciences.network`             | Set network name to attach the VM's network interface to. The value will be prefixed with global/networks/ unless it contains a /, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used. Requires version `21.03.0-edge` or later.                                                  |
-| `google.lifeSciences.serviceAccountEmail` | Define the Google service account email to use for the pipeline execution. If not specified, the default Compute Engine service account for the project will be used. Requires version `20.05.0-edge` or later.                                                                                                                                             |
-| `google.lifeSciences.subnetwork`          | Define the name of the subnetwork to attach the instance to must be specified here, when the specified network is configured for custom subnet creation. The value is prefixed with `regions/subnetworks/` unless it contains a `/`, in which case it is assumed to be a fully specified subnetwork resource URL. Requires version `21.03.0-edge` or later. |
-| `google.lifeSciences.sshDaemon`           | When `true` runs SSH daemon in the VM carrying out the job to which it's possible to connect for debugging purposes (default: `false`).                                                                                                                                                                                                                     |
-| `google.lifeSciences.sshImage`            | The container image used to run the SSH daemon (default: `gcr.io/cloud-genomics-pipelines/tools`).                                                                                                                                                                                                                                                          |
-| `google.lifeSciences.keepAliveOnFailure`  | When `true` and a task complete with an unexpected exit status the associated compute node is kept up for 1 hour. This options implies `sshDaemon=true` (default: `false`, requires Nextflow version `21.06.0-edge` or later).                                                                                                                              |
-| `google.storage.delayBetweenAttempts`     | Delay between download attempts from Google Storage (default `10 sec`, requires version `21.06.0-edge` or later).                                                                                                                                                                                                                                           |
-| `google.storage.maxParallelTransfers`     | Max parallel upload/download transfer operations *per job* (default: `4`, requires version `21.06.0-edge` or later).                                                                                                                                                                                                                                        |
-| `google.storage.maxTransferAttempts`      | Max number of downloads attempts from Google Storage (default: `1`, requires version `21.06.0-edge` or later).                                                                                                                                                                                                                                              |
-| `google.storage.parallelThreadCount`      | Defines the value for the option `GSUtil:parallel_thread_count` used by `gsutil` for transfer input and output data (default: `1`, requires version `21.06.0-edge` or later).                                                                                                                                                                               |
-| `google.storage.downloadMaxComponents`    | Defines the value for the option `GSUtil:sliced_object_download_max_components` used by `gsutil` for transfer input and output data (default: `8`, requires version `21.06.0-edge` or later).                                                                                                                                                               |
+Read the {ref}`Google configuration<config-google>` section to learn more about advanced configuration options.
 
 ### Process definition
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -21,43 +21,98 @@ To shortcut access to multiple `workflow` properties, you can use the Groovy [wi
 
 The following table lists the properties that can be accessed on the `workflow` object:
 
-| Name                  | Description                                                                                                                                             |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| scriptId              | Project main script unique hash ID.                                                                                                                     |
-| scriptName            | Project main script file name.                                                                                                                          |
-| scriptFile            | Project main script file path.                                                                                                                          |
-| repository            | Project repository Git remote URL.                                                                                                                      |
-| commitId              | Git commit ID of the executed workflow repository.                                                                                                      |
-| revision              | Git branch/tag of the executed workflow repository.                                                                                                     |
-| projectDir            | Directory where the workflow project is stored in the computer.                                                                                         |
-| launchDir             | Directory where the workflow execution has been launched.                                                                                               |
-| workDir               | Workflow working directory.                                                                                                                             |
-| homeDir               | User system home directory.                                                                                                                             |
-| userName              | User system account name.                                                                                                                               |
-| configFiles           | Configuration files used for the workflow execution.                                                                                                    |
-| container             | Docker image used to run workflow tasks. When more than one image is used it returns a map object containing `[process name, image name]` pair entries. |
-| containerEngine       | Returns the name of the container engine (e.g. docker or singularity) or null if no container engine is enabled.                                        |
-| commandLine           | Command line as entered by the user to launch the workflow execution.                                                                                   |
-| profile               | Used configuration profile.                                                                                                                             |
-| runName               | Mnemonic name assigned to this execution instance.                                                                                                      |
-| sessionId             | Unique identifier (UUID) associated to current execution.                                                                                               |
-| resume                | Returns `true` whenever the current instance is resumed from a previous execution.                                                                      |
-| stubRun               | Returns `true` whenever the current instance is a stub-run execution .                                                                                  |
-| start                 | Timestamp of workflow at execution start.                                                                                                               |
-| manifest              | Entries of the workflow manifest.                                                                                                                       |
-| {sup}`✝` complete     | Timestamp of workflow when execution is completed.                                                                                                      |
-| {sup}`✝` duration     | Time elapsed to complete workflow execution.                                                                                                            |
-| {sup}`*` success      | Reports if the execution completed successfully.                                                                                                        |
-| {sup}`*` exitStatus   | Exit status of the task that caused the workflow execution to fail.                                                                                     |
-| {sup}`*` errorMessage | Error message of the task that caused the workflow execution to fail.                                                                                   |
-| {sup}`*` errorReport  | Detailed error of the task that caused the workflow execution to fail.                                                                                  |
 
-- Properties marked with a `✝` are accessible only in the workflow completion handler.
-- Properties marked with a `*` are accessible only in the workflow completion and error handlers. See the [Completion handler] section for details.
+`workflow.commandLine`
+: Command line as entered by the user to launch the workflow execution.
 
-:::{note} 
-When passing a Git tag or branch name using the `-r` option in your command, the `workflow.revision` and the associated `workflow.commitId` are populated. When passing only the Git commit ID using `-r`, no `workflow.revision` is returned. 
-:::
+`workflow.commitId`
+: Git commit ID of the executed workflow repository.
+: When providing a Git tag, branch name, or commit hash using the `-r` CLI option, the associated `workflow.commitId` is also populated.
+
+`workflow.complete`
+: *Available only in the `workflow.onComplete` handler*
+: Timestamp of workflow when execution is completed.
+
+`workflow.configFiles`
+: Configuration files used for the workflow execution.
+
+`workflow.container`
+: Docker image used to run workflow tasks. When more than one image is used it returns a map object containing `[process name, image name]` pair entries.
+
+`workflow.containerEngine`
+: Returns the name of the container engine (e.g. docker or singularity) or null if no container engine is enabled.
+
+`workflow.duration`
+: *Available only in the `workflow.onComplete` handler*
+: Time elapsed to complete workflow execution.
+
+`workflow.errorMessage`
+: *Available only in the `workflow.onComplete` and `workflow.onError` handlers*
+: Error message of the task that caused the workflow execution to fail.
+
+`workflow.errorReport`
+: *Available only in the `workflow.onComplete` and `workflow.onError` handlers*
+: Detailed error of the task that caused the workflow execution to fail.
+
+`workflow.exitStatus`
+: *Available only in the `workflow.onComplete` and `workflow.onError` handlers*
+: Exit status of the task that caused the workflow execution to fail.
+
+`workflow.homeDir`
+: User system home directory.
+
+`workflow.launchDir`
+: Directory where the workflow execution has been launched.
+
+`workflow.manifest`
+: Entries of the workflow manifest.
+
+`workflow.profile`
+: Used configuration profile.
+
+`workflow.projectDir`
+: Directory where the workflow project is stored in the computer.
+
+`workflow.repository`
+: Project repository Git remote URL.
+
+`workflow.resume`
+: Returns `true` whenever the current instance is resumed from a previous execution.
+
+`workflow.revision`
+: Git branch/tag of the executed workflow repository.
+: When providing a Git tag or branch name using the `-r` CLI option, the `workflow.revision` is also populated.
+
+`workflow.runName`
+: Mnemonic name assigned to this execution instance.
+
+`workflow.scriptFile`
+: Project main script file path.
+
+`workflow.scriptId`
+: Project main script unique hash ID.
+
+`workflow.scriptName`
+: Project main script file name.
+
+`workflow.sessionId`
+: Unique identifier (UUID) associated to current execution.
+
+`workflow.start`
+: Timestamp of workflow at execution start.
+
+`workflow.stubRun`
+: Returns `true` whenever the current instance is a stub-run execution .
+
+`workflow.success`
+: *Available only in the `workflow.onComplete` and `workflow.onError` handlers*
+: Reports if the execution completed successfully.
+
+`workflow.userName`
+: User system account name.
+
+`workflow.workDir`
+: Workflow working directory.
 
 (metadata-nextflow)=
 
@@ -65,20 +120,24 @@ When passing a Git tag or branch name using the `-r` option in your command, the
 
 The implicit `nextflow` object allows you to access the metadata information of the Nextflow runtime.
 
-| Name               | Description                         |
-| ------------------ | ----------------------------------- |
-| nextflow.version   | Nextflow runtime version number.    |
-| nextflow.build     | Nextflow runtime build number.      |
-| nextflow.timestamp | Nextflow runtime compile timestamp. |
+`nextflow.build`
+: Nextflow runtime build number.
 
-The method `nextflow.version.matches` allows you to check if the Nextflow runtime satisfies the version requirement eventually needed by your workflow script. The required version string can be prefixed with the usual comparison operators eg `>`, `>=`, `=`, etc. or postfixed with the `+` operator to specify a minimal version requirement. For example:
+`nextflow.timestamp`
+: Nextflow runtime compile timestamp.
 
-```groovy
-if( !nextflow.version.matches('21.04+') ) {
-    println "This workflow requires Nextflow version 21.04 or greater -- You are running version $nextflow.version"
-    exit 1
-}
-```
+`nextflow.version`
+: Nextflow runtime version number.
+
+`nextflow.version.matches()`
+: This method allows you to check if the Nextflow runtime satisfies a version requirement for your workflow script. The version requirement string can be prefixed with the usual comparison operators eg `>`, `>=`, `=`, etc. or postfixed with the `+` operator to specify a minimum version requirement. For example:
+
+  ```groovy
+  if( !nextflow.version.matches('21.04+') ) {
+      println "This workflow requires Nextflow version 21.04 or greater -- You are running version $nextflow.version"
+      exit 1
+  }
+  ```
 
 (metadata-completion-handler)=
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -255,12 +255,13 @@ Channel
 [5,4,7]
 ```
 
-Available parameters:
+Available options:
 
-| Field | Description                                                                                                                                                                                                                                                                                                |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| flat  | When `true` nested list structures are normalised and their items are added to the resulting list object (default: `true`).                                                                                                                                                                                |
-| sort  | When `true` the items in the resulting list are sorted by their natural ordering. It is possible to provide a custom ordering criteria by using either a {ref}`closure <script-closure>` or a [Comparator](https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html) object (default: `false`). |
+`flat`
+: When `true` nested list structures are normalised and their items are added to the resulting list object (default: `true`).
+
+`sort`
+: When `true` the items in the resulting list are sorted by their natural ordering. It is possible to provide a custom ordering criteria by using either a {ref}`closure <script-closure>` or a [Comparator](https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html) object (default: `false`).
 
 See also: [toList](#tolist) and [toSortedList](#tosortedlist) operator.
 
@@ -311,36 +312,45 @@ Hello
 When the items emitted by the source channel are files, the grouping criteria can be omitted. In this case the items content will be grouped into file(s) having the same name as the source items.
 :::
 
-The following parameters can be used with the `collectFile` operator:
+Available options:
 
-| Name         | Description                                                                                                                                                                                                                                                                                          |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cache`      | Controls the caching ability of the `collectFile` operator when using the *resume* feature. It follows the same semantic of the {ref}`process-cache` directive (default: `true`).                                                                                                                    |
-| `keepHeader` | Prepend the resulting file with the header fetched in the first collected file. The header size (ie. lines) can be specified by using the `skip` parameter (default: `false`), to determine how many lines to remove from all collected files except for the first (where no lines will be removed). |
-| `name`       | Name of the file where all received values are stored.                                                                                                                                                                                                                                               |
-| `newLine`    | Appends a `newline` character automatically after each entry (default: `false`).                                                                                                                                                                                                                     |
-| `seed`       | A value or a map of values used to initialise the files content.                                                                                                                                                                                                                                     |
-| `skip`       | Skip the first `n` lines eg. `skip: 1`.                                                                                                                                                                                                                                                              |
-| `sort`       | Defines sorting criteria of content in resulting file(s). See below for sorting options.                                                                                                                                                                                                             |
-| `storeDir`   | Folder where the resulting file(s) are be stored.                                                                                                                                                                                                                                                    |
-| `tempDir`    | Folder where temporary files, used by the collecting process, are stored.                                                                                                                                                                                                                            |
+`cache`
+: Controls the caching ability of the `collectFile` operator when using the *resume* feature. It follows the same semantic of the {ref}`process-cache` directive (default: `true`).
 
-:::{note}
-The file content is sorted in such a way that it does not depend on the order in which entries were added to it, which guarantees that it is consistent (i.e. does not change) across different executions with the same data.
-:::
+`keepHeader`
+: Prepend the resulting file with the header fetched in the first collected file. The header size (ie. lines) can be specified by using the `skip` parameter (default: `false`), to determine how many lines to remove from all collected files except for the first (where no lines will be removed).
 
-The ordering of file's content can be defined by using the `sort` parameter. The following criteria can be specified:
+`name`
+: Name of the file where all received values are stored.
 
-| Sort      | Description                                                                                                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `false`   | Disable content sorting. Entries are appended as they are produced.                                                                                                                        |
-| `true`    | Order the content by the entries natural ordering i.e. numerical for number, lexicographic for string, etc. See <http://docs.oracle.com/javase/tutorial/collections/interfaces/order.html> |
-| `'index'` | Order the content by the incremental index number assigned to each entry while they are collected.                                                                                         |
-| `'hash'`  | Order the content by the hash number associated to each entry (default)                                                                                                                    |
-| `'deep'`  | Similar to the previous, but the hash number is created on actual entries content e.g. when the entry is a file the hash is created on the actual file content.                            |
-| `custom`  | A custom sorting criteria can be specified by using either a {ref}`Closure <script-closure>` or a [Comparator](http://docs.oracle.com/javase/7/docs/api/java/util/Comparator.html) object. |
+`newLine`
+: Appends a `newline` character automatically after each entry (default: `false`).
 
-For example the following snippet shows how sort the content of the result file alphabetically:
+`seed`
+: A value or a map of values used to initialise the files content.
+
+`skip`
+: Skip the first `n` lines eg. `skip: 1`.
+
+`sort`
+: Defines sorting criteria of content in resulting file(s). Can be one of the following values:
+
+  - `false`: Disable content sorting. Entries are appended as they are produced.
+  - `true`: Order the content by the entry's natural ordering i.e. numerical for number, lexicographic for string, etc. See the [Java documentation](http://docs.oracle.com/javase/tutorial/collections/interfaces/order.html) for more information.
+  - `'index'`: Order the content by the incremental index number assigned to each entry while they are collected.
+  - `'hash'`: (default) Order the content by the hash number associated to each entry
+  - `'deep'`: Similar to the previous, but the hash number is created on actual entries content e.g. when the entry is a file the hash is created on the actual file content.
+  - A custom sorting criteria can be specified by using either a {ref}`Closure <script-closure>` or a [Comparator](http://docs.oracle.com/javase/7/docs/api/java/util/Comparator.html) object.
+
+  The file content is sorted in such a way that it does not depend on the order in which entries were added to it, which guarantees that it is consistent (i.e. does not change) across different executions with the same data.
+
+`storeDir`
+: Folder where the resulting file(s) are be stored.
+
+`tempDir`
+: Folder where temporary files, used by the collecting process, are stored.
+
+The following snippet shows how sort the content of the result file alphabetically:
 
 ```groovy
 Channel
@@ -807,24 +817,25 @@ Channel
 [[3], D]
 ```
 
-Available parameters:
+Available options:
 
-| Field     | Description                                                                                                                                                                                                           |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by        | The index (zero based) of the element to be used as grouping key. A key composed by multiple elements can be defined specifying a list of indices e.g. `by: [0,2]`                                                    |
-| sort      | Defines the sorting criteria for the grouped items. See below for available sorting options.                                                                                                                          |
-| size      | The number of items the grouped list(s) has to contain. When the specified size is reached, the tuple is emitted.                                                                                                     |
-| remainder | When `false` incomplete tuples (i.e. with less than `size` grouped items) are discarded (default). When `true` incomplete tuples are emitted as the ending emission. Only valid when a `size` parameter is specified. |
+`by`
+: The index (zero based) of the element to be used as grouping key. A key composed by multiple elements can be defined specifying a list of indices e.g. `by: [0,2]`
 
-Sorting options:
+`remainder`
+: When `false` incomplete tuples (i.e. with less than `size` grouped items) are discarded (default). When `true` incomplete tuples are emitted as the ending emission. Only valid when a `size` parameter is specified.
 
-| Sort     | Description                                                                                                                                                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| false    | No sorting is applied (default).                                                                                                                                                                                                                       |
-| true     | Order the grouped items by the item natural ordering i.e. numerical for number, lexicographic for string, etc. See <http://docs.oracle.com/javase/tutorial/collections/interfaces/order.html>                                                          |
-| hash     | Order the grouped items by the hash number associated to each entry.                                                                                                                                                                                   |
-| deep     | Similar to the previous, but the hash number is created on actual entries content e.g. when the item is a file, the hash is created on the actual file content.                                                                                        |
-| `custom` | A custom sorting criteria used to order the tuples element holding list of values. It can be specified by using either a {ref}`Closure <script-closure>` or a [Comparator](http://docs.oracle.com/javase/7/docs/api/java/util/Comparator.html) object. |
+`size`
+: The number of items the grouped list(s) has to contain. When the specified size is reached, the tuple is emitted.
+
+`sort`
+: Defines the sorting criteria for the grouped items. Can be one of the following values:
+
+  - `false`: No sorting is applied (default).
+  - `true`: Order the grouped items by the item's natural ordering i.e. numerical for number, lexicographic for string, etc. See the [Java documentation](http://docs.oracle.com/javase/tutorial/collections/interfaces/order.html) for more information.
+  - `hash`: Order the grouped items by the hash number associated to each entry.
+  - `deep`: Similar to the previous, but the hash number is created on actual entries content e.g. when the item is a file, the hash is created on the actual file content.
+  - A custom sorting criteria used to order the tuples element holding list of values. It can be specified by using either a {ref}`Closure <script-closure>` or a [Comparator](http://docs.oracle.com/javase/7/docs/api/java/util/Comparator.html) object.
 
 :::{tip}
 You should always specify the number of expected elements in each tuple with the `size` attribute, so that the `groupTuple` operator can stream each collected value as soon as possible. In cases where the size of each tuple may vary depending on the grouping key, you can use the built-in `groupKey` function, which allows you to create a special grouping key object with an associated size.
@@ -930,14 +941,19 @@ left.join(right, remainder: true).view()
 [P, 7, null]
 ```
 
-The following parameters can be used with the `join` operator:
+Available options:
 
-| Name            | Description                                                                                                                                                          |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by              | The index (zero based) of the element to be used as grouping key. A key composed by multiple elements can be defined specifying a list of indices e.g. `by: [0,2]`   |
-| remainder       | When `false` incomplete tuples (i.e. with less than `size` grouped items) are discarded (default). When `true` incomplete tuples are emitted as the ending emission. |
-| failOnDuplicate | An error is reported when the same key is found more than once.                                                                                                      |
-| failOnMismatch  | An error is reported when a channel emits a value for which there isn't a corresponding element in the joining channel. This option cannot be used with `remainder`. |
+`by`
+: The index (zero based) of the element to be used as grouping key. A key composed by multiple elements can be defined specifying a list of indices e.g. `by: [0,2]`.
+
+`failOnDuplicate`
+: An error is reported when the same key is found more than once.
+
+`failOnMismatch`
+: An error is reported when a channel emits a value for which there isn't a corresponding element in the joining channel. This option cannot be used with `remainder`.
+
+`remainder`
+: When `false` incomplete tuples (i.e. with less than `size` grouped items) are discarded (default). When `true` incomplete tuples are emitted as the ending emission.
 
 (operator-last)=
 
@@ -1318,20 +1334,37 @@ Channel
     .view { row -> "${row.col1} - ${row.col2} - ${row.col3}" }
 ```
 
-Available parameters:
+Available options:
 
-| Field      | Description                                                                                                                                                     |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by         | The number of rows in each `chunk`                                                                                                                              |
-| sep        | The character used to separate the values (default: `,`)                                                                                                        |
-| quote      | Values may be quoted by single or double quote characters.                                                                                                      |
-| header     | When `true` the first line is used as columns names. Alternatively it can be used to provide the list of columns names.                                         |
-| charset    | Parse the content by using the specified charset e.g. `UTF-8`                                                                                                   |
-| strip      | Removes leading and trailing blanks from values (default: `false`)                                                                                              |
-| skip       | Number of lines since the file beginning to ignore when parsing the CSV content.                                                                                |
-| limit      | Limits the number of retrieved records for each file to the specified value.                                                                                    |
-| decompress | When `true` decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically) |
-| elem       | The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element)           |
+`by`
+: The number of rows in each `chunk`
+
+`charset`
+: Parse the content by using the specified charset e.g. `UTF-8`
+
+`decompress`
+: When `true` decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically)
+
+`elem`
+: The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element)
+
+`header`
+: When `true` the first line is used as columns names. Alternatively it can be used to provide the list of columns names.
+
+`limit`
+: Limits the number of retrieved records for each file to the specified value.
+
+`quote`
+: Values may be quoted by single or double quote characters.
+
+`sep`
+: The character used to separate the values (default: `,`)
+
+`skip`
+: Number of lines since the file beginning to ignore when parsing the CSV content.
+
+`strip`
+: Removes leading and trailing blanks from values (default: `false`)
 
 ## splitFasta
 
@@ -1364,31 +1397,42 @@ Channel
 
 In this example, the file `misc/sample.fa` is split into records containing the `id` and the `seqString` fields (i.e. the sequence id and the sequence data). The following `filter` operator only keeps the sequences whose ID starts with the `ENST0` prefix, finally the sequence content is printed by using the `subscribe` operator.
 
-Available parameters:
+Available options:
 
-| Field      | Description                                                                                                                                                                                                                                                                            |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by         | Defines the number of sequences in each `chunk` (default: `1`)                                                                                                                                                                                                                         |
-| size       | Defines the size in memory units of the expected chunks eg. `1.MB`.                                                                                                                                                                                                                    |
-| limit      | Limits the number of retrieved sequences for each file to the specified value.                                                                                                                                                                                                         |
-| record     | Parse each entry in the FASTA file as record objects (see following table for accepted values)                                                                                                                                                                                         |
-| charset    | Parse the content by using the specified charset e.g. `UTF-8`                                                                                                                                                                                                                          |
-| compress   | When `true` resulting file chunks are GZIP compressed. The `.gz` suffix is automatically added to chunk file names.                                                                                                                                                                    |
-| decompress | When `true`, decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically)                                                                                                                       |
-| file       | When `true` saves each split to a file. Use a string instead of `true` value to create split files with a specific name (split index number is automatically added). Finally, set this attribute to an existing directory, in order to save the split files into the specified folder. |
-| elem       | The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element)                                                                                                                                  |
+`by`
+: Defines the number of sequences in each `chunk` (default: `1`)
 
-The following fields are available when using the `record` parameter:
+`charset`
+: Parse the content by using the specified charset e.g. `UTF-8`.
 
-| Field     | Description                                                                                                                 |
-| --------- | --------------------------------------------------------------------------------------------------------------------------- |
-| id        | The FASTA sequence identifier i.e. the word following the `>` symbol up to the first `blank` or `newline` character         |
-| header    | The first line in a FASTA sequence without the `>` character                                                                |
-| desc      | The text in the FASTA header following the ID value                                                                         |
-| text      | The complete FASTA sequence including the header                                                                            |
-| seqString | The sequence data as a single line string i.e. containing no `newline` characters                                           |
-| sequence  | The sequence data as a multi-line string (always ending with a `newline` character)                                         |
-| width     | Define the length of a single line when the `sequence` field is used, after that the sequence data continues on a new line. |
+`compress`
+: When `true` resulting file chunks are GZIP compressed. The `.gz` suffix is automatically added to chunk file names.
+
+`decompress`
+: When `true`, decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically).
+
+`elem`
+: The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element).
+
+`file`
+: When `true` saves each split to a file. Use a string instead of `true` value to create split files with a specific name (split index number is automatically added). Finally, set this attribute to an existing directory, in order to save the split files into the specified folder.
+
+`limit`
+: Limits the number of retrieved sequences for each file to the specified value.
+
+`record`
+: Parse each entry in the FASTA file as record objects. The following fields are available:
+
+  - `id`: The FASTA sequence identifier i.e. the word following the `>` symbol up to the first `blank` or `newline` character
+  - `header`: The first line in a FASTA sequence without the `>` character
+  - `desc`: The text in the FASTA header following the ID value
+  - `text`: The complete FASTA sequence including the header
+  - `seqString`: The sequence data as a single line string i.e. containing no `newline` characters
+  - `sequence`: The sequence data as a multi-line string (always ending with a `newline` character)
+  - `width`: Define the length of a single line when the `sequence` field is used, after that the sequence data continues on a new line.
+
+`size`
+: Defines the size in memory units of the expected chunks eg. `1.MB`.
 
 :::{tip}
 You can also use `countFasta` to count the number of entries in the FASTA file(s).
@@ -1439,28 +1483,39 @@ The `fromFilePairs` requires the `flat: true` option in order to emit the file p
 This operator assumes that the order of the paired-end reads correspond with each other and both files contain the same number of reads.
 :::
 
-Available parameters:
+Available options:
 
-| Field      | Description                                                                                                                                                                                                                                                                            |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by         | Defines the number of *reads* in each `chunk` (default: `1`)                                                                                                                                                                                                                           |
-| pe         | When `true` splits paired-end read files, therefore items emitted by the source channel must be tuples in which at least two elements are the read-pair files to be split.                                                                                                             |
-| limit      | Limits the number of retrieved *reads* for each file to the specified value.                                                                                                                                                                                                           |
-| record     | Parse each entry in the FASTQ file as record objects (see following table for accepted values)                                                                                                                                                                                         |
-| charset    | Parse the content by using the specified charset e.g. `UTF-8`                                                                                                                                                                                                                          |
-| compress   | When `true` resulting file chunks are GZIP compressed. The `.gz` suffix is automatically added to chunk file names.                                                                                                                                                                    |
-| decompress | When `true` decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically)                                                                                                                        |
-| file       | When `true` saves each split to a file. Use a string instead of `true` value to create split files with a specific name (split index number is automatically added). Finally, set this attribute to an existing directory, in order to save the split files into the specified folder. |
-| elem       | The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element)                                                                                                                                  |
+`by`
+: Defines the number of *reads* in each `chunk` (default: `1`)
 
-The following fields are available when using the `record` parameter:
+`charset`
+: Parse the content by using the specified charset e.g. `UTF-8`
 
-| Field         | Description                              |
-| ------------- | ---------------------------------------- |
-| readHeader    | Sequence header (without the `@` prefix) |
-| readString    | The raw sequence data                    |
-| qualityHeader | Base quality header (it may be empty)    |
-| qualityString | Quality values for the sequence          |
+`compress`
+: When `true` resulting file chunks are GZIP compressed. The `.gz` suffix is automatically added to chunk file names.
+
+`decompress`
+: When `true` decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically)
+
+`elem`
+: The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element)
+
+`file`
+: When `true` saves each split to a file. Use a string instead of `true` value to create split files with a specific name (split index number is automatically added). Finally, set this attribute to an existing directory, in order to save the split files into the specified folder.
+
+`limit`
+: Limits the number of retrieved *reads* for each file to the specified value.
+
+`pe`
+: When `true` splits paired-end read files, therefore items emitted by the source channel must be tuples in which at least two elements are the read-pair files to be split.
+
+`record`
+: Parse each entry in the FASTQ file as record objects. The following fields are available:
+
+  - `readHeader`: Sequence header (without the `@` prefix)
+  - `readString`: The raw sequence data
+  - `qualityHeader`: Base quality header (it may be empty)
+  - `qualityString`: Quality values for the sequence
 
 :::{tip}
 You can also use `countFastq` to count the number of entries in the FASTQ file(s).
@@ -1506,18 +1561,31 @@ Channel
 Text chunks returned by the `splitText` operator are always terminated by a `\n` newline character.
 :::
 
-Available parameters:
+Available options:
 
-| Field      | Description                                                                                                                                                                                                                                                                           |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by         | Defines the number of lines in each `chunk` (default: `1`).                                                                                                                                                                                                                           |
-| limit      | Limits the number of retrieved lines for each file to the specified value.                                                                                                                                                                                                            |
-| charset    | Parse the content by using the specified charset e.g. `UTF-8`.                                                                                                                                                                                                                        |
-| compress   | When `true` resulting file chunks are GZIP compressed. The `.gz` suffix is automatically added to chunk file names.                                                                                                                                                                   |
-| decompress | When `true`, decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically).                                                                                                                     |
-| file       | When `true` saves each split to a file. Use a string instead of `true` value to create split files with a specific name (split index number is automatically added). Finally, set this attribute to an existing directory, in oder to save the split files into the specified folder. |
-| elem       | The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element).                                                                                                                                |
-| keepHeader | Parses the first line as header and prepends it to each emitted chunk.                                                                                                                                                                                                                |
+`by`
+: Defines the number of lines in each `chunk` (default: `1`).
+
+`charset`
+: Parse the content by using the specified charset e.g. `UTF-8`.
+
+`compress`
+: When `true` resulting file chunks are GZIP compressed. The `.gz` suffix is automatically added to chunk file names.
+
+`decompress`
+: When `true`, decompress the content using the GZIP format before processing it (note: files whose name ends with `.gz` extension are decompressed automatically).
+
+`elem`
+: The index of the element to split when the operator is applied to a channel emitting list/tuple objects (default: first file object or first element).
+
+`file`
+: When `true` saves each split to a file. Use a string instead of `true` value to create split files with a specific name (split index number is automatically added). Finally, set this attribute to an existing directory, in oder to save the split files into the specified folder.
+
+`keepHeader`
+: Parses the first line as header and prepends it to each emitted chunk.
+
+`limit`
+: Limits the number of retrieved lines for each file to the specified value.
 
 :::{tip}
 You can also use `countLines` to count the number of lines in the text file(s).
@@ -1738,12 +1806,13 @@ The above snippet prints:
 [3, D]
 ```
 
-Available parameters:
+Available options:
 
-| Field     | Description                                                                                                                                          |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| by        | The index (zero based) of the element to be transposed. Multiple elements can be defined specifying as list of indices e.g. `by: [0,2]`              |
-| remainder | When `false` incomplete tuples are discarded (default). When `true` incomplete tuples are emitted containing a `null` in place of a missing element. |
+` by`
+: The index (zero based) of the element to be transposed. Multiple elements can be defined specifying as list of indices e.g. `by: [0,2]`
+
+` remainder`
+: When `false` incomplete tuples are discarded (default). When `true` incomplete tuples are emitted containing a `null` in place of a missing element.
 
 ## unique
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -332,17 +332,15 @@ An input definition consists of a *qualifier* and a *name*. The input qualifier 
 
 When a process is invoked in a workflow block, it must be provided a channel for each channel in the process input block, similar to calling a function with specific arguments. The examples provided in the following sections demonstrate how a process is invoked with input channels.
 
-The available input qualifiers are listed in the following table:
+The following input qualifiers are available:
 
-| Qualifier | Semantic                                                                                     |
-| --------- | -------------------------------------------------------------------------------------------- |
-| `val`     | Access the input value by name in the process script.                                        |
-| `file`    | (DEPRECATED) Handle the input value as a file, staging it properly in the execution context. |
-| `path`    | Handle the input value as a path, staging the file properly in the execution context.        |
-| `env`     | Use the input value to set an environment variable in the process script.                    |
-| `stdin`   | Forward the input value to the process `stdin` special file.                                 |
-| `tuple`   | Handle a group of input values having any of the above qualifiers.                           |
-| `each`    | Execute the process for each element in the input collection.                                |
+- `val`: Access the input value by name in the process script.
+- `file`: (DEPRECATED) Handle the input value as a file, staging it properly in the execution context.
+- `path`: Handle the input value as a path, staging the file properly in the execution context.
+- `env`: Use the input value to set an environment variable in the process script.
+- `stdin`: Forward the input value to the process `stdin` special file.
+- `tuple`: Handle a group of input values having any of the above qualifiers.
+- `each`: Execute the process for each element in the input collection.
 
 ### Input type `val`
 
@@ -493,7 +491,7 @@ workflow {
 }
 ```
 
-### Multiple input files
+#### Multiple input files
 
 A `path` input can also accept a collection of files instead of a single value. In this case, the input variable will be a Groovy list, and you can use it as such.
 
@@ -556,7 +554,7 @@ workflow {
 Rewriting input file names according to a named pattern is an extra feature and not at all required. The normal file input syntax introduced in the {ref}`process-input-path` section is valid for collections of multiple files as well. To handle multiple input files while preserving the original file names, use a variable identifier or the `*` wildcard.
 :::
 
-### Dynamic input file names
+#### Dynamic input file names
 
 When the input file name is specified by using the `name` option or a string literal, you can also use other input values as variables in the file name string. For example:
 
@@ -820,16 +818,14 @@ An output definition consists of a *qualifier* and a *name*. Some optional attri
 
 When a process is invoked, each process output is returned as a channel. The examples provided in the following sections demonstrate how to access the output channels of a process.
 
-The available output qualifiers are listed in the following table:
+The following output qualifiers are available:
 
-| Qualifier | Semantic                                                                      |
-| --------- | ----------------------------------------------------------------------------- |
-| `val`     | Emit the variable with the specified name.                                    |
-| `file`    | (DEPRECATED) Emit a file produced by the process with the specified name.     |
-| `path`    | Emit a file produced by the process with the specified name.                  |
-| `env`     | Emit the variable defined in the process environment with the specified name. |
-| `stdout`  | Emit the `stdout` of the executed process.                                    |
-| `tuple`   | Emit multiple values.                                                         |
+- `val`: Emit the variable with the specified name.
+- `file`: (DEPRECATED) Emit a file produced by the process with the specified name.
+- `path`: Emit a file produced by the process with the specified name.
+- `env`: Emit the variable defined in the process environment with the specified name.
+- `stdout`: Emit the `stdout` of the executed process.
+- `tuple`: Emit multiple values.
 
 ### Output type `val`
 
@@ -915,18 +911,27 @@ workflow {
 
 In the above example, the `randomNum` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding output channel. A downstream process with a compatible input channel will be able to receive it.
 
-A `path` output can be defined with any of the additional options defined in the following table.
+Available options:
 
-| Name            | Description                                                                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `glob`          | When `true` the specified name is interpreted as a glob pattern (default: `true`)                                                                  |
-| `hidden`        | When `true` hidden files are included in the matching output files (default: `false`)                                                              |
-| `followLinks`   | When `true` target files are return in place of any matching symlink (default: `true`)                                                             |
-| `type`          | Type of paths returned, either `file`, `dir` or `any` (default: `any`, or `file` if the specified file name pattern contains a double star (`**`)) |
-| `maxDepth`      | Maximum number of directory levels to visit (default: no limit)                                                                                    |
-| `includeInputs` | When `true` any input files matching an output file glob pattern are included.                                                                     |
+`followLinks`
+: When `true` target files are return in place of any matching symlink (default: `true`)
 
-### Multiple output files
+`glob`
+: When `true` the specified name is interpreted as a glob pattern (default: `true`)
+
+`hidden`
+: When `true` hidden files are included in the matching output files (default: `false`)
+
+`includeInputs`
+: When `true` any input files matching an output file glob pattern are included.
+
+`maxDepth`
+: Maximum number of directory levels to visit (default: no limit)
+
+`type`
+: Type of paths returned, either `file`, `dir` or `any` (default: `any`, or `file` if the specified file name pattern contains a double star (`**`))
+
+#### Multiple output files
 
 When an output file name contains a `*` or `?` wildcard character, it is interpreted as a [glob][glob] path matcher. This allows you to capture multiple files into a list and emit the list as a single value. For example:
 
@@ -969,7 +974,7 @@ Although the input files matching a glob output declaration are not included in 
 
 Read more about glob syntax at the following link [What is a glob?][what is a glob?]
 
-### Dynamic output file names
+#### Dynamic output file names
 
 When an output file name needs to be expressed dynamically, it is possible to define it using a dynamic string which references variables in the `input` block or in the script global context. For example:
 
@@ -1250,14 +1255,19 @@ process noCacheThis {
 }
 ```
 
-The `cache` directive possible values are shown in the following table:
+The following values are available:
 
-| Value            | Description                                                                                                                                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `false`          | Disable cache feature.                                                                                                                                                                                                            |
-| `true` (default) | Enable caching. Cache keys are created indexing input files meta-data information (name, size and last update timestamp attributes).                                                                                              |
-| `'deep'`         | Enable caching. Cache keys are created indexing input files content.                                                                                                                                                              |
-| `'lenient'`      | Enable caching. Cache keys are created indexing input files path and size attributes (this policy provides a workaround for incorrect caching invalidation observed on shared file systems due to inconsistent files timestamps). |
+`false`
+: Disable caching.
+
+`true` (default)
+: Enable caching. Cache keys are created indexing input files meta-data information (name, size and last update timestamp attributes).
+
+`'deep'`
+: Enable caching. Cache keys are created indexing input files content.
+
+`'lenient'`
+: Enable caching. Cache keys are created indexing input files path and size attributes (this policy provides a workaround for incorrect caching invalidation observed on shared file systems due to inconsistent files timestamps).
 
 (process-clusteroptions)=
 
@@ -1434,14 +1444,19 @@ As of version 22.04.0, `echo` has been deprecated and replaced by `debug`.
 
 The `errorStrategy` directive allows you to define how an error condition is managed by the process. By default when an error status is returned by the executed script, the process stops immediately. This in turn forces the entire pipeline to terminate.
 
-Table of available error strategies:
+The following error strategies are available:
 
-| Name        | Executor                                                                                                               |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `terminate` | Terminates the execution as soon as an error condition is reported. Pending jobs are killed (default)                  |
-| `finish`    | Initiates an orderly pipeline shutdown when an error condition is raised, waiting the completion of any submitted job. |
-| `ignore`    | Ignores processes execution errors.                                                                                    |
-| `retry`     | Re-submit for execution a process returning an error condition.                                                        |
+`terminate` (default)
+: Terminate the execution as soon as an error condition is reported. Pending jobs are killed.
+
+`finish`
+: Initiate an orderly pipeline shutdown when an error condition is raised, waiting for the completion of any submitted jobs.
+
+`ignore`
+: Ignore process execution errors.
+
+`retry`
+: Re-submit any process that returns an error condition.
 
 When setting the `errorStrategy` directive to `ignore` the process doesn't stop on an error condition, it just reports a message notifying you of the error event.
 
@@ -1485,27 +1500,29 @@ See also: [maxErrors](#maxerrors), [maxRetries](#maxretries) and [Dynamic comput
 
 The `executor` defines the underlying system where processes are executed. By default a process uses the executor defined globally in the `nextflow.config` file.
 
-The `executor` directive allows you to configure what executor has to be used by the process, overriding the default configuration. The following values can be used:
+The `executor` directive allows you to configure what executor has to be used by the process, overriding the default configuration.
 
-| Name                  | Executor                                                                                                                       |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `awsbatch`            | The process is executed using the [AWS Batch](https://aws.amazon.com/batch/) service.                                          |
-| `azurebatch`          | The process is executed using the [Azure Batch](https://azure.microsoft.com/en-us/services/batch/) service.                    |
-| `condor`              | The process is executed using the [HTCondor](https://research.cs.wisc.edu/htcondor/) job scheduler.                            |
-| `google-lifesciences` | The process is executed using the [Google Genomics Pipelines](https://cloud.google.com/life-sciences) service.                 |
-| `ignite`              | The process is executed using the [Apache Ignite](https://ignite.apache.org/) cluster.                                         |
-| `k8s`                 | The process is executed using the [Kubernetes](https://kubernetes.io/) cluster.                                                |
-| `local`               | The process is executed in the computer where `Nextflow` is launched.                                                          |
-| `lsf`                 | The process is executed using the [Platform LSF](http://en.wikipedia.org/wiki/Platform_LSF) job scheduler.                     |
-| `moab`                | The process is executed using the [Moab](http://www.adaptivecomputing.com/moab-hpc-basic-edition/) job scheduler.              |
-| `nqsii`               | The process is executed using the [NQSII](https://www.rz.uni-kiel.de/en/our-portfolio/hiperf/nec-linux-cluster) job scheduler. |
-| `oge`                 | Alias for the `sge` executor.                                                                                                  |
-| `pbs`                 | The process is executed using the [PBS/Torque](http://en.wikipedia.org/wiki/Portable_Batch_System) job scheduler.              |
-| `pbspro`              | The process is executed using the [PBS Pro](https://www.pbsworks.com/) job scheduler.                                          |
-| `sge`                 | The process is executed using the Sun Grid Engine / [Open Grid Engine](http://gridscheduler.sourceforge.net/).                 |
-| `slurm`               | The process is executed using the SLURM job scheduler.                                                                         |
-| `tes`                 | The process is executed using the [GA4GH TES](https://github.com/ga4gh/task-execution-schemas) service.                        |
-| `uge`                 | Alias for the `sge` executor.                                                                                                  |
+The following executors are available:
+
+| Name                  | Executor                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `awsbatch`            | [AWS Batch](https://aws.amazon.com/batch/) service                                          |
+| `azurebatch`          | [Azure Batch](https://azure.microsoft.com/en-us/services/batch/) service                    |
+| `condor`              | [HTCondor](https://research.cs.wisc.edu/htcondor/) job scheduler                            |
+| `google-lifesciences` | [Google Genomics Pipelines](https://cloud.google.com/life-sciences) service                 |
+| `ignite`              | [Apache Ignite](https://ignite.apache.org/) cluster                                         |
+| `k8s`                 | [Kubernetes](https://kubernetes.io/) cluster                                                |
+| `local`               | The computer where `Nextflow` is launched                                                   |
+| `lsf`                 | [Platform LSF](http://en.wikipedia.org/wiki/Platform_LSF) job scheduler                     |
+| `moab`                | [Moab](http://www.adaptivecomputing.com/moab-hpc-basic-edition/) job scheduler              |
+| `nqsii`               | [NQSII](https://www.rz.uni-kiel.de/en/our-portfolio/hiperf/nec-linux-cluster) job scheduler |
+| `oge`                 | Alias for the `sge` executor                                                                |
+| `pbs`                 | [PBS/Torque](http://en.wikipedia.org/wiki/Portable_Batch_System) job scheduler              |
+| `pbspro`              | [PBS Pro](https://www.pbsworks.com/) job scheduler                                          |
+| `sge`                 | Sun Grid Engine / [Open Grid Engine](http://gridscheduler.sourceforge.net/)                 |
+| `slurm`               | [SLURM](https://en.wikipedia.org/wiki/Slurm_Workload_Manager) workload manager              |
+| `tes`                 | [GA4GH TES](https://github.com/ga4gh/task-execution-schemas) service                        |
+| `uge`                 | Alias for the `sge` executor                                                                |
 
 The following example shows how to set the process's executor:
 
@@ -1613,6 +1630,10 @@ See also: [resourceLabels](#resourcelabels)
 
 ### machineType
 
+:::{note}
+This feature requires Nextflow 19.07.0 or later.
+:::
+
 The `machineType` can be used to specify a predefined Google Compute Platform [machine type](https://cloud.google.com/compute/docs/machine-types) when running using the {ref}`Google Life Sciences <google-lifesciences-executor>` executor.
 
 This directive is optional and if specified overrides the cpus and memory directives:
@@ -1626,10 +1647,6 @@ process foo {
   """
 }
 ```
-
-:::{note}
-This feature requires Nextflow 19.07.0 or later.
-:::
 
 See also: [cpus](#cpus) and [memory](#memory).
 
@@ -1801,32 +1818,6 @@ process your_task {
 
 The above snippet defines an environment variable named `FOO` which value is `bar`.
 
-The `pod` directive allows the definition of the following options:
-
-| Name                                            | Description                                                                                                                                                                                                                                                                                                                                  |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label: <K>, value: <V>`                        | Defines a pod label with key `K` and value `V`.                                                                                                                                                                                                                                                                                              |
-| `annotation: <K>, value: <V>`                   | Defines a pod annotation with key `K` and value `V`.                                                                                                                                                                                                                                                                                         |
-| `env: <E>, value: <V>`                          | Defines an environment variable with name `E` and whose value is given by the `V` string.                                                                                                                                                                                                                                                    |
-| `env: <E>, fieldPath: <V>`                      | Defines an environment variable with name `E` and whose value is given by the `V` [field path](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).                                                                                                                                       |
-| `env: <E>, config: <C/K>`                       | Defines an environment variable with name `E` and whose value is given by the entry associated to the key with name `K` in the [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) with name `C`.                                                                                                 |
-| `env: <E>, secret: <S/K>`                       | Defines an environment variable with name `E` and whose value is given by the entry associated to the key with name `K` in the [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with name `S`.                                                                                                                            |
-| `config: <C/K>, mountPath: </absolute/path>`    | Mounts a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) with name `C` with key `K` to the path `/absolute/path`. When the key component is omitted the path is interpreted as a directory and all the `ConfigMap` entries are exposed in that path.                                          |
-| `csi: <V>, mountPath: </absolute/path>`         | Mounts a [CSI ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes) with config `V`to the path `/absolute/path` (requires `22.11.0-edge` or later).                                                                                                                                        |
-| `emptyDir: <V>, mountPath: </absolute/path>`    | Mounts an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) with configuration `V` to the path `/absolute/path` (requires `22.11.0-edge` or later).                                                                                                                                                                  |
-| `secret: <S/K>, mountPath: </absolute/path>`    | Mounts a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with name `S` with key `K` to the path `/absolute/path`. When the key component is omitted the path is interpreted as a directory and all the `Secret` entries are exposed in that path.                                                                        |
-| `volumeClaim: <V>, mountPath: </absolute/path>` | Mounts a [Persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) with name `V` to the specified path location. Use the optional `subPath` parameter to mount a directory inside the referenced volume instead of its root. The volume may be mounted with `readOnly: true`, but is read/write by default. |
-| `imagePullPolicy: <V>`                          | Specifies the strategy to be used to pull the container image e.g. `imagePullPolicy: 'Always'`.                                                                                                                                                                                                                                              |
-| `imagePullSecret: <V>`                          | Specifies the secret name to access a private container image registry. See [Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) for details.                                                                                                                             |
-| `runAsUser: <UID>`                              | Specifies the user ID to be used to run the container. Shortcut for the `securityContext` option.                                                                                                                                                                                                                                            |
-| `securityContext: <V>`                          | Specifies the pod security context. See [Kubernetes security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for details.                                                                                                                                                                               |
-| `nodeSelector: <V>`                             | Specifies which node the process will run on. See [Kubernetes nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for details.                                                                                                                                                              |
-| `affinity: <V>`                                 | Specifies affinity for which nodes the process should run on. See [Kubernetes affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for details.                                                                                                                                    |
-| `automountServiceAccountToken: <V>`             | Specifies whether to [automount service account token](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) into process pods. If `V` is true, service account token is automounted into task pods (default).                                                                                                |
-| `priorityClassName: <V>`                        | Specifies the [priority class name](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for pods.                                                                                                                                                                                                              |
-| `toleration: <V>`                               | Specifies a toleration for a node taint. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.                                                                                                                                                                            |
-| `privileged: <B>`                               | Whether the process task should run as a *privileged* container (default: `false`)                                                                                                                                                                                                                                                           |
-
 When defined in the Nextflow configuration file, a pod setting can be defined using the canonical associative array syntax. For example:
 
 ```groovy
@@ -1843,7 +1834,84 @@ process {
 }
 ```
 
-Some settings, including environment variables, configs, secrets, volume claims, and tolerations, can be specified multiple times for different values.
+The `pod` directive supports the following options:
+
+`affinity: <V>`
+: Specifies affinity for which nodes the process should run on. See [Kubernetes affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for details.
+
+`annotation: <K>, value: <V>`
+: *Can be specified multiple times*
+: Defines a pod annotation with key `K` and value `V`.
+
+`automountServiceAccountToken: <V>`
+: Specifies whether to [automount service account token](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) into process pods. If `V` is true, service account token is automounted into task pods (default).
+
+`config: <C/K>, mountPath: </absolute/path>`
+: *Can be specified multiple times*
+: Mounts a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) with name `C` with key `K` to the path `/absolute/path`. When the key component is omitted the path is interpreted as a directory and all the `ConfigMap` entries are exposed in that path.
+
+`csi: <V>, mountPath: </absolute/path>`
+: *Requires `22.11.0-edge` or later*
+: *Can be specified multiple times*
+: Mounts a [CSI ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes) with config `V`to the path `/absolute/path`.
+
+`emptyDir: <V>, mountPath: </absolute/path>`
+: *Requires `22.11.0-edge` or later*
+: *Can be specified multiple times*
+: Mounts an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) with configuration `V` to the path `/absolute/path`.
+
+`env: <E>, config: <C/K>`
+: *Can be specified multiple times*
+: Defines an environment variable with name `E` and whose value is given by the entry associated to the key with name `K` in the [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) with name `C`.
+
+`env: <E>, fieldPath: <V>`
+: *Can be specified multiple times*
+: Defines an environment variable with name `E` and whose value is given by the `V` [field path](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
+
+`env: <E>, secret: <S/K>`
+: *Can be specified multiple times*
+: Defines an environment variable with name `E` and whose value is given by the entry associated to the key with name `K` in the [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with name `S`.
+
+`env: <E>, value: <V>`
+: *Can be specified multiple times*
+: Defines an environment variable with name `E` and whose value is given by the `V` string.
+
+`imagePullPolicy: <V>`
+: Specifies the strategy to be used to pull the container image e.g. `imagePullPolicy: 'Always'`.
+
+`imagePullSecret: <V>`
+: Specifies the secret name to access a private container image registry. See [Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) for details.
+
+`label: <K>, value: <V>`
+: *Can be specified multiple times*
+: Defines a pod label with key `K` and value `V`.
+
+`nodeSelector: <V>`
+: Specifies which node the process will run on. See [Kubernetes nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for details.
+
+`priorityClassName: <V>`
+: Specifies the [priority class name](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for pods.
+
+`privileged: <B>`
+: Whether the process task should run as a *privileged* container (default: `false`)
+
+`runAsUser: <UID>`
+: Specifies the user ID to be used to run the container. Shortcut for the `securityContext` option.
+
+`secret: <S/K>, mountPath: </absolute/path>`
+: *Can be specified multiple times*
+: Mounts a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with name `S` with key `K` to the path `/absolute/path`. When the key component is omitted the path is interpreted as a directory and all the `Secret` entries are exposed in that path.
+
+`securityContext: <V>`
+: Specifies the pod security context. See [Kubernetes security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for details.
+
+`toleration: <V>`
+: *Can be specified multiple times*
+: Specifies a toleration for a node taint. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.
+
+`volumeClaim: <V>, mountPath: </absolute/path>`
+: *Can be specified multiple times*
+: Mounts a [Persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) with name `V` to the specified path location. Use the optional `subPath` parameter to mount a directory inside the referenced volume instead of its root. The volume may be mounted with `readOnly: true`, but is read/write by default.
 
 (process-publishdir)=
 
@@ -1874,36 +1942,7 @@ Only files that match the declaration in the `output` block are published, not a
 The `publishDir` directive can be specified more than once in order to publish output files to different target directories based on different rules.
 :::
 
-By default files are published to the target folder creating a *symbolic link* for each process output that links the file produced into the process working directory. This behavior can be modified using the `mode` parameter.
-
-Table of optional parameters that can be used with the `publishDir` directive:
-
-| Name         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| mode         | The file publishing method. See the following table for possible values.                                                                                                                                                                                                                                                                                                                                                                                |
-| overwrite    | When `true` any existing file in the specified folder will be overridden (default: `true` during normal pipeline execution and `false` when pipeline execution is `resumed`).                                                                                                                                                                                                                                                                           |
-| pattern      | Specifies a [glob][glob] file pattern that selects which files to publish from the overall set of output files.                                                                                                                                                                                                                                                                                                                                         |
-| path         | Specifies the directory where files need to be published. **Note**: the syntax `publishDir '/some/dir'` is a shortcut for `publishDir path: '/some/dir'`.                                                                                                                                                                                                                                                                                               |
-| saveAs       | A closure which, given the name of the file being published, returns the actual file name or a full path where the file is required to be stored. This can be used to rename or change the destination directory of the published files dynamically by using a custom strategy. Return the value `null` from the closure to *not* publish a file. This is useful when the process has multiple output files, but you want to publish only some of them. |
-| enabled      | Enable or disable the publish rule depending on the boolean value specified (default: `true`).                                                                                                                                                                                                                                                                                                                                                          |
-| failOnError  | When `true` abort the execution if some file can't be published to the specified target directory or bucket for any cause (default: `false`)                                                                                                                                                                                                                                                                                                            |
-| contentType  | Allow specifying the media content type of the published file a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types). If set to `true`, the content type is inferred from the file extension (EXPERIMENTAL. Currently only supported for S3. Default: `false`, requires version `22.10.0` or later).                                                                                                           |
-| storageClass | Allow specifying the storage class to be used for the published file (EXPERIMENTAL. Currently only supported for S3. Requires version `22.12.0-edge` or later).                                                                                                                                                                                                                                                                                         |
-| tags         | Allow the association of arbitrary tags with the published file e.g. `tags: [FOO: 'Hello world']` (EXPERIMENTAL. Currently only supported by files stored on AWS S3. Requires version `21.12.0-edge` or later).                                                                                                                                                                                                                                         |
-
-Table of publish modes:
-
-| Mode         | Description                                                                                                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| symlink      | Creates an absolute symbolic link in the published directory for each process output file (default).                                                                                                     |
-| rellink      | Creates a relative symbolic link in the published directory for each process output file.                                                                                                                |
-| link         | Creates a hard link in the published directory for each process output file.                                                                                                                             |
-| copy         | Copies the output files into the published directory.                                                                                                                                                    |
-| copyNoFollow | Copies the output files into the published directory without following symlinks ie. copies the links themselves.                                                                                         |
-| move         | Moves the output files into the published directory. **Note**: this is only supposed to be used for a *terminating* process i.e. a process whose output is not consumed by any other downstream process. |
-
-:::{note}
-The `mode` value must be specified as a string literal, i.e. in quotes. Multiple parameters need to be separated by a colon character. For example:
+By default files are published to the target folder creating a *symbolic link* for each process output that links the file produced into the process working directory. This behavior can be modified using the `mode` option, for example:
 
 ```groovy
 process foo {
@@ -1917,11 +1956,55 @@ process foo {
     '''
 }
 ```
-:::
 
 :::{warning}
-Files are copied into the specified directory in an *asynchronous* manner, so they may not be immediately available in the published directory at the end of the process execution. For this reason, downstream processes should not try to access output files through the publish directory, but through channels.
+Files are copied into the specified directory in an *asynchronous* manner, so they may not be immediately available in the publish directory at the end of the process execution. For this reason, downstream processes should not try to access output files through the publish directory, but through channels.
 :::
+
+Available options:
+
+`contentType`
+: *Requires version `22.10.0` or later*
+: *EXPERIMENTAL. Currently only supported for S3*
+: Allow specifying the media content type of the published file a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types). If set to `true`, the content type is inferred from the file extension (default: `false`).
+
+`enabled`
+: Enable or disable the publish rule depending on the boolean value specified (default: `true`).
+
+`failOnError`
+: When `true` abort the execution if some file can't be published to the specified target directory or bucket for any cause (default: `false`)
+
+`mode`
+: The file publishing method. Can be one of the following values:
+
+  - `'copy'`: Copies the output files into the publish directory.
+  - `'copyNoFollow'`: Copies the output files into the publish directory without following symlinks ie. copies the links themselves.
+  - `'link'`: Creates a hard link in the publish directory for each output file.
+  - `'move'`: Moves the output files into the publish directory. **Note**: this is only supposed to be used for a *terminal* process i.e. a process whose output is not consumed by any other downstream process.
+  - `'rellink'`: Creates a relative symbolic link in the publish directory for each output file.
+  - `'symlink'`: Creates an absolute symbolic link in the publish directory for each output file (default).
+
+`overwrite`
+: When `true` any existing file in the specified folder will be overridden (default: `true` during normal pipeline execution and `false` when pipeline execution is `resumed`).
+
+`path`
+: Specifies the directory where files need to be published. **Note**: the syntax `publishDir '/some/dir'` is a shortcut for `publishDir path: '/some/dir'`.
+
+`pattern`
+: Specifies a [glob][glob] file pattern that selects which files to publish from the overall set of output files.
+
+`saveAs`
+: A closure which, given the name of the file being published, returns the actual file name or a full path where the file is required to be stored. This can be used to rename or change the destination directory of the published files dynamically by using a custom strategy. Return the value `null` from the closure to *not* publish a file. This is useful when the process has multiple output files, but you want to publish only some of them.
+
+`storageClass`
+: *Requires version `22.12.0-edge` or later*
+: *EXPERIMENTAL. Currently only supported for S3*
+: Allow specifying the storage class to be used for the published file.
+
+`tags`
+: *Requires version `21.12.0-edge` or later*
+: *EXPERIMENTAL. Currently only supported for S3*
+: Allow the association of arbitrary tags with the published file e.g. `tags: [FOO: 'Hello world']`.
 
 (process-queue)=
 
@@ -2006,33 +2089,27 @@ process simpleTask {
 
 By doing this, it tries to execute the script in the directory defined by the variable `$TMPDIR` in the execution node. If this variable does not exist, it will create a new temporary directory by using the Linux command `mktemp`.
 
-A custom environment variable, other than `$TMPDIR`, can be specified by simply using it as the scratch value, for example:
+:::{note}
+Cloud-based executors use `scratch = true` by default, since the work directory resides in object storage.
+:::
 
-```groovy
-scratch '$MY_GRID_TMP'
-```
+The following values are supported:
 
-Note, it must be wrapped by single quotation characters, otherwise the variable will be evaluated in the pipeline script context.
+`false`
+: Do not use a scratch directory.
 
-You can also provide a specific folder path as scratch value, for example:
+`true`
+: Create a scratch directory in the directory defined by the `$TMPDIR` environment variable, or `$(mktemp /tmp)` if `$TMPDIR` is not set.
 
-```groovy
-scratch '/tmp/my/path'
-```
+`'$YOUR_VAR'`
+: Create a scratch directory in the directory defined by the given environment variable, or `$(mktemp /tmp)` if that variable is not set. The value must use single quotes, otherwise the environment variable will be evaluated in the pipeline script context.
 
-By doing this, a new temporary directory will be created in the specified path each time a process is executed.
+`'/my/tmp/path'`
+: Create a scratch directory in the specified directory.
 
-Finally, when the `ram-disk` string is provided as `scratch` value, the process will be execute in the node RAM virtual disk.
-
-Summary of allowed values:
-
-| scratch    | Description                                                                                                                                          |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| false      | Do not use the scratch folder.                                                                                                                       |
-| true       | Creates a scratch folder in the directory defined by the `$TMPDIR` variable; fallback to `mktemp /tmp` if that variable do not exists.               |
-| \$YOUR_VAR | Creates a scratch folder in the directory defined by the `$YOUR_VAR` environment variable; fallback to `mktemp /tmp` if that variable do not exists. |
-| /my/tmp    | Creates a scratch folder in the specified directory.                                                                                                 |
-| ram-disk   | Creates a scratch folder in the RAM disk `/dev/shm/` (experimental).                                                                                 |
+`'ram-disk'`
+: *EXPERIMENTAL*
+: Create a scratch directory in the RAM disk `/dev/shm/`.
 
 (process-directive-shell)=
 
@@ -2078,28 +2155,42 @@ The `spack` directive also allows the specification of a Spack environment file 
 
 ### stageInMode
 
-The `stageInMode` directive defines how input files are staged-in to the process work directory. The following values are allowed:
+The `stageInMode` directive defines how input files are staged into the process work directory. The following values are allowed:
 
-| Value   | Description                                                                                                                        |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| copy    | Input files are staged in the process work directory by creating a copy.                                                           |
-| link    | Input files are staged in the process work directory by creating an (hard) link for each of them.                                  |
-| symlink | Input files are staged in the process work directory by creating a symbolic link with an absolute path for each of them (default). |
-| rellink | Input files are staged in the process work directory by creating a symbolic link with a relative path for each of them.            |
+`'copy'`
+: Input files are staged in the process work directory by creating a copy.
+
+`'link'`
+: Input files are staged in the process work directory by creating a hard link for each of them.
+
+`'rellink'`
+: Input files are staged in the process work directory by creating a symbolic link with a relative path for each of them.
+
+`'symlink'`
+: Input files are staged in the process work directory by creating a symbolic link with an absolute path for each of them (default).
 
 (process-stageoutmode)=
 
 ### stageOutMode
 
-The `stageOutMode` directive defines how output files are staged-out from the scratch directory to the process work directory. The following values are allowed:
+The `stageOutMode` directive defines how output files are staged out from the scratch directory to the process work directory. The following values are allowed:
 
-| Value  | Description                                                                                            |
-| ------ | ------------------------------------------------------------------------------------------------------ |
-| copy   | Output files are copied from the scratch directory to the work directory.                              |
-| move   | Output files are moved from the scratch directory to the work directory.                               |
-| rsync  | Output files are copied from the scratch directory to the work directory by using the `rsync` utility. |
-| rclone | Output files are copied from the scratch directory to the work directory by using the [rclone](https://rclone.org) utility (note: it must be available in your cluster computing nodes, requires version `23.01.0-edge` or later). |
-| fcp    | Output files are copied from the scratch directory to the work directory by using the [fcp](https://github.com/Svetlitski/fcp) utility (note: it must be available in your cluster computing nodes, requires version `23.02.0-edge` or later). |
+`'copy'`
+: Output files are copied from the scratch directory to the work directory.
+
+`'fcp'`
+: *Requires version `23.02.0-edge` or later*
+: Output files are copied from the scratch directory to the work directory by using the [fcp](https://github.com/Svetlitski/fcp) utility (note: it must be available in your cluster computing nodes).
+
+`'move'`
+: Output files are moved from the scratch directory to the work directory.
+
+`'rclone'`
+: *Requires version `23.01.0-edge` or later*
+: Output files are copied from the scratch directory to the work directory by using the [rclone](https://rclone.org) utility (note: it must be available in your cluster computing nodes).
+
+`'rsync'`
+: Output files are copied from the scratch directory to the work directory by using the `rsync` utility.
 
 See also: [scratch](#scratch).
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -227,41 +227,74 @@ In the preceding example, `blastp` and its `-in`, `-out`, `-db` and `-html` swit
 
 The following variables are implicitly defined in the script global execution scope:
 
-| Name         | Description                                                                                                                                                |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `baseDir`    | The directory where the main workflow script is located (deprecated in favour of `projectDir` since `20.04.0`).                                            |
-| `launchDir`  | The directory where the workflow is run (requires version `20.04.0` or later).                                                                             |
-| `moduleDir`  | The directory where a module script is located for DSL2 modules or the same as `projectDir` for a non-module script (requires version `20.04.0` or later). |
-| `nextflow`   | Dictionary like object representing nextflow runtime information (see {ref}`metadata-nextflow`).                                                           |
-| `params`     | Dictionary like object holding workflow parameters specifying in the config file or as command line options.                                                |
-| `projectDir` | The directory where the main script is located (requires version `20.04.0` or later).                                                                      |
-| `workDir`    | The directory where tasks temporary files are created.                                                                                                     |
-| `workflow`   | Dictionary like object representing workflow runtime information (see {ref}`metadata-workflow`).                                                           |
+`baseDir`
+: *Deprecated since version `20.04.0` in favour of `projectDir`*
+: The directory where the main workflow script is located.
+
+`launchDir`
+: *Requires version `20.04.0` or later*
+: The directory where the workflow is run.
+
+`moduleDir`
+: *Requires version `20.04.0` or later*
+: The directory where a module script is located for DSL2 modules or the same as `projectDir` for a non-module script.
+
+`nextflow`
+: Dictionary like object representing nextflow runtime information (see {ref}`metadata-nextflow`).
+
+`params`
+: Dictionary like object holding workflow parameters specifying in the config file or as command line options.
+
+`projectDir`
+: *Requires version `20.04.0` or later*
+: The directory where the main script is located.
+
+`workDir`
+: The directory where tasks temporary files are created.
+
+`workflow`
+: Dictionary like object representing workflow runtime information (see {ref}`metadata-workflow`).
 
 ### Configuration implicit variables
 
 The following variables are implicitly defined in the Nextflow configuration file:
 
-| Name         | Description                                                                                                     |
-| ------------ | --------------------------------------------------------------------------------------------------------------- |
-| `baseDir`    | The directory where the main workflow script is located (deprecated in favour of `projectDir` since `20.04.0`). |
-| `launchDir`  | The directory where the workflow is run (requires version `20.04.0` or later).                                  |
-| `projectDir` | The directory where the main script is located (requires version `20.04.0` or later).                           |
+`baseDir`
+: *Deprecated since `20.04.0` in favour of `projectDir`*
+: The directory where the main workflow script is located.
+
+`launchDir`
+: *Requires version `20.04.0` or later*
+: The directory where the workflow is run.
+
+`projectDir`
+: *Requires version `20.04.0` or later*
+: The directory where the main script is located.
 
 ### Process implicit variables
 
 The following variables are implicitly defined in the `task` object of each process:
 
-| Name      | Description                                                      |
-| --------- | ---------------------------------------------------------------- |
-| `attempt` | The current task attempt                                         |
-| `hash`    | * The task unique hash ID                                        |
-| `index`   | The task index (corresponds to `task_id` in the execution trace) |
-| `name`    | * The current task name                                          |
-| `process` | The current process name                                         |
-| `workDir` | * The task unique directory                                      |
+`attempt`
+: The current task attempt
 
-Variables marked with (*) are only available in an `exec:` block.
+`hash`
+: *Available only in `exec:` blocks*
+: The task unique hash ID
+
+`index`
+: The task index (corresponds to `task_id` in the execution trace)
+
+`name`
+: *Available only in `exec:` blocks*
+: The current task name
+
+`process`
+: The current process name
+
+`workDir`
+: *Available only in `exec:` blocks*
+: The task unique directory
 
 The `task` object also contains the values of all process directives for the given task, which allows you to access these settings at runtime. For examples:
 
@@ -274,7 +307,7 @@ process foo {
 }
 ```
 
-In the above snippet the `task.cpus` report the value for the {ref}`cpus directive<process-cpus>` and the `task.memory` the current value for {ref}`memory directive<process-memory>` depending on the actual setting given in the workflow configuration file.
+In the above snippet the `task.cpus` holds the value for the {ref}`cpus directive<process-cpus>` and the `task.memory` the current value for {ref}`memory directive<process-memory>` depending on the actual setting given in the workflow configuration file.
 
 See {ref}`Process directives <process-directives>` for details.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -18,12 +18,17 @@ When the pipeline execution is launched Nextflow inject the secrets in pipeline 
 
 Nextflow provides a command named `secrets`. This command allows four simple operations:
 
-| Operation  | Description                                                                                                             |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `list`     | List secrets available in the current store e.g. `nextflow secrets list`.                                               |
-| `get`      | Allows retrieving a secret value e.g. `nextflow secrets get FOO`.                                                       |
-| `set`      | Allows creating a new secret or overriding an existing one e.g. `nextflow secrets set FOO "Hello world"`       |
-| `delete`   | Allows deleting an existing secret e.g. `nextflow secrets delete FOO`.                                                  |
+`list`
+: List secrets available in the current store e.g. `nextflow secrets list`.
+
+`get`
+: Retrieve a secret value e.g. `nextflow secrets get FOO`.
+
+`set`
+: Create or update a secret e.g. `nextflow secrets set FOO "Hello world"`
+
+`delete`
+: Delete a secret e.g. `nextflow secrets delete FOO`.
 
 ## Configuration file
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -169,16 +169,27 @@ In the above template replace `<provider-name>` with one of the "default" server
 
 The following configuration properties are supported for each provider configuration:
 
-| Name              | Description                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------ |
-| user              | User name required to access private repositories on the SCM server.                                   |
-| password          | User password required to access private repositories on the SCM server.                               |
-| token             | Private API access token (used only when the specified platform is `gitlab`).                          |
-| {sup}`*` platform | SCM platform name, either: `github`, `gitlab` or `bitbucket`.                                          |
-| {sup}`*` server   | SCM server name including the protocol prefix e.g. `https://github.com`.                               |
-| {sup}`*` endpoint | SCM API `endpoint` URL e.g. `https://api.github.com` (default: the same value specified for `server`). |
+`providers.<provider>.user`
+: User name required to access private repositories on the SCM server.
 
-The attributes marked with a * are only required when defining the configuration of a private SCM server.
+`providers.<provider>.password`
+: User password required to access private repositories on the SCM server.
+
+`providers.<provider>.token`
+: *Required only for private Gitlab servers*
+: Private API access token.
+
+`providers.<provider>.platform`
+: *Required only for private SCM servers*
+: SCM platform name, either: `github`, `gitlab` or `bitbucket`.
+
+`providers.<provider>.server`
+: *Required only for private SCM servers*
+: SCM server name including the protocol prefix e.g. `https://github.com`.
+
+`providers.<provider>.endpoint`
+: *Required only for private SCM servers*
+: SCM API `endpoint` URL e.g. `https://api.github.com` (default: the same as `providers.<provider>.server`).
 
 :::{tip}
 A custom location for the SCM file can be specified using the `NXF_SCM_FILE` environment variable (requires version `20.10.0` or later).

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -186,49 +186,129 @@ It will create a file named `trace.txt` in the current directory. The content lo
 
 The following table shows the fields that can be included in the execution report:
 
-| Name         | Description                                                                                                                                                                                               |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| task_id      | Task ID.                                                                                                                                                                                                  |
-| hash         | Task hash code.                                                                                                                                                                                           |
-| native_id    | Task ID given by the underlying execution system e.g. POSIX process PID when executed locally, job ID when executed by a grid engine, etc.                                                                |
-| process      | Nextflow process name.                                                                                                                                                                                    |
-| tag          | User provided identifier associated this task.                                                                                                                                                            |
-| name         | Task name.                                                                                                                                                                                                |
-| status       | Task status. Possible values are: `NEW`, `SUBMITTED`, `RUNNING`, `COMPLETED`, `FAILED`, and `ABORTED`.                                                                                                    |
-| exit         | POSIX process exit status.                                                                                                                                                                                |
-| module       | Environment module used to run the task.                                                                                                                                                                  |
-| container    | Docker image name used to execute the task.                                                                                                                                                               |
-| cpus         | The cpus number request for the task execution.                                                                                                                                                           |
-| time         | The time request for the task execution                                                                                                                                                                   |
-| disk         | The disk space request for the task execution.                                                                                                                                                            |
-| memory       | The memory request for the task execution.                                                                                                                                                                |
-| attempt      | Attempt at which the task completed.                                                                                                                                                                      |
-| submit       | Timestamp when the task has been submitted.                                                                                                                                                               |
-| start        | Timestamp when the task execution has started.                                                                                                                                                            |
-| complete     | Timestamp when task execution has completed.                                                                                                                                                              |
-| duration     | Time elapsed to complete since the submission.                                                                                                                                                            |
-| realtime     | Task execution time i.e. delta between completion and start timestamp.                                                                                                                                    |
-| queue        | The queue that the executor attempted to run the process on.                                                                                                                                              |
-| %cpu         | Percentage of CPU used by the process.                                                                                                                                                                    |
-| %mem         | Percentage of memory used by the process.                                                                                                                                                                 |
-| rss          | Real memory (resident set) size of the process. Equivalent to `ps -o rss` .                                                                                                                               |
-| vmem         | Virtual memory size of the process. Equivalent to `ps -o vsize` .                                                                                                                                         |
-| peak_rss     | Peak of real memory. This data is read from field `VmHWM` in `/proc/$pid/status` file.                                                                                                                    |
-| peak_vmem    | Peak of virtual memory. This data is read from field `VmPeak` in `/proc/$pid/status` file.                                                                                                                |
-| rchar        | Number of bytes the process read, using any read-like system call from files, pipes, tty, etc. This data is read from file `/proc/$pid/io`.                                                               |
-| wchar        | Number of bytes the process wrote, using any write-like system call. This data is read from file `/proc/$pid/io`.                                                                                         |
-| syscr        | Number of read-like system call invocations that the process performed. This data is read from file `/proc/$pid/io`.                                                                                      |
-| syscw        | Number of write-like system call invocations that the process performed. This data is read from file `/proc/$pid/io`.                                                                                     |
-| read_bytes   | Number of bytes the process directly read from disk. This data is read from file `/proc/$pid/io`.                                                                                                         |
-| write_bytes  | Number of bytes the process originally dirtied in the page-cache (assuming they will go to disk later). This data is read from file `/proc/$pid/io`.                                                      |
-| vol_ctxt     | Number of voluntary context switches.                                                                                                                                                                     |
-| inv_ctxt     | Number of involuntary context switches.                                                                                                                                                                   |
-| env          | The variables defined in task execution environment.                                                                                                                                                      |
-| workdir      | The directory path where the task was executed.                                                                                                                                                           |
-| script       | The task command script.                                                                                                                                                                                  |
-| scratch      | The value of the process `scratch` directive.                                                                                                                                                             |
-| error_action | The action applied on errof task failure.                                                                                                                                                                 |
-| hostname     | The host on which the task was executed. Supported only for the Kubernetes executor yet. Activate with `k8s.fetchNodeName = true` in the Nextflow config file. (requires version `22.05.0-edge` or later) |
+`task_id`
+: Task ID.
+
+`hash`
+: Task hash code.
+
+`native_id`
+: Task ID given by the underlying execution system e.g. POSIX process PID when executed locally, job ID when executed by a grid engine, etc.
+
+`process`
+: Nextflow process name.
+
+`tag`
+: User provided identifier associated this task.
+
+`name`
+: Task name.
+
+`status`
+: Task status. Possible values are: `NEW`, `SUBMITTED`, `RUNNING`, `COMPLETED`, `FAILED`, and `ABORTED`.
+
+`exit`
+: POSIX process exit status.
+
+`module`
+: Environment module used to run the task.
+
+`container`
+: Docker image name used to execute the task.
+
+`cpus`
+: The cpus number request for the task execution.
+
+`time`
+: The time request for the task execution
+
+`disk`
+: The disk space request for the task execution.
+
+`memory`
+: The memory request for the task execution.
+
+`attempt`
+: Attempt at which the task completed.
+
+`submit`
+: Timestamp when the task has been submitted.
+
+`start`
+: Timestamp when the task execution has started.
+
+`complete`
+: Timestamp when task execution has completed.
+
+`duration`
+: Time elapsed to complete since the submission.
+
+`realtime`
+: Task execution time i.e. delta between completion and start timestamp.
+
+`queue`
+: The queue that the executor attempted to run the process on.
+
+`%cpu`
+: Percentage of CPU used by the process.
+
+`%mem`
+: Percentage of memory used by the process.
+
+`rss`
+: Real memory (resident set) size of the process. Equivalent to `ps -o rss` .
+
+`vmem`
+: Virtual memory size of the process. Equivalent to `ps -o vsize` .
+
+`peak_rss`
+: Peak of real memory. This data is read from field `VmHWM` in `/proc/$pid/status` file.
+
+`peak_vmem`
+: Peak of virtual memory. This data is read from field `VmPeak` in `/proc/$pid/status` file.
+
+`rchar`
+: Number of bytes the process read, using any read-like system call from files, pipes, tty, etc. This data is read from file `/proc/$pid/io`.
+
+`wchar`
+: Number of bytes the process wrote, using any write-like system call. This data is read from file `/proc/$pid/io`.
+
+`syscr`
+: Number of read-like system call invocations that the process performed. This data is read from file `/proc/$pid/io`.
+
+`syscw`
+: Number of write-like system call invocations that the process performed. This data is read from file `/proc/$pid/io`.
+
+`read_bytes`
+: Number of bytes the process directly read from disk. This data is read from file `/proc/$pid/io`.
+
+`write_bytes`
+: Number of bytes the process originally dirtied in the page-cache (assuming they will go to disk later). This data is read from file `/proc/$pid/io`.
+
+`vol_ctxt`
+: Number of voluntary context switches.
+
+`inv_ctxt`
+: Number of involuntary context switches.
+
+`env`
+: The variables defined in task execution environment.
+
+`workdir`
+: The directory path where the task was executed.
+
+`script`
+: The task command script.
+
+`scratch`
+: The value of the process `scratch` directive.
+
+`error_action`
+: The action applied on errof task failure.
+
+`hostname`
+: *Requires version `22.05.0-edge` or later*
+: The host on which the task was executed. Supported only for the Kubernetes executor yet. Activate with `k8s.fetchNodeName = true` in the Nextflow config file.
 
 :::{note}
 These metrics provide an estimation of the resources used by running tasks. They are not an alternative to low-level performance analysis tools, and they may not be completely accurate, especially for very short-lived tasks (running for less than a few seconds).
@@ -365,20 +445,28 @@ Workflow events are sent as HTTP POST requests to the given URL. The message con
 
 The JSON object contains the following attributes:
 
-| Attribute | Description                                                                                                                                                                                                                          |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| runName   | The workflow execution run name.                                                                                                                                                                                                     |
-| runId     | The workflow execution unique ID.                                                                                                                                                                                                    |
-| event     | The workflow execution event. One of `started`, `process_submitted`, `process_started`, `process_completed`, `error`, `completed`.                                                                                                   |
-| utcTime   | The UTC timestamp in ISO 8601 format.                                                                                                                                                                                                |
-| trace     | A process runtime information as described in the {ref}`trace fields<trace-fields>` section. This attribute is only provided for the following events: `process_submitted`, `process_started`, `process_completed`, `error`.         |
-| metadata  | The workflow metadata including the {ref}`config manifest<config-manifest>`. For a list of all fields, have a look at the bottom message examples. This attribute is only provided for the following events: `started`, `completed`. |
+`runName`
+: The workflow execution run name.
 
-:::{note}
-The content of the `trace` attribute depends on the [Trace report](#trace-report) settings defined in the `nextflow.config` file. See the {ref}`Trace configuration<config-trace>` section to learn more.
-:::
+`runId`
+: The workflow execution unique ID.
 
-### Weblog Started example message
+`event`
+: The workflow execution event. One of `started`, `process_submitted`, `process_started`, `process_completed`, `error`, `completed`.
+
+`utcTime`
+: The UTC timestamp in ISO 8601 format.
+
+`trace`
+: *Included only for the following events: `process_submitted`, `process_started`, `process_completed`, `error`*
+: The task runtime information as described in the {ref}`trace fields<trace-fields>` section.
+: The set of included fields is determined by the `trace.fields` setting in the Nextflow configuration file. See the {ref}`Trace configuration<config-trace>` and [Trace report](#trace-report) sections to learn more.
+
+`metadata`
+: *Included only for the following events: `started`, `completed`*
+: The workflow metadata including the {ref}`config manifest<config-manifest>`. For a list of all fields, have a look at the bottom message examples.
+
+### Example `started` event
 
 When a workflow execution is started, a message like the following is posted to the specified end-point. Be aware that the properties in the parameter scope will look different for your workflow. Here is an example output from the `nf-core/hlatyping` pipeline with the weblog feature enabled:
 
@@ -479,9 +567,9 @@ When a workflow execution is started, a message like the following is posted to 
 }
 ```
 
-### Weblog Completed example message
+### Example `completed` event
 
-Once a process is completed, a message like the following is posted to the specified end-point:
+When a task is completed, a message like the following is posted to the specified end-point:
 
 ```json
 {

--- a/docs/wave.md
+++ b/docs/wave.md
@@ -121,16 +121,29 @@ See the {ref}`Fusion documentation <fusion-page>` for more details.
 
 The following configuration options are available:
 
-| Name                       | Description                                                                                                                                                             |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| wave.enabled               | Enable/disable the execution of Wave containers                                                                                                                         |
-| wave.endpoint              | The Wave service endpoint (default: `https://wave.seqera.io`)                                                                                                           |
-| wave.build.repository      | The container repository where images built by Wave are uploaded (note: the corresponding credentials must be provided in your Nextflow Tower account).                 |
-| wave.build.cacheRepository | The container repository used to cache image layers built by the Wave service (note: the corresponding credentials must be provided in your Nextflow Tower account).    |
-| wave.conda.mambaImage      | The Mamba container image is used to build Conda based container. This is expected to be [micromamba-docker](https://github.com/mamba-org/micromamba-docker) image.     |
-| wave.conda.commands        | One or more commands to be added to the Dockerfile used by build a Conda based image.                                                                                   |
-| wave.conda.basePackages    | One or more Conda packages that should always added in the resulting container e.g. `conda-forge::procps-ng`.                                                           |
-| wave.strategy              | The strategy to be used when resolving ambiguous Wave container requirement (default: `'container,dockerfile,conda'`)                                                   |
+`wave.enabled`
+: Enable/disable the execution of Wave containers
+
+`wave.endpoint`
+: The Wave service endpoint (default: `https://wave.seqera.io`)
+
+`wave.build.repository`
+: The container repository where images built by Wave are uploaded (note: the corresponding credentials must be provided in your Nextflow Tower account).
+
+`wave.build.cacheRepositor`
+: The container repository used to cache image layers built by the Wave service (note: the corresponding credentials must be provided in your Nextflow Tower account).
+
+`wave.conda.mambaImage`
+: The Mamba container image is used to build Conda based container. This is expected to be [micromamba-docker](https://github.com/mamba-org/micromamba-docker) image.
+
+`wave.conda.commands`
+: One or more commands to be added to the Dockerfile used by build a Conda based image.
+
+`wave.conda.basePackages`
+: One or more Conda packages that should always added in the resulting container e.g. `conda-forge::procps-ng`.
+
+`wave.strategy`
+: The strategy to be used when resolving ambiguous Wave container requirement (default: `'container,dockerfile,conda'`)
 
 ### More examples
 


### PR DESCRIPTION
I'm experimenting with something in the Markdown docs and wanted to run it by the two of you.

There are all of these huge tables, mostly on the Configuration page. They are hard to use because each option is packed onto a single line and you have to scroll horizontally to read a long option.

I converted some of these tables to definition lists and I think they are much better. Each option description is just a paragraph, so no more scrolling. I also moved version notes to separate lines so that they stand out. I think this change could set us up nicely in the future to expand on options that need it and just be more organized overall.

If you guys like what you see, I'll add these changes to the Markdown PR. 