### PR TITLE
Fix cleanup with remote work dir

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
@@ -237,7 +237,6 @@ class ScriptRunner {
 
     protected shutdown() {
         session.destroy()
-        session.cleanup()
         Global.cleanUp()
         log.debug "> Execution complete -- Goodbye"
     }


### PR DESCRIPTION
Closes #3645 and #2683 

Fixes an issue with cleanup on a remote work directory, which is caused by the plugin manager being shutdown before the cleanup.

I moved the cleanup code to happen after publishing is done but before the plugin manager and cache db are shutdown. However, I haven't been able to verify that the cleanup works. When I run the `hello` pipeline on AWS Batch with `-trace nextflow`, I don't get the error message anymore, but also the task directories aren't deleted.

Currently I have this code:
```groovy
            log.trace "Cleaning-up workdir"
            cache.eachRecord { HashCode hash, TraceRecord record ->
                log.trace "Cleaning task: ${hash.toString()}"

                def deleted = cache.removeTaskEntry(hash)
                if( deleted ) {
                    // delete folder
                    FileHelper.deletePath(FileHelper.asPath(record.workDir))
                }
            }
            log.trace "Clean workdir complete"
```

The log shows the outer trace messages, but not the inner message for each task. It's like the task records aren't there during the iteration.

The only difference with the old code is that the cleanup now uses the session's cache db reference rather than opening the cache itself. That was necessary because at that point the session's cache had been closed. Also, the old version used openForRead() instead of open(). But that shouldn't matter right?

@pditommaso what do you suggest?