### PR TITLE
Document return type of operators

### DIFF
--- a/docs/channel.rst
+++ b/docs/channel.rst
@@ -30,9 +30,9 @@ Queue channel
 A `queue channel` is a non-blocking unidirectional FIFO queue which connects two processes,
 channel factories, or operators.
 
-A queue channel is usually created using a factory method (:ref:`_channel-of`, :ref:`_channel-path`, etc)
-or chaining it with a channel operator (:ref:`operator-map`, :ref:`operator-flatmap`, etc). Queue channels
-are also created by process output declarations.
+A queue channel can be created by factory methods (`of`_, `fromPath`_, etc),
+operators (:ref:`operator-map`, :ref:`operator-flatmap`, etc), and
+processes (see :ref:`Process outputs <process-output>`).
 
 
 .. _channel-type-value:
@@ -40,16 +40,13 @@ are also created by process output declarations.
 Value channel
 -------------
 
-A `value channel` a.k.a. *singleton channel* is bound to a single value and can be read an
-unlimited number of times without consuming its content.
+A `value channel` a.k.a. *singleton channel* is bound to a single value and can be read any
+number of times without being consumed.
 
-A value channel is created using the `value`_ factory method or by operators returning
-a single value, such as :ref:`operator-first`, :ref:`operator-last`, :ref:`operator-collect`,
-:ref:`operator-count`, :ref:`operator-min`, :ref:`operator-max`, :ref:`operator-reduce`, :ref:`operator-sum`, etc.
-
-A value channel is implicitly created by a process when it is invoked with a simple value.
-Furthermore, a value channel is also implicitly created as output for a process whose
-inputs are all value channels.
+A value channel can be created with the `value`_ factory method or by any operator that produces
+a single value (:ref:`operator-first`, :ref:`operator-collect`, :ref:`operator-reduce`, etc). Additionally,
+a process will emit value channels if it is invoked with all value channels, including
+simple values which are implicitly wrapped in a value channel.
 
 For example::
 
@@ -71,7 +68,7 @@ For example::
     }
 
 In the above example, since the ``foo`` process is invoked with a simple value instead of a channel,
-the input is implicitly converted to a value channel, and the output is also provided as a value channel.
+the input is implicitly converted to a value channel, and the output is also emitted as a value channel.
 
 See also: :ref:`process-multiple-input-channels`.
 
@@ -95,7 +92,7 @@ empty
 
 The ``empty`` factory method, by definition, creates a channel that doesn't emit any value.
 
-See also: :ref:`operator-ifempty` and :ref:`operator-close` operators.
+See also: :ref:`operator-ifempty` operator.
 
 
 .. _channel-from:

--- a/docs/operator.rst
+++ b/docs/operator.rst
@@ -27,6 +27,8 @@ branch
 
 .. note:: Requires Nextflow version ``19.08.0-edge`` or later.
 
+*Returns: map of queue channels*
+
 The ``branch`` operator allows you to forward the items emitted by a source channel to one
 or more output channels, `choosing` one out of them at a time.
 
@@ -101,6 +103,8 @@ To create a branch criteria as variable that can be passed as an argument to mor
 
 buffer
 ------
+
+*Returns: queue channel*
 
 The ``buffer`` operator gathers the items emitted by the source channel into subsets and emits these subsets separately.
 
@@ -186,6 +190,8 @@ See also: `collate`_ operator.
 collate
 -------
 
+*Returns: queue channel*
+
 The ``collate`` operator transforms a channel in such a way that the emitted values are grouped in tuples containing `n` items. For example::
 
     Channel
@@ -237,6 +243,8 @@ See also: `buffer`_ operator.
 collect
 -------
 
+*Returns: value channel*
+
 The ``collect`` operator collects all the items emitted by a channel to a ``List`` and return
 the resulting object as a sole emission. For example::
 
@@ -273,6 +281,8 @@ See also: `toList`_ and `toSortedList`_ operator.
 
 collectFile
 -----------
+
+*Returns: queue channel*
 
 The ``collectFile`` operator allows you to gather the items emitted by a channel and save them to one or more files.
 The operator returns a new channel that emits the collected file(s).
@@ -389,6 +399,8 @@ The following example shows how use a `closure` to collect and sort all sequence
 combine
 -------
 
+*Returns: queue channel*
+
 The ``combine`` operator combines (cartesian product) the items emitted by two channels or by a channel and a ``Collection``
 object (as right operand). For example::
 
@@ -434,6 +446,8 @@ See also `join`_.
 concat
 ------
 
+*Returns: queue channel*
+
 The ``concat`` operator allows you to `concatenate` the items emitted by two or more channels to a new channel. The items emitted by the resulting channel are in the same order as specified in the operator arguments.
 
 Given `n` number of channels, the concatenation channel emits the items proceeding from the `i+1 th` channel 
@@ -463,6 +477,8 @@ It will output::
 
 count
 -----
+
+*Returns: value channel*
 
 The ``count`` operator creates a channel that emits a single item: a number that represents the total number of
 items emitted by the source channel. For example::
@@ -501,6 +517,8 @@ a literal value, a Java class, or a `boolean predicate` that needs to be satisfi
 cross
 -----
 
+*Returns: queue channel*
+
 The ``cross`` operator allows you to combine the items of two channels in such a way that
 the items of the source channel are emitted along with the items emitted by the target channel
 for which they have a matching key.
@@ -536,6 +554,8 @@ Optionally, a mapping function can be specified in order to provide a custom rul
 
 distinct
 --------
+
+*Returns: queue channel*
 
 The ``distinct`` operator allows you to remove `consecutive` duplicated items from a channel, so that each emitted item
 is different from the preceding one. For example::
@@ -577,6 +597,8 @@ For example::
 dump
 ----
 
+*Returns: queue channel or value channel, depending on the input*
+
 The ``dump`` operator prints the items emitted by the channel to which is applied only when the option
 ``-dump-channels`` is specified on the ``run`` command line, otherwise it is ignored.
 
@@ -607,6 +629,8 @@ The output can be formatted using the optional ``pretty`` boolean option. For ex
 
 filter
 ------
+
+*Returns: queue channel*
 
 The ``filter`` operator allows you to get only the items emitted by a channel that satisfy a condition and discarding
 all the others. The filtering condition can be specified by using either a :ref:`regular expression <script-regexp>`,
@@ -663,6 +687,8 @@ a channel emitting numbers so that the `odd` values are returned::
 first
 -----
 
+*Returns: value channel*
+
 The ``first`` operator creates a channel that returns the first item emitted by the source channel, or eventually
 the first item that matches an optional condition. The condition can be specified by using a :ref:`regular expression<script-regexp>`,
 a Java `class` type or any boolean `predicate`. For example::
@@ -696,6 +722,8 @@ a Java `class` type or any boolean `predicate`. For example::
 
 flatMap
 -------
+
+*Returns: queue channel*
 
 The ``flatMap`` operator applies a function of your choosing to every item emitted by a channel, and
 returns the items so obtained as a new channel. Whereas the `mapping` function returns a list of items,
@@ -744,6 +772,8 @@ Associative arrays are handled in the same way, so that each array entry is emit
 flatten
 -------
 
+*Returns: queue channel*
+
 The ``flatten`` operator transforms a channel in such a way that every item of type ``Collection`` or ``Array``
 is flattened so that each single entry is emitted separately by the resulting channel. For example::
 
@@ -764,40 +794,12 @@ is flattened so that each single entry is emitted separately by the resulting ch
 See also: `flatMap`_ operator.
 
 
-groupBy
--------
-
-.. warning::
-    This operator is deprecated. Use the `groupTuple`_ operator instead.
-
-The ``groupBy`` operator collects the values emitted by the source channel grouping them together using a `mapping`
-function that associates each item with a key. When finished, it emits an associative
-array that maps each key to the set of items identified by that key.
-
-For example::
-
-    Channel
-        .from('hello', 'ciao', 'hola', 'hi', 'bonjour')
-        .groupBy { String str -> str[0] }
-        .view()
-
-::
-
-    [ b:['bonjour'], c:['ciao'], h:['hello','hola','hi'] ]
-
-The `mapping` function is an optional parameter. When omitted, the values are grouped
-according to these rules:
-
-* Any value of type ``Map`` is associated with the value of its first entry, or ``null`` when the map itself is empty.
-* Any value of type ``Map.Entry`` is associated with the value of its ``key`` attribute.
-* Any value of type ``Collection`` or ``Array`` is associated with its first entry.
-* For any other value, the value itself is used as a key.
-
-
 .. _operator-grouptuple:
 
 groupTuple
 ----------
+
+*Returns: queue channel*
 
 The ``groupTuple`` operator collects tuples (or lists) of values emitted by the source channel grouping together the
 elements that share the same key. Finally it emits a new tuple object for each distinct key collected.
@@ -918,6 +920,8 @@ deep            Similar to the previous, but the hash number is created on actua
 ifEmpty
 -------
 
+*Returns: value channel*
+
 The ``ifEmpty`` operator creates a channel which emits a default value, specified as the operator parameter, when the channel to which
 is applied is *empty* i.e. doesn't emit any value. Otherwise it will emit the same sequence of entries as the original channel.
 
@@ -948,6 +952,8 @@ See also `tap`_.
 
 join
 ----
+
+*Returns: queue channel*
 
 The ``join`` operator creates a channel that joins together the items emitted by two channels for which exists
 a matching key. The key is defined, by default, as the first element in each item emitted.
@@ -999,6 +1005,8 @@ failOnMismatch  An error is reported when a channel emits a value for which ther
 last
 ----
 
+*Returns: value channel*
+
 The ``last`` operator creates a channel that only returns the last item emitted by the source channel. For example::
 
     Channel
@@ -1015,6 +1023,8 @@ The ``last`` operator creates a channel that only returns the last item emitted 
 
 map
 ---
+
+*Returns: queue channel*
 
 The ``map`` operator applies a function of your choosing to every item emitted by a channel, and
 returns the items so obtained as a new channel. The function applied is called the `mapping` function
@@ -1039,6 +1049,8 @@ and is expressed with a :ref:`closure <script-closure>` as shown in the example 
 
 max
 ---
+
+*Returns: value channel*
 
 The ``max`` operator waits until the source channel completes, and then emits the item that has the greatest value.
 For example::
@@ -1078,6 +1090,8 @@ taking two parameters that represent two emitted items to be compared. For examp
 
 merge
 -----
+
+*Returns: queue channel*
 
 The ``merge`` operator lets you join items emitted by two (or more) channels into a new channel.
 
@@ -1121,6 +1135,8 @@ An optional closure can be provided to customise the items emitted by the result
 min
 ---
 
+*Returns: value channel*
+
 The ``min`` operator waits until the source channel completes, and then emits the item that has the lowest value.
 For example::
 
@@ -1159,6 +1175,8 @@ taking two parameters that represent two emitted items to be compared. For examp
 
 mix
 ---
+
+*Returns: queue channel*
 
 The ``mix`` operator combines the items emitted by two (or more) channels into a single channel.
 
@@ -1199,6 +1217,8 @@ multiMap
 --------
 
 .. note:: Requires Nextflow version ``19.11.0-edge`` or later.
+
+*Returns: map of queue channels*
 
 The ``multiMap`` operator allows you to forward the items emitted by a source channel to two
 or more output channels, mapping each input value as a separate element.
@@ -1265,6 +1285,8 @@ that can be passed as an argument to one or more ``multiMap`` operations, as sho
 randomSample
 ------------
 
+*Returns: queue channel*
+
 The ``randomSample`` operator allows you to create a channel emitting the specified number of items randomly taken
 from the channel to which is applied. For example::
 
@@ -1291,6 +1313,8 @@ sequence will be returned.
 
 reduce
 ------
+
+*Returns: value channel*
 
 The ``reduce`` operator applies a function of your choosing to every item emitted by a channel.
 Each time this function is invoked it takes two parameters: firstly the accumulated value and
@@ -1325,6 +1349,8 @@ Optionally you can specify an initial value for the accumulator as shown below::
 set
 ---
 
+*Returns: nothing*
+
 The ``set`` operator assigns the channel to a variable whose name is specified as a closure parameter.
 For example::
 
@@ -1340,6 +1366,8 @@ of a chain of operator transformations, thus resulting in a more fluent and read
 
 splitCsv
 --------
+
+*Returns: queue channel*
 
 The ``splitCsv`` operator allows you to parse text items emitted by a channel, that are formatted using the
 `CSV format <http://en.wikipedia.org/wiki/Comma-separated_values>`_, and split them into records or group them into
@@ -1397,6 +1425,8 @@ elem        The index of the element to split when the operator is applied to a 
 
 splitFasta
 ----------
+
+*Returns: queue channel*
 
 The ``splitFasta`` operator allows you to split the entries emitted by a channel, that are formatted using the
 `FASTA format <http://en.wikipedia.org/wiki/FASTA_format>`_. It returns a channel which emits text item
@@ -1468,6 +1498,8 @@ width       Define the length of a single line when the ``sequence`` field is us
 
 splitFastq
 ----------
+
+*Returns: queue channel*
 
 The ``splitFastq`` operator allows you to split the entries emitted by a channel, that are formatted using the
 `FASTQ format <http://en.wikipedia.org/wiki/FASTQ_format>`_. It returns a channel which emits a text chunk
@@ -1548,6 +1580,8 @@ qualityString   Quality values for the sequence
 splitText
 ---------
 
+*Returns: queue channel*
+
 The ``splitText`` operator allows you to split multi-line strings or text file items, emitted by a source channel
 into chunks containing `n` lines, which will be emitted by the resulting channel.
 
@@ -1606,6 +1640,8 @@ keepHeader  Parses the first line as header and prepends it to each emitted chun
 
 subscribe
 ---------
+
+*Returns: nothing*
 
 The ``subscribe`` operator allows you to execute a user defined function each time a new value is emitted by the source channel.
 
@@ -1672,6 +1708,8 @@ For example::
 sum
 ---
 
+*Returns: value channel*
+
 The ``sum`` operator creates a channel that emits the sum of all the items emitted by the channel itself.
 For example::
 
@@ -1700,6 +1738,8 @@ a function that, given an item, returns the value to be summed. For example::
 take
 ----
 
+*Returns: queue channel*
+
 The ``take`` operator allows you to filter only the first `n` items emitted by a channel. For example::
 
     Channel
@@ -1722,7 +1762,9 @@ See also `until`_.
 tap
 ---
 
-The ``tap`` operator combines the functions of `into`_ and `separate`_ operators in such a way that
+*Returns: queue channel*
+
+The ``tap`` operator combines the functions of ``into`` and ``separate`` operators in such a way that
 it connects two channels, copying the values from the source into the `tapped` channel. At the same
 time it splits the source channel into a newly created channel that is returned by the operator itself.
 
@@ -1777,6 +1819,8 @@ Using the closure syntax the above example can be rewritten as shown below::
 toInteger
 ---------
 
+*Returns: queue channel*
+
 The ``toInteger`` operator allows you to convert the string values emitted by a channel to ``Integer`` values. For
 example::
 
@@ -1791,6 +1835,8 @@ example::
 
 toList
 ------
+
+*Returns: value channel*
 
 The ``toList`` operator collects all the items emitted by a channel to a ``List`` object
 and emits the resulting collection as a single item. For example::
@@ -1821,6 +1867,8 @@ See also: `collect`_ operator.
 toSortedList
 ------------
 
+*Returns: value channel*
+
 The ``toSortedList`` operator collects all the items emitted by a channel to a ``List`` object where they are sorted
 and emits the resulting collection as a single item. For example::
 
@@ -1850,6 +1898,8 @@ See also: `collect`_ operator.
 
 transpose
 ---------
+
+*Returns: queue channel*
 
 The ``transpose`` operator transforms a channel in such a way that the emitted items are the result of a transposition
 of all tuple elements in each item. For example::
@@ -1888,6 +1938,8 @@ remainder   When ``false`` incomplete tuples are discarded (default). When ``tru
 unique
 ------
 
+*Returns: queue channel*
+
 The ``unique`` operator allows you to remove duplicate items from a channel and only emit single items with no repetition.
 
 For example::
@@ -1921,6 +1973,8 @@ For example::
 until
 -----
 
+*Returns: queue channel*
+
 The ``until`` operator creates a channel that returns the items emitted by the source channel and stop when
 the condition specified is verified. For example::
 
@@ -1942,6 +1996,8 @@ See also `take`_.
 
 view
 ----
+
+*Returns: queue channel*
 
 The ``view`` operator prints the items emitted by a channel to the console standard output. For example::
 

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -895,6 +895,8 @@ It outputs::
 See also: :ref:`channel-types`.
 
 
+.. _process-output:
+
 Outputs
 =======
 


### PR DESCRIPTION
Documents for each operator whether it returns a queue channel or value channel.