### PR TITLE
Skip build CI for pull-requests too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
       - 'docs/**'
   pull_request:
     types: [opened, reopened, synchronize]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
The build CI tests are already skipped when only editing `docs/**` for the `push` event, but not for the `pull_request` event. This means that they run on every PR even if it's only to the docs.

This adds the `paths-ignore` config to the `pull_request` event, the same as `push`.