### PR TITLE
CI for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+# Dummy workflow to trigger the CI on PRs to the docs
+#
+# These PRs do not trigger the main Nextflow build + test CI
+# but that CI is required.
+# This workflow runs in that scenario and has the same name,
+# meaning that the required tests pass and the PR can be merged.
+# Ref: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Nextflow CI
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'docs/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,10 @@
-# Dummy workflow to trigger the CI on PRs to the docs
+# Docs CI
 #
-# These PRs do not trigger the main Nextflow build + test CI
-# but that CI is required.
-# This workflow runs in that scenario and has the same name,
-# meaning that the required tests pass and the PR can be merged.
+# Note that the workflow / job name is important and must match that in
+# build.yml. These names are required tests and PRs cannot be merged
+# unless they are passing.
+# The build triggers are complementary, so this workflow only runs if the PR is *all* docs.
+# The build.yml workflow runs if there are *any* changes outside of the docs.
 # Ref: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 name: Nextflow CI
 on:
@@ -15,4 +16,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip' # caching pip dependencies
+
+      - name: Test docs build
+        run: |
+          pip install sphinx==3.5.4 sphinx_rtd_theme
+          cd docs/
+          make clean html


### PR DESCRIPTION
See PR https://github.com/nextflow-io/nextflow/pull/3840 and discussion in https://github.com/nextflow-io/nextflow/pull/3839#issuecomment-1498691963

This PR adds a new CI workflow that has exactly the same name as the Nextflow build CI. It is only triggered in the complementary situation, so there should be no pull request where both run at the same time.

Having it here means that those tests can be set as required, but GitHub doesn't sit and wait forever for them to show up, meaning that pull-requests can be merged without forcing an admin override.