### PR TITLE
Propsal: Different CI trigger logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
     types: [opened, reopened, synchronize]
     paths-ignore:
       - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ name: Nextflow CI
 on:
   push:
     branches:
-      - '*'
-      - '!refs/tags/.*'
-    tags-ignore:
-      - '*'
+      - 'master'
     paths-ignore:
       - 'docs/**'
   pull_request:
@@ -17,7 +14,6 @@ on:
 
 jobs:
   build:
-    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 90


### PR DESCRIPTION
See discussion in https://github.com/nextflow-io/nextflow/pull/3839#issuecomment-1498736576

This PR changes the CI logic so that jobs only run on `push` to the `master` branch - ie. after PRs are merged, or on direct push to master.

The logic within the build steps is then simplified, so that jobs _always_ run on the `pull_request` event.

This should still mean that CI isn't double-triggered, but makes things a bit simpler and the logic a bit clearer when PRs are coming from forks / internal branches.