### PR TITLE
Fix `interval` channel factory

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
@@ -250,9 +250,9 @@ class Channel  {
         }
 
         if( NF.isDsl2() )
-            session.addIgniter { timer.schedule( task as TimerTask, millis ) }  
+            session.addIgniter { timer.schedule( task as TimerTask, 0, millis ) }  
         else 
-            timer.schedule( task as TimerTask, millis )
+            timer.schedule( task as TimerTask, 0, millis )
         
         return result
     }


### PR DESCRIPTION
Not really a high priority item, but I discovered this `Channel.interval` factory and found that it didn't work, it would only emit one item. I checked the [Timer](https://docs.oracle.com/javase/7/docs/api/java/util/Timer.html) API and found that the wrong method was being used, so I fixed it.

I assume no one is using it since it currently doesn't work, but I guess an interval function is a good component of any reactive library. If you want to keep it then I can document it as well.