### PR TITLE
Run build CI tests on push to branches starting with `test*` or `dev*`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - 'master'
+      - 'test*'
+      - 'dev*'
     paths-ignore:
       - 'docs/**'
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          cache: 'pip' # caching pip dependencies
 
       - name: Test docs build
         run: |


### PR DESCRIPTION
Adding in the suggested changes from @pditommaso to run build CI tests on branches beginning with `test*` or `dev*` (in addition to tests on pull-requests).

See https://github.com/nextflow-io/nextflow/pull/3842#discussion_r1163009298