### PR TITLE
Fix docs CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup env
         run: |
-             rm -f $HOME/.gitconfig; 
+             rm -f $HOME/.gitconfig;
              mkdir -p "$HOME/.nextflow";
              echo "providers.github.auth='$NXF_GITHUB_ACCESS_TOKEN'" > "$HOME/.nextflow/scm"
         env:
@@ -82,7 +82,7 @@ jobs:
           submodules: true
       - name: Setup env
         run: |
-          rm -f $HOME/.gitconfig; 
+          rm -f $HOME/.gitconfig;
           mkdir -p "$HOME/.nextflow";
           echo "providers.github.auth='$NXF_GITHUB_ACCESS_TOKEN'" > "$HOME/.nextflow/scm"
         env:
@@ -97,7 +97,7 @@ jobs:
       - name: Run tests
         run: |
           cat $HOME/.nextflow/scm
-          make assemble install 
+          make assemble install
           bash test-ci.sh
         env:
           TEST_JDK: ${{ matrix.java_version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,16 @@
 # The build triggers are complementary, so this workflow only runs if the PR is *all* docs.
 # The build.yml workflow runs if there are *any* changes outside of the docs.
 # Ref: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-name: Nextflow CI
+name: Docs CI
 on:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
       - 'docs/**'
+  workflow_dispatch:
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -23,6 +25,6 @@ jobs:
 
       - name: Test docs build
         run: |
-          pip install sphinx==3.5.4 sphinx_rtd_theme
+          pip install sphinx sphinx_rtd_theme
           cd docs/
           make clean html


### PR DESCRIPTION
* Remove sphinx version pin, this was breaking Jinja I think
* Add a trigger for the docs CI for workflow_dispatch
* Add specific job name, for required CI jobs
* Change workflow name, for nicer inspection in the UI

I actually tested this one in GitHub Actions [on my fork](https://github.com/ewels/nextflow/actions/runs/4675882335/jobs/8281504238) this time, instead of just testing commands locally. So I'm more confident that it'll work!

Sorry for the multiple-PR spam 😬 

Follow-on from https://github.com/nextflow-io/nextflow/pull/3842#issuecomment-1504813002