### PR TITLE
CI: Trigger build CI jobs when only docs changed, but skip all steps.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,11 @@ jobs:
           path: |
             **/build/reports/tests/test
 
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+
   test:
-    if: "!contains(github.event.head_commit.message, '[ci fast]')"
+    if: ${{ !contains(github.event.head_commit.message, '[ci fast]') && needs.build.outputs.any_changed == 'true' }}
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -92,14 +95,7 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v35
-        with:
-          files_ignore: docs
-
       - name: Setup env
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           rm -f $HOME/.gitconfig;
           mkdir -p "$HOME/.nextflow";
@@ -108,7 +104,6 @@ jobs:
           NXF_GITHUB_ACCESS_TOKEN: ${{ secrets.NXF_GITHUB_ACCESS_TOKEN }}
 
       - name: Setup Java ${{ matrix.java_version }}
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
@@ -117,7 +112,6 @@ jobs:
           cache: gradle
 
       - name: Run tests
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cat $HOME/.nextflow/scm
           make assemble install
@@ -141,12 +135,12 @@ jobs:
           AZURE_BATCH_ACCOUNT_KEY: ${{ secrets.AZURE_BATCH_ACCOUNT_KEY }}
 
       - name: Tar integration tests
-        if: steps.changed-files.outputs.any_changed == 'true' && always()
+        if: always()
         run: tar -cvf integration-tests.tar tests/checks
 
       - name: Publish tests report
         uses: actions/upload-artifact@v3
-        if: steps.changed-files.outputs.any_changed == 'true' && always()
+        if: always()
         with:
           name: report-${{ matrix.test_mode }}-jdk-${{ matrix.java_version }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,19 @@
 name: Nextflow CI
-# read more here
-# https://help.github.com/en/articles/workflow-syntax-for-github-actions#on
+# read more here: https://help.github.com/en/articles/workflow-syntax-for-github-actions#on
+
+# Note: We don't use the `on: path` option for docs,
+# because the Build steps are *required* tests.
+# Instead, we trigger + skip the tests if the only changes
+# are in the docs folder. GitHub treats this as passing.
+
 on:
   push:
     branches:
       - 'master'
       - 'test*'
       - 'dev*'
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     types: [opened, reopened, synchronize]
-    paths-ignore:
-      - 'docs/**'
   workflow_dispatch:
 
 jobs:
@@ -35,7 +36,14 @@ jobs:
           fetch-depth: 1
           submodules: true
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files_ignore: docs
+
       - name: Setup env
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
              rm -f $HOME/.gitconfig;
              mkdir -p "$HOME/.nextflow";
@@ -44,6 +52,7 @@ jobs:
           NXF_GITHUB_ACCESS_TOKEN: ${{ secrets.NXF_GITHUB_ACCESS_TOKEN }}
 
       - name: Setup Java ${{ matrix.java_version }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
@@ -52,14 +61,16 @@ jobs:
           cache: gradle
 
       - name: Compile
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make assemble
 
       - name: Test
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make test
 
       - name: Publish tests report
         uses: actions/upload-artifact@v3
-        if: always()
+        if: steps.changed-files.outputs.any_changed == 'true' && always()
         with:
           name: report-unit-tests-jdk-${{ matrix.java_version }}
           path: |
@@ -80,21 +91,33 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files_ignore: docs
+
       - name: Setup env
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           rm -f $HOME/.gitconfig;
           mkdir -p "$HOME/.nextflow";
           echo "providers.github.auth='$NXF_GITHUB_ACCESS_TOKEN'" > "$HOME/.nextflow/scm"
         env:
           NXF_GITHUB_ACCESS_TOKEN: ${{ secrets.NXF_GITHUB_ACCESS_TOKEN }}
+
       - name: Setup Java ${{ matrix.java_version }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
           distribution: 'adopt'
           architecture: x64
           cache: gradle
+
       - name: Run tests
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cat $HOME/.nextflow/scm
           make assemble install
@@ -118,12 +141,12 @@ jobs:
           AZURE_BATCH_ACCOUNT_KEY: ${{ secrets.AZURE_BATCH_ACCOUNT_KEY }}
 
       - name: Tar integration tests
-        if: always()
+        if: steps.changed-files.outputs.any_changed == 'true' && always()
         run: tar -cvf integration-tests.tar tests/checks
 
       - name: Publish tests report
         uses: actions/upload-artifact@v3
-        if: always()
+        if: steps.changed-files.outputs.any_changed == 'true' && always()
         with:
           name: report-${{ matrix.test_mode }}-jdk-${{ matrix.java_version }}
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,3 @@
-# Docs CI
-#
-# Note that the workflow / job name is important and must match that in
-# build.yml. These names are required tests and PRs cannot be merged
-# unless they are passing.
-# The build triggers are complementary, so this workflow only runs if the PR is *all* docs.
-# The build.yml workflow runs if there are *any* changes outside of the docs.
-# Ref: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 name: Docs CI
 on:
   pull_request:
@@ -14,7 +6,7 @@ on:
       - 'docs/**'
   workflow_dispatch:
 jobs:
-  build:
+  docs-build:
     name: Build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ok, _this is the one_... 🤣 

This will allow merging docs-only PRs with the required CI check in branch-protection, as GitHub treats skipped tests as passing.

Previous PRs used the `path` filter to avoid triggering the CI if a PR was docs-only, but this meant that the required tests never ran and the branch protection was never happy.

I mocked up the protected branch settings on my fork and have tested this in action in two PRs: [docs-only](https://github.com/ewels/nextflow/pull/1) and [core code](https://github.com/ewels/nextflow/pull/2).

---

## [Docs only](https://github.com/ewels/nextflow/pull/1):

* Docs CI runs
* Required Build steps run and pass, skipping basically all steps
* Test job is skipped

<img width="368" alt="image" src="https://user-images.githubusercontent.com/465550/231403619-0c3befc5-108f-4ffc-baa8-9a86b7856a2c.png">


<img width="756" alt="image" src="https://user-images.githubusercontent.com/465550/231403326-596a6951-deb3-4eb9-9d6b-ad9887f81616.png">

---

## [Code change](https://github.com/ewels/nextflow/pull/2) (no docs):

* Docs CI doesn't run
* Required Build steps run
* Test jobs run

<img width="489" alt="image" src="https://user-images.githubusercontent.com/465550/231405857-b9dccb44-64bc-4c9a-81a3-c19e801d4adc.png">
