### PR TITLE
Separate script parse from script run

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -147,12 +147,16 @@ class IncludeDef {
     static BaseScript loadModule0(Path path, Map params, Session session) {
         final binding = new ScriptBinding() .setParams(params)
 
-        // the execution of a library file has as side effect the registration of declared processes
-        new ScriptParser(session)
+        // parse the module script
+        final script = new ScriptParser(session)
                 .setModule(true)
                 .setBinding(binding)
-                .runScript(path)
-                .getScript()
+                .parse(path)
+
+        // execute the module script to register any definitions
+        script.run()
+
+        return script
     }
 
     @PackageScope

--- a/modules/nextflow/src/test/groovy/nextflow/script/BaseScriptTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/BaseScriptTest.groovy
@@ -22,11 +22,12 @@ import java.nio.file.Paths
 import nextflow.NextflowMeta
 import nextflow.Session
 import spock.lang.Specification
+import test.Dsl2Spec
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-class BaseScriptTest extends Specification {
+class BaseScriptTest extends Dsl2Spec {
 
 
     def 'should define implicit variables' () {
@@ -61,8 +62,7 @@ class BaseScriptTest extends Specification {
                 '''
 
         parser.setBinding(binding)
-        parser.runScript(script)
-
+        parser.parse(script).run()
 
         then:
         binding.result.baseDir ==PROJECT_DIR

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptParserTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptParserTest.groovy
@@ -26,12 +26,12 @@ class ScriptParserTest extends Specification {
         '''
 
         when:
-        parser.setBinding(binding)
-        parser.runScript(file)
+        def script = parser.setBinding(binding).parse(file)
+        def result = script.run()
         then:
-        parser.script instanceof BaseScript
-        parser.result == 'Hello world!'
-        parser.result == binding.getVariable('bar')
+        script instanceof BaseScript
+        result == 'Hello world!'
+        result == binding.getVariable('bar')
         parser.binding.getScriptPath() == file
         parser.binding.getSession() == session
         !session.binding.hasVariable('bar')
@@ -49,12 +49,12 @@ class ScriptParserTest extends Specification {
         '''
 
         when:
-        parser.setBinding(binding)
-        parser.runScript(TEXT)
+        def script = parser.setBinding(binding).parse(TEXT)
+        def result = script.run()
         then:
-        parser.script instanceof BaseScript
-        parser.result == 'Hello world!'
-        parser.result == binding.getVariable('bar')
+        script instanceof BaseScript
+        result == 'Hello world!'
+        result == binding.getVariable('bar')
         parser.binding.getScriptPath() == null
         parser.binding.getSession() == session
         !session.binding.hasVariable('bar')
@@ -72,30 +72,15 @@ class ScriptParserTest extends Specification {
         '''
 
         when:
-        parser.runScript(TEXT)
+        def script = parser.parse(TEXT)
+        def result = script.run()
         then:
-        parser.script instanceof BaseScript
-        parser.result == 'Hello world!'
+        script instanceof BaseScript
+        result == 'Hello world!'
         parser.binding.getScriptPath() == null
         parser.binding.getSession() == session
         session.binding.getVariable('foo') == 'Hello'
         session.binding.getVariable('bar') == 'Hello world!'
-    }
-
-    def 'should normalise script name'() {
-
-        given:
-        def parser = new ScriptParser(Mock(Session))
-
-        expect:
-        parser.computeClassName(Paths.get(SCRIPT)) == EXPECTED
-
-        where:
-        SCRIPT              | EXPECTED
-        'foo.nf'            | 'Script_foo'
-        'foo-bar-baz.nf'    | 'Script_foo_bar_baz'
-        '123-fo0'           | 'Script_23_fo0'
-        '--a  b  c'         | 'Script_a_b_c'
     }
 
     def 'should normalise script text' () {
@@ -134,7 +119,7 @@ class ScriptParserTest extends Specification {
         '''
 
         when:
-        parser.runScript(file)
+        parser.parse(file)
         then:
         def e = thrown(ScriptCompilationException)
         e.message.startsWith('Script compilation error')

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptRunnerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptRunnerTest.groovy
@@ -157,10 +157,10 @@ class ScriptRunnerTest extends Dsl2Spec {
 
         when:
         def runner = new MockScriptRunner().setScript(script)
-        runner.execute()
+        def result = runner.execute()
 
         then:
-        runner.result.val == 'echo 1'
+        result.val == 'echo 1'
         TaskProcessor.currentProcessor().name == 'simpleTask'
 
     }

--- a/modules/nextflow/src/testFixtures/groovy/test/TestParser.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/TestParser.groovy
@@ -50,7 +50,7 @@ class TestParser {
         }
 
         session.init(null,null)
-        new ScriptParser(session) .runScript(scriptText)
+        new ScriptParser(session).parse(scriptText).run()
         session.fireDataflowNetwork(false)
         return TaskProcessor.currentProcessor()
     }

--- a/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/extension/PluginExtensionMethodsTest.groovy
@@ -28,12 +28,14 @@ import nextflow.plugin.TestPluginManager
 import nextflow.plugin.extension.PluginExtensionProvider
 import spock.lang.Shared
 import spock.lang.TempDir
+import spock.lang.Timeout
 import test.Dsl2Spec
 import test.MockScriptRunner
 /**
  *
  * @author Jorge Aguilera <jorge.aguilera@seqera.io>
  */
+@Timeout(10)
 class PluginExtensionMethodsTest extends Dsl2Spec {
 
     @TempDir


### PR DESCRIPTION
Closes #3854 

The ScriptParser has a runScript() method which parses the script and then runs it, which is a confusing interface. So I separated the calls to parse and run a script. This fixes the issue where a runtime error is reported as a parse error.

Before:
```console
$ nextflow run gh-3854/
N E X T F L O W  ~  version 23.04.0
Launching `gh-3854/main.nf` [amazing_allen] DSL2 - revision: e672254d14
ERROR ~ Unable to read script: 'gh-3854/./test.nf' -- cause: non-existing-file.txt

 -- Check script 'gh-3854/main.nf' at line: 1 or see '.nextflow.log' file for more details
```

After:
```console
$ ../launch.sh run gh-3854/
N E X T F L O W  ~  version 23.04.0
Launching `gh-3854/main.nf` [magical_meitner] DSL2 - revision: e672254d14
ERROR ~ No such file or directory: non-existing-file.txt

 -- Check script 'gh-3854/./test.nf' at line: 2 or see '.nextflow.log' file for more details
```

Unfortunately a side effect of these changes is that some of the plugin tests are timing out and I can't figure out why 😢 