### PR TITLE
Tentative solution of unstage exit code

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -615,7 +615,7 @@ class BashWrapperBuilder {
 
     protected String getStageCommand() { 'nxf_stage' }
 
-    protected String getUnstageCommand() { 'nxf_unstage' }
+    protected String getUnstageCommand() { '(set -e; nxf_unstage)' }
 
     protected String getUnstageControls() {
         def result = copyFileToWorkDir(TaskRun.CMD_OUTFILE) + ' || true' + ENDL

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -183,7 +183,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
         return """\
             IFS=\$'\\n'
             for name in \$(eval "ls -1d ${escape.join(' ')}" | sort | uniq); do
-                ${stageOutCommand('$name', targetDir, mode)} || true
+                ${stageOutCommand('$name', targetDir, mode)}
             done
             unset IFS""".stripIndent(true)
     }

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -99,7 +99,12 @@ nxf_fs_fcp() {
 }
 
 on_exit() {
-    exit_status=${nxf_main_ret:=$?}
+    ## capture the last error
+    ## can be caused either by the task script or the unstage script
+    local last_err=$?
+    ## capture the task error first or fallback to the last error
+    exit_status=${nxf_main_ret:=$last_err}
+    [[ $exit_status -eq 0 && $last_err -ne 0 ]] && exit_status=$last_err
     printf $exit_status {{exit_file}}
     set +u
     [[ "$tee1" ]] && kill $tee1 2>/dev/null

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -411,7 +411,7 @@ class BashWrapperBuilderTest extends Specification {
         binding.unstage_outputs == '''\
                 IFS=$'\\n'
                 for name in $(eval "ls -1d test.bam test.bai" | sort | uniq); do
-                    nxf_fs_copy "$name" /work/dir || true
+                    nxf_fs_copy "$name" /work/dir
                 done
                 unset IFS
                 '''.stripIndent().rightTrim()
@@ -428,7 +428,7 @@ class BashWrapperBuilderTest extends Specification {
         binding.unstage_outputs == '''\
                 IFS=$'\\n'
                 for name in $(eval "ls -1d test.bam test.bai" | sort | uniq); do
-                    nxf_fs_move "$name" /another/dir || true
+                    nxf_fs_move "$name" /another/dir
                 done
                 unset IFS
                 '''.stripIndent().rightTrim()
@@ -1066,13 +1066,13 @@ class BashWrapperBuilderTest extends Specification {
         def builder = newBashWrapperBuilder()
         then:
         builder.getStageCommand() == 'nxf_stage'
-        builder.getUnstageCommand() == 'nxf_unstage'
+        builder.getUnstageCommand() == '(set -e; nxf_unstage)'
 
         when:
         def binding = builder.makeBinding()
         then:
         binding.stage_cmd == 'nxf_stage'
-        binding.unstage_cmd == 'nxf_unstage'
+        binding.unstage_cmd == '(set -e; nxf_unstage)'
         
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -270,7 +270,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         script == '''
                 IFS=$'\\n'
                 for name in $(eval "ls -1d simple.txt my/path/file.bam" | sort | uniq); do
-                    nxf_fs_copy "$name" /target/work\\ dir || true
+                    nxf_fs_copy "$name" /target/work\\ dir
                 done
                 unset IFS
                 '''
@@ -293,7 +293,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         script == '''
                 IFS=$'\\n'
                 for name in $(eval "ls -1d simple.txt my/path/file.bam" | sort | uniq); do
-                    nxf_fs_move "$name" /target/store || true
+                    nxf_fs_move "$name" /target/store
                 done
                 unset IFS
                 '''
@@ -315,7 +315,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         script == '''
                 IFS=$'\\n'
                 for name in $(eval "ls -1d simple.txt my/path/file.bam" | sort | uniq); do
-                    nxf_fs_rsync "$name" /target/work\\'s || true
+                    nxf_fs_rsync "$name" /target/work\\'s
                 done
                 unset IFS
                 '''

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -264,7 +264,9 @@ nxf_fs_fcp() {
 }
 
 on_exit() {
-    exit_status=${nxf_main_ret:=$?}
+    local last_err=$?
+    exit_status=${nxf_main_ret:=$last_err}
+    [[ $exit_status -eq 0 && $last_err -ne 0 ]] && exit_status=$last_err
     printf $exit_status > {{folder}}/.exitcode
     set +u
     [[ "$tee1" ]] && kill $tee1 2>/dev/null
@@ -318,7 +320,7 @@ nxf_main() {
     pid=$!
     wait $pid || nxf_main_ret=$?
     wait $tee1 $tee2
-    nxf_unstage
+    (set -e; nxf_unstage)
 }
 
 $NXF_ENTRY

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
@@ -79,7 +79,9 @@ nxf_fs_fcp() {
 }
 
 on_exit() {
-    exit_status=${nxf_main_ret:=$?}
+    local last_err=$?
+    exit_status=${nxf_main_ret:=$last_err}
+    [[ $exit_status -eq 0 && $last_err -ne 0 ]] && exit_status=$last_err
     printf $exit_status > {{folder}}/.exitcode
     set +u
     [[ "$tee1" ]] && kill $tee1 2>/dev/null
@@ -139,7 +141,7 @@ nxf_main() {
     pid=$!
     wait $pid || nxf_main_ret=$?
     wait $tee1 $tee2
-    nxf_unstage
+    (set -e; nxf_unstage)
 }
 
 $NXF_ENTRY

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
@@ -58,7 +58,7 @@ class BashWrapperBuilderWithS3Test extends Specification {
         binding.unstage_outputs == '''\
                     IFS=$'\\n'
                     for name in $(eval "ls -1d test.bam test.bai bla\\ nk.txt" | sort | uniq); do
-                        nxf_s3_upload $name s3://some/buck\\ et || true
+                        nxf_s3_upload $name s3://some/buck\\ et
                     done
                     unset IFS
                     '''.stripIndent().rightTrim()

--- a/plugins/nf-amazon/src/testResources/logback-test.xml
+++ b/plugins/nf-amazon/src/testResources/logback-test.xml
@@ -23,7 +23,7 @@
 
     <logger name="org.apache.http" level="INFO" />
     <logger name="com.amazonaws" level="INFO" />
-    <logger name="com.upplication" level="DEBUG" />
+    <logger name="nextflow.cloud.aws.nio" level="DEBUG" />
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT"/>

--- a/plugins/nf-azure/src/test/nextflow/executor/BashWrapperBuilderWithAzTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/executor/BashWrapperBuilderWithAzTest.groovy
@@ -47,7 +47,7 @@ class BashWrapperBuilderWithAzTest extends Specification {
         binding.unstage_outputs == """\
                     IFS=\$'\\n'
                     for name in \$(eval "ls -1d test.bam test.bai" | sort | uniq); do
-                        nxf_az_upload \$name '${AzHelper.toHttpUrl(target)}' || true
+                        nxf_az_upload \$name '${AzHelper.toHttpUrl(target)}'
                     done
                     unset IFS
                     """.stripIndent().rightTrim()

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -164,7 +164,9 @@ nxf_fs_fcp() {
 }
 
 on_exit() {
-    exit_status=${nxf_main_ret:=$?}
+    local last_err=$?
+    exit_status=${nxf_main_ret:=$last_err}
+    [[ $exit_status -eq 0 && $last_err -ne 0 ]] && exit_status=$last_err
     printf $exit_status > {{folder}}/.exitcode
     set +u
     [[ "$tee1" ]] && kill $tee1 2>/dev/null


### PR DESCRIPTION
Tentative solution for issue #3711. 

This change allows capturing the failing exit code while copying the result files. 

However, I'm not sure it will improve the troubleshooting much because the main problem is that cloud providers copy those files in background process. In this guess the error message, and likely also the error code, get lost 