### PR TITLE
Improve task out redirect

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -102,9 +102,6 @@ on_exit() {
     exit_status=${nxf_main_ret:=$?}
     printf $exit_status {{exit_file}}
     set +u
-    [[ "$tee1" ]] && kill $tee1 2>/dev/null
-    [[ "$tee2" ]] && kill $tee2 2>/dev/null
-    [[ "$ctmp" ]] && rm -rf $ctmp || true
     {{cleanup_cmd}}
     {{sync_cmd}}
     exit $exit_status
@@ -153,17 +150,9 @@ nxf_main() {
     {{stage_cmd}}
 
     set +e
-    ctmp=$(set +u; nxf_mktemp /dev/shm 2>/dev/null || nxf_mktemp $TMPDIR)
-    local cout=$ctmp/.command.out; mkfifo $cout
-    local cerr=$ctmp/.command.err; mkfifo $cerr
-    tee {{stdout_file}} < $cout &
-    tee1=$!
-    tee {{stderr_file}} < $cerr >&2 &
-    tee2=$!
-    ( nxf_launch ) >$cout 2>$cerr &
+    (set -o pipefail; (nxf_launch | tee {{stdout_file}}) 3>&1 1>&2 2>&3 | tee {{stderr_file}}) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    wait $tee1 $tee2
     {{unstage_cmd}}
     {{after_script}}
 }

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -267,9 +267,6 @@ on_exit() {
     exit_status=${nxf_main_ret:=$?}
     printf $exit_status > {{folder}}/.exitcode
     set +u
-    [[ "$tee1" ]] && kill $tee1 2>/dev/null
-    [[ "$tee2" ]] && kill $tee2 2>/dev/null
-    [[ "$ctmp" ]] && rm -rf $ctmp || true
     sync || true
     exit $exit_status
 }
@@ -307,17 +304,9 @@ nxf_main() {
     nxf_stage
 
     set +e
-    ctmp=$(set +u; nxf_mktemp /dev/shm 2>/dev/null || nxf_mktemp $TMPDIR)
-    local cout=$ctmp/.command.out; mkfifo $cout
-    local cerr=$ctmp/.command.err; mkfifo $cerr
-    tee .command.out < $cout &
-    tee1=$!
-    tee .command.err < $cerr >&2 &
-    tee2=$!
-    ( nxf_launch ) >$cout 2>$cerr &
+    (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    wait $tee1 $tee2
     nxf_unstage
 }
 

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
@@ -82,9 +82,6 @@ on_exit() {
     exit_status=${nxf_main_ret:=$?}
     printf $exit_status > {{folder}}/.exitcode
     set +u
-    [[ "$tee1" ]] && kill $tee1 2>/dev/null
-    [[ "$tee2" ]] && kill $tee2 2>/dev/null
-    [[ "$ctmp" ]] && rm -rf $ctmp || true
     sync || true
     exit $exit_status
 }
@@ -128,17 +125,9 @@ nxf_main() {
     nxf_stage
 
     set +e
-    ctmp=$(set +u; nxf_mktemp /dev/shm 2>/dev/null || nxf_mktemp $TMPDIR)
-    local cout=$ctmp/.command.out; mkfifo $cout
-    local cerr=$ctmp/.command.err; mkfifo $cerr
-    tee .command.out < $cout &
-    tee1=$!
-    tee .command.err < $cerr >&2 &
-    tee2=$!
-    ( nxf_launch ) >$cout 2>$cerr &
+    (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    wait $tee1 $tee2
     nxf_unstage
 }
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -113,11 +113,16 @@ class PluginUpdater extends UpdateManager {
         // Check if it's a plugin meta file. The name must match the pattern `<plugin id>-X.Y.Z-meta.json`
         final matcher = META_REGEX.matcher(uri.tokenize('/')[-1])
         if( matcher.matches() ) {
-            final pluginId = matcher.group(1)
-            final temp = File.createTempFile('nxf-','json')
-            temp.deleteOnExit()
-            temp.text = /[{"id":"${pluginId}", "releases":[ ${new URL(uri).text} ]}]/
-            uri = 'file://' + temp.absolutePath
+            try {
+                final pluginId = matcher.group(1)
+                final temp = File.createTempFile('nxf-','json')
+                temp.deleteOnExit()
+                temp.text = /[{"id":"${pluginId}", "releases":[ ${new URL(uri).text} ]}]/
+                uri = 'file://' + temp.absolutePath
+            }
+            catch (FileNotFoundException e) {
+                throw new IllegalArgumentException("Provided repository URL does not exists or cannot be accessed: $uri")
+            }
         }
         // create the update repository instance
         final fileName = uri.tokenize('/')[-1]

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -167,9 +167,6 @@ on_exit() {
     exit_status=${nxf_main_ret:=$?}
     printf $exit_status > {{folder}}/.exitcode
     set +u
-    [[ "$tee1" ]] && kill $tee1 2>/dev/null
-    [[ "$tee2" ]] && kill $tee2 2>/dev/null
-    [[ "$ctmp" ]] && rm -rf $ctmp || true
     {{sync_cmd}}
     exit $exit_status
 }
@@ -213,17 +210,9 @@ nxf_main() {
     [[ $NXF_SCRATCH ]] && cd $NXF_SCRATCH
 
     set +e
-    ctmp=$(set +u; nxf_mktemp /dev/shm 2>/dev/null || nxf_mktemp $TMPDIR)
-    local cout=$ctmp/.command.out; mkfifo $cout
-    local cerr=$ctmp/.command.err; mkfifo $cerr
-    tee .command.out < $cout &
-    tee1=$!
-    tee .command.err < $cerr >&2 &
-    tee2=$!
-    ( nxf_launch ) >$cout 2>$cerr &
+    (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    wait $tee1 $tee2
 }
 
 $NXF_ENTRY


### PR DESCRIPTION
This PR simplifies the stdout and stderr redirection made in the task launcher script removing the need to use two FIFO pipe redirections.
