### PR TITLE
Fix DSL2 support in nextflow console

### DIFF
--- a/plugins/nf-console/src/main/nextflow/ui/console/Nextflow.groovy
+++ b/plugins/nf-console/src/main/nextflow/ui/console/Nextflow.groovy
@@ -25,6 +25,7 @@ import groovy.transform.ThreadInterrupt
 import groovy.console.ui.Console
 import groovy.console.ui.OutputTransforms
 import groovy.util.logging.Slf4j
+import nextflow.NextflowMeta
 import nextflow.Session
 import nextflow.cli.CliOptions
 import nextflow.cli.CmdInfo
@@ -72,6 +73,8 @@ class Nextflow extends Console {
     Nextflow(ClassLoader loader) {
         super(loader, new ScriptBinding())
         this.scriptConfig = createScriptConfig()
+
+        NextflowMeta.instance.enableDsl2()
     }
 
     protected Map createScriptConfig() {
@@ -134,8 +137,14 @@ class Nextflow extends Console {
         binding.setSession(session)
         binding.setScriptPath(path)
 
-        beforeExecution = { session.start() }
-        afterExecution = { session.await(); session.destroy() }
+        beforeExecution = {
+            session.start()
+        }
+        afterExecution = {
+            session.fireDataflowNetwork()
+            session.await()
+            session.destroy()
+        }
 
         launcher.call()
     }


### PR DESCRIPTION
Closes #2689 and #3461 

This PR adds a few missing pieces to the nextflow console:
- set DSL mode to 2 by default
- fire the dataflow network after running the script

These changes solves issues where the console didn't support DSL2 syntax by default, and setting `nextflow.enable.dsl=2` would cause the execution to hang.

I determined the necessary changes by comparing the Nextflow console class to CmdRun and ScriptRunner, since these two classes are bypassed by the console.