### PR TITLE
Support `time` directive in Azure Batch

### DIFF
--- a/docs/executor.rst
+++ b/docs/executor.rst
@@ -33,6 +33,8 @@ The pipeline can be launched either in a local computer, or an EC2 instance. EC2
 Resource requests and other job characteristics can be controlled via the following process directives:
 
 * :ref:`process-accelerator`
+* :ref:`process-container`
+* :ref:`process-containerOptions`
 * :ref:`process-cpus`
 * :ref:`process-memory`
 * :ref:`process-queue`
@@ -56,6 +58,16 @@ script or the ``nextflow.config`` file.
 To enable this executor, set the property ``process.executor = 'azurebatch'`` in the ``nextflow.config`` file.
 
 The pipeline can be launched either in a local computer, or a cloud virtual machine. The cloud VM is suggested for heavy or long-running workloads. Moreover, an Azure Blob storage container must be used as the pipeline work directory.
+
+Resource requests and other job characteristics can be controlled via the following process directives:
+
+* :ref:`process-container`
+* :ref:`process-containerOptions`
+* :ref:`process-cpus`
+* :ref:`process-machineType`
+* :ref:`process-memory`
+* :ref:`process-queue`
+* :ref:`process-time`
 
 See the :ref:`Azure Batch <azure-batch>` page for further configuration details.
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -51,6 +51,7 @@ import com.microsoft.azure.batch.protocol.models.PoolState
 import com.microsoft.azure.batch.protocol.models.ResourceFile
 import com.microsoft.azure.batch.protocol.models.StartTask
 import com.microsoft.azure.batch.protocol.models.TaskAddParameter
+import com.microsoft.azure.batch.protocol.models.TaskConstraints
 import com.microsoft.azure.batch.protocol.models.TaskContainerSettings
 import com.microsoft.azure.batch.protocol.models.TaskSchedulingPolicy
 import com.microsoft.azure.batch.protocol.models.UserIdentity
@@ -412,8 +413,13 @@ class AzBatchService implements Closeable {
         final String cmd = fusionEnabled
                 ? launcher.fusionSubmitCli(task).join(' ')
                 : "sh -c 'bash ${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}'"
-
+        // cpus and memory
         final slots = computeSlots(task, pool)
+        // max wall time
+        final constraints = new TaskConstraints()
+        if( task.config.getTime() )
+            constraints.withMaxWallClockTime( new Period(task.config.getTime().toMillis()) )
+
         log.trace "[AZURE BATCH] Submitting task: $taskId, cpus=${task.config.getCpus()}, mem=${task.config.getMemory()?:'-'}, slots: $slots"
 
         return new TaskAddParameter()
@@ -424,6 +430,7 @@ class AzBatchService implements Closeable {
                 .withResourceFiles(resourceFileUrls(task,sas))
                 .withOutputFiles(outputFileUrls(task, sas))
                 .withRequiredSlots(slots)
+                .withConstraints(constraints)
     }
 
     AzTaskKey runTask(String poolId, String jobId, TaskRun task) {


### PR DESCRIPTION
Closes #3865 

The issue OP technically asked for a time constraint on pools, but AFAIK it is only possible for tasks, also that is the model that Nextflow already uses via the `time` directive.