### PR TITLE
Add reference in Google section in the docs to the nextflow's blogpost

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -193,7 +193,6 @@ the ``-work-dir`` command line options. For example::
 .. warning::
   The Google Storage path needs to contain at least sub-directory. Don't use only the bucket name e.g. ``gs://my-bucket``.
 
-
 Spot instances
 ---------------
 
@@ -252,6 +251,9 @@ supported:
 * :ref:`process-memory`
 * :ref:`process-time`
 
+.. note::
+    For a more hands-on source on getting started with Nextflow on Google Cloud Batch,
+    check `this blog post <https://www.nextflow.io/blog/2023/nextflow-with-gbatch.html>`_.
 
 .. _google-lifesciences:
 


### PR DESCRIPTION
In other sections of the official documentation, such as the Amazon section, a blog post is mentioned as an additional source of content on that topic. With that in mind, it's also worth referring to the Google Cloud Batch blog post in the Nextflow blog in the Google section of the official documentation.