### PR TITLE
Support enums in cache helper

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -218,7 +218,7 @@ public class CacheHelper {
         }
 
         if( value instanceof Enum )
-            return hasher.putUnencodedChars( value.toString() );
+            return hasher.putUnencodedChars( value.getClass().getName() + "." + value.toString() );
 
         Bolts.debug1(log, FIRST_ONLY, "[WARN] Unknown hashing type: "+value.getClass());
         return hasher.putInt( value.hashCode() );

--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -134,10 +134,10 @@ public class CacheHelper {
         if( value instanceof Short )
             return hasher.putShort((Short) value);
 
-         if( value instanceof Integer)
+        if( value instanceof Integer)
             return hasher.putInt((Integer) value);
 
-         if( value instanceof Long )
+        if( value instanceof Long )
             return hasher.putLong((Long) value);
 
         if( value instanceof Float )
@@ -216,6 +216,9 @@ public class CacheHelper {
         if( value instanceof CacheFunnel ) {
             return ((CacheFunnel) value).funnel(hasher,mode);
         }
+
+        if( value instanceof Enum )
+            return hasher.putUnencodedChars( value.toString() );
 
         Bolts.debug1(log, FIRST_ONLY, "[WARN] Unknown hashing type: "+value.getClass());
         return hasher.putInt( value.hashCode() );

--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -217,8 +217,9 @@ public class CacheHelper {
             return ((CacheFunnel) value).funnel(hasher,mode);
         }
 
-        if( value instanceof Enum )
-            return hasher.putUnencodedChars( value.getClass().getName() + "." + value.toString() );
+        if( value instanceof Enum ) {
+            return hasher.putUnencodedChars( value.getClass().getName() + "." + value );
+        }
 
         Bolts.debug1(log, FIRST_ONLY, "[WARN] Unknown hashing type: "+value.getClass());
         return hasher.putInt( value.hashCode() );

--- a/modules/nf-commons/src/test/nextflow/util/CacheHelperTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/CacheHelperTest.groovy
@@ -46,7 +46,7 @@ class CacheHelperTest extends Specification {
         def anObjectArray = Hashing.murmur3_128().newHasher().putInt(1).putInt(2).putInt(3).hash()
         def aMap =  Hashing.murmur3_128().newHasher().putInt(1).putUnencodedChars('String1').putBoolean(true).hash()
         def aList = Hashing.murmur3_128().newHasher().putUnencodedChars('A').putUnencodedChars('B').putUnencodedChars('C').hash()
-        def anEnum = Hashing.murmur3_128().newHasher().putUnencodedChars('TEST_A').hash()
+        def anEnum = Hashing.murmur3_128().newHasher().putUnencodedChars('nextflow.util.CacheHelperTest$TestEnum.TEST_A').hash()
 
         def file = Files.createTempFile('test', null)
         file.deleteOnExit()

--- a/modules/nf-commons/src/test/nextflow/util/CacheHelperTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/CacheHelperTest.groovy
@@ -32,6 +32,8 @@ import test.TestHelper
  */
 class CacheHelperTest extends Specification {
 
+    enum TestEnum { TEST_A, TEST_B, TEST_C }
+
     def 'test hashCode' () {
 
         setup:
@@ -44,6 +46,7 @@ class CacheHelperTest extends Specification {
         def anObjectArray = Hashing.murmur3_128().newHasher().putInt(1).putInt(2).putInt(3).hash()
         def aMap =  Hashing.murmur3_128().newHasher().putInt(1).putUnencodedChars('String1').putBoolean(true).hash()
         def aList = Hashing.murmur3_128().newHasher().putUnencodedChars('A').putUnencodedChars('B').putUnencodedChars('C').hash()
+        def anEnum = Hashing.murmur3_128().newHasher().putUnencodedChars('TEST_A').hash()
 
         def file = Files.createTempFile('test', null)
         file.deleteOnExit()
@@ -66,6 +69,7 @@ class CacheHelperTest extends Specification {
         CacheHelper.hasher([1,2,3] as Object[]).hash() == anObjectArray
         CacheHelper.hasher( [f1: 1, f2: 'String1', f3: true] ) .hash() == aMap
         CacheHelper.hasher( ['A','B','C'] ).hash() == aList
+        CacheHelper.hasher(TestEnum.TEST_A).hash() == anEnum
         CacheHelper.hasher(file).hash() == aFile
 
         CacheHelper.hasher(['abc',123]).hash() == CacheHelper.hasher(['abc',123]).hash()


### PR DESCRIPTION
Close #3899 

Nextflow currently caches enums using their hash code, which is not guaranteed to be the same across runs. This PR updates the CacheHelper to use the enum string value instead. This way, renaming an enum value will break the cache but changing the enum ordering will not.