### PR TITLE
Fix problem args were not correctly represented in debug yaml

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
@@ -147,7 +147,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
 
     protected List<String> classicSubmitCli(TaskRun task) {
         final result = new ArrayList(BashWrapperBuilder.BASH)
-        result.add("${Escape.path(task.workDir)}/${TaskRun.CMD_RUN}")
+        result.add("${Escape.path(task.workDir)}/${TaskRun.CMD_RUN}".toString())
         return result
     }
 


### PR DESCRIPTION
This problem occurred when a workflow was run with `k8s.debug.yaml = true`
The created `.command.yaml` file contained an args like this:
```
...
    args:
    - /bin/bash
    - -ue
    - !!org.codehaus.groovy.runtime.GStringImpl {}
...
```
Converting the GString to String looks like it should:
```
...
args: [/bin/bash, -ue, /input/data/work/aa/abf3408753f4c094567abc16d1e543/.command.run]
...
```