### PR TITLE
Phil docs version notes

### DIFF
--- a/docs/_static/theme.css
+++ b/docs/_static/theme.css
@@ -19,3 +19,43 @@
     margin-top: 0.5rem;
     width: 60%;
 }
+
+/* Version change admonitions */
+div.deprecated, div.versionadded, div.versionchanged {
+    color: #555555;
+    border-radius: 0.25rem;
+    box-shadow: 0 0.2rem 0.5rem var(--pst-color-shadow),0 0 0.0625rem var(--pst-color-shadow)!important;
+    margin: 1.5625em auto;
+    overflow: hidden;
+    padding: 0.2rem 0.6rem;
+    page-break-inside: avoid;
+    position: relative;
+    transition: color .25s,background-color .25s,border-color .25s;
+    vertical-align: middle;
+}
+div.deprecated p, div.versionadded p, div.versionchanged p {
+    margin-bottom: 0.6rem;
+}
+div.deprecated p:last-child, div.versionadded p:last-child, div.versionchanged p:last-child {
+    margin-bottom: 0;
+}
+div.deprecated p:first-child::before, div.versionadded p:first-child::before, div.versionchanged p:first-child::before {
+    font-family: FontAwesome;
+    display: inline-block;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 1;
+    text-decoration: inherit;
+    margin-right: 0.5rem;
+    content: "";
+    -webkit-font-smoothing: antialiased;
+    color: #ffffff;
+    padding: 0.4rem 0.6rem;
+    margin: -0.2rem 0.6rem -0.2rem -0.6rem;
+}
+div.versionadded p:first-child::before   { background-color: #1abc9c; }
+div.versionadded                         { background-color: #dbfaf4; }
+div.versionchanged p:first-child::before { background-color: #f0b37e; }
+div.versionchanged                       { background-color: #ffedcc; }
+div.deprecated p:first-child::before     { background-color: #f29f97; }
+div.deprecated                           { background-color: #fdf3f2; }

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -309,7 +309,9 @@ aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
 
 Replace the path above with the one matching the location where the `aws` tool is installed in your AMI.
 
-*Changed in version `19.07.0`:* the `executor.awscli` config option was replaced by `aws.batch.cliPath`.
+:::{versionchanged} 19.07.0
+The `executor.awscli` config option was replaced by `aws.batch.cliPath`.
+:::
 
 :::{warning}
 The grandparent directory of the `aws` tool will be mounted into the container at the same path as the host, e.g. `/home/ec2-user/miniconda`, which will shadow existing files in the container. Make sure you use a path that is not already present in the container.
@@ -417,7 +419,8 @@ With the above configuration, processes with the `bigTask` {ref}`process-label` 
 
 ### Volume mounts
 
-*New in version `19.07.0`*
+:::{versionadded} 19.07.0
+:::
 
 User provided container volume mounts can be provided as shown below:
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -196,7 +196,8 @@ Different queues bound to the same or different Compute Environments can be conf
 
 ## Container Options
 
-*New in version `21.12.1-edge`*
+:::{versionadded} 21.12.1-edge
+:::
 
 The {ref}`process-containerOptions` directive can be used to control the properties of the container execution associated with each Batch job.
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -2,7 +2,8 @@
 
 # Azure Cloud
 
-*New in version `21.04.0`*
+:::{versionadded} 21.04.0
+:::
 
 (azure-blobstorage)=
 
@@ -314,7 +315,8 @@ See the {ref}`Azure configuration <config-azure>` section and the [Azure Batch n
 
 ### Private container registry
 
-*New in version `21.05.0-edge`*
+:::{versionadded} 21.05.0-edge
+:::
 
 A private container registry for Docker images can be specified as follows:
 
@@ -336,7 +338,8 @@ When using containers hosted in a private registry, the registry name must also 
 
 ## Active Directory Authentication
 
-*New in version `22.11.0-edge`*
+:::{versionadded} 22.11.0-edge
+:::
 
 [Service Principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) credentials can optionally be used instead of Shared Keys for Azure Batch and Storage accounts.
 

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -64,7 +64,9 @@ See also: {ref}`process-multiple-input-channels`.
 
 Channels may be created explicitly using the following channel factory methods.
 
-*New in version `20.07.0`:* `channel` was introduced as an alias of `Channel`, allowing factory methods to be specified as `channel.of()` or `Channel.of()`, and so on.
+:::{versionadded} 20.07.0
+`channel` was introduced as an alias of `Channel`, allowing factory methods to be specified as `channel.of()` or `Channel.of()`, and so on.
+:::
 
 (channel-empty)=
 
@@ -78,7 +80,9 @@ See also: {ref}`operator-ifempty`.
 
 ### from
 
-*Deprecated, use [of](#of) or [fromList](#fromlist) instead*
+:::{deprecated} x
+Use [of](#of) or [fromList](#fromlist) instead.
+:::
 
 The `from` method allows you to create a channel emitting any sequence of values that are specified as the method argument, for example:
 
@@ -124,7 +128,8 @@ Channel.from( [1, 2], [5,6], [7,9] )
 
 ### fromList
 
-*New in version `19.10.0`*
+:::{versionadded} 19.10.0
+:::
 
 The `fromList` method allows you to create a channel emitting the values provided as a list of elements, for example:
 
@@ -305,7 +310,8 @@ Available options:
 
 ### fromSRA
 
-*New in version `19.04.0`*
+:::{versionadded} 19.04.0
+:::
 
 The `fromSRA` method queries the [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) database and returns a channel emitting the FASTQ files matching the specified criteria i.e project or accession number(s). For example:
 
@@ -378,7 +384,8 @@ Available options:
 
 ### of
 
-*New in version `19.10.0`*
+:::{versionadded} 19.10.0
+:::
 
 The `of` method allows you to create a channel that emits the arguments provided to it, for example:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -688,19 +688,23 @@ The `kuberun` command supports the following options from [`run`](#run):
 The following new options are also available:
 
 `-head-cpus`
-: *New in version `22.01.0-edge`*
+: :::{versionadded} 22.01.0-edge
+  :::
 : Specify number of CPUs requested for the Nextflow pod.
 
 `-head-image`
-: *New in version `22.07.1-edge`*
+: :::{versionadded} 22.07.1-edge
+  :::
 : Specify the container image for the Nextflow driver pod.
 
 `-head-memory`
-: *New in version `22.01.0-edge`*
+: :::{versionadded} 22.01.0-edge
+  :::
 : Specify amount of memory requested for the Nextflow pod.
 
 `-head-prescript`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : Specify script to be run before the Nextflow pod starts.
 
 `-n, -namespace`
@@ -1014,7 +1018,8 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
 : Library extension path.
 
 `-main-script` (`main.nf`)
-: *New in version `20.09.1-edge`*
+: :::{versionadded} 20.09.1-edge
+  :::
 : The script file to be executed when launching a project directory or repository.
 
 `-name`
@@ -1030,7 +1035,8 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
 : Comma separated list of plugin ids to be applied in the pipeline execution.
 
 `-preview`
-: *New in version `22.06.0-edge`*
+: :::{versionadded} 22.06.0-edge
+  :::
 : Run the workflow script skipping the execution of all processes
 
 `-process.<key>=<value>`
@@ -1247,13 +1253,13 @@ The `view` command is used to inspect the pipelines that are already stored in t
 **Options**
 
 `-h, -help`
-: Print the command usage. 
+: Print the command usage.
 
-`-l`       
-: List repository content. 
+`-l`
+: List repository content.
 
-`-q`       
-: Hide header line.        
+`-q`
+: Hide header line.
 
 **Examples**
 

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -30,7 +30,8 @@ The Conda environment feature is not supported by executors that use remote obje
 
 ### Enabling Conda environment
 
-*New in version `22.08.0-edge`*
+:::{versionadded} 22.08.0-edge
+:::
 
 The use of Conda recipes specified using the {ref}`process-conda` directive needs to be enabled explicitly by setting the option shown below in the pipeline configuration file (i.e. `nextflow.config`):
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -149,7 +149,8 @@ The following settings are available:
 : AWS account access key
 
 `aws.profile`
-: *New in version `22.12.0-edge`*
+: :::{versionadded} 22.12.0-edge
+  :::
 : AWS profile from `~/.aws/credentials`
 
 `aws.region`
@@ -168,14 +169,16 @@ The following settings are available:
 : The AWS Job Role ARN that needs to be used to execute the Batch Job.
 
 `aws.batch.logsGroup`
-: *New in version `22.09.0-edge`*
+: :::{versionadded} 22.09.0-edge
+  :::
 : The name of the logs group used by Batch Jobs (default: `/aws/batch`).
 
 `aws.batch.maxParallelTransfers`
 : Max parallel upload/download transfer operations *per job* (default: `4`).
 
 `aws.batch.maxSpotAttempts`
-: *New in version `22.04.0`*
+: :::{versionadded} 22.04.0
+  :::
 : Max number of execution attempts of a job interrupted by a EC2 spot reclaim event (default: `5`)
 
 `aws.batch.maxTransferAttempts`
@@ -185,11 +188,13 @@ The following settings are available:
 : The retry mode configuration setting, to accommodate rate-limiting on [AWS services](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html) (default: `standard`)
 
 `aws.batch.schedulingPriority`
-: *New in version `23.01.0-edge`*
+: :::{versionadded} 23.01.0-edge
+  :::
 : The scheduling priority for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/) (default: `0`)
 
 `aws.batch.shareIdentifier`
-: *New in version `22.09.0-edge`*
+: :::{versionadded} 22.09.0-edge
+  :::
 : The share identifier for all tasks when using [fair-share scheduling for AWS Batch](https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/)
 
 `aws.batch.volumes`
@@ -208,17 +213,20 @@ The following settings are available:
 : The AWS S3 API entry point e.g. `s3-us-west-1.amazonaws.com`.
 
 `aws.client.glacierAutoRetrieval`
-: *New in version `22.12.0-edge`*
+: :::{versionadded} 22.12.0-edge
+  :::
 : *EXPERIMENTAL: may change in a future release*
 : Enable auto retrieval of S3 objects stored with Glacier class store (default: `false`).
 
 `aws.client.glacierExpirationDays`
-: *New in version `22.12.0-edge`*
+: :::{versionadded} 22.12.0-edge
+  :::
 : *EXPERIMENTAL: may change in a future release*
 : The time, in days, between when an object is restored to the bucket and when it expires (default: `7`).
 
 `aws.client.glacierRetrievalTier`
-: *New in version `23.03.0-edge`*
+: :::{versionadded} 23.03.0-edge
+  :::
 : *EXPERIMENTAL: may change in a future release*
 : The retrieval tier to use when restoring objects from Glacier, one of [`Expedited`, `Standard`, `Bulk`].
 
@@ -262,7 +270,8 @@ The following settings are available:
 : The S3 server side encryption to be used when saving objects on S3, either `AES256` or `aws:kms` values are allowed.
 
 `aws.client.storageKmsKeyId`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : The AWS KMS key Id to be used to encrypt files stored in the target S3 bucket ().
 
 `aws.client.userAgent`
@@ -371,7 +380,8 @@ The following settings are available:
 : Specify the ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.centos 8`).
 
 `azure.batch.pools.<name>.virtualNetwork`
-: *New in version `23.03.0-edge`*
+: :::{versionadded} 23.03.0-edge
+  :::
 : Specify the subnet ID of a virtual network in which to create the pool.
 
 `azure.batch.pools.<name>.vmCount`
@@ -465,7 +475,8 @@ The following settings are available:
 : Uses the `mamba` binary instead of `conda` to create the Conda environments. For details see the [Mamba documentation](https://github.com/mamba-org/mamba).
 
 `conda.useMicromamba`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : uses the `micromamba` binary instead of `conda` to create the Conda environments. For details see the [Micromamba documentation](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html).
 
 Read the {ref}`conda-page` page to learn more about how to use Conda environments with Nextflow.
@@ -600,7 +611,8 @@ The following settings are available:
 : Determines how often to check for process termination. Default varies for each executor (see below).
 
 `executor.queueGlobalStatus`
-: *New in version `23.01.0-edge`*
+: :::{versionadded} 23.01.0-edge
+  :::
 : Determines how job status is retrieved. When `false` only the queue associated with the job execution is queried. When `true` the job status is queried globally i.e. irrespective of the submission queue (default: `false`).
 
 `executor.queueSize`
@@ -610,23 +622,28 @@ The following settings are available:
 : Determines how often to fetch the queue status from the scheduler (default: `1min`). Used only by grid executors.
 
 `executor.retry.delay`
-: *New in version `22.03.0-edge`*
+: :::{versionadded} 22.03.0-edge
+  :::
 : Delay when retrying failed job submissions (default: `500ms`). Used only by grid executors.
 
 `executor.retry.jitter`
-: *New in version `22.03.0-edge`*
+: :::{versionadded} 22.03.0-edge
+  :::
 : Jitter value when retrying failed job submissions (default: `0.25`). Used only by grid executors.
 
 `executor.retry.maxAttempt`
-: *New in version `22.03.0-edge`*
+: :::{versionadded} 22.03.0-edge
+  :::
 : Max attempts when retrying failed job submissions (default: `3`). Used only by grid executors.
 
 `executor.retry.maxDelay`
-: *New in version `22.03.0-edge`*
+: :::{versionadded} 22.03.0-edge
+  :::
 : Max delay when retrying failed job submissions (default: `30s`). Used only by grid executors.
 
 `executor.retry.reason`
-: *New in version `22.03.0-edge`*
+: :::{versionadded} 22.03.0-edge
+  :::
 : Regex pattern that when verified cause a failed submit operation to be re-tried (default: `Socket timed out`). Used only by grid executors.
 
 `executor.submitRateLimit`
@@ -706,7 +723,8 @@ The following settings are available:
 : The Google Cloud zone where jobs are executed. Multiple zones can be provided as a comma-separated list. Cannot be used with the `google.region` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
 
 `google.batch.allowedLocations`
-: *New in version `22.12.0-edge`*
+: :::{versionadded} 22.12.0-edge
+  :::
 : Define the set of allowed locations for VMs to be provisioned. See [Google documentation](https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#locationpolicy) for details (default: no restriction).
 
 `google.batch.bootDiskSize`
@@ -743,22 +761,26 @@ The following settings are available:
 : When `true` copies the `/google` debug directory in that task bucket directory (default: `false`).
 
 `google.lifeSciences.keepAliveOnFailure`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : When `true` and a task complete with an unexpected exit status the associated compute node is kept up for 1 hour. This options implies `sshDaemon=true` (default: `false`).
 
 `google.lifeSciences.network`
-: *New in version `21.03.0-edge`*
+: :::{versionadded} 21.03.0-edge
+  :::
 : Set network name to attach the VM's network interface to. The value will be prefixed with `global/networks/` unless it contains a `/`, in which case it is assumed to be a fully specified network resource URL. If unspecified, the global default network is used.
 
 `google.lifeSciences.preemptible`
 : When `true` enables the usage of *preemptible* virtual machines or `false` otherwise (default: `true`).
 
 `google.lifeSciences.serviceAccountEmail`
-: *New in version `20.05.0-edge`*
+: :::{versionadded} 20.05.0-edge
+  :::
 : Define the Google service account email to use for the pipeline execution. If not specified, the default Compute Engine service account for the project will be used.
 
 `google.lifeSciences.subnetwork`
-: *New in version `21.03.0-edge`*
+: :::{versionadded} 21.03.0-edge
+  :::
 : Define the name of the subnetwork to attach the instance to must be specified here, when the specified network is configured for custom subnet creation. The value is prefixed with `regions/subnetworks/` unless it contains a `/`, in which case it is assumed to be a fully specified subnetwork resource URL.
 
 `google.lifeSciences.sshDaemon`
@@ -768,27 +790,33 @@ The following settings are available:
 : The container image used to run the SSH daemon (default: `gcr.io/cloud-genomics-pipelines/tools`).
 
 `google.lifeSciences.usePrivateAddress`
-: *New in version `20.03.0-edge`*
+: :::{versionadded} 20.03.0-edge
+  :::
 : When `true` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: `false`).
 
 `google.storage.delayBetweenAttempts`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : Delay between download attempts from Google Storage (default `10 sec`).
 
 `google.storage.downloadMaxComponents`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : Defines the value for the option `GSUtil:sliced_object_download_max_components` used by `gsutil` for transfer input and output data (default: `8`).
 
 `google.storage.maxParallelTransfers`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : Max parallel upload/download transfer operations *per job* (default: `4`).
 
 `google.storage.maxTransferAttempts`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : Max number of downloads attempts from Google Storage (default: `1`).
 
 `google.storage.parallelThreadCount`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : Defines the value for the option `GSUtil:parallel_thread_count` used by `gsutil` for transfer input and output data (default: `1`).
 
 (config-k8s)=
@@ -803,29 +831,34 @@ The following settings are available:
 : Automatically mounts host paths in the job pods. Only for development purpose when using a single node cluster (default: `false`).
 
 `k8s.computeResourceType`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : Define whether use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`).
 
 `k8s.context`
 : Defines the Kubernetes [configuration context name](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to use.
 
 `k8s.fetchNodeName`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : If you trace the hostname, activate this option (default: `false`).
 
 `k8s.httpConnectTimeout`
-: *New in version `22.10.0`*
+: :::{versionadded} 22.10.0
+  :::
 : Defines the Kubernetes client request HTTP connection timeout e.g. `'60s'`.
 
 `k8s.httpReadTimeout`
-: *New in version `22.10.0`*
+: :::{versionadded} 22.10.0
+  :::
 : Defines the Kubernetes client request HTTP connection read timeout e.g. `'60s'`.
 
 `k8s.launchDir`
 : Defines the path where the workflow is launched and the user data is stored. This must be a path in a shared K8s persistent volume (default: `<volume-claim-mount-path>/<user-name>`).
 
 `k8s.maxErrorRetry`
-: *New in version `22.09.6-edge`*
+: :::{versionadded} 22.09.6-edge
+  :::
 : Defines the Kubernetes API max request retries (default: 4).
 
 `k8s.namespace`
@@ -859,7 +892,8 @@ The following settings are available:
 : The path in the persistent volume to be mounted (default: `/`).
 
 `k8s.volumeClaims`
-: *DEPRECATED*
+: :::{deprecated} x
+  :::
 
 `k8s.workDir`
 : Defines the path where the workflow temporary data is stored. This must be a path in a shared K8s persistent volume (default: `<user-dir>/work`).
@@ -1247,7 +1281,8 @@ The following settings are available:
 : The amount of time the Singularity pull can last, exceeding which the process is terminated (default: `20 min`).
 
 `singularity.registry`
-: *New in version `22.12.0-edge`*
+: :::{versionadded} 22.12.0-edge
+  :::
 : The registry from where Docker images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
 
 `singularity.runOptions`
@@ -1475,33 +1510,39 @@ The following environment variables control the configuration of the Nextflow ru
 : Directory where Conda environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
 
 `NXF_CONDA_ENABLED`
-: *New in version `22.08.0-edge`*
+: :::{versionadded} 22.08.0-edge
+  :::
 : Enable the use of Conda recipes defined by using the {ref}`process-conda` directive. (default: `false`).
 
 `NXF_DEBUG`
 : Defines scripts debugging level: `1` dump task environment variables in the task log file; `2` enables command script execution tracing; `3` enables command wrapper execution tracing.
 
 `NXF_DEFAULT_DSL`
-: *New in version `22.03.0-edge`*
+: :::{versionadded} 22.03.0-edge
+  :::
 : Defines the DSL version that should be used in not specified otherwise in the script of config file (default: `2`)
 
 `NXF_DISABLE_JOBS_CANCELLATION`
-: *New in version `21.12.0-edge`*
+: :::{versionadded} 21.12.0-edge
+  :::
 : Disables the cancellation of child jobs on workflow execution termination.
 
 `NXF_ENABLE_SECRETS`
-: *New in version `21.09.0-edge`*
+: :::{versionadded} 21.09.0-edge
+  :::
 : Enable Nextflow secrets features (default: `true`)
 
 `NXF_ENABLE_STRICT`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : Enable Nextflow *strict* execution mode (default: `false`)
 
 `NXF_EXECUTOR`
 : Defines the default process executor e.g. `sge`
 
 `NXF_GRAB`
-: *DEPRECATED*
+: :::{deprecated} x
+  :::
 : Provides extra runtime dependencies downloaded from a Maven repository service
 
 `NXF_HOME`
@@ -1511,7 +1552,8 @@ The following environment variables control the configuration of the Nextflow ru
 : Defines the path location of the Java VM installation used to run Nextflow. This variable overrides the `JAVA_HOME` variable if defined.
 
 `NXF_JVM_ARGS`
-: *New in version `21.12.1-edge`*
+: :::{versionadded} 21.12.1-edge
+  :::
 : Allows the setting Java VM options. This is similar to `NXF_OPTS` however it's only applied the JVM running Nextflow and not to any java pre-launching commands.
 
 `NXF_OFFLINE`
@@ -1524,28 +1566,32 @@ The following environment variables control the configuration of the Nextflow ru
 : Default `organization` prefix when looking for a hosted repository (default: `nextflow-io`).
 
 `NXF_PARAMS_FILE`
-: *New in version `20.10.0`*
+: :::{versionadded} 20.10.0
+  :::
 : Defines the path location of the pipeline parameters file .
 
 `NXF_PID_FILE`
 : Name of the file where the process PID is saved when Nextflow is launched in background.
 
 `NXF_SCM_FILE`
-: *New in version `20.10.0`*
+: :::{versionadded} 20.10.0
+  :::
 : Defines the path location of the SCM config file .
 
 `NXF_SINGULARITY_CACHEDIR`
 : Directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
 
 `NXF_SINGULARITY_LIBRARYDIR`
-: *New in version `21.09.0-edge`*
+: :::{versionadded} 21.09.0-edge
+  :::
 : Directory where remote Singularity images are retrieved. It should be a directory accessible to all compute nodes.
 
 `NXF_SPACK_CACHEDIR`
 : Directory where Spack environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
 
 `NXF_SPACK_ENABLED`
-: *New in version `23.02.0-edge`*
+: :::{versionadded} 23.02.0-edge
+  :::
 : Enable the use of Spack recipes defined by using the {ref}`process-spack` directive. (default: `false`).
 
 `NXF_TEMP`
@@ -1565,14 +1611,19 @@ The following environment variables control the configuration of the Nextflow ru
 
 `HTTP_PROXY`
 : Defines the HTTP proxy server.
-: *New in version `21.06.0-edge`:* proxy authentication is supported by providing the credentials in the proxy URL, e.g. `http://user:password@proxy-host.com:port`.
+: :::{versionadded} 21.06.0-edge
+  Proxy authentication is supported by providing the credentials in the proxy URL, e.g. `http://user:password@proxy-host.com:port`.
+  :::
 
 `HTTPS_PROXY`
 : Defines the HTTPS proxy server.
-: *New in version `21.06.0-edge`:* proxy authentication is supported by providing the credentials in the proxy URL, e.g. `https://user:password@proxy-host.com:port`.
+: :::{versionadded} 21.06.0-edge
+  Proxy authentication is supported by providing the credentials in the proxy URL, e.g. `https://user:password@proxy-host.com:port`.
+  :::
 
 `FTP_PROXY`
-: *New in version `21.06.0-edge`*
+: :::{versionadded} 21.06.0-edge
+  :::
 : Defines the FTP proxy server. Proxy authentication is supported by providing the credentials in the proxy URL, e.g. `ftp://user:password@proxy-host.com:port`.
 
 `NO_PROXY`
@@ -1592,9 +1643,13 @@ Some features can be enabled using the `nextflow.enable` and `nextflow.preview` 
 
 : Defines the DSL version to use (`1` or `2`).
 
-: *New in version `22.03.0-edge`:* DSL2 is the default DSL version.
+: :::{versionadded} 22.03.0-edge
+  DSL2 is the default DSL version.
+  :::
 
-: *New in version `22.12.0-edge`:* DSL1 is no longer supported.
+: :::{versionadded} 22.12.0-edge
+  DSL1 is no longer supported.
+  :::
 
 `nextflow.enable.moduleBinaries`
 
@@ -1602,7 +1657,8 @@ Some features can be enabled using the `nextflow.enable` and `nextflow.preview` 
 
 `nextflow.enable.strict`
 
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 
 : When `true`, the pipeline is executed in "strict" mode, which introduces the following rules:
 
@@ -1630,7 +1686,8 @@ Some features can be enabled using the `nextflow.enable` and `nextflow.preview` 
 
 `nextflow.preview.recursion`
 
-: *New in version `21.11.0-edge`*
+: :::{versionadded} 21.11.0-edge
+  :::
 
 : *EXPERIMENTAL: may change in a future release*
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -5,14 +5,15 @@
 Nextflow supports a variety of container runtimes. Containerization allows you to write self-contained and truly reproducible computational pipelines, by packaging the binary dependencies of a script into a standard and portable format that can be executed on any platform that supports a container runtime. Furthermore, the same pipeline can be transparently executed with any of the supported container runtimes, depending on which runtimes are available in the target compute environment.
 
 :::{note}
-When creating your container image to use with Nextflow, make sure that Bash (3.x or later) and `ps` are installed in your image, along with other tools required for collecting metrics (See  {ref}`this section <execution-report-tasks>`). Also, Bash should be available on the path `/bin/bash` and it should be the container entrypoint. 
+When creating your container image to use with Nextflow, make sure that Bash (3.x or later) and `ps` are installed in your image, along with other tools required for collecting metrics (See  {ref}`this section <execution-report-tasks>`). Also, Bash should be available on the path `/bin/bash` and it should be the container entrypoint.
 :::
 
 (container-apptainer)=
 
 ## Apptainer
 
-*New in version `22.11.0-edge`*
+:::{versionadded} 22.11.0-edge
+:::
 
 [Apptainer](https://apptainer.org) is an alternative container runtime to Docker and an open source fork of Singularity. The main advantages of Apptainer are that it can be used without root privileges and it doesn't require a separate daemon process. These, along with other features such as support for autofs mounts, makes Apptainer better suited to the requirements of HPC workloads. Apptainer is able to use existing Docker images and can pull from Docker registries.
 
@@ -117,7 +118,9 @@ This feature requires the `apptainer` tool to be installed where the workflow ex
 
 Nextflow caches those images in the `apptainer` directory in the pipeline work directory by default. However it is suggested to provide a centralised cache directory by using either the `NXF_APPTAINER_CACHEDIR` environment variable or the `apptainer.cacheDir` setting in the Nextflow config file.
 
-*New in version `21.09.0-edge`:* when looking for a Apptainer image file, Nextflow first checks the *library* directory, and if the image file is not found, the *cache* directory is used as usual. The library directory can be defined either using the `NXF_APPTAINER_LIBRARYDIR` environment variable or the `apptainer.libraryDir` configuration setting (the latter overrides the former).
+:::{versionadded} 21.09.0-edge
+When looking for a Apptainer image file, Nextflow first checks the *library* directory, and if the image file is not found, the *cache* directory is used s usual. The library directory can be defined either using the `NXF_APPTAINER_LIBRARYDIR` environment variable or the `apptainer.libraryDir` configuration setting (the latter overrides the former).
+:::
 
 :::{warning}
 When using a compute cluster, the Apptainer cache directory must reside in a shared filesystem accessible to all compute nodes.
@@ -135,13 +138,20 @@ Apptainer advanced configuration settings are described in {ref}`config-apptaine
 
 ## Charliecloud
 
-*New in version `20.12.0-edge`*
+:::{versionadded} 20.12.0-edge
+:::
 
-*Changed in version `21.03.0-edge`: requires Charliecloud 0.22 to 0.27*
+:::{versionchanged} 21.03.0-edge
+Requires Charliecloud 0.22 to 0.27.
+:::
 
-*Changed in version `22.09.0-edge`: requires Charliecloud 0.28 or later*
+:::{versionchanged} 22.09.0-edge
+Requires Charliecloud 0.28 or later.
+:::
 
-*EXPERIMENTAL: not recommended for production environments*
+:::{warning}
+EXPERIMENTAL: not recommended for production environments.
+:::
 
 [Charliecloud](https://hpc.github.io/charliecloud) is an alternative container runtime to Docker, that is better suited for use in HPC environments. Its main advantage is that it can be used without root privileges, making use of user namespaces in the Linux kernel. Charliecloud is able to pull from Docker registries.
 
@@ -321,7 +331,8 @@ Docker advanced configuration settings are described in {ref}`config-docker` sec
 
 ## Podman
 
-*New in version `20.01.0`*
+:::{versionadded} 20.01.0
+:::
 
 *EXPERIMENTAL: not recommended for production environments*
 
@@ -409,7 +420,9 @@ Podman advanced configuration settings are described in {ref}`config-podman` sec
 
 ## Sarus
 
-*New in version `22.12.0-edge`, requires Sarus 1.5.1 or later*
+:::{versionadded} 22.12.0-edge
+Requires Sarus 1.5.1 or later.
+:::
 
 [Sarus](https://sarus.readthedocs.io) is an alternative container runtime to Docker. Sarus works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Sarus enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
 
@@ -461,7 +474,9 @@ Read the {ref}`Process scope <config-process>` section to learn more about proce
 
 ## Shifter
 
-*New in version `19.10.0`, requires Shifter 18.03 or later*
+:::{versionadded} 19.10.0
+Requires Shifter 18.03 or later.
+:::
 
 [Shifter](https://docs.nersc.gov/programming/shifter/overview/) is an alternative container runtime to Docker. Shifter works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Shifter enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
 
@@ -609,7 +624,11 @@ singularity.enabled = true
 
 You do not need to specify `docker://` to pull from a Docker repository. Nextflow will automatically prepend it to your image name when Singularity is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
 
-*New in version `19.04.0`, requires Singularity 3.0.3 or later:* Nextflow supports the [Singularity Library](https://cloud.sylabs.io/library/) repository:
+:::{versionadded} 19.04.0
+Requires Singularity 3.0.3 or later.
+:::
+
+Nextflow supports the [Singularity Library](https://cloud.sylabs.io/library/) repository:
 
 ```groovy
 process.container = 'library://library/default/alpine:3.8'
@@ -619,7 +638,9 @@ The `library://` pseudo-protocol allows you to import Singularity images from a 
 
 Nextflow caches the images in `${NXF_WORK}/singularity` by default. However, it is recommended to define a centralised cache directory using either the `NXF_SINGULARITY_CACHEDIR` environment variable or the `singularity.cacheDir` setting in the Nextflow config file.
 
-*New in version `21.09.0-edge`:* when looking for a Singularity image file, Nextflow first checks the *library* directory, and if the image file is not found, the *cache* directory is used as usual. The library directory can be defined either using the `NXF_SINGULARITY_LIBRARYDIR` environment variable or the `singularity.libraryDir` configuration setting (the latter overrides the former).
+:::{versionadded} 21.09.0-edge
+When looking for a Singularity image file, Nextflow first checks the *library* directory, and if the image file is not found, the *cache* directory is used as usual. The library directory can be defined either using the `NXF_SINGULARITY_LIBRARYDIR` environment variable or the `singularity.libraryDir` configuration setting (the latter overrides the former).
+:::
 
 :::{warning}
 When using a compute cluster, the Singularity cache directory must reside in a shared filesystem accessible to all compute nodes.

--- a/docs/dsl2.md
+++ b/docs/dsl2.md
@@ -10,15 +10,21 @@ To enable this feature you need to define the following directive at the beginni
 nextflow.enable.dsl=2
 ```
 
-*Changed in version `22.03.0-edge`:* Nextflow uses DSL2 if no version is specified explicitly. You can restore the previous behavior by setting the following environment variable:
+:::{versionchanged} 22.03.0-edge
+Nextflow uses DSL2 if no version is specified explicitly. You can restore the previous behavior by setting the following environment variable:
 
 ```bash
 export NXF_DEFAULT_DSL=1
 ```
+:::
 
-*Changed in version `22.03.0-edge`:* the DSL version specification (either 1 or 2) can also be specified in the Nextflow configuration file using the same notation shown above.
+:::{versionchanged} 22.03.0-edge
+The DSL version specification (either 1 or 2) can also be specified in the Nextflow configuration file using the same notation shown above.
+:::
 
-*Changed in version `22.11.0-edge`:* support for DSL1 was removed from Nextflow.
+:::{versionchanged} 22.11.0-edge
+Support for DSL1 was removed from Nextflow.
+:::
 
 ## Function
 
@@ -356,7 +362,8 @@ Relative paths must begin with the `./` prefix. Also, the `include` statement mu
 
 ### Module directory
 
-*New in version `22.10.0`*
+:::{versionadded} 22.10.0
+:::
 
 The module can be defined as a directory whose name matches the module name and contains a script named `main.nf`. For example:
 
@@ -539,7 +546,8 @@ baseDir
 
 ### Module binaries
 
-*New in version `22.10.0`*
+:::{versionadded} 22.10.0
+:::
 
 Modules can define binary scripts that are locally scoped to the processes defined by the tasks.
 

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -36,7 +36,8 @@ See the {ref}`AWS Batch<aws-batch>` page for further configuration details.
 
 ## Azure Batch
 
-*New in version `21.04.0`*
+:::{versionadded} 21.04.0
+:::
 
 Nextflow supports the [Azure Batch](https://azure.microsoft.com/en-us/services/batch/) service that allows job submission in the cloud without having to spin out and manage a cluster of virtual machines. Azure Batch uses Docker containers to run tasks, which greatly simplifies pipeline deployment.
 
@@ -62,7 +63,8 @@ See the {ref}`Azure Batch <azure-batch>` page for further configuration details.
 
 ## Bridge
 
-*New in version `22.09.1-edge`*
+:::{versionadded} 22.09.1-edge
+:::
 
 [Bridge](https://github.com/cea-hpc/bridge) is an abstraction layer to ease batch system and resource manager usage in heterogeneous HPC environments.
 
@@ -84,7 +86,8 @@ Resource requests and other job characteristics can be controlled via the follow
 
 ## Flux Executor
 
-*New in version `22.11.0-edge`*
+:::{versionadded} 22.11.0-edge
+:::
 
 The `flux` executor allows you to run your pipeline script using the [Flux Framework](https://flux-framework.org).
 
@@ -161,7 +164,8 @@ Make sure the TES backend can access the Nextflow work directory when data is ex
 
 ## Google Cloud Batch
 
-*New in version `22.07.1-edge`*
+:::{versionadded} 22.07.1-edge
+:::
 
 [Google Cloud Batch](https://cloud.google.com/batch) is a managed computing service that allows the execution of containerized workloads in the Google Cloud Platform infrastructure.
 
@@ -189,7 +193,8 @@ See the {ref}`Google Cloud Batch <google-batch>` page for further configuration 
 
 ## Google Life Sciences
 
-*New in version `20.01.0`*
+:::{versionadded} 20.01.0
+:::
 
 [Google Cloud Life Sciences](https://cloud.google.com/life-sciences) is a managed computing service that allows the execution of containerized workloads in the Google Cloud Platform infrastructure.
 
@@ -240,7 +245,8 @@ Resource requests and other job characteristics can be controlled via the follow
 
 ## HyperQueue
 
-*New in version `22.05.0-edge`*
+:::{versionadded} 22.05.0-edge
+:::
 
 *EXPERIMENTAL: may change in a future release*
 
@@ -268,7 +274,9 @@ Resource requests and other job characteristics can be controlled via the follow
 This feature is no longer maintained.
 :::
 
-*Changed in version `22.01.0-edge`:* the `ignite` executor must be enabled via the `nf-ignite` plugin.
+:::{versionchanged} 22.01.0-edge
+The `ignite` executor must be enabled via the `nf-ignite` plugin.
+:::
 
 The `ignite` executor allows you to run a pipeline on an [Apache Ignite](https://ignite.apache.org/) cluster.
 
@@ -339,7 +347,8 @@ See also the [Platform LSF documentation](https://www.ibm.com/support/knowledgec
 
 ## Moab
 
-*New in version `19.07.0`*
+:::{versionadded} 19.07.0
+:::
 
 *EXPERIMENTAL: may change in a future release*
 
@@ -383,7 +392,8 @@ Resource requests and other job characteristics can be controlled via the follow
 
 ## OAR
 
-*New in version `19.11.0-edge`*
+:::{versionadded} 19.11.0-edge
+:::
 
 The `oar` executor allows you to run your pipeline script using the [OAR](https://oar.imag.fr) resource manager.
 

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -2,7 +2,8 @@
 
 # Flux Framework
 
-*New in version `22.11.0-edge`*
+:::{versionadded} 22.11.0-edge
+:::
 
 The [Flux Framework](https://flux-framework.org/) is a modern resource manager that can span the space between cloud and HPC. If your center does not provide Flux for you, you can [build Flux on your own](https://flux-framework.readthedocs.io/en/latest/quickstart.html#building-the-code) and launch it as a job with your resource manager of choice (e.g. SLURM or a cloud provider).
 

--- a/docs/fusion.md
+++ b/docs/fusion.md
@@ -2,9 +2,12 @@
 
 # Fusion file system
 
-*New in version `22.10.0`*
+:::{versionadded} 22.10.0
+:::
 
-*New in version `23.02.0-edge`: support for Google Cloud Storage*
+:::{versionadded} 23.02.0-edge
+Support for Google Cloud Storage.
+:::
 
 ## Introduction
 

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -124,7 +124,7 @@ workflow {
 }
 ```
 
-:::{note} 
+:::{note}
 For versions of Nextflow prior to `22.10.0`, you must explicitly enable DSL2 by adding `nextflow.enable.dsl=2` to the top of the script or by using the `-dsl2` command-line option.
 :::
 
@@ -228,4 +228,6 @@ edno
 uojnoB
 ```
 
-*Changed in version `20.11.0-edge`:* any `.` (dot) character in a parameter name is interpreted as the delimiter of a nested scope. For example, `--foo.bar Hello` will be interpreted as `params.foo.bar`. If you want to have a parameter name that contains a `.` (dot) character, escape it using the back-slash character, e.g. `--foo\.bar Hello`.
+:::{versionchanged} 20.11.0-edge
+Any `.` (dot) character in a parameter name is interpreted as the delimiter of a nested scope. For example, `--foo.bar Hello` will be interpreted as `params.foo.bar`. If you want to have a parameter name that contains a `.` (dot) character, escape it using the back-slash character, e.g. `--foo\.bar Hello`.
+:::

--- a/docs/google.md
+++ b/docs/google.md
@@ -39,7 +39,8 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/your/file/creds.json"
 
 ## Cloud Batch
 
-*New in version `22.07.1-edge`*
+:::{versionadded} 22.07.1-edge
+:::
 
 [Google Cloud Batch](https://cloud.google.com/batch) is a managed computing service that allows the execution of containerized workloads in the Google Cloud Platform infrastructure.
 
@@ -89,9 +90,11 @@ Read the {ref}`Google configuration<config-google>` section to learn more about 
 
 Processes can be defined as usual and by default the `cpus` and `memory` directives are used to find the cheapest machine type available at current location that fits the requested resources. If `memory` is not specified, 1GB of memory is allocated per cpu.
 
-*New in version `23.02.0-edge`:* the `machineType` directive can be a list of patterns separated by comma. The pattern can contain a `*` to match any number of characters and `?` to match any single character. Examples of valid patterns: `c2-*`, `m?-standard*`, `n*`.
+:::{versionadded} 23.02.0-edge
+The `machineType` directive can be a list of patterns separated by comma. The pattern can contain a `*` to match any number of characters and `?` to match any single character. Examples of valid patterns: `c2-*`, `m?-standard*`, `n*`.
 
 Alternatively it can also be used to define a specific predefined Google Compute Platform [machine type](https://cloud.google.com/compute/docs/machine-types) or a custom machine type.
+:::
 
 Examples:
 
@@ -163,7 +166,8 @@ process {
 
 ### Fusion file system
 
-*New in version `23.02.0-edge`*
+:::{versionadded} 23.02.0-edge
+:::
 
 The Google Batch executor supports the use of {ref}`fusion-page`. Fusion allows the use of Google Cloud Storage as a virtual distributed file system, optimising the data transfer and speeding up most job I/O operations.
 
@@ -200,7 +204,8 @@ The integration with Google Batch is a developer preview feature. Currently the 
 
 ## Cloud Life Sciences
 
-*New in version `20.01.0-edge`*
+:::{versionadded} 20.01.0-edge
+:::
 
 :::{note}
 In versions of Nextflow prior to `21.04.0`, the following variables must be defined in your system environment:

--- a/docs/ignite.md
+++ b/docs/ignite.md
@@ -6,7 +6,9 @@
 This feature is no longer maintained.
 :::
 
-*Changed in version `22.01.0-edge`:* the `ignite` executor must be enabled via the `nf-ignite` plugin.
+:::{versionchanged} 22.01.0-edge
+The `ignite` executor must be enabled via the `nf-ignite` plugin.
+:::
 
 Nextflow can be deployed in a *cluster* mode by using [Apache Ignite](https://ignite.apache.org/), an in-memory data-grid and clustering platform.
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -79,7 +79,8 @@ The pod is automatically destroyed once the shell session terminates. Do not use
 
 ### Launch with Fusion
 
-*New in version `22.10.0`*
+:::{versionadded} 22.10.0
+:::
 
 The use of {ref}`fusion-page` allows deploying a Nextflow pipeline to a remote (or local) cluster without the need to use a shared file system and configure a persistent volume claim for the deployment of Nextflow pipeline with Kubernetes.
 

--- a/docs/make-html.sh
+++ b/docs/make-html.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 docker run -v $(pwd):/tmp nextflow/sphinx:5.3.0 -- make html
+echo "Done. See _build/html/index.html"

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -18,7 +18,8 @@ This page is a comprehensive reference for all Nextflow operators. However, if y
 
 ## branch
 
-*New in version `19.08.0-edge`*
+:::{versionadded} 19.08.0-edge
+:::
 
 *Returns: map of queue channels*
 
@@ -608,13 +609,15 @@ Channel
 
 Then you will be able to specify the tag `foo` or `bar` as an argument of the `-dump-channels` option to print either the content of the first or the second channel. Multiple tag names can be specified separating them with a `,` character.
 
-*New in version `22.10.0`:* The output can be formatted by enabling the `pretty` option:
+:::{versionadded} 22.10.0
+The output can be formatted by enabling the `pretty` option:
 
 ```groovy
 Channel
     .fromSRA('SRP043510')
     .dump(tag: 'foo', pretty: true)
 ```
+:::
 
 ## filter
 
@@ -1173,7 +1176,8 @@ The items emitted by the resulting mixed channel may appear in any order, regard
 
 ## multiMap
 
-*New in version `19.11.0-edge`*
+:::{versionadded} 19.11.0-edge
+:::
 
 *Returns: map of queue channels*
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -45,7 +45,8 @@ To add a new plugin to the Index, create a pull request including the request pl
 
 ## Import operators from plugin
 
-*New in version `22.04.0`*
+:::{versionadded} 22.04.0
+:::
 
 Nextflow supports the inclusion of custom operators from Nextflow plugins.
 
@@ -68,7 +69,8 @@ The prefix `plugin/` must precede the plugin name in the include `from` statemen
 
 ## Import custom functions from plugin
 
-*New in version `22.09.0-edge`*
+:::{versionadded} 22.09.0-edge
+:::
 
 Nextflow supports the inclusion of custom functions from Nextflow plugins.
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -280,7 +280,8 @@ Hello Mr. c
 
 ## Stub
 
-*New in version `20.11.0-edge`*
+:::{versionadded} 20.11.0-edge
+:::
 
 You can define a command *stub*, which replaces the actual process command when the `-stub-run` or `-stub` command-line option is enabled:
 
@@ -636,7 +637,9 @@ hello
 
 ### Input type `set`
 
-*Deprecated, use `tuple` instead*
+:::{deprecated} x
+Use `tuple` instead.
+:::
 
 (process-input-tuple)=
 
@@ -1050,7 +1053,9 @@ workflow {
 
 ### Output type `set`
 
-*Deprecated, use `tuple` instead*
+:::{deprecated} x
+Use `tuple` instead.
+:::
 
 (process-out-tuple)=
 
@@ -1171,7 +1176,8 @@ Some directives are generally available to all processes, while others depend on
 
 ### accelerator
 
-*New in version `19.09.0-edge`*
+:::{versionadded} 19.09.0-edge
+:::
 
 The `accelerator` directive allows you to request hardware accelerators (e.g. GPUs) for the task execution. For example:
 
@@ -1461,7 +1467,9 @@ See also: [cpus](#cpus), [memory](#memory) [time](#time), [queue](#queue) and [D
 
 ### echo
 
-*Deprecated since version `22.04.0`, use `debug` instead*
+:::{deprecated} `22.04.0`
+Use `debug` instead
+:::
 
 (process-error-strategy)=
 
@@ -1594,7 +1602,8 @@ process.ext.version = '2.5.3'
 
 ### fair
 
-*New in version `22.12.0-edge`*
+:::{versionadded} 22.12.0-edge
+:::
 
 The `fair` directive, when enabled, guarantees that process outputs will be emitted in the order in which they were received. For example:
 
@@ -1657,7 +1666,8 @@ See also: [resourceLabels](#resourcelabels)
 
 ### machineType
 
-*New in version `19.07.0`*
+:::{versionadded} 19.07.0
+:::
 
 The `machineType` can be used to specify a predefined Google Compute Platform [machine type](https://cloud.google.com/compute/docs/machine-types) when running using the {ref}`Google Life Sciences <google-lifesciences-executor>` executor.
 
@@ -1862,7 +1872,8 @@ process {
 The `pod` directive supports the following options:
 
 `affinity: <V>`
-: *New in version `22.01.0-edge`*
+: :::{versionadded} 22.01.0-edge
+  :::
 : Specifies affinity for which nodes the process should run on. See [Kubernetes affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for details.
 
 `annotation: <K>, value: <V>`
@@ -1870,7 +1881,8 @@ The `pod` directive supports the following options:
 : Defines a pod annotation with key `K` and value `V`.
 
 `automountServiceAccountToken: <V>`
-: *New in version `22.01.0-edge`*
+: :::{versionadded} 22.01.0-edge
+  :::
 : Specifies whether to [automount service account token](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) into process pods. If `V` is true, service account token is automounted into task pods (default).
 
 `config: <C/K>, mountPath: </absolute/path>`
@@ -1878,12 +1890,14 @@ The `pod` directive supports the following options:
 : Mounts a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) with name `C` with key `K` to the path `/absolute/path`. When the key component is omitted the path is interpreted as a directory and all the `ConfigMap` entries are exposed in that path.
 
 `csi: <V>, mountPath: </absolute/path>`
-: *New in version `22.11.0-edge`*
+: :::{versionadded} 22.11.0-edge
+  :::
 : *Can be specified multiple times*
 : Mounts a [CSI ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes) with config `V`to the path `/absolute/path`.
 
 `emptyDir: <V>, mountPath: </absolute/path>`
-: *New in version `22.11.0-edge`*
+: :::{versionadded} 22.11.0-edge
+  :::
 : *Can be specified multiple times*
 : Mounts an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) with configuration `V` to the path `/absolute/path`.
 
@@ -1892,7 +1906,8 @@ The `pod` directive supports the following options:
 : Defines an environment variable with name `E` and whose value is given by the entry associated to the key with name `K` in the [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) with name `C`.
 
 `env: <E>, fieldPath: <V>`
-: *New in version `21.09.1-edge`*
+: :::{versionadded} 21.09.1-edge
+  :::
 : *Can be specified multiple times*
 : Defines an environment variable with name `E` and whose value is given by the `V` [field path](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
 
@@ -1918,11 +1933,13 @@ The `pod` directive supports the following options:
 : Specifies which node the process will run on. See [Kubernetes nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for details.
 
 `priorityClassName: <V>`
-: *New in version `22.01.0-edge`*
+: :::{versionadded} 22.01.0-edge
+  :::
 : Specifies the [priority class name](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for pods.
 
 `privileged: <B>`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : Whether the process task should run as a *privileged* container (default: `false`)
 
 `runAsUser: <UID>`
@@ -1936,7 +1953,8 @@ The `pod` directive supports the following options:
 : Specifies the pod security context. See [Kubernetes security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for details.
 
 `toleration: <V>`
-: *New in version `22.04.0`*
+: :::{versionadded} 22.04.0
+  :::
 : *Can be specified multiple times*
 : Specifies a toleration for a node taint. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.
 
@@ -1995,7 +2013,8 @@ Files are copied into the specified directory in an *asynchronous* manner, so th
 Available options:
 
 `contentType`
-: *New in version `22.10.0`*
+: :::{versionadded} 22.10.0
+  :::
 : *EXPERIMENTAL: currently only supported for S3*
 : Allow specifying the media content type of the published file a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types). If set to `true`, the content type is inferred from the file extension (default: `false`).
 
@@ -2028,12 +2047,14 @@ Available options:
 : A closure which, given the name of the file being published, returns the actual file name or a full path where the file is required to be stored. This can be used to rename or change the destination directory of the published files dynamically by using a custom strategy. Return the value `null` from the closure to *not* publish a file. This is useful when the process has multiple output files, but you want to publish only some of them.
 
 `storageClass`
-: *New in version `22.12.0-edge`*
+: :::{versionadded} 22.12.0-edge
+  :::
 : *EXPERIMENTAL: currently only supported for S3*
 : Allow specifying the storage class to be used for the published file.
 
 `tags`
-: *New in version `21.12.0-edge`*
+: :::{versionadded} 21.12.0-edge
+  :::
 : *EXPERIMENTAL: currently only supported for S3*
 : Allow the association of arbitrary tags with the published file e.g. `tags: [FOO: 'Hello world']`.
 
@@ -2075,7 +2096,8 @@ This directive is only used by certain executors. Refer to the {ref}`executor-pa
 
 ### resourceLabels
 
-*New in version `22.09.1-edge`*
+:::{versionadded} 22.09.1-edge
+:::
 
 The `resourceLabels` directive allows you to specify custom name-value pairs that Nextflow applies to the computing resource used to carry out the process execution. Resource labels can be specified using the syntax shown below:
 
@@ -2215,14 +2237,16 @@ The `stageOutMode` directive defines how output files are staged out from the sc
 : Output files are copied from the scratch directory to the work directory.
 
 `'fcp'`
-: *New in version `23.02.0-edge`*
+: :::{versionadded} 23.02.0-edge
+  :::
 : Output files are copied from the scratch directory to the work directory by using the [fcp](https://github.com/Svetlitski/fcp) utility (note: it must be available in your cluster computing nodes).
 
 `'move'`
 : Output files are moved from the scratch directory to the work directory.
 
 `'rclone'`
-: *New in version `23.01.0-edge`*
+: :::{versionadded} 23.01.0-edge
+  :::
 : Output files are copied from the scratch directory to the work directory by using the [rclone](https://rclone.org) utility (note: it must be available in your cluster computing nodes).
 
 `'rsync'`

--- a/docs/script.md
+++ b/docs/script.md
@@ -228,15 +228,19 @@ In the preceding example, `blastp` and its `-in`, `-out`, `-db` and `-html` swit
 The following variables are implicitly defined in the script global execution scope:
 
 `baseDir`
-: *Deprecated since version `20.04.0`, use `projectDir` instead*
+: :::{deprecated} 20.04.0
+  Use `projectDir` instead
+  :::
 : The directory where the main workflow script is located.
 
 `launchDir`
-: *New in version `20.04.0`*
+: :::{versionadded} 20.04.0
+  :::
 : The directory where the workflow is run.
 
 `moduleDir`
-: *New in version `20.04.0`*
+: :::{versionadded} 20.04.0
+  :::
 : The directory where a module script is located for DSL2 modules or the same as `projectDir` for a non-module script.
 
 `nextflow`
@@ -246,7 +250,8 @@ The following variables are implicitly defined in the script global execution sc
 : Dictionary like object holding workflow parameters specifying in the config file or as command line options.
 
 `projectDir`
-: *New in version `20.04.0`*
+: :::{versionadded} 20.04.0
+  :::
 : The directory where the main script is located.
 
 `workDir`
@@ -260,15 +265,19 @@ The following variables are implicitly defined in the script global execution sc
 The following variables are implicitly defined in the Nextflow configuration file:
 
 `baseDir`
-: *Deprecated since version `20.04.0`, use `projectDir` instead*
+: :::{deprecated} 20.04.0
+  Use `projectDir` instead
+  :::
 : The directory where the main workflow script is located.
 
 `launchDir`
-: *New in version `20.04.0`*
+: :::{versionadded} 20.04.0
+  :::
 : The directory where the workflow is run.
 
 `projectDir`
-: *New in version `20.04.0`*
+: :::{versionadded} 20.04.0
+  :::
 : The directory where the main script is located.
 
 ### Process implicit variables

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,7 +2,9 @@
 
 # Secrets
 
-*New in version `22.10.0` (previewed in `21.09.0-edge`)*
+:::{versionadded} 22.10.0
+Previewed in `21.09.0-edge`.
+:::
 
 Nextflow has built-in support for pipeline secrets to allow users to safely provide sensitive information to a pipeline execution.
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -167,7 +167,9 @@ providers {
 
 In the above template replace `<provider-name>` with one of the "default" servers (i.e. `bitbucket`, `github` or `gitlab`) or a custom identifier representing a private SCM server installation.
 
-*New in version `20.10.0`:* A custom location for the SCM file can be specified using the `NXF_SCM_FILE` environment variable.
+:::{versionadded} 20.10.0
+A custom location for the SCM file can be specified using the `NXF_SCM_FILE` environment variable.
+:::
 
 The following configuration properties are supported for each provider configuration:
 
@@ -247,7 +249,9 @@ providers {
 
 GitHub requires the use of a personal access token (PAT) in place of a password when accessing APIs. Learn more about PAT and how to create it at [this link](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
-*New in version `23.01.0-edge`:* Nextflow automatically uses the `GITHUB_TOKEN` environment variable to authenticate access to the GitHub repository if no credentials are provided via the `scm` file. This is useful especially when accessing pipeline code from a GitHub Action. Read more about the token authentication in the [GitHub documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).
+:::{versionadded} 23.01.0-edge
+Nextflow automatically uses the `GITHUB_TOKEN` environment variable to authenticate access to the GitHub repository if no credentials are provided via the `scm` file. This is useful especially when accessing pipeline code from a GitHub Action. Read more about the token authentication in the [GitHub documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).
+:::
 
 ### GitLab credentials
 
@@ -305,7 +309,8 @@ The Personal access token can be generated in the repository `Clone Repository` 
 
 ### AWS CodeCommit credentials
 
-*New in version `22.06.0-edge`*
+:::{versionadded} 22.06.0-edge
+:::
 
 Nextflow supports [AWS CodeCommit](https://aws.amazon.com/codecommit/) as a Git provider to access and to share pipelines code.
 

--- a/docs/spack.md
+++ b/docs/spack.md
@@ -2,7 +2,8 @@
 
 # Spack environments
 
-*New in version `23.02.0-edge`*
+:::{versionadded} 23.02.0-edge
+:::
 
 [Spack](https://spack.io/) is a package manager for supercomputers, Linux, and macOS. It makes installing scientific software easy. Spack is not tied to a particular language; you can build a software stack in Python or R, link to libraries written in C, C++, or Fortran, and easily swap compilers or target specific microarchitectures.
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -303,7 +303,8 @@ The following table shows the fields that can be included in the execution repor
 : The action applied on errof task failure.
 
 `hostname`
-: *New in version `22.05.0-edge`*
+: :::{versionadded} 22.05.0-edge
+  :::
 : The host on which the task was executed. Supported only for the Kubernetes executor yet. Activate with `k8s.fetchNodeName = true` in the Nextflow config file.
 
 :::{note}
@@ -372,7 +373,11 @@ The DAG produced by Nextflow for the [Unistrap](https://github.com/cbcrg/unistra
 ```{image} images/dag.png
 ```
 
-*New in version `22.04.0`:* Nextflow can render the DAG as a [Mermaid](https://mermaid-js.github.io/) diagram. Mermaid diagrams are particularly useful because they can be embedded in [GitHub Flavored Markdown](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) without having to render them yourself. You can customize the diagram with CSS, and you can even add links! Visit the [Mermaid documentation](https://mermaid-js.github.io/mermaid/#/flowchart?id=styling-and-classes) for details.
+:::{versionadded} 22.04.0
+Nextflow can render the DAG as a [Mermaid](https://mermaid-js.github.io/) diagram.
+:::
+
+Mermaid diagrams are particularly useful because they can be embedded in [GitHub Flavored Markdown](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) without having to render them yourself. You can customize the diagram with CSS, and you can even add links! Visit the [Mermaid documentation](https://mermaid-js.github.io/mermaid/#/flowchart?id=styling-and-classes) for details.
 
 Here is the Mermaid diagram produced by Nextflow for the above example:
 

--- a/docs/wave.md
+++ b/docs/wave.md
@@ -2,7 +2,8 @@
 
 # Wave containers
 
-*New in version `22.10.0`*
+:::{versionadded} 22.10.0
+:::
 
 [Wave](https://seqera.io/wave/) is a container provisioning service integrated with Nextflow. With Wave, you can build, upload, and manage the container images required by your data analysis workflows automatically and on-demand during pipeline execution.
 


### PR DESCRIPTION
Converted the new italic version notices added by @bentsherman in #3902 to admonitions, using dedicated version-change admonition types:

https://myst-parser.readthedocs.io/en/latest/syntax/admonitions.html#admonition-types

```markdown
:::{versionadded} 19.07.0
A new feature was added.
:::

:::{versionchanged} 22.08.0-edge
Something changed.
:::

:::{deprecated} 21.04.0
:::
```

Added a bit of custom CSS to style them:

<img width="751" alt="CleanShot 2023-05-01 at 23 36 12@2x" src="https://user-images.githubusercontent.com/465550/235535802-0053e48e-ec7e-4c2c-a08e-954e89f9bdbe.png">

This syntax should be no problem in a new Astro site. Worst case scenario, they will be easier to change using global find + replace.

Sanity checks / making sure I didn't break anything / suggestions on styling welcome 🙏🏻 

Note that we can [make admonitions collapsible](https://myst-parser.readthedocs.io/en/latest/syntax/admonitions.html#collapsible-admonitions) if we want as well.