### PR TITLE
Add CPU model name to trace files and traceRecord

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -307,6 +307,9 @@ The following table shows the fields that can be included in the execution repor
   :::
 : The host on which the task was executed. Supported only for the Kubernetes executor yet. Activate with `k8s.fetchNodeName = true` in the Nextflow config file.
 
+`cpu_model`
+: The name of the CPU model which was used to execute the task. This data is read from file `/proc/cpuinfo`.
+
 :::{note}
 These metrics provide an estimation of the resources used by running tasks. They are not an alternative to low-level performance analysis tools, and they may not be completely accurate, especially for very short-lived tasks (running for less than a few seconds).
 :::

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -308,7 +308,9 @@ The following table shows the fields that can be included in the execution repor
 : The host on which the task was executed. Supported only for the Kubernetes executor yet. Activate with `k8s.fetchNodeName = true` in the Nextflow config file.
 
 `cpu_model`
-: The name of the CPU model which was used to execute the task. This data is read from file `/proc/cpuinfo`.
+: :::{versionadded} 22.07.0-edge
+  :::
+: The name of the CPU model used to execute the task. This data is read from file `/proc/cpuinfo`.
 
 :::{note}
 These metrics provide an estimation of the resources used by running tasks. They are not an alternative to low-level performance analysis tools, and they may not be completely accurate, especially for very short-lived tasks (running for less than a few seconds).

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -87,6 +87,7 @@ class TraceRecord implements Serializable {
             syscw:      'num',      // -- /proc/$pid/io
             read_bytes: 'mem',      // -- /proc/$pid/io
             write_bytes:'mem',      // -- /proc/$pid/io
+            cpu_model:  'str',      // -- /proc/cpuinfo field 'model name'
             attempt:    'num',
             workdir:    'str',
             script:     'str',
@@ -446,6 +447,10 @@ class TraceRecord implements Serializable {
                     // these fields are provided in KB, so they are normalized to bytes
                     def val = parseLong(value, file, name) * 1024
                     this.put(name, val)
+                    break
+
+                case 'cpu_model':
+                    this.put(name, value)
                     break
 
                 default:

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -87,7 +87,6 @@ class TraceRecord implements Serializable {
             syscw:      'num',      // -- /proc/$pid/io
             read_bytes: 'mem',      // -- /proc/$pid/io
             write_bytes:'mem',      // -- /proc/$pid/io
-            cpu_model:  'str',      // -- /proc/cpuinfo field 'model name'
             attempt:    'num',
             workdir:    'str',
             script:     'str',
@@ -101,7 +100,8 @@ class TraceRecord implements Serializable {
             error_action:'str',
             vol_ctxt: 'num',
             inv_ctxt: 'num',
-            hostname: 'str'
+            hostname: 'str',
+            cpu_model:  'str',      // -- /proc/cpuinfo field 'model name'
     ]
 
     static public Map<String,Closure<String>> FORMATTER = [

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -101,7 +101,7 @@ class TraceRecord implements Serializable {
             vol_ctxt: 'num',
             inv_ctxt: 'num',
             hostname: 'str',
-            cpu_model:  'str',      // -- /proc/cpuinfo field 'model name'
+            cpu_model:  'str'
     ]
 
     static public Map<String,Closure<String>> FORMATTER = [

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -127,6 +127,7 @@ nxf_write_trace() {
     echo "nextflow.trace/v2"           > $trace_file
     echo "realtime=$wall_time"         >> $trace_file
     echo "%cpu=$ucpu"                  >> $trace_file
+    echo "cpu_model=$cpu_model"        >> $trace_file
     echo "rchar=${io_stat1[0]}"        >> $trace_file
     echo "wchar=${io_stat1[1]}"        >> $trace_file
     echo "syscr=${io_stat1[2]}"        >> $trace_file
@@ -144,6 +145,7 @@ nxf_trace_mac() {
     local end_millis=$(nxf_date)
     local wall_time=$((end_millis-start_millis))
     local ucpu=''
+    local cpu_model=''
     local io_stat1=('' '' '' '' '' '')
     nxf_write_trace
 }

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -163,6 +163,7 @@ nxf_trace_linux() {
     ##  https://stackoverflow.com/questions/27508531/calculate-cpu-per-process/27514562##27514562
     ##  https://stackoverflow.com/questions/16726779/how-do-i-get-the-total-cpu-usage-of-an-application-from-proc-pid-stat
     local num_cpus=$(< /proc/cpuinfo grep '^processor' -c)
+    local cpu_model=$(< /proc/cpuinfo grep '^model name' | head -n 1 | awk 'BEGIN{FS="\t: "} { print $2 }')
     local tot_time0=$(grep '^cpu ' /proc/stat | awk '{sum=$2+$3+$4+$5+$6+$7+$8+$9; printf "%.0f",sum}')
     local cpu_time0=$(2> /dev/null < /proc/$pid/stat awk '{printf "%.0f", ($16+$17)*10 }' || echo -n 'X')
     local io_stat0=($(2> /dev/null < /proc/$pid/io sed 's/^.*:\s*//' | head -n 6 | tr '\n' ' ' || echo -n '0 0 0 0 0 0'))
@@ -199,6 +200,7 @@ nxf_trace_linux() {
     echo "nextflow.trace/v2"           > $trace_file
     echo "realtime=$wall_time"         >> $trace_file
     echo "%cpu=$ucpu"                  >> $trace_file
+    echo "cpu_model=$cpu_model"        >> $trace_file
     echo "rchar=${io_stat1[0]}"        >> $trace_file
     echo "wchar=${io_stat1[1]}"        >> $trace_file
     echo "syscr=${io_stat1[2]}"        >> $trace_file

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -109,6 +109,7 @@ nxf_write_trace() {
     echo "nextflow.trace/v2"           > $trace_file
     echo "realtime=$wall_time"         >> $trace_file
     echo "%cpu=$ucpu"                  >> $trace_file
+    echo "cpu_model=$cpu_model"        >> $trace_file
     echo "rchar=${io_stat1[0]}"        >> $trace_file
     echo "wchar=${io_stat1[1]}"        >> $trace_file
     echo "syscr=${io_stat1[2]}"        >> $trace_file
@@ -125,6 +126,7 @@ nxf_trace_mac() {
     local end_millis=$(nxf_date)
     local wall_time=$((end_millis-start_millis))
     local ucpu=''
+    local cpu_model=''
     local io_stat1=('' '' '' '' '' '')
     nxf_write_trace
 }
@@ -139,6 +141,7 @@ nxf_trace_linux() {
     local pid=$$
     command -v ps &>/dev/null || { >&2 echo "Command 'ps' required by nextflow to collect task metrics cannot be found"; exit 1; }
     local num_cpus=$(< /proc/cpuinfo grep '^processor' -c)
+    local cpu_model=$(< /proc/cpuinfo grep '^model name' | head -n 1 | awk 'BEGIN{FS="\t: "} { print $2 }')
     local tot_time0=$(grep '^cpu ' /proc/stat | awk '{sum=$2+$3+$4+$5+$6+$7+$8+$9; printf "%.0f",sum}')
     local cpu_time0=$(2> /dev/null < /proc/$pid/stat awk '{printf "%.0f", ($16+$17)*10 }' || echo -n 'X')
     local io_stat0=($(2> /dev/null < /proc/$pid/io sed 's/^.*:\s*//' | head -n 6 | tr '\n' ' ' || echo -n '0 0 0 0 0 0'))
@@ -171,6 +174,7 @@ nxf_trace_linux() {
     echo "nextflow.trace/v2"           > $trace_file
     echo "realtime=$wall_time"         >> $trace_file
     echo "%cpu=$ucpu"                  >> $trace_file
+    echo "cpu_model=$cpu_model"        >> $trace_file
     echo "rchar=${io_stat1[0]}"        >> $trace_file
     echo "wchar=${io_stat1[1]}"        >> $trace_file
     echo "syscr=${io_stat1[2]}"        >> $trace_file


### PR DESCRIPTION
This adds the CPU model name to the trace files (to allow using this information for a CO2 footprint plugin) and accordingly to the `traceRecord`.

It is not added to any tests yet.