### PR TITLE
Use full map of valid options for JsonSplitter creation

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
@@ -70,10 +70,8 @@ class JsonSplitter extends AbstractTextSplitter {
     @Override
     protected Map<String,?> validOptions() {
         def baseOptions = super.validOptions()
-        return [
-            path: String,
-            limit: baseOptions.limit
-        ]
+        baseOptions.path = String
+        return baseOptions
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
@@ -69,7 +69,7 @@ class JsonSplitter extends AbstractTextSplitter {
      */
     @Override
     protected Map<String,?> validOptions() {
-        def baseOptions = super.validOptions()
+        final baseOptions = super.validOptions()
         return [
             autoClose: baseOptions.autoClose,
             into: baseOptions.into,

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
@@ -73,7 +73,7 @@ class JsonSplitter extends AbstractTextSplitter {
         return [
             autoClose: baseOptions.autoClose,
             into: baseOptions.into,
-            limit: baseOptions.limit
+            limit: baseOptions.limit,
             path: String,
         ]
     }

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/JsonSplitter.groovy
@@ -70,8 +70,12 @@ class JsonSplitter extends AbstractTextSplitter {
     @Override
     protected Map<String,?> validOptions() {
         def baseOptions = super.validOptions()
-        baseOptions.path = String
-        return baseOptions
+        return [
+            autoClose: baseOptions.autoClose,
+            into: baseOptions.into,
+            limit: baseOptions.limit
+            path: String,
+        ]
     }
 
     @Override


### PR DESCRIPTION
At the moment, the JsonSplitter abandons the list of valid options from `super`, leading to errors when splitting any Json string as noted by @mribeirodantas.

This fix ensures that the inherited valid methods are preserved.