### PR TITLE
Fix invalid machine type setting when no valid machine type is found

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -228,9 +228,6 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         if( executor.config.cpuPlatform )
             instancePolicy.setMinCpuPlatform( executor.config.cpuPlatform )
 
-        if( task.config.getMachineType() )
-            instancePolicy.setMachineType( task.config.getMachineType() )
-
         machineInfo = findBestMachineType(task.config)
         if( machineInfo )
             instancePolicy.setMachineType(machineInfo.type)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -22,6 +22,8 @@ import com.google.cloud.batch.v1.Volume
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
 import nextflow.cloud.google.batch.client.BatchClient
 import nextflow.cloud.google.batch.client.BatchConfig
+import nextflow.cloud.types.CloudMachineInfo
+import nextflow.cloud.types.PriceModel
 import nextflow.executor.Executor
 import nextflow.executor.res.AcceleratorResource
 import nextflow.processor.TaskBean
@@ -159,7 +161,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def req = handler.newSubmitRequest(task, launcher)
         then:
         handler.fusionEnabled() >> false
-        handler.findBestMachineType(_) >> null
+        handler.findBestMachineType(_) >> new CloudMachineInfo(type: MACHINE_TYPE, zone: "location", priceModel: PriceModel.spot)
 
         and:
         def taskGroup = req.getTaskGroups(0)


### PR DESCRIPTION
## Description

When the method `findBestMachineType` fails to find a best candidate the `machineType` provided by the user should only be used if it is a correct machine type, and not if it's a list of families that can contain a wildcard. In that case, `machineType` should be empty so Google Batch will decide a custom type depending on the CPU and Memory allocated.
 