### PR TITLE
Add shared storage support for AWS Batch executor

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
@@ -110,16 +110,6 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint {
         session.bucketDir ?: session.workDir
     }
 
-    protected void validateWorkDir() {
-        /*
-         * make sure the work dir is a S3 bucket
-         */
-        if( !(workDir instanceof S3Path) ) {
-            session.abort()
-            throw new AbortOperationException("When using `$name` executor an S3 bucket must be provided as working directory using either the `-bucket-dir` or `-work-dir` command line option")
-        }
-    }
-
     protected void validatePathDir() {
         def path = session.config.navigate('env.PATH')
         if( path ) {
@@ -160,7 +150,6 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint {
     @Override
     protected void register() {
         super.register()
-        validateWorkDir()
         validatePathDir()
         uploadBinDir()
         createAwsClient()

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchScriptLauncher.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchScriptLauncher.groovy
@@ -18,6 +18,8 @@ package nextflow.cloud.aws.batch
 
 import groovy.transform.CompileStatic
 import nextflow.executor.BashWrapperBuilder
+import nextflow.executor.ScriptFileCopyStrategy
+import nextflow.executor.SimpleFileCopyStrategy
 import nextflow.processor.TaskBean
 import nextflow.processor.TaskRun
 
@@ -27,8 +29,12 @@ import nextflow.processor.TaskRun
 @CompileStatic
 class AwsBatchScriptLauncher extends BashWrapperBuilder {
 
+    static protected ScriptFileCopyStrategy getFileCopyStrategy(TaskBean bean, AwsOptions opts ) {
+        return bean.workDir.scheme == 's3' ? new AwsBatchFileCopyStrategy(bean,opts) : new SimpleFileCopyStrategy(bean)
+    }
+
     AwsBatchScriptLauncher(TaskBean bean, AwsOptions opts ) {
-        super(bean, new AwsBatchFileCopyStrategy(bean,opts))
+        super(bean, getFileCopyStrategy(bean,opts))
         // enable the copying of output file to the S3 work dir
         if( scratch==null )
             scratch = true


### PR DESCRIPTION
## Description

AWS Batch integration always assumes that the workDir is an S3 bucket so by default uses AwsBatchFileCopyStrategy. This PR add a check of schema of workDir to use SimpleFileCopyStrategy if the schema is not s3. Therefor shared storage can be used with AWS Batch integration.
