### PR TITLE
feat: add remote bin support for TES in a workdir

### DIFF
--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesBashBuilder.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesBashBuilder.groovy
@@ -29,12 +29,12 @@ import nextflow.processor.TaskRun
 @CompileStatic
 class TesBashBuilder extends BashWrapperBuilder {
 
-    TesBashBuilder(TaskRun task) {
-        super(new TaskBean(task), new TesFileCopyStrategy())
+    TesBashBuilder(TaskRun task, String remoteBinDir) {
+        super(new TaskBean(task), new TesFileCopyStrategy(remoteBinDir))
     }
 
-    TesBashBuilder(TaskBean task) {
-        super(task, new TesFileCopyStrategy())
+    TesBashBuilder(TaskBean task, String remoteBinDir) {
+        super(task, new TesFileCopyStrategy(remoteBinDir))
     }
 
 }

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesExecutor.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesExecutor.groovy
@@ -55,14 +55,8 @@ class TesExecutor extends Executor implements ExtensionPoint {
 
     @Override
     protected void register() {
-        if( session.binDir && !session.binDir.empty() && !session.workDir ) {
-            session.abort()
-            throw new AbortOperationException("ERROR: TES executor does not allow the use of custom scripts in the `bin` folder without a workdir")
-        } else {
-            uploadBinDir()
-        }
-
         super.register()
+        uploadBinDir()
 
         client = new TaskServiceApi( new ApiClient(basePath: getEndPoint()) )
     }

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesExecutor.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesExecutor.groovy
@@ -17,9 +17,11 @@
 package nextflow.ga4gh.tes.executor
 
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.exception.AbortOperationException
 import nextflow.executor.Executor
+import nextflow.extension.FilesEx
 import nextflow.ga4gh.tes.client.ApiClient
 import nextflow.ga4gh.tes.client.api.TaskServiceApi
 import nextflow.processor.TaskHandler
@@ -29,6 +31,8 @@ import nextflow.processor.TaskRun
 import nextflow.util.Duration
 import nextflow.util.ServiceName
 import org.pf4j.ExtensionPoint
+
+import java.nio.file.Path
 
 /**
  * Experimental TES executor
@@ -44,11 +48,18 @@ class TesExecutor extends Executor implements ExtensionPoint {
 
     private TaskServiceApi client
 
+    /**
+     * A path accessible to TES where executable scripts need to be uploaded
+     */
+    private Path remoteBinDir = null
+
     @Override
     protected void register() {
-        if( session.binDir && !session.binDir.empty() ) {
+        if( session.binDir && !session.binDir.empty() && !session.workDir ) {
             session.abort()
-            throw new AbortOperationException("ERROR: TES executor does not allow the use of custom scripts in the `bin` folder")
+            throw new AbortOperationException("ERROR: TES executor does not allow the use of custom scripts in the `bin` folder without a workdir")
+        } else {
+            uploadBinDir()
         }
 
         super.register()
@@ -62,6 +73,22 @@ class TesExecutor extends Executor implements ExtensionPoint {
 
     TaskServiceApi getClient() {
         client
+    }
+
+    @PackageScope
+    Path getRemoteBinDir() {
+        remoteBinDir
+    }
+
+    protected void uploadBinDir() {
+        /*
+         * upload local binaries
+         */
+        if( session.binDir && !session.binDir.empty() && !session.disableRemoteBinDir ) {
+            def tempBin = getTempDir()
+            log.info "Uploading local `bin` scripts folder to ${tempBin.toUriString()}/bin"
+            remoteBinDir = FilesEx.copyTo(session.binDir, tempBin)
+        }
     }
 
     protected String getEndPoint() {

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesFileCopyStrategy.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesFileCopyStrategy.groovy
@@ -30,6 +30,11 @@ import nextflow.util.Escape
  */
 @CompileStatic
 class TesFileCopyStrategy implements ScriptFileCopyStrategy {
+    private String remoteBinDir
+
+    TesFileCopyStrategy(String remoteBinDir) {
+        this.remoteBinDir = remoteBinDir
+    }
 
     /**
      * {@inheritDoc}
@@ -97,7 +102,25 @@ class TesFileCopyStrategy implements ScriptFileCopyStrategy {
      */
     @Override
     String getEnvScript(Map env, boolean container) {
-        if(container) throw new UnsupportedOperationException()
-        TaskProcessor.bashEnvironmentScript(env,false)
+        if( container )
+            throw new UnsupportedOperationException("Parameter `container` not supported by ${this.class.simpleName}")
+
+        final result = new StringBuilder()
+        final copy = env ? new HashMap<String,String>(env) : Collections.<String,String>emptyMap()
+        final path = copy.containsKey('PATH')
+        // remove any external PATH
+        if( path )
+            copy.remove('PATH')
+        // when a remote bin directory is provide managed it properly
+        if( remoteBinDir ) {
+            result << "cp -r ${remoteBinDir}/* \$PWD/nextflow-bin/\n"
+            result << "chmod +x \$PWD/nextflow-bin/* || true\n"
+            result << "export PATH=\$PWD/nextflow-bin:\$PATH\n"
+        }
+        // finally render the environment
+        final envSnippet = TaskProcessor.bashEnvironmentScript(copy,false)
+        if( envSnippet )
+            result << envSnippet
+        return result.toString()
     }
 }

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -148,7 +148,8 @@ class TesTaskHandler extends TaskHandler {
     void submit() {
 
         // create task wrapper
-        final bash = new TesBashBuilder(task)
+        String remoteBinDir = executor.getRemoteBinDir()
+        final bash = new TesBashBuilder(task, remoteBinDir)
         bash.build()
 
         final body = newTesTask()
@@ -194,6 +195,8 @@ class TesTaskHandler extends TaskHandler {
         task.outputFilesNames?.each { fileName ->
             body.addOutputsItem(outItem(fileName))
         }
+
+        body.setName(task.getName())
 
         // add the executor
         body.executors = [exec]

--- a/plugins/nf-ga4gh/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-ga4gh/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: nextflow.ga4gh.Ga4ghPlugin
 Plugin-Id: nf-ga4gh
-Plugin-Version: 1.0.6
+Plugin-Version: 1.0.7
 Plugin-Provider: Seqera Labs
 Plugin-Requires: >=23.05.0-edge

--- a/plugins/nf-ga4gh/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-ga4gh/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: nextflow.ga4gh.Ga4ghPlugin
 Plugin-Id: nf-ga4gh
-Plugin-Version: 1.0.7
+Plugin-Version: 1.0.6
 Plugin-Provider: Seqera Labs
 Plugin-Requires: >=23.05.0-edge

--- a/plugins/nf-ga4gh/src/test/nextflow/ga4gh/tes/executor/TesBashBuilderTest.groovy
+++ b/plugins/nf-ga4gh/src/test/nextflow/ga4gh/tes/executor/TesBashBuilderTest.groovy
@@ -41,7 +41,7 @@ class TesBashBuilderTest extends Specification {
                 name: 'Hello 1',
                 workDir: folder,
                 script: 'echo Hello world!',
-        ] as TaskBean )
+        ] as TaskBean, null)
         bash.build()
 
         then:


### PR DESCRIPTION
Adds support for using remote bin with TES in a shared file system workdir. The shared file system mount on the server running the pipeline needs to be the same the mount in the image, so a mount off root is easiest. Code is based on the AWS Batch plugin's remote bin support. 

Also sets the TES name to the task name.

@pditommaso I see you have done all the updates in the plugin repository for the official plugins, do you want/need to handle that or should I create a pr there to go along with this one? 