### PR TITLE
Add rule to build Nextflow docker image for ARM

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -17,7 +17,7 @@ version ?= none
 
 build: dist/docker/amd64
 	cp ../nextflow .
-	docker buildx build --platform linux/amd64 --output=type=docker --progress=plain --tag nextflow/nextflow:${version} .
+	docker buildx build --platform linux/amd64 --output=type=docker --progress=plain --tag nextflow/nextflow:${version} --build-arg TARGETPLATFORM=linux/amd64 .
 
 build-arm: dist/docker/arm64
 	cp ../nextflow .

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,7 +21,7 @@ build: dist/docker/amd64
 
 build-arm: dist/docker/arm64
 	cp ../nextflow .
-	docker buildx build --platform linux/arm64 --output=type=docker --progress=plain --tag nextflow/nextflow:${version} .
+	docker buildx build --platform linux/arm64 --output=type=docker --progress=plain --tag nextflow/nextflow:${version} --build-arg TARGETPLATFORM=linux/arm64 .
 
 release: build
 	docker tag nextflow/nextflow:${version} nextflow/nextflow:latest

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,9 +15,13 @@
 
 version ?= none
 
-build: dist/docker
+build: dist/docker/amd64
 	cp ../nextflow .
 	docker buildx build --platform linux/amd64 --output=type=docker --progress=plain --tag nextflow/nextflow:${version} .
+
+build-arm: dist/docker/arm64
+	cp ../nextflow .
+	docker buildx build --platform linux/arm64 --output=type=docker --progress=plain --tag nextflow/nextflow:${version} .
 
 release: build
 	docker tag nextflow/nextflow:${version} nextflow/nextflow:latest
@@ -35,9 +39,11 @@ release: build
 #  MacOS:   https://download.docker.com/mac/static
 #  Windows: https://download.docker.com/win/static
 
-dist/docker:
+dist/docker/amd64:
 	mkdir -p dist/linux/amd64
 	curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-17.09.0-ce.tgz | tar --strip-components=1 -xvz -C dist/linux/amd64
-#	mkdir -p dist/linux/arm64
-#	curl -fsSL https://download.docker.com/linux/static/stable/aarch64/docker-17.09.0-ce.tgz | tar --strip-components=1 -xvz -C dist/linux/arm64
+
+dist/docker/arm64:
+	mkdir -p dist/linux/arm64
+	curl -fsSL https://download.docker.com/linux/static/stable/aarch64/docker-17.09.0-ce.tgz | tar --strip-components=1 -xvz -C dist/linux/arm64
 


### PR DESCRIPTION
Close #2750 

Haven't tested it myself, just drafting a PR for anyone who wants to try a Nextflow docker image on ARM:
```bash
cd docker
make build-arm
```