### PR TITLE
feat: Allow SLURM executor option `--mem-per-cpu`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -605,6 +605,11 @@ The following settings are available:
 `executor.memory`
 : The maximum amount of memory made available by the underlying system. Used only by the `local` executor.
 
+`executor.memPerCpu`
+: :::{versionadded} 23.06.0-edge
+  :::
+: Used only by SLURM. Use `--mem-per-cpu` instead of `--mem` to specify memory allocations for SLURM jobs. See {ref}`slurm-executor`.
+
 `executor.name`
 : The name of the executor to be used (default: `local`).
 
@@ -613,9 +618,6 @@ The following settings are available:
 
 `executor.perTaskReserve`
 : Specifies Platform LSF *per-task* memory reserve mode. See {ref}`lsf-executor`.
-
-`executor.memPerCpu`
-: Specific to Slurm. Uses `--mem-per-cpu`instead of `--mem` to specify memory allocation for `sbatch` as required by some clusters. See {ref}`slurm-executor`.
 
 `executor.pollInterval`
 : Determines how often to check for process termination. Default varies for each executor (see below).

--- a/docs/config.md
+++ b/docs/config.md
@@ -606,7 +606,7 @@ The following settings are available:
 : The maximum amount of memory made available by the underlying system. Used only by the `local` executor.
 
 `executor.memPerCpu`
-: :::{versionadded} 23.06.0-edge
+: :::{versionadded} 23.07.0-edge
   :::
 : Used only by SLURM. Use `--mem-per-cpu` instead of `--mem` to specify memory allocations for SLURM jobs. See {ref}`slurm-executor`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -608,7 +608,8 @@ The following settings are available:
 `executor.memPerCpu`
 : :::{versionadded} 23.07.0-edge
   :::
-: Used only by SLURM. Use `--mem-per-cpu` instead of `--mem` to specify memory allocations for SLURM jobs. See {ref}`slurm-executor`.
+: *Used only by the {ref}`slurm-executor` executor.*
+: When `true`, specifies memory allocations for SLURM jobs as `--mem-per-cpu <task.memory / task.cpus>` instead of `--mem <task.memory>`.
 
 `executor.name`
 : The name of the executor to be used (default: `local`).

--- a/docs/config.md
+++ b/docs/config.md
@@ -605,14 +605,14 @@ The following settings are available:
 `executor.memory`
 : The maximum amount of memory made available by the underlying system. Used only by the `local` executor.
 
-`executor.memPerCpu`
+`executor.name`
+: The name of the executor to be used (default: `local`).
+
+`executor.perCpuMemAllocation`
 : :::{versionadded} 23.07.0-edge
   :::
 : *Used only by the {ref}`slurm-executor` executor.*
 : When `true`, specifies memory allocations for SLURM jobs as `--mem-per-cpu <task.memory / task.cpus>` instead of `--mem <task.memory>`.
-
-`executor.name`
-: The name of the executor to be used (default: `local`).
 
 `executor.perJobMemLimit`
 : Specifies Platform LSF *per-job* memory limit mode. See {ref}`lsf-executor`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -614,6 +614,9 @@ The following settings are available:
 `executor.perTaskReserve`
 : Specifies Platform LSF *per-task* memory reserve mode. See {ref}`lsf-executor`.
 
+`executor.memPerCpu`
+: Specific to Slurm. Uses `--mem-per-cpu`instead of `--mem` to specify memory allocation for `sbatch` as required by some clusters. See {ref}`slurm-executor`.
+
 `executor.pollInterval`
 : Determines how often to check for process termination. Default varies for each executor (see below).
 

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -508,12 +508,9 @@ SLURM partitions can be specified with the `queue` directive.
 :::
 
 :::{note}
-Some SLURM clusters require memory allocation to be specified with `--mem-per-cpu` instead by `--mem`. 
-Specify `executor.memPerCpu = true` in the config to activate with behaviour.
+Nextflow does not provide direct support for SLURM multi-clusters. If you need to submit workflow executions to a cluster other than the current one, specify it with the `SLURM_CLUSTERS` variable in the launch environment.
 :::
 
-
-
-:::{tip}
-Nextflow does not provide direct support for SLURM multi-clusters. If you need to submit workflow executions to a cluster other than the current one, specify it with the `SLURM_CLUSTERS` variable in the launch environment.
+:::{versionadded} 23.06.0-edge
+Some SLURM clusters require memory allocation to be specified with `--mem-per-cpu` instead of `--mem`. You can specify `executor.memPerCpu = true` in the Nextflow configuration to enable this behavior.
 :::

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -511,6 +511,6 @@ SLURM partitions can be specified with the `queue` directive.
 Nextflow does not provide direct support for SLURM multi-clusters. If you need to submit workflow executions to a cluster other than the current one, specify it with the `SLURM_CLUSTERS` variable in the launch environment.
 :::
 
-:::{versionadded} 23.06.0-edge
+:::{versionadded} 23.07.0-edge
 Some SLURM clusters require memory allocation to be specified with `--mem-per-cpu` instead of `--mem`. You can specify `executor.memPerCpu = true` in the Nextflow configuration to enable this behavior.
 :::

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -512,5 +512,5 @@ Nextflow does not provide direct support for SLURM multi-clusters. If you need t
 :::
 
 :::{versionadded} 23.07.0-edge
-Some SLURM clusters require memory allocation to be specified with `--mem-per-cpu` instead of `--mem`. You can specify `executor.memPerCpu = true` in the Nextflow configuration to enable this behavior.
+Some SLURM clusters require memory allocations to be specified with `--mem-per-cpu` instead of `--mem`. You can specify `executor.memPerCpu = true` in the Nextflow configuration to enable this behavior. Nextflow will automatically compute the memory per CPU for each task (by default 1 CPU is used).
 :::

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -512,5 +512,5 @@ Nextflow does not provide direct support for SLURM multi-clusters. If you need t
 :::
 
 :::{versionadded} 23.07.0-edge
-Some SLURM clusters require memory allocations to be specified with `--mem-per-cpu` instead of `--mem`. You can specify `executor.memPerCpu = true` in the Nextflow configuration to enable this behavior. Nextflow will automatically compute the memory per CPU for each task (by default 1 CPU is used).
+Some SLURM clusters require memory allocations to be specified with `--mem-per-cpu` instead of `--mem`. You can specify `executor.perCpuMemAllocation = true` in the Nextflow configuration to enable this behavior. Nextflow will automatically compute the memory per CPU for each task (by default 1 CPU is used).
 :::

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -507,6 +507,13 @@ Resource requests and other job characteristics can be controlled via the follow
 SLURM partitions can be specified with the `queue` directive.
 :::
 
+:::{note}
+Some SLURM clusters require memory allocation to be specified with `--mem-per-cpu` instead by `--mem`. 
+Specify `executor.memPerCpu = true` in the config to activate with behaviour.
+:::
+
+
+
 :::{tip}
 Nextflow does not provide direct support for SLURM multi-clusters. If you need to submit workflow executions to a cluster other than the current one, specify it with the `SLURM_CLUSTERS` variable in the launch environment.
 :::

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -42,7 +42,10 @@ class SlurmExecutor extends AbstractGridExecutor {
         return opts ? opts.contains('--signal ') || opts.contains('--signal=') : false
     }
 
+    private boolean memPerCpu
 
+    protected boolean memPerCpu() { memPerCpu }
+    
     /**
      * Gets the directives to submit the specified task to the cluster for execution
      *
@@ -76,7 +79,13 @@ class SlurmExecutor extends AbstractGridExecutor {
             // be stored, just collected). In both cases memory use is based upon the job's
             // Resident Set Size (RSS). A task may exceed the memory limit until the next periodic
             // accounting sample. -- https://slurm.schedmd.com/sbatch.html
-            result << '--mem' << task.config.getMemory().toMega().toString() + 'M'
+            
+            if( memPerCpu ) {
+                result << '--mem-per-cpu' << task.config.getMemory().toMega().toString() + 'M'
+            else {
+                result << '--mem' << task.config.getMemory().toMega().toString() + 'M'
+            }
+            
         }
 
         // the requested partition (a.k.a queue) name

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -78,8 +78,11 @@ class SlurmExecutor extends AbstractGridExecutor {
             // be stored, just collected). In both cases memory use is based upon the job's
             // Resident Set Size (RSS). A task may exceed the memory limit until the next periodic
             // accounting sample. -- https://slurm.schedmd.com/sbatch.html
-            final memOption = memPerCpu ? '--mem-per-cpu' : '--mem'
-            result << memOption << task.config.getMemory().toMega().toString() + 'M'
+            final mem = task.config.getMemory().toMega()
+            if( memPerCpu )
+                result << '--mem-per-cpu' << mem.intdiv(task.config.getCpus()).toString() + 'M'
+            else
+                result << '--mem' << mem.toString() + 'M'
         }
 
         // the requested partition (a.k.a queue) name

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -42,7 +42,10 @@ class SlurmExecutor extends AbstractGridExecutor {
         return opts ? opts.contains('--signal ') || opts.contains('--signal=') : false
     }
 
+
     private boolean memPerCpu
+
+    memPerCpu = session.getExecConfigProp(name, 'memPerCpu', memPerCpu)
 
     protected boolean memPerCpu() { memPerCpu }
     
@@ -203,6 +206,8 @@ class SlurmExecutor extends AbstractGridExecutor {
     protected boolean pipeLauncherScript() {
         return isFusionEnabled()
     }
+
+
 
     @Override
     boolean isFusionEnabled() {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -37,7 +37,7 @@ class SlurmExecutor extends AbstractGridExecutor {
 
     static private Pattern SUBMIT_REGEX = ~/Submitted batch job (\d+)/
 
-    private boolean memPerCpu
+    private boolean perCpuMemAllocation
 
     private boolean hasSignalOpt(Map config) {
         def opts = config.clusterOptions?.toString()
@@ -79,7 +79,7 @@ class SlurmExecutor extends AbstractGridExecutor {
             // Resident Set Size (RSS). A task may exceed the memory limit until the next periodic
             // accounting sample. -- https://slurm.schedmd.com/sbatch.html
             final mem = task.config.getMemory().toMega()
-            if( memPerCpu )
+            if( perCpuMemAllocation )
                 result << '--mem-per-cpu' << mem.intdiv(task.config.getCpus()).toString() + 'M'
             else
                 result << '--mem' << mem.toString() + 'M'
@@ -199,7 +199,7 @@ class SlurmExecutor extends AbstractGridExecutor {
     @Override
     void register() {
         super.register()
-        memPerCpu = session.getExecConfigProp(name, 'memPerCpu', memPerCpu)
+        perCpuMemAllocation = session.getExecConfigProp(name, 'perCpuMemAllocation', false)
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -195,6 +195,7 @@ class SlurmExecutor extends AbstractGridExecutor {
 
     @Override
     void register() {
+        super.register()
         memPerCpu = session.getExecConfigProp(name, 'memPerCpu', memPerCpu)
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -187,9 +187,9 @@ class SlurmExecutorTest extends Specification {
                 '''
                 .stripIndent().leftTrim()
 
-        // test memPerCpu
+        // test perCpuMemAllocation
         when:
-        executor.@memPerCpu = true
+        executor.@perCpuMemAllocation = true
         task.config = new TaskConfig()
         task.config.cpus = 8
         task.config.memory = '24 GB'

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -192,8 +192,7 @@ class SlurmExecutorTest extends Specification {
         executor.@memPerCpu = true
         task.config = new TaskConfig()
         task.config.cpus = 8
-        task.config.time = '2d 3h'
-        task.config.memory = '3 G'
+        task.config.memory = '24 GB'
         then:
         executor.getHeaders(task) == '''
                 #SBATCH -J nf-the_task_name
@@ -201,7 +200,6 @@ class SlurmExecutorTest extends Specification {
                 #SBATCH --no-requeue
                 #SBATCH --signal B:USR2@30
                 #SBATCH -c 8
-                #SBATCH -t 51:00:00
                 #SBATCH --mem-per-cpu 3072M
                 '''
                 .stripIndent().leftTrim()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -80,7 +80,7 @@ class SlurmExecutorTest extends Specification {
     def testGetHeaders() {
 
         setup:
-        // LSF executor
+        // SLURM executor
         def executor = [:] as SlurmExecutor
 
         // mock process
@@ -187,17 +187,13 @@ class SlurmExecutorTest extends Specification {
                 '''
                 .stripIndent().leftTrim()
 
-        /* test memPerCpu flag
-        *
-        */
+        // test memPerCpu
         when:
         executor.@memPerCpu = true
-
         task.config = new TaskConfig()
         task.config.cpus = 8
         task.config.time = '2d 3h'
         task.config.memory = '3 G'
-
         then:
         executor.getHeaders(task) == '''
                 #SBATCH -J nf-the_task_name

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -186,6 +186,29 @@ class SlurmExecutorTest extends Specification {
                 #SBATCH -x 3
                 '''
                 .stripIndent().leftTrim()
+
+        /* test memPerCpu flag
+        *
+        */
+        when:
+        executor.@memPerCpu = true
+
+        task.config = new TaskConfig()
+        task.config.cpus = 8
+        task.config.time = '2d 3h'
+        task.config.memory = '3 G'
+
+        then:
+        executor.getHeaders(task) == '''
+                #SBATCH -J nf-the_task_name
+                #SBATCH -o /work/path/.command.log
+                #SBATCH --no-requeue
+                #SBATCH --signal B:USR2@30
+                #SBATCH -c 8
+                #SBATCH -t 51:00:00
+                #SBATCH --mem-per-cpu 3072M
+                '''
+                .stripIndent().leftTrim()
     }
 
     def testWorkDirWithBlanks() {


### PR DESCRIPTION
This PR addresses #2054. 

Some SLURM cluster require memory to be defined per CPU using the `--mem-per-cpu` argument in the `sbatch` command and disallow using `--mem`. 

Currently, nextflow translates the `task.memory` directive into `--mem` only. 

The proposed changes introduces the boolean `executor.memPerCpu` option to execute `sbatch` with `--mem-per-cpu`. 

This is my first time working with the Nextflow codebase and using Groovy, so any help getting this to work is appreciated 🙏 