### PR TITLE
Ignore accelerator type for AWS Batch

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1201,9 +1201,10 @@ This directive is only used by certain executors. Refer to the {ref}`executor-pa
 :::{note}
 The accelerator `type` option depends on the target execution platform. Refer to the platform-specific documentation for details on the available accelerators:
 
-- [AWS](https://aws.amazon.com/batch/faqs/?#GPU_Scheduling_)
 - [Google Cloud](https://cloud.google.com/compute/docs/gpus/)
 - [Kubernetes](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#clusters-containing-different-types-of-gpus)
+
+The accelerator `type` option is not supported for AWS Batch. You can control the accelerator type indirectly through the allowed instance types in your Compute Environment. See the [AWS Batch FAQs](https://aws.amazon.com/batch/faqs/?#GPU_Scheduling_) for more information.
 :::
 
 (process-afterscript)=

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -59,7 +59,6 @@ import nextflow.container.ContainerNameValidator
 import nextflow.exception.ProcessSubmitException
 import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.BashWrapperBuilder
-import nextflow.executor.res.AcceleratorResource
 import nextflow.fusion.FusionAwareTask
 import nextflow.processor.BatchContext
 import nextflow.processor.BatchHandler

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -715,8 +715,12 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         if( task.config.getCpus() > 1 )
             resources << new ResourceRequirement().withType(ResourceType.VCPU).withValue(task.config.getCpus().toString())
 
-        if( task.config.getAccelerator() )
-            resources << createGpuResource(task.config.getAccelerator())
+        final accelerator = task.config.getAccelerator()
+        if( accelerator ) {
+            if( accelerator.type )
+                log.warn1 "Ignoring task ${task.lazyName()} accelerator type: ${accelerator.type} -- AWS Batch doesn't support accelerator type in job definition"
+            resources << new ResourceRequirement().withType(ResourceType.GPU).withValue(accelerator.request.toString())
+        }
 
         if( resources )
             container.withResourceRequirements(resources)
@@ -729,15 +733,6 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         result.setContainerOverrides(container)
 
         return result
-    }
-
-    protected ResourceRequirement createGpuResource(AcceleratorResource acc) {
-        final res = new ResourceRequirement()
-        final type = acc.type ?: 'GPU'
-        final count = acc.request?.toString() ?: '1'
-        res.setType(type.toUpperCase())
-        res.setValue(count)
-        return res
     }
 
     /**


### PR DESCRIPTION
Nextflow is applying the accelerator type to the AWS Batch job definition. However, according to the [AWS documentation](https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html), the type must be "GPU", and does not support specific GPU types. It looks like the only way to control the GPU type is indirectly through the allowed instance types in a compute environment.

This PR ignores the accelerator type for AWS Batch and adds a warning if the type is specified, so that it's clear that it isn't supported.