### PR TITLE
Fix invalid detection of hierarchical namespace stub blobs as files

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzFileAttributes.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzFileAttributes.groovy
@@ -60,6 +60,12 @@ class AzFileAttributes implements BasicFileAttributes {
         updateTime = time(props.getLastModified())
         directory = client.blobName.endsWith('/')
         size = props.getBlobSize()
+
+        // Support for Azure Data Lake Storage Gen2 with hierarchical namespace enabled
+        final meta = props.getMetadata()
+        if( meta.containsKey("hdi_isfolder") && size == 0 ){
+            directory = meta.get("hdi_isfolder")
+        }
     }
 
     AzFileAttributes(String containerName, BlobItem item) {


### PR DESCRIPTION
Using Azure Batch executor with storage account enabling hierarchical namespaces have problems publishing directories.
The problem is that for each directory azure will create an empty "stub blob" with a metadata field: `"hdi_isfolder": "true"`

Nextflow currently detects these as files and will create a download request for that stub blob using a directory path which will cause a BlobStorageException (Status code 400: InvalidInput)

This PR adds a simple to check to detect such blobs and mark those as directories.

Fixes: #4016, #2557
