### PR TITLE
Wait for _all_ child processes in nxf_parallel

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
@@ -95,7 +95,11 @@ class BashFunLib<V extends BashFunLib> {
             while ((i<\${#cmd[@]})); do
                 local copy=()
                 for x in "\${pid[@]}"; do
-                  [[ -e /proc/\$x ]] && copy+=(\$x)
+                  if [[ -e /proc/\$x ]]; then
+                    copy+=(\$x)   # process still exists, remember it
+                  else
+                    wait \$x      # process exited, wait on it
+                  fi
                 done
                 pid=("\${copy[@]}")
                 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
@@ -95,11 +95,9 @@ class BashFunLib<V extends BashFunLib> {
             while ((i<\${#cmd[@]})); do
                 local copy=()
                 for x in "\${pid[@]}"; do
-                  if [[ -e /proc/\$x ]]; then
-                    copy+=(\$x)   # process still exists, remember it
-                  else
-                    wait \$x      # process exited, wait on it
-                  fi
+                  # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                  # see https://github.com/nextflow-io/nextflow/pull/4050 
+                  [[ -e /proc/\$x ]] && copy+=(\$x) || wait \$x 
                 done
                 pid=("\${copy[@]}")
                 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashFunLib.groovy
@@ -96,8 +96,8 @@ class BashFunLib<V extends BashFunLib> {
                 local copy=()
                 for x in "\${pid[@]}"; do
                   # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
-                  # see https://github.com/nextflow-io/nextflow/pull/4050 
-                  [[ -e /proc/\$x ]] && copy+=(\$x) || wait \$x 
+                  # see https://github.com/nextflow-io/nextflow/pull/4050
+                  [[ -e /proc/\$x ]] && copy+=(\$x) || wait \$x
                 done
                 pid=("\${copy[@]}")
                 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
@@ -52,7 +52,11 @@ class BashFunLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             
@@ -88,8 +92,8 @@ class BashFunLibTest extends Specification {
 
         """
         cmds=()
-        cmds+=("true")
         cmds+=("false")
+        cmds+=("true")
         nxf_parallel "\${cmds[@]}"
         """.stripIndent()
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashFunLibTest.groovy
@@ -52,11 +52,9 @@ class BashFunLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
@@ -164,7 +164,11 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
                     
@@ -253,7 +257,11 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          [[ -e /proc/$x ]] && copy+=($x)
+                          if [[ -e /proc/$x ]]; then
+                            copy+=($x)   # process still exists, remember it
+                          else
+                            wait $x      # process exited, wait on it
+                          fi
                         done
                         pid=("${copy[@]}")
                 

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
@@ -164,11 +164,9 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
                     
@@ -257,11 +255,9 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          if [[ -e /proc/$x ]]; then
-                            copy+=($x)   # process still exists, remember it
-                          else
-                            wait $x      # process exited, wait on it
-                          fi
+                          # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                          # see https://github.com/nextflow-io/nextflow/pull/4050
+                          [[ -e /proc/$x ]] && copy+=($x) || wait $x
                         done
                         pid=("${copy[@]}")
                 

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -94,11 +94,9 @@ class AwsBatchScriptLauncherTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          if [[ -e /proc/$x ]]; then
-                            copy+=($x)   # process still exists, remember it
-                          else
-                            wait $x      # process exited, wait on it
-                          fi
+                          # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                          # see https://github.com/nextflow-io/nextflow/pull/4050
+                          [[ -e /proc/$x ]] && copy+=($x) || wait $x
                         done
                         pid=("${copy[@]}")
                 
@@ -275,11 +273,9 @@ class AwsBatchScriptLauncherTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
                     
@@ -449,11 +445,9 @@ class AwsBatchScriptLauncherTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
                     
@@ -564,11 +558,9 @@ class AwsBatchScriptLauncherTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
                     

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -94,7 +94,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          [[ -e /proc/$x ]] && copy+=($x)
+                          if [[ -e /proc/$x ]]; then
+                            copy+=($x)   # process still exists, remember it
+                          else
+                            wait $x      # process exited, wait on it
+                          fi
                         done
                         pid=("${copy[@]}")
                 
@@ -271,7 +275,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
                     
@@ -441,7 +449,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
                     
@@ -552,7 +564,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
                     

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
@@ -63,11 +63,9 @@ class S3BashLibTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
                     
@@ -164,11 +162,9 @@ class S3BashLibTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
                     
@@ -413,11 +409,9 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             
@@ -506,11 +500,9 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             
@@ -602,11 +594,9 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             
@@ -702,11 +692,9 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
@@ -63,7 +63,11 @@ class S3BashLibTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
                     
@@ -160,7 +164,11 @@ class S3BashLibTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
                     
@@ -405,7 +413,11 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             
@@ -494,7 +506,11 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             
@@ -586,7 +602,11 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             
@@ -682,7 +702,11 @@ class S3BashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
@@ -166,7 +166,11 @@ class BashWrapperBuilderWithS3Test extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
@@ -166,11 +166,9 @@ class BashWrapperBuilderWithS3Test extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -132,7 +132,11 @@ class AzFileCopyStrategyTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          [[ -e /proc/$x ]] && copy+=($x)
+                          if [[ -e /proc/$x ]]; then
+                            copy+=($x)   # process still exists, remember it
+                          else
+                            wait $x      # process exited, wait on it
+                          fi
                         done
                         pid=("${copy[@]}")
                 
@@ -267,7 +271,11 @@ class AzFileCopyStrategyTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          [[ -e /proc/$x ]] && copy+=($x)
+                          if [[ -e /proc/$x ]]; then
+                            copy+=($x)   # process still exists, remember it
+                          else
+                            wait $x      # process exited, wait on it
+                          fi
                         done
                         pid=("${copy[@]}")
                 
@@ -426,7 +434,11 @@ class AzFileCopyStrategyTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              [[ -e /proc/$x ]] && copy+=($x)
+                              if [[ -e /proc/$x ]]; then
+                                copy+=($x)   # process still exists, remember it
+                              else
+                                wait $x      # process exited, wait on it
+                              fi
                             done
                             pid=("${copy[@]}")
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -132,11 +132,9 @@ class AzFileCopyStrategyTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          if [[ -e /proc/$x ]]; then
-                            copy+=($x)   # process still exists, remember it
-                          else
-                            wait $x      # process exited, wait on it
-                          fi
+                          # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                          # see https://github.com/nextflow-io/nextflow/pull/4050
+                          [[ -e /proc/$x ]] && copy+=($x) || wait $x
                         done
                         pid=("${copy[@]}")
                 
@@ -271,11 +269,9 @@ class AzFileCopyStrategyTest extends Specification {
                     while ((i<${#cmd[@]})); do
                         local copy=()
                         for x in "${pid[@]}"; do
-                          if [[ -e /proc/$x ]]; then
-                            copy+=($x)   # process still exists, remember it
-                          else
-                            wait $x      # process exited, wait on it
-                          fi
+                          # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                          # see https://github.com/nextflow-io/nextflow/pull/4050
+                          [[ -e /proc/$x ]] && copy+=($x) || wait $x
                         done
                         pid=("${copy[@]}")
                 
@@ -434,11 +430,9 @@ class AzFileCopyStrategyTest extends Specification {
                         while ((i<${#cmd[@]})); do
                             local copy=()
                             for x in "${pid[@]}"; do
-                              if [[ -e /proc/$x ]]; then
-                                copy+=($x)   # process still exists, remember it
-                              else
-                                wait $x      # process exited, wait on it
-                              fi
+                              # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                              # see https://github.com/nextflow-io/nextflow/pull/4050
+                              [[ -e /proc/$x ]] && copy+=($x) || wait $x
                             done
                             pid=("${copy[@]}")
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/file/AzBashLibTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/file/AzBashLibTest.groovy
@@ -94,7 +94,11 @@ class AzBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             
@@ -194,7 +198,11 @@ class AzBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/file/AzBashLibTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/file/AzBashLibTest.groovy
@@ -94,11 +94,9 @@ class AzBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             
@@ -198,11 +196,9 @@ class AzBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -41,11 +41,9 @@ nxf_parallel() {
     while ((i<${#cmd[@]})); do
         local copy=()
         for x in "${pid[@]}"; do
-          if [[ -e /proc/$x ]]; then
-            copy+=($x)   # process still exists, remember it
-          else
-            wait $x      # process exited, wait on it
-          fi
+          # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+          # see https://github.com/nextflow-io/nextflow/pull/4050
+          [[ -e /proc/$x ]] && copy+=($x) || wait $x
         done
         pid=("${copy[@]}")
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -41,7 +41,11 @@ nxf_parallel() {
     while ((i<${#cmd[@]})); do
         local copy=()
         for x in "${pid[@]}"; do
-          [[ -e /proc/$x ]] && copy+=($x)
+          if [[ -e /proc/$x ]]; then
+            copy+=($x)   # process still exists, remember it
+          else
+            wait $x      # process exited, wait on it
+          fi
         done
         pid=("${copy[@]}")
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/util/GsBashLibTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/util/GsBashLibTest.groovy
@@ -151,7 +151,11 @@ class GsBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             
@@ -256,7 +260,11 @@ class GsBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      [[ -e /proc/$x ]] && copy+=($x)
+                      if [[ -e /proc/$x ]]; then
+                        copy+=($x)   # process still exists, remember it
+                      else
+                        wait $x      # process exited, wait on it
+                      fi
                     done
                     pid=("${copy[@]}")
             

--- a/plugins/nf-google/src/test/nextflow/cloud/google/util/GsBashLibTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/util/GsBashLibTest.groovy
@@ -151,11 +151,9 @@ class GsBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             
@@ -260,11 +258,9 @@ class GsBashLibTest extends Specification {
                 while ((i<${#cmd[@]})); do
                     local copy=()
                     for x in "${pid[@]}"; do
-                      if [[ -e /proc/$x ]]; then
-                        copy+=($x)   # process still exists, remember it
-                      else
-                        wait $x      # process exited, wait on it
-                      fi
+                      # if the process exist, keep in the 'copy' array, otherwise wait on it to capture the exit code
+                      # see https://github.com/nextflow-io/nextflow/pull/4050
+                      [[ -e /proc/$x ]] && copy+=($x) || wait $x
                     done
                     pid=("${copy[@]}")
             


### PR DESCRIPTION
`nxf_parallel` runs a number of processes in parallel, distributing them
across a limited number of workers.

Prior to PR #1884, errors were not being checked.  PR #1884 was
intended to remedy this but effectively only checked the _last_
command (or some subset of the commands) to exit (which was,
unfortunately the case that was tested for).

Processes that exit while there is still work going on were not being
"waited" on, so their exit status was not being checked, and failures
were escaping unnoticed.

This commit:

- updates the loop that's tracking the work so that it waits on
  processes that have exited; and
- updates the test cases so that the failing command is _not_ the
  last in the list and ensures that the templated text is as expected.

Note that an alternative change would be:

    [[ -e /proc/\$x ]] && copy+=(\$x) || wait \$x

While this wins at vim golf, it's not really clear about what's happening.

We also experimented with maintaining a separate array containing the
ids of all the processes that have been started and then waiting on
them before exiting, this made what was going on clearer but didn't
short circuit work if/when there was an error.

I based this change off of the STABLE-23.04.x branch because I was
unable to get master to test cleanly and am not groovy enough to figure
out how to just run _these_ tests.  It might be nice to include some basic
developer documentation (or highlight it, I swear I looked...).
