### PR TITLE
Netlify: No deployment (previews) unless 'docs/' files change

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,10 @@
+# No deployment previews unless the docs are edited
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
+
+# Tell Google not to spider the Netlify staging site
+[[headers]]
+for = "/*"
+
+[headers.values]
+    X-Robots-Tag = "noindex"


### PR DESCRIPTION
Turn _off_ the new Netlify deployment previews, unless something in the `docs/` folder changes.