### PR TITLE
List process container images in preview mode

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -468,10 +468,24 @@ class Session implements ISession {
         CH.broadcast()
 
         if( preview ) {
+            dumpContainerImages()
             terminated = true
         }
         else {
             callIgniters()
+        }
+    }
+
+    private void dumpContainerImages() {
+        for( def vertex : dag.vertices ) {
+            // skip nodes that are not processes
+            if( !vertex.process )
+                continue
+
+            // print process name and container image
+            def process = vertex.process
+            log.debug "Querying container image for process `${process.name}`..."
+            log.info "${process.name} ${process.getContainer()}"
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -367,6 +367,23 @@ class TaskProcessor {
 
     boolean hasErrors() { errorCount>0 }
 
+    /**
+     * Get the container image of the process, or return
+     * null if it can't be resolved.
+     */
+    String getContainer() {
+        try {
+            def config = config.createTaskConfig()
+            config.context = new TaskContext(this)
+
+            return config.getContainer()
+        }
+        catch( Exception e ) {
+            log.warn1 "Unable to resolve container image for process `${name}`", e
+            return null
+        }
+    }
+
     protected void checkWarn(String msg, Map opts=null) {
         if( NF.isStrictMode() )
             throw new ProcessUnrecoverableException(msg)


### PR DESCRIPTION
Close #3340 

Currently, this PR just lists the container image for each process during a preview run. It creates a basic task config for each process and tries to resolve the container directive. Even if the directive is dynamic, as long as it's defined in terms of variables that are defined at the pipeline level (e.g. `workflow`, `ext` directive from config), it will work.

If for some reason the container is defined in terms of some task specific property, it resolve will fail and just print null. But in practice I think this is extremely rare.

Successful tests:
- rnaseq
- sarek

Remaining questions:

1. Do we want to create a separate `download` command for this?
2. What should the output format be? CSV? JSON?