### PR TITLE
Prefer to use CacheFunnel implementation when available for caching non-trivial objects

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -162,6 +162,10 @@ public class CacheHelper {
         if( value instanceof byte[] )
             return hasher.putBytes( (byte[])value );
 
+        if( value instanceof CacheFunnel ) {
+            return ((CacheFunnel) value).funnel(hasher,mode);
+        }
+
         if( value instanceof Object[]) {
             for( Object item: ((Object[])value) )
                 hasher = CacheHelper.hasher( hasher, item, mode );
@@ -211,10 +215,6 @@ public class CacheHelper {
 
         if( value instanceof SerializableMarker) {
             return hasher.putInt( value.hashCode() );
-        }
-
-        if( value instanceof CacheFunnel ) {
-            return ((CacheFunnel) value).funnel(hasher,mode);
         }
 
         if( value instanceof Enum ) {


### PR DESCRIPTION
This change will allow us to define custom caching strategies for objects that are also Maps (custom Meta objects, for example).

Currently, if a Map-like object implements CacheFunnel, it is never used because the CacheHelper's `value instanceof Map` will return true earlier than the test `value instanceof CacheFunnel`.