### PR TITLE
Fix incorrect error message on missing comma

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/params/BaseParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/BaseParam.groovy
@@ -18,7 +18,7 @@ package nextflow.script.params
 
 import groovy.util.logging.Slf4j
 import nextflow.exception.ScriptRuntimeException
-
+import nextflow.script.TokenVar
 /**
  * Base class for input/output parameters
  *
@@ -146,7 +146,25 @@ abstract class BaseParam implements Cloneable {
      * Report missing method calls as possible syntax errors.
      */
     def methodMissing( String name, def args ) {
-        throw new ScriptRuntimeException("Invalid method call `${name}(${args})` -- possible syntax error")
+        throw new ScriptRuntimeException("Invalid function call `${name}(${argsToString0(args)})` -- possible syntax error")
     }
 
+    private String argsToString0(args) {
+        if( args instanceof Object[] )
+            args = Arrays.asList(args)
+        if( args instanceof List ) {
+            final result = new ArrayList()
+            for( def it : args )
+                result.add(argsToString1(it))
+            return result.join(',')
+        }
+        return argsToString1(args)
+    }
+
+    private String argsToString1(arg) {
+        if( arg instanceof TokenVar )
+            return arg.name
+        else
+            return String.valueOf((Object)arg)
+    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/BaseParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/BaseParam.groovy
@@ -17,6 +17,7 @@
 package nextflow.script.params
 
 import groovy.util.logging.Slf4j
+import nextflow.exception.ScriptRuntimeException
 
 /**
  * Base class for input/output parameters
@@ -139,6 +140,13 @@ abstract class BaseParam implements Cloneable {
 
     boolean isNestedParam() {
         return mapIndex >= 0
+    }
+
+    /**
+     * Report missing method calls as possible syntax errors.
+     */
+    def methodMissing( String name, def args ) {
+        throw new ScriptRuntimeException("Invalid method call `${name}(${args})` -- possible syntax error")
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsInTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsInTest.groovy
@@ -1001,10 +1001,11 @@ class ParamsInTest extends Dsl2Spec {
             }
             '''
         when:
-        def process = parseAndReturnProcess(text)
+        parseAndReturnProcess(text)
 
         then:
-        thrown(ScriptRuntimeException)
+        def e = thrown(ScriptRuntimeException)
+        e.message == 'Invalid function call `val(y)` -- possible syntax error'
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsInTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsInTest.groovy
@@ -23,6 +23,7 @@ import java.nio.file.Paths
 import groovyx.gpars.dataflow.DataflowQueue
 import groovyx.gpars.dataflow.DataflowVariable
 import nextflow.Channel
+import nextflow.exception.ScriptRuntimeException
 import nextflow.processor.TaskProcessor
 import spock.lang.Timeout
 import test.Dsl2Spec
@@ -983,6 +984,27 @@ class ParamsInTest extends Dsl2Spec {
         !in1.isNestedParam()
         (in1.inner[0] as ValueInParam).isNestedParam()
         (in1.inner[1] as FileInParam).isNestedParam()
+    }
+
+    def 'should throw error on missing comma' () {
+        setup:
+        def text = '''
+            process hola {
+              input:
+              tuple val(x) val(y)
+
+              /command/
+            }
+            
+            workflow {
+              hola(['x', 'y'])
+            }
+            '''
+        when:
+        def process = parseAndReturnProcess(text)
+
+        then:
+        thrown(ScriptRuntimeException)
     }
 
 }


### PR DESCRIPTION
Close #3185 

This PR fixes a particularly nasty error message that occurs with missing commas in process inputs/outputs.

Consider the following example:
```groovy
process foo {
  debug true

  input:
  tuple val(x) val(y) // missing comma

  script:
  """
  echo "foo ${task.index} ${task.workDir}"
  """
}

workflow {
  foo(['x', 'y'])
}
```

Currently, the script compiles despite the missing comma but then Nextflow reports that the process has been used twice:
```console
 nextflow run gh-3185/bad-error-message-4.nf
N E X T F L O W  ~  version 23.06.0-edge
Launching `gh-3185/bad-error-message-4.nf` [loving_keller] DSL2 - revision: 63eb6918e1
Process 'foo' has been already used -- If you need to reuse the same component, include it with a different name or include it in a different workflow context

 -- Check script 'gh-3185/bad-error-message-4.nf' at line: 14 or see '.nextflow.log' file for more details
```

The transpiled Groovy code looks like this:
```groovy
this._in_tuple(
    new nextflow.script.TokenValCall(new nextflow.script.TokenVar('x'))
).val(new nextflow.script.TokenVar('y'))
```

So I just add a `methodMissing()` implementation to `BaseParam` to catch the incorrect `.val()` call. With that change, the error now looks like this:
```console
$ ../launch.sh run gh-3185/bad-error-message-4.nf
N E X T F L O W  ~  version 23.06.0-edge
Launching `gh-3185/bad-error-message-4.nf` [nasty_bohr] DSL2 - revision: 63eb6918e1
Invalid method call `val([nextflow.script.TokenVar(y)])` -- possible syntax error

 -- Check script 'gh-3185/bad-error-message-4.nf' at line: 5 or see '.nextflow.log' file for more details
```

The error message is correctly called a syntax error and it gives the exact line where it happened.

Note however that it doesn't catch all missing comma errors. For example if you forget a comma before `emit: ...`, the script fails to compile so we can't catch the error.