### PR TITLE
Fix container status check on aws batch

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -252,9 +252,6 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
             // take the exit code from the `.exitcode` file create by nextflow
             // the rationale of this is that, in case of error, the exit code return
             // by the batch API is more reliable.
-            log.info "[JOSH] exitCode `${job.container.exitCode}`"
-            log.info "[JOSH] readExitFile `${readExitFile()}`"
-            log.info "[JOSH] exitCode updated `${(job.container.exitCode || job.container.exitCode == 0) ? job.container.exitCode : 451}`"
             task.exitStatus = (job.container.exitCode || job.container.exitCode == 0) ? job.container.exitCode : readExitFile()
             // finalize the task
             task.stdout = outputFile

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -252,7 +252,10 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
             // take the exit code from the `.exitcode` file create by nextflow
             // the rationale of this is that, in case of error, the exit code return
             // by the batch API is more reliable.
-            task.exitStatus = job.container.exitCode ?: readExitFile()
+            log.info "[JOSH] exitCode `${job.container.exitCode}`"
+            log.info "[JOSH] readExitFile `${readExitFile()}`"
+            log.info "[JOSH] exitCode updated `${(job.container.exitCode || job.container.exitCode == 0) ? job.container.exitCode : 451}`"
+            task.exitStatus = (job.container.exitCode || job.container.exitCode == 0) ? job.container.exitCode : readExitFile()
             // finalize the task
             task.stdout = outputFile
             if( job?.status == 'FAILED' ) {


### PR DESCRIPTION
From the comment, it seems the intention is to use the container status if it exists. However, because 0 is falsy, it was still falling back to reading `.exitcode` when the batch job finished successfully.

Tbh, the old behaviour was a good sanity check to make sure the process really finished and all files got written. I'm not sure if other such checks exist.

But anyway, I believe the behaviour now matches the commented behaviour.