### PR TITLE
Add deleteTasksOnCompletion to Azure Batch configuration

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -340,7 +340,10 @@ The following settings are available:
 : Delete all compute node pools when the workflow completes (default: `false`).
 
 `azure.batch.deleteTasksOnCompletion`
-: Delete each task when it completes (default: `false`).
+: :::{versionadded} 23.08.0-edge
+  :::
+: Delete each task when it completes (default: `true`).
+: Although this setting is enabled by default, failed tasks will not be deleted unless it is explicitly enabled. This way, the default behavior is that successful tasks are deleted while failed tasks are preserved for debugging purposes.
 
 `azure.batch.endpoint`
 : The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -346,7 +346,7 @@ The following settings are available:
 : The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
 
 `azure.batch.terminateJobsOnCompletion`
-: When the workflow completes, set all jobs to complete on task completion. (default: `true`).
+: When the workflow completes, set all jobs to terminate on task completion. (default: `true`).
 
 `azure.batch.pools.<name>.autoScale`
 : Enable autoscaling feature for the pool identified with `<name>`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -332,12 +332,15 @@ The following settings are available:
 
 `azure.batch.deleteJobsOnCompletion`
 : Delete all jobs when the workflow completes (default: `false`).
+: :::{versionchanged} 23.08.0-edge
+  Default value was changed from `true` to `false`.
+  :::
 
 `azure.batch.deletePoolsOnCompletion`
 : Delete all compute node pools when the workflow completes (default: `false`).
 
 `azure.batch.deleteTasksOnCompletion`
-: Delete each task when it completes (default: `true`).
+: Delete each task when it completes (default: `false`).
 
 `azure.batch.endpoint`
 : The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.
@@ -346,6 +349,8 @@ The following settings are available:
 : The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
 
 `azure.batch.terminateJobsOnCompletion`
+: :::{versionadded} 23.05.0-edge
+  :::
 : When the workflow completes, set all jobs to terminate on task completion. (default: `true`).
 
 `azure.batch.pools.<name>.autoScale`

--- a/docs/config.md
+++ b/docs/config.md
@@ -331,7 +331,7 @@ The following settings are available:
 : Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
 
 `azure.batch.deleteJobsOnCompletion`
-: Delete all jobs when the workflow completes (default: `true`).
+: Delete all jobs when the workflow completes (default: `false`).
 
 `azure.batch.deletePoolsOnCompletion`
 : Delete all compute node pools when the workflow completes (default: `false`).

--- a/docs/config.md
+++ b/docs/config.md
@@ -331,13 +331,13 @@ The following settings are available:
 : Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
 
 `azure.batch.deleteJobsOnCompletion`
-: Enable the automatic deletion of jobs created by the pipeline execution (default: `true`).
+: Delete all jobs when the workflow completes (default: `true`).
 
 `azure.batch.deletePoolsOnCompletion`
-: Enable the automatic deletion of compute node pools upon pipeline completion (default: `false`).
+: Delete all compute node pools when the workflow completes (default: `false`).
 
 `azure.batch.deleteTasksOnCompletion`
-: Delete tasks after successful completion. This deletes them on the Azure Batch service but files and resources may persist on the compute nodes (default: `true`).
+: Delete each task when it completes (default: `true`).
 
 `azure.batch.endpoint`
 : The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.
@@ -346,7 +346,7 @@ The following settings are available:
 : The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
 
 `azure.batch.terminateJobsOnCompletion`
-: Enables the Batch Job to automatically terminate a job once all tasks have completed (default: `true`).
+: Terminate each job once all of its tasks have completed (default: `true`).
 
 `azure.batch.pools.<name>.autoScale`
 : Enable autoscaling feature for the pool identified with `<name>`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -330,23 +330,23 @@ The following settings are available:
 `azure.batch.copyToolInstallMode`
 : Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
 
-`azure.batch.terminateJobsOnCompletion`
-: Enables the Batch Job to automatically terminate a job once all tasks have completed (default: `true`).
-
-`azure.batch.deleteTasksOnCompletion`
-: Delete tasks after successful completion. This deletes them on the Azure Batch service but files and resources may persist on the compute nodes (default: `true`).
-
 `azure.batch.deleteJobsOnCompletion`
 : Enable the automatic deletion of jobs created by the pipeline execution (default: `true`).
 
 `azure.batch.deletePoolsOnCompletion`
 : Enable the automatic deletion of compute node pools upon pipeline completion (default: `false`).
 
+`azure.batch.deleteTasksOnCompletion`
+: Delete tasks after successful completion. This deletes them on the Azure Batch service but files and resources may persist on the compute nodes (default: `true`).
+
 `azure.batch.endpoint`
 : The batch service endpoint e.g. `https://nfbatch1.westeurope.batch.azure.com`.
 
 `azure.batch.location`
 : The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
+
+`azure.batch.terminateJobsOnCompletion`
+: Enables the Batch Job to automatically terminate a job once all tasks have completed (default: `true`).
 
 `azure.batch.pools.<name>.autoScale`
 : Enable autoscaling feature for the pool identified with `<name>`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -333,6 +333,9 @@ The following settings are available:
 `azure.batch.terminateJobsOnCompletion`
 : Enables the Batch Job to automatically terminate a job once all tasks have completed (default: `true`).
 
+`azure.batch.deleteTasksOnCompletion`
+: Delete tasks after successful completion. This deletes them on the Azure Batch service but files and resources may persist on the compute nodes (default: `true`).
+
 `azure.batch.deleteJobsOnCompletion`
 : Enable the automatic deletion of jobs created by the pipeline execution (default: `true`).
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -346,7 +346,7 @@ The following settings are available:
 : The name of the batch service region, e.g. `westeurope` or `eastus2`. This is not needed when the endpoint is specified.
 
 `azure.batch.terminateJobsOnCompletion`
-: Terminate each job once all of its tasks have completed (default: `true`).
+: When the workflow completes, set all jobs to complete on task completion. (default: `true`).
 
 `azure.batch.pools.<name>.autoScale`
 : Enable autoscaling feature for the pool identified with `<name>`.

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -57,12 +57,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1689766233402
+    static public final long APP_TIMESTAMP = 1686776566745
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 5867
+    static public final int APP_BUILDNUM = 5864
 
     /**
      * The app build time string relative to UTC timezone

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -57,12 +57,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1686776566745
+    static public final long APP_TIMESTAMP = 1689766233402
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 5864
+    static public final int APP_BUILDNUM = 5867
 
     /**
      * The app build time string relative to UTC timezone

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -785,17 +785,13 @@ class AzBatchService implements Closeable {
         apply(() -> client.taskOperations().deleteTask(key.jobId, key.taskId))
     }
 
+    /**
+     * Set all jobs to terminate on completion.
+     */
     protected void terminateJobs() {
-        /* 
-        We set the job to terminate when all tasks are complete rather than directly terminating, this allows Azure Batch to handle the termination for us.
-        */
-
-        for( Map.Entry<TaskProcessor,String> entry : allJobIds ) {
-            final proc = entry.key
-            final jobId = entry.value
-
+        for( String jobId : allJobIds.values() ) {
             try {
-                log.trace "Terminating Azure job ${jobId}"
+                log.trace "Setting Azure job ${jobId} to terminate on completion"
 
                 CloudJob job = apply(() -> client.jobOperations().getJob(jobId))
                 final poolInfo = job.poolInfo()
@@ -813,10 +809,7 @@ class AzBatchService implements Closeable {
     }
 
     protected void cleanupJobs() {
-        for( Map.Entry<TaskProcessor,String> entry : allJobIds ) {
-            final proc = entry.key
-            final jobId = entry.value
-
+        for( String jobId : allJobIds.values() ) {
             try {
                 log.trace "Deleting Azure job ${jobId}"
                 apply(() -> client.jobOperations().deleteJob(jobId))
@@ -828,7 +821,7 @@ class AzBatchService implements Closeable {
     }
 
     protected void cleanupPools() {
-        for( String poolId : allPools.keySet()) {
+        for( String poolId : allPools.keySet() ) {
             try {
                 apply(() -> client.poolOperations().deletePool(poolId))
             }
@@ -849,17 +842,20 @@ class AzBatchService implements Closeable {
         }
         return identity
     }
+
     @Override
     void close() {
-        // Terminate existing jobs to prevent them occupying quota
-        if( config.batch().terminateJobsOnCompletion!=Boolean.FALSE ) {
+        // terminate all jobs to prevent them from occupying quota
+        if( config.batch().terminateJobsOnCompletion ) {
             terminateJobs()
         }
 
-        // cleanup app successful jobs
-        if( config.batch().deleteJobsOnCompletion!=Boolean.FALSE ) {
+        // delete all jobs
+        if( config.batch().deleteJobsOnCompletion ) {
             cleanupJobs()
         }
+
+        // delete all autopools
         if( config.batch().canCreatePool() && config.batch().deletePoolsOnCompletion ) {
             cleanupPools()
         }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -130,7 +130,7 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     private Boolean shouldDelete() {
-        executor.config.batch().deleteJobsOnCompletion
+        executor.config.batch().deleteTasksOnCompletion
     }
 
     protected void deleteTask(AzTaskKey taskKey, TaskRun task) {
@@ -138,7 +138,7 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             return
 
         if( !task.isSuccess() && shouldDelete()==null ) {
-            // do not delete successfully executed pods for debugging purpose
+            // do not delete successfully executed tasks for debugging purpose
             return
         }
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -138,7 +138,7 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             return
 
         if( !task.isSuccess() && shouldDelete()==null ) {
-            // do not delete successfully executed tasks for debugging purpose
+            // preserve failed tasks for debugging purposes, unless deletion is explicitly enabled
             return
         }
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -48,6 +48,7 @@ class AzBatchOpts implements CloudTransferOptions {
     Boolean autoPoolMode
     Boolean allowPoolCreation
     Boolean terminateJobsOnCompletion
+    Boolean deleteTasksOnCompletion
     Boolean deleteJobsOnCompletion
     Boolean deletePoolsOnCompletion
     CopyToolInstallMode copyToolInstallMode
@@ -64,6 +65,7 @@ class AzBatchOpts implements CloudTransferOptions {
         autoPoolMode = config.autoPoolMode
         allowPoolCreation = config.allowPoolCreation
         terminateJobsOnCompletion = config.terminateJobsOnCompletion
+        deleteTasksOnCompletion = config.deleteTasksOnCompletion
         deleteJobsOnCompletion = config.deleteJobsOnCompletion
         deletePoolsOnCompletion = config.deletePoolsOnCompletion
         pools = parsePools(config.pools instanceof Map ? config.pools as Map<String,Map> : Collections.<String,Map>emptyMap())

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -64,8 +64,8 @@ class AzBatchOpts implements CloudTransferOptions {
         location = config.location
         autoPoolMode = config.autoPoolMode
         allowPoolCreation = config.allowPoolCreation
-        terminateJobsOnCompletion = config.terminateJobsOnCompletion
-        deleteJobsOnCompletion = config.deleteJobsOnCompletion
+        terminateJobsOnCompletion = config.terminateJobsOnCompletion != Boolean.FALSE
+        deleteJobsOnCompletion = config.deleteJobsOnCompletion != Boolean.FALSE
         deletePoolsOnCompletion = config.deletePoolsOnCompletion
         deleteTasksOnCompletion = config.deleteTasksOnCompletion
         pools = parsePools(config.pools instanceof Map ? config.pools as Map<String,Map> : Collections.<String,Map>emptyMap())

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -65,7 +65,7 @@ class AzBatchOpts implements CloudTransferOptions {
         autoPoolMode = config.autoPoolMode
         allowPoolCreation = config.allowPoolCreation
         terminateJobsOnCompletion = config.terminateJobsOnCompletion != Boolean.FALSE
-        deleteJobsOnCompletion = config.deleteJobsOnCompletion != Boolean.FALSE
+        deleteJobsOnCompletion = config.deleteJobsOnCompletion
         deletePoolsOnCompletion = config.deletePoolsOnCompletion
         deleteTasksOnCompletion = config.deleteTasksOnCompletion
         pools = parsePools(config.pools instanceof Map ? config.pools as Map<String,Map> : Collections.<String,Map>emptyMap())

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -48,9 +48,9 @@ class AzBatchOpts implements CloudTransferOptions {
     Boolean autoPoolMode
     Boolean allowPoolCreation
     Boolean terminateJobsOnCompletion
-    Boolean deleteTasksOnCompletion
     Boolean deleteJobsOnCompletion
     Boolean deletePoolsOnCompletion
+    Boolean deleteTasksOnCompletion
     CopyToolInstallMode copyToolInstallMode
 
     Map<String,AzPoolOpts> pools
@@ -65,9 +65,9 @@ class AzBatchOpts implements CloudTransferOptions {
         autoPoolMode = config.autoPoolMode
         allowPoolCreation = config.allowPoolCreation
         terminateJobsOnCompletion = config.terminateJobsOnCompletion
-        deleteTasksOnCompletion = config.deleteTasksOnCompletion
         deleteJobsOnCompletion = config.deleteJobsOnCompletion
         deletePoolsOnCompletion = config.deletePoolsOnCompletion
+        deleteTasksOnCompletion = config.deleteTasksOnCompletion
         pools = parsePools(config.pools instanceof Map ? config.pools as Map<String,Map> : Collections.<String,Map>emptyMap())
         maxParallelTransfers = config.maxParallelTransfers ? config.maxParallelTransfers as int : MAX_TRANSFER
         maxTransferAttempts = config.maxTransferAttempts ? config.maxTransferAttempts as int : MAX_TRANSFER_ATTEMPTS

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -350,8 +350,7 @@ class AzBatchServiceTest extends Specification {
 
     }
 
-
-    def 'should cleanup jobs by default' () {
+    def 'should set jobs to automatically terminate by default' () {
         given:
         def CONFIG = [:]
         def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
@@ -359,12 +358,12 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        1 * svc.cleanupJobs() >> null
+        1 * svc.terminateJobs() >> null
     }
 
-    def 'should cleanup jobs no cleanup jobs' () {
+    def 'should not cleanup jobs by default' () {
         given:
-        def CONFIG = [batch:[deleteJobsOnCompletion: false]]
+        def CONFIG = [:]
         def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
         AzBatchService svc = Spy(AzBatchService, constructorArgs:[exec])
         when:
@@ -373,7 +372,18 @@ class AzBatchServiceTest extends Specification {
         0 * svc.cleanupJobs() >> null
     }
 
-    def 'should cleanup not cleanup pools by default' () {
+    def 'should cleanup jobs if specified' () {
+        given:
+        def CONFIG = [batch:[deleteJobsOnCompletion: true]]
+        def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
+        AzBatchService svc = Spy(AzBatchService, constructorArgs:[exec])
+        when:
+        svc.close()
+        then:
+        1 * svc.cleanupJobs() >> null
+    }
+
+    def 'should not cleanup pools by default' () {
         given:
         def CONFIG = [:]
         def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
@@ -395,7 +405,7 @@ class AzBatchServiceTest extends Specification {
         1 * svc.cleanupPools() >> null
     }
 
-    def 'should cleanup cleanup pools with allowPoolCreation' () {
+    def 'should cleanup pools with allowPoolCreation' () {
         given:
         def CONFIG = [batch:[allowPoolCreation: true, deletePoolsOnCompletion: true]]
         def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -350,6 +350,7 @@ class AzBatchServiceTest extends Specification {
 
     }
 
+
     def 'should cleanup jobs by default' () {
         given:
         def CONFIG = [:]

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -350,7 +350,6 @@ class AzBatchServiceTest extends Specification {
 
     }
 
-
     def 'should cleanup jobs by default' () {
         given:
         def CONFIG = [:]

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -70,8 +70,10 @@ class AzureConfigTest extends Specification {
 
         and:
         cfg.batch().endpoint == null
-        cfg.batch().deleteJobsOnCompletion == null
+        cfg.batch().terminateJobsOnCompletion == true
+        cfg.batch().deleteJobsOnCompletion == true
         cfg.batch().deletePoolsOnCompletion == null
+        cfg.batch().deleteTasksOnCompletion == null
         cfg.batch().location == null
         cfg.batch().autoPoolMode == null
         cfg.batch().allowPoolCreation == null
@@ -101,9 +103,9 @@ class AzureConfigTest extends Specification {
                                              autoPoolMode: true,
                                              allowPoolCreation: true,
                                              terminateJobsOnCompletion: false,
-                                             deleteTasksOnCompletion: false,
                                              deleteJobsOnCompletion: false,
                                              deletePoolsOnCompletion: true,
+                                             deleteTasksOnCompletion: false,
                                              pools: [ myPool: [
                                                      vmType: 'Foo_A1',
                                                      autoScale: true,
@@ -128,9 +130,9 @@ class AzureConfigTest extends Specification {
         cfg.batch().autoPoolMode == true
         cfg.batch().allowPoolCreation == true
         cfg.batch().terminateJobsOnCompletion == false
-        cfg.batch().deleteTasksOnCompletion == false
         cfg.batch().deleteJobsOnCompletion == false
         cfg.batch().deletePoolsOnCompletion == true
+        cfg.batch().deleteTasksOnCompletion == false
         cfg.batch().canCreatePool()
         and:
         cfg.batch().pool('myPool').vmType == 'Foo_A1'

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -71,7 +71,7 @@ class AzureConfigTest extends Specification {
         and:
         cfg.batch().endpoint == null
         cfg.batch().terminateJobsOnCompletion == true
-        cfg.batch().deleteJobsOnCompletion == true
+        cfg.batch().deleteJobsOnCompletion == null
         cfg.batch().deletePoolsOnCompletion == null
         cfg.batch().deleteTasksOnCompletion == null
         cfg.batch().location == null
@@ -103,7 +103,7 @@ class AzureConfigTest extends Specification {
                                              autoPoolMode: true,
                                              allowPoolCreation: true,
                                              terminateJobsOnCompletion: false,
-                                             deleteJobsOnCompletion: false,
+                                             deleteJobsOnCompletion: true,
                                              deletePoolsOnCompletion: true,
                                              deleteTasksOnCompletion: false,
                                              pools: [ myPool: [
@@ -130,7 +130,7 @@ class AzureConfigTest extends Specification {
         cfg.batch().autoPoolMode == true
         cfg.batch().allowPoolCreation == true
         cfg.batch().terminateJobsOnCompletion == false
-        cfg.batch().deleteJobsOnCompletion == false
+        cfg.batch().deleteJobsOnCompletion == true
         cfg.batch().deletePoolsOnCompletion == true
         cfg.batch().deleteTasksOnCompletion == false
         cfg.batch().canCreatePool()

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -99,7 +99,10 @@ class AzureConfigTest extends Specification {
                                              endpoint: ENDPOINT,
                                              location: LOCATION,
                                              autoPoolMode: true,
-                                             allowPoolCreation: true,                                            deleteJobsOnCompletion: false,
+                                             allowPoolCreation: true,                                            
+                                             terminateJobsOnCompletion: false,
+                                             deleteTasksOnCompletion: false,
+                                             deleteJobsOnCompletion: false,
                                              deletePoolsOnCompletion: true,
                                              pools: [ myPool: [
                                                      vmType: 'Foo_A1',
@@ -124,6 +127,8 @@ class AzureConfigTest extends Specification {
         cfg.batch().location == LOCATION
         cfg.batch().autoPoolMode == true
         cfg.batch().allowPoolCreation == true
+        cfg.batch().terminateJobsOnCompletion == false
+        cfg.batch().deleteTasksOnCompletion == false
         cfg.batch().deleteJobsOnCompletion == false
         cfg.batch().deletePoolsOnCompletion == true
         cfg.batch().canCreatePool()

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -99,7 +99,7 @@ class AzureConfigTest extends Specification {
                                              endpoint: ENDPOINT,
                                              location: LOCATION,
                                              autoPoolMode: true,
-                                             allowPoolCreation: true,                                            
+                                             allowPoolCreation: true,
                                              terminateJobsOnCompletion: false,
                                              deleteTasksOnCompletion: false,
                                              deleteJobsOnCompletion: false,


### PR DESCRIPTION
Deleting Azure Tasks was checking the configuration object `deleteJobsOnCompletion` which was incorrect since a task belongs to a job. This adds the equivalent configuration for tasks which is checked before deleting the tasks.

