### PR TITLE
Improve "Unexpected input: '{'" error message

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptParser.groovy
@@ -184,6 +184,9 @@ class ScriptParser {
             msg = msg != 'startup failed' ? msg : header
             msg = msg.replaceAll(/startup failed:\n/,'')
             msg = msg.replaceAll(~/$clazzName(: \d+:\b*)?/, header+'\n- cause:')
+            if( msg.contains "Unexpected input: '{'" ) {
+                msg += "\nNOTE: If this is the beginning of a process or workflow, there may be a syntax error in the body, such as a missing or extra comma, for which a more specific error message could not be produced."
+            }
             throw new ScriptCompilationException(msg, e)
         }
     }


### PR DESCRIPTION
Close #2082 #3325 

Some syntax errors in processes and workflows, such as missing/extra commas, are not handled well by the Groovy parser, likely because the custom DSL syntax makes it difficult to determine exactly which token is the cause. As a result, Groovy simply reports the opening brace as the cause: `Unexpected input: '{'`, which causes many users to look for errors *before* this point, when in reality the error is almost always after it.

Unfortunately, we can't use the DSL to improve this error because it happens during parsing, before our custom AST transforms. The most we can do is to intercept the error and try to provide a hint to the user. The long-term solution is to create a DSL that doesn't require as many syntax transformations.

Try any of the pipeline examples in the liked issues, you will see that the error message now includes an extra note about checking the process/workflow body.