### PR TITLE
Disable cache backup/restore if cloudcache is used

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheCommand.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheCommand.groovy
@@ -46,7 +46,9 @@ class CacheCommand implements PluginAbstractExec {
 
     protected void cacheBackup() {
         log.debug "Running Nextflow cache backup"
-        new CacheManager(System.getenv()).saveCacheFiles()
+        final manager = new CacheManager(System.getenv())
+        manager.saveCacheFiles()
+        manager.saveMiscFiles()
     }
 
     protected void archiveLogs(Session sess) {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy
@@ -65,7 +65,9 @@ class CacheManager {
         if( !sessionUuid )
             throw new AbortOperationException("Missing target uuid - cache sync cannot be performed")
 
-        this.localCachePath = Paths.get(".nextflow/cache/${sessionUuid}")
+        this.localCachePath = env.containsKey('NXF_CLOUDCACHE_PATH')
+            ? null
+            : Paths.get(".nextflow/cache/${sessionUuid}")
 
         if( env.NXF_OUT_FILE )
             localOutFile = Paths.get(env.NXF_OUT_FILE)
@@ -80,7 +82,7 @@ class CacheManager {
     }
 
     protected void restoreCacheFiles() {
-        if( !remoteWorkDir || !sessionUuid )
+        if( !remoteWorkDir || !sessionUuid || !localCachePath )
             return
 
         if(!Files.exists(remoteCachePath)) {
@@ -100,7 +102,7 @@ class CacheManager {
     }
 
     protected void saveCacheFiles() {
-        if( !remoteWorkDir || !sessionUuid )
+        if( !remoteWorkDir || !sessionUuid || !localCachePath )
             return
 
         if( !Files.exists(localCachePath) ) {
@@ -118,7 +120,9 @@ class CacheManager {
         catch (Throwable e) {
             log.warn "Failed to backup resume metadata to remote store path: ${remoteCachePath.toUriString()} — cause: ${e}", e
         }
+    }
 
+    protected void saveMiscFiles() {
         // — upload out file
         try {
             if( localOutFile?.exists() )

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy
@@ -65,9 +65,10 @@ class CacheManager {
         if( !sessionUuid )
             throw new AbortOperationException("Missing target uuid - cache sync cannot be performed")
 
-        this.localCachePath = env.containsKey('NXF_CLOUDCACHE_PATH')
-            ? null
-            : Paths.get(".nextflow/cache/${sessionUuid}")
+        // ignore the `localCachePath` when the `NXF_CLOUDCACHE_PATH` variable is set because
+        // the nextflow cache metadata is going to be managed (and stored) via the nf-cloudcache plugin
+        if( !env.containsKey('NXF_CLOUDCACHE_PATH') )
+            this.localCachePath = Paths.get(".nextflow/cache/${sessionUuid}")
 
         if( env.NXF_OUT_FILE )
             localOutFile = Paths.get(env.NXF_OUT_FILE)

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/CacheManagerTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/CacheManagerTest.groovy
@@ -78,6 +78,7 @@ class CacheManagerTest extends Specification {
         tower.localCachePath.resolve('db/yyy').text = 'data yyy'
         and:
         tower.saveCacheFiles()
+        tower.saveMiscFiles()
         then:
         tower.remoteCachePath.resolve('index-foo').text == 'index foo'
         tower.remoteCachePath.resolve('db/xxx').text == 'data xxx'
@@ -99,6 +100,7 @@ class CacheManagerTest extends Specification {
         tower.localCachePath.resolve('db/delta').text = 'data delta'
         and:
         tower.saveCacheFiles()
+        tower.saveMiscFiles()
         then:
         tower.remoteCachePath.resolve('index-bar').text == 'index bar'
         tower.remoteCachePath.resolve('db/alpha').text == 'data alpha'

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/CacheManagerTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/CacheManagerTest.groovy
@@ -156,4 +156,26 @@ class CacheManagerTest extends Specification {
         cleanup:
         folder?.deleteDir()
     }
+
+    def 'should not backup/restore cache if cloudcache is enabled' () {
+        given:
+        def ENV = [
+                NXF_UUID: 'uuid',
+                NXF_WORK: '/work',
+                NXF_CLOUDCACHE_PATH: 's3://my-bucket/cache'
+        ]
+        and:
+        def tower = new CacheManager(ENV)
+
+        when:
+        tower.saveCacheFiles()
+        then:
+        0 * tower.getRemoteCachePath()
+
+        when:
+        tower.restoreCacheFiles()
+        then:
+        0 * tower.getRemoteCachePath()
+
+    }
 }


### PR DESCRIPTION
This PR changes the nf-tower `cache` command to not try to save/restore the Nextflow cache if `NXF_CLOUDCACHE_PATH` is set.