### PR TITLE
Allow workflow entry from module import

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -108,15 +108,14 @@ abstract class BaseScript extends Script implements ExecutionContext {
     protected workflow(Closure<BodyDef> workflowBody) {
         // launch the execution
         final workflow = new WorkflowDef(this, workflowBody)
-        if( !binding.entryName )
-            this.entryFlow = workflow
+        // capture the main (unnamed) workflow definition
+        this.entryFlow = workflow
+        // add it to the list of workflow definitions
         meta.addDefinition(workflow)
     }
 
     protected workflow(String name, Closure<BodyDef> workflowDef) {
         final workflow = new WorkflowDef(this,workflowDef,name)
-        if( binding.entryName==name )
-            this.entryFlow = workflow
         meta.addDefinition(workflow)
     }
 
@@ -147,19 +146,14 @@ abstract class BaseScript extends Script implements ExecutionContext {
             return result
         }
 
-        if( binding.entryName && !entryFlow ) {
-            component = meta.getComponent(binding.entryName)
-            if( component instanceof WorkflowDef ) {
-                entryFlow = component
-            }
-            else {
-                def msg = "Unknown workflow entry name: ${binding.entryName}"
-                final allNames = meta.getLocalWorkflowNames()
-                final guess = allNames.closest(binding.entryName)
-                if( guess )
-                    msg += " -- Did you mean?\n" + guess.collect { "  $it"}.join('\n')
-                throw new IllegalArgumentException(msg)
-            }
+        // if an `entryName` was specified via the command line, override `entryFlow` to be executed
+        if( binding.entryName && !(entryFlow=meta.getWorkflow(binding.entryName) ) ) {
+            def msg = "Unknown workflow entry name: ${binding.entryName}"
+            final allNames = meta.getWorkflowNames()
+            final guess = allNames.closest(binding.entryName)
+            if( guess )
+                msg += " -- Did you mean?\n" + guess.collect { "  $it"}.join('\n')
+            throw new IllegalArgumentException(msg)
         }
 
         if( !entryFlow ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -146,7 +146,7 @@ abstract class BaseScript extends Script implements ExecutionContext {
             return result
         }
 
-        // if an `entryName` was specified via the command line, override `entryFlow` to be executed
+        // if an `entryName` was specified via the command line, override the `entryFlow` to be executed
         if( binding.entryName && !(entryFlow=meta.getWorkflow(binding.entryName) ) ) {
             def msg = "Unknown workflow entry name: ${binding.entryName}"
             final allNames = meta.getWorkflowNames()

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -148,12 +148,18 @@ abstract class BaseScript extends Script implements ExecutionContext {
         }
 
         if( binding.entryName && !entryFlow ) {
-            def msg = "Unknown workflow entry name: ${binding.entryName}"
-            final allNames = meta.getLocalWorkflowNames()
-            final guess = allNames.closest(binding.entryName)
-            if( guess )
-                msg += " -- Did you mean?\n" + guess.collect { "  $it"}.join('\n')
-            throw new IllegalArgumentException(msg)
+            component = meta.getComponent(binding.entryName)
+            if( component instanceof WorkflowDef ) {
+                entryFlow = component
+            }
+            else {
+                def msg = "Unknown workflow entry name: ${binding.entryName}"
+                final allNames = meta.getLocalWorkflowNames()
+                final guess = allNames.closest(binding.entryName)
+                if( guess )
+                    msg += " -- Did you mean?\n" + guess.collect { "  $it"}.join('\n')
+                throw new IllegalArgumentException(msg)
+            }
         }
 
         if( !entryFlow ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -237,15 +237,18 @@ class ScriptMeta {
     }
 
     WorkflowDef getWorkflow(String name) {
-        (WorkflowDef)getComponent(name)
+        final result = getComponent(name)
+        return result instanceof WorkflowDef ? result : null
     }
 
     ProcessDef getProcess(String name) {
-        (ProcessDef)getComponent(name)
+        final result = getComponent(name)
+        return result instanceof ProcessDef ? result : null
     }
 
     FunctionDef getFunction(String name) {
-        (FunctionDef)getComponent(name)
+        final result = getComponent(name)
+        return result instanceof FunctionDef ? result : null
     }
 
     Set<String> getAllNames() {
@@ -258,6 +261,21 @@ class ScriptMeta {
         // processes from imports
         for( def item: imports.values() ) {
             if( item.name )
+                result.add(item.name)
+        }
+        return result
+    }
+
+    Set<String> getWorkflowNames() {
+        final result = new HashSet(definitions.size() + imports.size())
+        // local definitions
+        for( def item : definitions.values() ) {
+            if( item instanceof WorkflowDef )
+                result.add(item.name)
+        }
+        // processes from imports
+        for( def item: imports.values() ) {
+            if( item instanceof WorkflowDef )
                 result.add(item.name)
         }
         return result

--- a/modules/nextflow/src/test/groovy/nextflow/script/BaseScriptTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/BaseScriptTest.groovy
@@ -21,30 +21,29 @@ import java.nio.file.Paths
 
 import nextflow.NextflowMeta
 import nextflow.Session
-import spock.lang.Specification
+import test.Dsl2Spec
+import test.TestHelper
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-class BaseScriptTest extends Specification {
+class BaseScriptTest extends Dsl2Spec {
 
 
     def 'should define implicit variables' () {
 
         given:
         def script = Files.createTempFile('test',null)
-
+        and:
         def WORKFLOW = Mock(WorkflowMetadata)
         def WORK_DIR = Paths.get('/work/dir')
         def PROJECT_DIR = Paths.get('/some/base')
-
         and:
         def session = Mock(Session) {
             getBaseDir() >> PROJECT_DIR
             getWorkDir() >> WORK_DIR
             getWorkflowMetadata() >> WORKFLOW
         }
-
         def binding = new ScriptBinding([:])
         def parser = new ScriptParser(session)
 
@@ -63,9 +62,8 @@ class BaseScriptTest extends Specification {
         parser.setBinding(binding)
         parser.runScript(script)
 
-
         then:
-        binding.result.baseDir ==PROJECT_DIR
+        binding.result.baseDir == PROJECT_DIR
         binding.result.projectDir == PROJECT_DIR
         binding.result.workDir == WORK_DIR
         binding.result.launchDir == Paths.get('.').toRealPath()
@@ -77,5 +75,70 @@ class BaseScriptTest extends Specification {
         script?.delete()
     }
 
+    def 'should use custom entry workflow' () {
+
+        given:
+        def script = Files.createTempFile('test',null)
+        and:
+        def session = Mock(Session)
+        def binding = new ScriptBinding([:])
+        def parser = new ScriptParser(session)
+
+        when:
+        script.text = '''
+                workflow foo {
+                }
+
+                workflow {
+                    error 'you were supposed to run foo!'
+                }
+                '''
+
+        parser.setBinding(binding)
+        parser.setEntryName('foo')
+        parser.runScript(script)
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        script?.delete()
+    }
+
+    def 'should use entry workflow from module' () {
+
+        given:
+        def folder = TestHelper.createInMemTempDir()
+        def module = folder.resolve('module.nf')
+        def script = folder.resolve('main.nf')
+        and:
+        def session = Mock(Session)
+        def binding = new ScriptBinding([:])
+        def parser = new ScriptParser(session)
+
+        when:
+        module.text = '''
+                workflow foo {
+                }
+                '''
+
+        script.text = '''
+                include { foo } from './module.nf'
+
+                workflow {
+                    error 'you were supposed to run foo!'
+                }
+                '''
+
+        parser.setBinding(binding)
+        parser.setEntryName('foo')
+        parser.runScript(script)
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        folder?.delete()
+    }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessDefTest.groovy
@@ -44,7 +44,7 @@ class ProcessDefTest extends Specification {
         def script = (BaseScript)new GroovyShell(binding,config).parse(SCRIPT)
 
         then:
-        true
+        ScriptMeta.get(script).getProcessNames() == ['foo','bar'] as Set
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptMetaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptMetaTest.groovy
@@ -104,12 +104,15 @@ class ScriptMetaTest extends Dsl2Spec {
         meta1.getComponent('xxx') == null
         meta1.getComponent('func3') == null
         meta1.getComponent('proc3') == null
+        and:
         meta1.getComponent('work3') == work3
         meta1.getComponent('my_process') instanceof ProcessDef
         meta1.getComponent('my_process').name == 'my_process'
 
-//        then:
-//        meta1.getProcessNames() == ['proc1','proc2','my_process'] as Set
+        then:
+        meta1.getProcessNames() == ['proc1','proc2','my_process'] as Set
+        and:
+        meta1.getWorkflowNames() == ['work1', 'work2', 'work3'] as Set
     }
 
 


### PR DESCRIPTION
Close #4127 

The entryFlow is updated when workflows are defined in the main script, but not when they are imported from a module. This PR checks the imported workflows for a matching entry flow if it wasn't found in the main script.