### PR TITLE
Hide processes that haven't been executed yet

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1493,11 +1493,14 @@ In the above example, the `process.cpus` attribute is not correctly applied beca
 
 The following environment variables control the configuration of the Nextflow runtime and the underlying Java virtual machine.
 
+`NXF_ANSI_HIDE_NASCENT_PROCESSES`
+: When `true`, hide processes that haven't been executed yet (default: `false`).
+
 `NXF_ANSI_LOG`
-: Enables/disables ANSI console output (default `true` when ANSI terminal is detected).
+: Enables/disables ANSI console output (default: `true` when ANSI terminal is detected).
 
 `NXF_ANSI_SUMMARY`
-: Enables/disables ANSI completion summary: `true\|false` (default: print summary if execution last more than 1 minute).
+: Enables/disables ANSI completion summary (default: `true` if execution lasts more than 1 minute).
 
 `NXF_ASSETS`
 : Defines the directory where downloaded pipeline repositories are stored (default: `$NXF_HOME/assets`)

--- a/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
@@ -93,6 +93,8 @@ class AnsiLogObserver implements TraceObserver {
 
     private Boolean enableSummary = System.getenv('NXF_ANSI_SUMMARY') as Boolean
 
+    private Boolean hideNascentProcesses = System.getenv('NXF_ANSI_HIDE_NASCENT_PROCESSES') as Boolean
+
     private final int WARN_MESSAGE_TIMEOUT = 35_000
 
     private WorkflowStatsObserver statsObserver
@@ -264,7 +266,7 @@ class AnsiLogObserver implements TraceObserver {
 
         // render line
         for( ProgressRecord entry : processes ) {
-            if( entry.getTotalCount() == 0 )
+            if( hideNascentProcesses && entry.getTotalCount() == 0 )
                 continue
             term.a(line(entry))
             term.newline()

--- a/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
@@ -264,6 +264,8 @@ class AnsiLogObserver implements TraceObserver {
 
         // render line
         for( ProgressRecord entry : processes ) {
+            if( entry.getTotalCount() == 0 )
+                continue
             term.a(line(entry))
             term.newline()
         }


### PR DESCRIPTION
Original discussion: https://github.com/nextflow-io/nextflow/discussions/3107?sort=new#discussioncomment-3388088

Hides the process status from the log until it has created some tasks.

I suggest we add an environment variable to toggle it.