### PR TITLE
Allow to skip publishDir

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -2018,6 +2018,10 @@ process foo {
 Files are copied into the specified directory in an *asynchronous* manner, so they may not be immediately available in the publish directory at the end of the process execution. For this reason, downstream processes should not try to access output files through the publish directory, but through channels.
 :::
 
+:::{tip}
+To skip all publishDir directives for a process, set the `skipPublishDir` directive for the according process.
+:::
+
 Available options:
 
 `contentType`
@@ -2065,6 +2069,33 @@ Available options:
   :::
 : *Experimental: currently only supported for S3.*
 : Allow the association of arbitrary tags with the published file e.g. `tags: [FOO: 'Hello world']`.
+
+(process-skippublishdir)=
+
+### skipPublishDir
+`contentType`
+: :::{versionadded} 23.08.0-edge
+:::
+The `publishDir` directives for one task can be spread over the workflow file and many config files. Each `publishDir` has to be disabled individually. To skip all publishDir directives at once for a process, set the `skipPublishDir` directive for the according process.
+
+```groovy
+process foo {
+    publishDir '/data/chunks1', mode: 'copy', overwrite: false
+    publishDir '/data/chunks2', mode: 'copy', overwrite: false
+    publishDir '/data/chunks3', mode: 'copy', overwrite: false
+    skipPublishDir true
+
+    output:
+    path 'chunk_*'
+
+    '''
+    printf 'Hola' | split -b 1 - chunk_
+    '''
+}
+```
+
+```groovy
+
 
 (process-queue)=
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -354,7 +354,7 @@ class TaskConfig extends LazyMap implements Cloneable {
 
     List<PublishDir> getPublishDir() {
         def dirs = get('publishDir')
-        if( !dirs ) {
+        if( !dirs || target.skipPublishDir ) {
             return Collections.emptyList()
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -490,6 +490,23 @@ class TaskConfigTest extends Specification {
 
     }
 
+    def 'should skip publishDir object' () {
+
+        setup:
+        def script = Mock(BaseScript)
+        ProcessConfig process
+        List<PublishDir> publish
+
+        when:
+        process = new ProcessConfig(script)
+        process.publishDir '/data'
+        process.skipPublishDir = true
+        publish = process.createTaskConfig().getPublishDir()
+        then:
+        publish.isEmpty()
+
+    }
+
     def 'should create publishDir with local variables' () {
 
         given:


### PR DESCRIPTION
If you have a big project such as nf-core it happens that `publishDir` directives are spread over different config files that you don't wan't to touch. However, a publishDir has to be disabled in the place of creation.
`process.publishDir.enable = false` is not applied to existing `publishDirs`.
Therefore, I implemented this small feature.
