### PR TITLE
Add `-value` option to `config` command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -406,7 +406,9 @@ The `config` command is used for printing the project's configuration i.e. the `
 : Print config using Java properties notation.
 
 `-property`
-: Prints a config property using Java properties notation
+: :::{versionadded} 23.08.0-edge
+  :::
+: Print the value of a config property, or fail if the property is not defined.
 
 `-a, -show-profiles`
 : Show all configuration profiles.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -405,6 +405,9 @@ The `config` command is used for printing the project's configuration i.e. the `
 `-properties`
 : Print config using Java properties notation.
 
+`-property`
+: Prints a config property using Java properties notation
+
 `-a, -show-profiles`
 : Show all configuration profiles.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -453,7 +453,7 @@ process.executor = local
 Print out the value of a specific configuration property.
 
 ```console
-$ nextflow config -property process.executor
+$ nextflow config -value process.executor
 local
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -405,16 +405,16 @@ The `config` command is used for printing the project's configuration i.e. the `
 `-properties`
 : Print config using Java properties notation.
 
-`-property`
-: :::{versionadded} 23.08.0-edge
-  :::
-: Print the value of a config property, or fail if the property is not defined.
-
 `-a, -show-profiles`
 : Show all configuration profiles.
 
 `-sort`
 : Sort config attributes.
+
+`-value`
+: :::{versionadded} 23.08.0-edge
+  :::
+: Print the value of a config option, or fail if the option is not defined.
 
 **Examples**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -450,6 +450,13 @@ docker.enabled = true
 process.executor = local
 ```
 
+Print out a single config property.
+
+```console
+$ nextflow config -property process.executor
+local
+```
+
 Print out all profiles from the project's configuration.
 
 ```console

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -450,7 +450,7 @@ docker.enabled = true
 process.executor = local
 ```
 
-Print out a single config property.
+Print out the value of a specific configuration property.
 
 ```console
 $ nextflow config -property process.executor

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -59,7 +59,7 @@ class CmdConfig extends CmdBase {
     @Parameter(names = '-sort', description = 'Sort config attributes')
     boolean sort
 
-    @Parameter(names = '-value', description = 'Print the value of a config option, or fail if the option is not defined.')
+    @Parameter(names = '-value', description = 'Print the value of a config option, or fail if the option is not defined')
     String printValue
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -145,7 +145,7 @@ class CmdConfig extends CmdBase {
     @PackageScope void printProperty(ConfigObject config, String name, OutputStream output) {
         final map = config.flatten()
         if( !map.containsKey(name) )
-            throw new IllegalArgumentException("Property '$name' not found")
+            throw new AbortOperationException("Configuration property '$name' not found")
 
         output << map.get(name).toString()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -50,9 +50,6 @@ class CmdConfig extends CmdBase {
     @Parameter(names=['-profile'], description = 'Choose a configuration profile')
     String profile
 
-    @Parameter(names = '-property', description = 'Print the value of a config property, or fail if the property is not defined.')
-    String printProperty
-
     @Parameter(names = '-properties', description = 'Prints config using Java properties notation')
     boolean printProperties
 
@@ -62,6 +59,8 @@ class CmdConfig extends CmdBase {
     @Parameter(names = '-sort', description = 'Sort config attributes')
     boolean sort
 
+    @Parameter(names = '-value', description = 'Print the value of a config option, or fail if the option is not defined.')
+    String printValue
 
     @Override
     String getName() { NAME }
@@ -82,11 +81,11 @@ class CmdConfig extends CmdBase {
         if( printProperties && printFlatten )
             throw new AbortOperationException("Option `-flat` and `-properties` conflicts")
 
-        if ( printProperty && printFlatten )
-            throw new AbortOperationException("Option `-property` and `-flat` conflicts")
+        if ( printValue && printFlatten )
+            throw new AbortOperationException("Option `-value` and `-flat` conflicts")
 
-        if ( printProperty && printProperties )
-            throw new AbortOperationException("Option `-property` and `-properties` conflicts")
+        if ( printValue && printProperties )
+            throw new AbortOperationException("Option `-value` and `-properties` conflicts")
 
         final builder = new ConfigBuilder()
                 .setShowClosures(true)
@@ -103,8 +102,8 @@ class CmdConfig extends CmdBase {
         else if( printFlatten ) {
             printFlatten0(config, stdout)
         }
-        else if( printProperty ) {
-            printProperty(config, printProperty, stdout)
+        else if( printValue ) {
+            printValue0(config, printValue, stdout)
         }
         else {
             printCanonical0(config, stdout)
@@ -142,12 +141,12 @@ class CmdConfig extends CmdBase {
      * @param name The {@link String} representing the property name using dot notation
      * @param output The stream where output the formatted configuration notation
      */
-    @PackageScope void printProperty(ConfigObject config, String name, OutputStream output) {
+    @PackageScope void printValue0(ConfigObject config, String name, OutputStream output) {
         final map = config.flatten()
         if( !map.containsKey(name) )
-            throw new AbortOperationException("Configuration property '$name' not found")
+            throw new AbortOperationException("Configuration option '$name' not found")
 
-        output << map.get(name).toString()
+        output << map.get(name).toString() << '\n'
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -51,7 +51,7 @@ class CmdConfig extends CmdBase {
     String profile
 
     @Parameter(names = '-property', description = 'Prints a config property using Java properties notation')
-    String printProperty = null
+    String printProperty
 
     @Parameter(names = '-properties', description = 'Prints config using Java properties notation')
     boolean printProperties

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -141,7 +141,7 @@ class CmdConfig extends CmdBase {
      * @param output The stream where output the formatted configuration notation
      */
     @PackageScope void printProperty(ConfigObject config, String name, OutputStream output) {
-        if (!config.flatten().containsKey(printProperty)) {
+        if (!config.flatten().containsKey(name)) {
             throw new AbortOperationException("Property '$name' not found")
         }
         output << config.navigate(name).toString()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -50,7 +50,7 @@ class CmdConfig extends CmdBase {
     @Parameter(names=['-profile'], description = 'Choose a configuration profile')
     String profile
 
-    @Parameter(names = '-property', description = 'Prints a config property using Java properties notation')
+    @Parameter(names = '-property', description = 'Print the value of a config property, or fail if the property is not defined.')
     String printProperty
 
     @Parameter(names = '-properties', description = 'Prints config using Java properties notation')
@@ -61,6 +61,7 @@ class CmdConfig extends CmdBase {
 
     @Parameter(names = '-sort', description = 'Sort config attributes')
     boolean sort
+
 
     @Override
     String getName() { NAME }
@@ -78,13 +79,14 @@ class CmdConfig extends CmdBase {
             throw new AbortOperationException("Option `-profile` conflicts with option `-show-profiles`")
         }
 
-        if( printProperties && printFlatten ) {
+        if( printProperties && printFlatten )
             throw new AbortOperationException("Option `-flat` and `-properties` conflicts")
-        }
 
-        if ( printProperty && (printProperties || printFlatten) ) {
-            throw new AbortOperationException("Option `-property` conflicts with `-flat` and `-properties` options")
-        }
+        if ( printProperty && printFlatten )
+            throw new AbortOperationException("Option `-property` and `-flat` conflicts")
+
+        if ( printProperty && printProperties )
+            throw new AbortOperationException("Option `-property` and `-properties` conflicts")
 
         final builder = new ConfigBuilder()
                 .setShowClosures(true)
@@ -134,17 +136,18 @@ class CmdConfig extends CmdBase {
     }
 
     /**
-     * Prints a property of a {@link ConfigObject} using Java {@link Properties} format
+     * Prints a property of a {@link ConfigObject}.
      *
      * @param config The {@link ConfigObject} representing the parsed workflow configuration
      * @param name The {@link String} representing the property name using dot notation
      * @param output The stream where output the formatted configuration notation
      */
     @PackageScope void printProperty(ConfigObject config, String name, OutputStream output) {
-        if (!config.flatten().containsKey(name)) {
-            throw new AbortOperationException("Property '$name' not found")
-        }
-        output << config.navigate(name).toString()
+        final map = config.flatten()
+        if( !map.containsKey(name) )
+            throw new IllegalArgumentException("Property '$name' not found")
+
+        output << map.get(name).toString()
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
@@ -166,6 +166,32 @@ class CmdConfigTest extends Specification {
 
     }
 
+    def 'should print the value of a config property' () {
+
+        given:
+        def cmd = new CmdConfig()
+        and:
+        def config = new ConfigObject()
+        config.process.executor = 'slurm'
+        config.process.queue = 'long'
+        config.docker.enabled = true
+        and:
+        def buffer
+
+        when:
+        buffer = new ByteArrayOutputStream()
+        cmd.printProperty(config, 'process.executor', buffer)
+        then:
+        buffer.toString() == 'slurm'
+
+        when:
+        buffer = new ByteArrayOutputStream()
+        cmd.printProperty(config, 'does.not.exist', buffer)
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Property 'does.not.exist' not found"
+
+    }
 
     def 'should parse config file' () {
         given:

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
@@ -16,11 +16,11 @@
 
 package nextflow.cli
 
-import nextflow.plugin.Plugins
-import spock.lang.IgnoreIf
-
 import java.nio.file.Files
 
+import nextflow.exception.AbortOperationException
+import nextflow.plugin.Plugins
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 /**
  *
@@ -166,7 +166,7 @@ class CmdConfigTest extends Specification {
 
     }
 
-    def 'should print the value of a config property' () {
+    def 'should print the value of a config option' () {
 
         given:
         def cmd = new CmdConfig()
@@ -180,16 +180,16 @@ class CmdConfigTest extends Specification {
 
         when:
         buffer = new ByteArrayOutputStream()
-        cmd.printProperty(config, 'process.executor', buffer)
+        cmd.printValue0(config, 'process.executor', buffer)
         then:
-        buffer.toString() == 'slurm'
+        buffer.toString() == 'slurm\n'
 
         when:
         buffer = new ByteArrayOutputStream()
-        cmd.printProperty(config, 'does.not.exist', buffer)
+        cmd.printValue0(config, 'does.not.exist', buffer)
         then:
-        def e = thrown(IllegalArgumentException)
-        e.message == "Property 'does.not.exist' not found"
+        def e = thrown(AbortOperationException)
+        e.message == "Configuration option 'does.not.exist' not found"
 
     }
 

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -57,12 +57,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1690040653541
+    static public final long APP_TIMESTAMP = 1690879865426
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 5870
+    static public final int APP_BUILDNUM = 5872
 
     /**
      * The app build time string relative to UTC timezone

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -57,12 +57,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1690879865426
+    static public final long APP_TIMESTAMP = 1690040653541
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 5872
+    static public final int APP_BUILDNUM = 5870
 
     /**
      * The app build time string relative to UTC timezone


### PR DESCRIPTION
Close #4138 

The config CLI `-property` optional has been implemented here. I have also updated the docs accordingly. I tested the feature with the following config and test script:

## `test.config`
```groovy
some {
    nullval = null
    nested = [
        key: "value"
    ]
}

profiles {
    myprofile {
        some.nested.key = "alt-value"
    }
}
```

## `test.bash`
```bash
echo "Running tests..."

# Run tests
echo "Should print 'value'"
./launch.sh -C test.config config -property some.nested.key
echo ""

echo "Should print 'alt-value'"
./launch.sh -C test.config config -property some.nested.key -profile myprofile
echo ""

echo "Should print 'null'"
./launch.sh -C test.config config -property some.nullval -profile myprofile
echo ""

echo "Should return a non-zero exit code"
./launch.sh -C test.config config -property does.not.exist
echo "Exit Code: $?"
```

## Output
```
Running tests...
Should print 'value'
value
Should print 'alt-value'
alt-value
Should print 'null'
null
Should return non-zero exit code error
Property 'does.not.exist' not found
Exit Code: 1
```