### PR TITLE
Save aws batch instance id to trace record

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -169,6 +169,10 @@ The following settings are available:
 `aws.batch.delayBetweenAttempts`
 : Delay between download attempts from S3 (default: `10 sec`).
 
+`aws.batch.fetchInstanceType`
+: When `true` fetches the instance type and instance ID of each task (default: `false`).
+: The instance ID can be accessed from the trace file under the `hostname` field.
+
 `aws.batch.jobRole`
 : The AWS Job Role ARN that needs to be used to execute the Batch Job.
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -304,8 +304,12 @@ The following table shows the fields that can be included in the execution repor
 
 `hostname`
 : :::{versionadded} 22.05.0-edge
+  Supported by Kubernetes with `k8s.fetchNodeName = true`.
   :::
-: The host on which the task was executed. Supported only for the Kubernetes executor yet. Activate with `k8s.fetchNodeName = true` in the Nextflow config file.
+: :::{versionchanged} 23.08.0-edge
+  Supported by AWS Batch with `aws.fetchInstanceType = true`.
+  :::
+: The name of the host on which the task was executed.
 
 `cpu_model`
 : :::{versionadded} 22.07.0-edge

--- a/modules/nextflow/src/main/groovy/nextflow/cloud/types/CloudMachineInfo.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/types/CloudMachineInfo.groovy
@@ -28,4 +28,5 @@ class CloudMachineInfo {
     String type
     String zone
     PriceModel priceModel
+    String instanceId = null
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -602,6 +602,8 @@ class TraceRecord implements Serializable {
 
     void setMachineInfo(CloudMachineInfo value) {
         this.machineInfo = value
+        if( value?.instanceId )
+            put('hostname', value.instanceId)
     }
 
 }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchHelper.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchHelper.groovy
@@ -157,7 +157,8 @@ class AwsBatchHelper {
         new CloudMachineInfo(
                 instance.getInstanceType(),
                 instance.getPlacement().getAvailabilityZone(),
-                getPrice(instance))
+                getPrice(instance),
+                instanceId)
     }
 
     private PriceModel getPrice(Instance instance) {


### PR DESCRIPTION
Nextflow already fetches the instance id in order to fetch the machine info, it just wasn't saving it. This PR saves the instance id to the `hostname` field of the trace record. Set `aws.batch.fetchInstanceType = true` to enable it.

If you want to avoid changing the CloudMachineInfo, an alternative approach would be to separate the calls to fetch the instance id vs the machine info. That would require more changes but happy to do it if you prefer.

Quick test:
```console
$ ../launch.sh run hello -profile awsbatch -with-trace
N E X T F L O W  ~  version 23.07.0-edge
Launching `https://github.com/nextflow-io/hello` [nostalgic_goodall] DSL2 - revision: 1d71f857bb [master]
[ce/bff2a9] process > sayHello (2) [100%] 4 of 4 ✔
Hello world!

Hola world!

Ciao world!

Bonjour world!

$ cat trace-20230804-48381761.txt 
task_id hash    native_id       %cpu    peak_rss        realtime        hostname
3       47/e2dabf       504ded65-e21b-49dd-b193-85810f1fdf6a    -       -       454ms   i-01a2837115229b513
4       c8/c36c49       4d5557a2-84bc-4df4-93e7-bc136319e6af    -       -       461ms   i-00ff2821fe2499302
1       ad/ac4632       9ac30279-42ee-4307-94c1-bbe0afafe940    -       -       2.9s    i-01a2837115229b513
2       ce/bff2a9       3053e752-9577-432f-8b68-69e03be09136    -       -       705ms   i-00ff2821fe2499302
```