### PR TITLE
more clear explanation about join() operators

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -952,6 +952,10 @@ left.join(right).view()
 [X, 1, 4]
 ```
 
+:::{note}
+In the output, items from the 'left' channel always precede the corresponding items from the 'right' channel."
+:::
+
 The `index` of a different matching element can be specified by using the `by` parameter.
 
 The `join` operator can emit all the pairs that are incomplete, i.e. the items for which a matching element is missing, by specifying the optional parameter `remainder` as shown below:

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -953,7 +953,7 @@ left.join(right).view()
 ```
 
 :::{note}
-In the output, items from the 'left' channel always precede the corresponding items from the 'right' channel."
+In the output, items from the 'left' channel always precede the corresponding items from the 'right' channel.
 :::
 
 The `index` of a different matching element can be specified by using the `by` parameter.


### PR DESCRIPTION
I propose adding a line to clarify this as follows:

In the output, items from the 'left' channel always precede the corresponding items from the 'right' channel."

And @mribeirodantas mentioned "the concat operator has an equivalent comment, so I  guess join operator deserves the same." Thank you Marcel

This would make it clearer for new users and provide a more complete understanding of the function's behavior. Please let me know if this change would be acceptable.

