### PR TITLE
Fix typos in source code comments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1361,7 +1361,7 @@ NEXTFLOW CHANGE-LOG
 - see 20.07.0 and 20.07.0-RC1
 
 20.07.0 - (skipped)
-- Allow unqualified stdin/stdout defintions with DSL2 [bcdcaab6]
+- Allow unqualified stdin/stdout definitions with DSL2 [bcdcaab6]
 
 20.07.0-RC1 - 21 Jul 2020 
 - Add Dsl2 enable flag [08238109]

--- a/modules/nextflow/src/main/groovy/nextflow/ast/TaskTemplateVarsXformImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/TaskTemplateVarsXformImpl.groovy
@@ -26,7 +26,7 @@ import org.codehaus.groovy.transform.ASTTransformation
 import org.codehaus.groovy.transform.GroovyASTTransformation
 /**
  * Implements a xform that captures variable names declared
- * in task tamplate
+ * in task template
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -115,7 +115,7 @@ class CmdConfig extends CmdBase {
 
     /**
      * Prints a {@link ConfigObject} using Java {@link Properties} in canonical format
-     * ie. any nested config object is printed withing curly brackets
+     * ie. any nested config object is printed within curly brackets
      *
      * @param config The {@link ConfigObject} representing the parsed workflow configuration
      * @param output The stream where output the formatted configuration notation

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaConfig.groovy
@@ -55,6 +55,6 @@ class CondaConfig extends LinkedHashMap {
             return value.tokenize(',').collect(it -> it.trim())
         }
 
-        throw new IllegalArgumentException("Unexected conda.channels value: $value")
+        throw new IllegalArgumentException("Unexpected conda.channels value: $value")
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/config/CascadingConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/CascadingConfig.groovy
@@ -122,7 +122,7 @@ abstract class CascadingConfig<K,V> {
     /**
      * Convert this object to an equivalent {@link ConfigObject}
      *
-     * @return A {@link ConfigObject} holding teh same data
+     * @return A {@link ConfigObject} holding the same data
      */
     ConfigObject toConfigObject() {
         toConfigObject0(this.config)

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -224,7 +224,7 @@ class SingularityCache {
             return libraryPath
         }
 
-        // check for the image in teh cache dir
+        // check for the image in the cache dir
         // if the image does not exist in the cache dir, download it
         final localPath = localCachePath(imageUrl)
         if( localPath.exists() ) {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
@@ -212,7 +212,7 @@ class ExecutorFactory {
     }
 
     /**
-     * Find out the 'executor' to be used in the process definition or in teh session configuration object
+     * Find out the 'executor' to be used in the process definition or in the session configuration object
      *
      * @param taskConfig
      */

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -381,7 +381,7 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
         else {
             /*
              * Since working with NFS it may happen that the file exists BUT it is empty due to network latencies,
-             * before retuning an invalid exit code, wait some seconds.
+             * before returning an invalid exit code, wait some seconds.
              *
              * More in detail:
              * 1) the very first time that arrive here initialize the 'exitTimestampMillis' to the current timestamp

--- a/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
@@ -1048,7 +1048,7 @@ class OperatorImpl {
     static private final Map PARAMS_VIEW = [newLine: Boolean]
 
     /**
-     * Print out the channel content retuning a new channel emitting the identical content as the original one
+     * Print out the channel content returning a new channel emitting the identical content as the original one
      *
      * @param source
      * @param closure

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodHostMount.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodHostMount.groovy
@@ -21,7 +21,7 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
 /**
- * Model a K8s pod host mount defintion
+ * Model a K8s pod host mount definition
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -379,7 +379,7 @@ class TaskProcessor {
     /**
      * Launch the 'script' define by the code closure as a local bash script
      *
-     * @param code A {@code Closure} retuning a bash script e.g.
+     * @param code A {@code Closure} returning a bash script e.g.
      *          <pre>
      *              {
      *                 """

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderPath.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderPath.groovy
@@ -89,7 +89,7 @@ class ProviderPath implements Path {
             return true
         }
         catch (Exception e) {
-            log.trace "Failed to check existance -- cause [${e.class.name}] ${e.message}"
+            log.trace "Failed to check existence -- cause [${e.class.name}] ${e.message}"
             return false
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/spack/SpackConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/spack/SpackConfig.groovy
@@ -55,6 +55,6 @@ class SpackConfig extends LinkedHashMap {
             return value.tokenize(',').collect(it -> it.trim())
         }
 
-        throw new IllegalArgumentException("Unexected spack.channels value: $value")
+        throw new IllegalArgumentException("Unexpected spack.channels value: $value")
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
@@ -228,7 +228,7 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
             // -- append to the list buffer
             collector.add(record)
 
-            if( counter.isChunckComplete() ) {
+            if( counter.isChunkComplete() ) {
                 result = invokeEachClosure(closure, collector.nextChunk())
                 counter.reset()
             }

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/AbstractTextSplitter.groovy
@@ -228,7 +228,7 @@ abstract class AbstractTextSplitter extends AbstractSplitter<Reader> {
             // -- append to the list buffer
             collector.add(record)
 
-            if( counter.isChunkComplete() ) {
+            if( counter.isChunckComplete() ) {
                 result = invokeEachClosure(closure, collector.nextChunk())
                 counter.reset()
             }

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/BytesSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/BytesSplitter.groovy
@@ -43,7 +43,7 @@ class BytesSplitter extends AbstractBinarySplitter {
             while( (item=targetObject.read()) != -1 ) {
                 buffer[c++] = (byte)item
 
-                if ( counter.isChunkComplete() ) {
+                if ( counter.isChunckComplete() ) {
                     result = invokeEachClosure(closure, buffer)
                     buffer = new byte[counter.size]
                     c = 0

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/BytesSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/BytesSplitter.groovy
@@ -43,7 +43,7 @@ class BytesSplitter extends AbstractBinarySplitter {
             while( (item=targetObject.read()) != -1 ) {
                 buffer[c++] = (byte)item
 
-                if ( counter.isChunckComplete() ) {
+                if ( counter.isChunkComplete() ) {
                     result = invokeEachClosure(closure, buffer)
                     buffer = new byte[counter.size]
                     c = 0

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/EntryCounter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/EntryCounter.groovy
@@ -72,7 +72,7 @@ class EntryCounter {
      *
      * @return
      */
-    boolean isChunckComplete() {
+    boolean isChunkComplete() {
         current += increment
         current >= size
     }

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/EntryCounter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/EntryCounter.groovy
@@ -72,7 +72,7 @@ class EntryCounter {
      *
      * @return
      */
-    boolean isChunkComplete() {
+    boolean isChunckComplete() {
         current += increment
         current >= size
     }

--- a/modules/nextflow/src/main/groovy/nextflow/splitter/FastaSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/FastaSplitter.groovy
@@ -79,7 +79,7 @@ class FastaSplitter extends AbstractTextSplitter {
     }
 
     /**
-     * Parse a {@code CharSequence} as a FASTA formatted text, retuning a {@code Map} object
+     * Parse a {@code CharSequence} as a FASTA formatted text, returning a {@code Map} object
      * containing the fields as specified by the @{code record} parameter.
      * <p>
      *  For example:

--- a/modules/nextflow/src/main/groovy/nextflow/trace/GraphObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/GraphObserver.groovy
@@ -67,7 +67,7 @@ class GraphObserver implements TraceObserver {
     @Override
     void onFlowCreate(Session session) {
         this.dag = session.dag
-        // check file existance
+        // check file existence
         final attrs = FileHelper.readAttributes(file)
         if( attrs ) {
             if( overwrite && (attrs.isDirectory() || !file.delete()) )

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportSummary.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportSummary.groovy
@@ -113,11 +113,11 @@ class ReportSummary {
      *      - q3: third quartile
      *      - max: maximum value
      *      - mean: average value
-     *      - minLabel: label fot the task reporting the min value
-     *      - q1Label: label fot the task reporting the q1 value
-     *      - q2Label: label fot the task reporting the q2 value
-     *      - q3Label: label fot the task reporting the q3 value
-     *      - maxLabel: label fot the task reporting the max value
+     *      - minLabel: label for the task reporting the min value
+     *      - q1Label: label for the task reporting the q1 value
+     *      - q2Label: label for the task reporting the q2 value
+     *      - q3Label: label for the task reporting the q3 value
+     *      - maxLabel: label for the task reporting the max value
      */
     Map<String,?> compute(String name) {
         if( !names.contains(name) )
@@ -207,11 +207,11 @@ class ReportSummary {
          *      - q3: third quartile
          *      - max: maximum value
          *      - mean: average value
-         *      - minLabel: label fot the task reporting the min value
-         *      - q1Label: label fot the task reporting the q1 value
-         *      - q2Label: label fot the task reporting the q2 value
-         *      - q3Label: label fot the task reporting the q3 value
-         *      - maxLabel: label fot the task reporting the max value
+         *      - minLabel: label for the task reporting the min value
+         *      - q1Label: label for the task reporting the q1 value
+         *      - q2Label: label for the task reporting the q2 value
+         *      - q3Label: label for the task reporting the q3 value
+         *      - maxLabel: label for the task reporting the max value
          */
         Map<String,?> compute() {
             if( count==0 )

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
@@ -71,7 +71,7 @@ trait TraceObserver {
      * @param handler
      *      The {@link TaskHandler} instance for the current task.
      * @param trace
-     *      The associated {@link TraceRecord} fot the current task.
+     *      The associated {@link TraceRecord} for the current task.
      */
     void onProcessSubmit(TaskHandler handler, TraceRecord trace){}
 
@@ -81,7 +81,7 @@ trait TraceObserver {
      * @param handler
      *      The {@link TaskHandler} instance for the current task.
      * @param trace
-     *      The associated {@link TraceRecord} fot the current task.
+     *      The associated {@link TraceRecord} for the current task.
      */
     void onProcessStart(TaskHandler handler, TraceRecord trace){}
 
@@ -91,7 +91,7 @@ trait TraceObserver {
      * @param handler
      *      The {@link TaskHandler} instance for the current task.
      * @param trace
-     *      The associated {@link TraceRecord} fot the current task.
+     *      The associated {@link TraceRecord} for the current task.
      */
     void onProcessComplete(TaskHandler handler, TraceRecord trace){}
 
@@ -118,7 +118,7 @@ trait TraceObserver {
      * @param handler
      *      The {@link TaskHandler} instance for the current task.
      * @param trace
-     *      The associated {@link TraceRecord} fot the current task.
+     *      The associated {@link TraceRecord} for the current task.
      */
     void onFlowError(TaskHandler handler, TraceRecord trace){}
 

--- a/modules/nextflow/src/main/groovy/nextflow/util/LoggerHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/LoggerHelper.groovy
@@ -336,7 +336,7 @@ class LoggerHelper {
      *     instead in the file are saved the DEBUG level messages.
      *
      * @param logFileName The file where save the application log
-     * @param quiet When {@code true} only Warning and Error messages are visualized to teh console
+     * @param quiet When {@code true} only Warning and Error messages are visualized to the console
      * @param debugConf The list of packages for which use a Debug logging level
      * @param traceConf The list of packages for which use a Trace logging level
      */

--- a/modules/nextflow/src/main/groovy/nextflow/util/NameGenerator.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/NameGenerator.groovy
@@ -441,7 +441,7 @@ class NameGenerator {
             // A. P. J. Abdul Kalam - is an Indian scientist aka Missile Man of India for his work on the development of ballistic missile and launch vehicle technology. https://en.wikipedia.org/wiki/A._P._J._Abdul_Kalam
             "kalam",
 
-            // Rudolf E. Kálmán, American engineer and mathematican of Hungarian origin. One of the inventors of the smoother/predictor commonly known as "Kalman Filter". https://en.wikipedia.org/wiki/Rudolf_E._K%C3%A1lm%C3%A1n
+            // Rudolf E. Kálmán, American engineer and mathematician of Hungarian origin. One of the inventors of the smoother/predictor commonly known as "Kalman Filter". https://en.wikipedia.org/wiki/Rudolf_E._K%C3%A1lm%C3%A1n
             "kalman",
 
             // Susan Kare, created the icons and many of the interface elements for the original Apple Macintosh in the 1980s, and was an original employee of NeXT, working as the Creative Director. https://en.wikipedia.org/wiki/Susan_Kare
@@ -654,7 +654,7 @@ class NameGenerator {
             // Max Karl Ernst Ludwig Planck was a German theoretical physicist, best known for the discovery of energy quenta and Planck's constant. https://en.wikipedia.org/wiki/Max_Planck
             "planck",
 
-            // Joseph Plateau - Belgian physisist known for being one of the first persons to demonstrate the illusion of moving image. https://en.wikipedia.org/wiki/Joseph_Plateau
+            // Joseph Plateau - Belgian physicist known for being one of the first persons to demonstrate the illusion of moving image. https://en.wikipedia.org/wiki/Joseph_Plateau
             "plateau",
 
             // Henri Poincaré made fundamental contributions in several fields of mathematics. https://en.wikipedia.org/wiki/Henri_Poincar%C3%A9

--- a/modules/nf-commons/src/main/nextflow/extension/Bolts.groovy
+++ b/modules/nf-commons/src/main/nextflow/extension/Bolts.groovy
@@ -275,7 +275,7 @@ class Bolts {
     }
 
     /**
-     * Check if a alphabetic characters in a string are lowercase. Non alphabetic characters are ingored
+     * Check if a alphabetic characters in a string are lowercase. Non alphabetic characters are ignored
      * @param self The string to check
      * @return {@true} if the string contains no uppercase characters, {@code false} otherwise
      */

--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -365,7 +365,7 @@ class FileHelper {
                 throw new IllegalArgumentException("Malformed file URI: $uri -- It must start either with a `file:/` or `file:///` prefix")
 
             if( !uri.path )
-                throw new IllegalArgumentException("Malformed file URI: $uri -- Make sure it starts with an absolue path prefix i.e. `file:/`")
+                throw new IllegalArgumentException("Malformed file URI: $uri -- Make sure it starts with an absolute path prefix i.e. `file:/`")
         }
         else if( !uri.path ) {
             throw new IllegalArgumentException("URI path cannot be empty")

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -252,7 +252,7 @@ class PluginsFacade implements PluginStateListener {
             return manager.getExtensions(type)
         }
         else {
-            // this should oly be used to load system extensions
+            // this should only be used to load system extensions
             // i.e. included in the app class path not provided by
             // a plugin extension
             log.debug "Using Default plugin manager"

--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -230,7 +230,7 @@ public class CacheHelper {
      *
      * @param hasher The current {@code Hasher} object
      * @param file The {@code File} object to hash
-     * @param mode When {@code mode} is equals to the string {@code deep} is used teh file content
+     * @param mode When {@code mode} is equals to the string {@code deep} is used the file content
      *   in order to create the hash key for this file, otherwise just the file metadata information
      *   (full name, size and last update timestamp)
      * @return The updated {@code Hasher} object
@@ -244,7 +244,7 @@ public class CacheHelper {
      *
      * @param hasher The current {@code Hasher} object
      * @param path The {@code Path} object to hash
-     * @param mode When {@code mode} is equals to the string {@code deep} is used teh file content
+     * @param mode When {@code mode} is equals to the string {@code deep} is used the file content
      *   in order to create the hash key for this file, otherwise just the file metadata information
      *   (full name, size and last update timestamp)
      * @return The updated {@code Hasher} object

--- a/modules/nf-commons/src/main/nextflow/util/CharsetHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/CharsetHelper.groovy
@@ -43,7 +43,7 @@ class CharsetHelper {
             return Charset.forName(object)
 
         if( object != null )
-            log.warn "Invalid charset object: $object -- using defualt: ${Charset.defaultCharset()}"
+            log.warn "Invalid charset object: $object -- using default: ${Charset.defaultCharset()}"
 
         Charset.defaultCharset()
     }

--- a/modules/nf-commons/src/test/nextflow/extension/FilesExTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/extension/FilesExTest.groovy
@@ -1272,7 +1272,7 @@ class FilesExTest extends Specification {
         FilesEx.toPosixFilePermission(0644) == [OWNER_READ, OWNER_WRITE, GROUP_READ, OTHERS_READ] as Set
     }
 
-    def 'should convert permissions to actal' () {
+    def 'should convert permissions to octal' () {
         expect:
         FilesEx.toOctalFileMode([] as Set) == 0
         and:

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginsFacadeTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginsFacadeTest.groovy
@@ -288,7 +288,7 @@ class PluginsFacadeTest extends Specification {
         plugins.size()==4
         plugins.find { it.id == 'nf-amazon' && it.version=='0.1.0' }    // <-- version from default
         plugins.find { it.id == 'nf-tower' && it.version=='1.0.1' }     // <-- version from the env var
-        plugins.find { it.id == 'nf-foo' && it.version=='2.2.0' }       // <-- version from tne env var
+        plugins.find { it.id == 'nf-foo' && it.version=='2.2.0' }       // <-- version from the env var
         plugins.find { it.id == 'nf-bar' && it.version==null }          // <-- no version 
     }
 

--- a/modules/nf-commons/src/testFixtures/groovy/nextflow/plugin/hello/HelloExtension.groovy
+++ b/modules/nf-commons/src/testFixtures/groovy/nextflow/plugin/hello/HelloExtension.groovy
@@ -139,7 +139,7 @@ class HelloExtension extends PluginExtensionPoint {
      */
     @Function
     String sayHello(String lang='en'){
-        assert initialized, "PluginExtension was not initilized"
+        assert initialized, "PluginExtension was not initialized"
         // sayHello is the entrypoint where we can write all the logic or delegate to other classes, ...
         return functions.sayHello(lang)
     }

--- a/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
@@ -389,7 +389,7 @@ abstract class XFileSystemProvider extends FileSystemProvider {
 
     @Override
     DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException {
-        throw new UnsupportedOperationException("Direcotry listing unsupported by ${getScheme().toUpperCase()} file system provider")
+        throw new UnsupportedOperationException("Directory listing unsupported by ${getScheme().toUpperCase()} file system provider")
     }
 
     @Override

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -107,7 +107,7 @@ If no plugins are specified in the nextflow.config file, Nextflow default plugin
 The default plugins list is defined in the Nextflow resources file included in the distribution runtime 
 `./modules/nextflow/src/main/resources/META-INF/plugins-info.txt`. 
 
-To disable the use of defualt plugins set the following variable `NXF_PLUGINS_DEFAULT=false`.
+To disable the use of default plugins set the following variable `NXF_PLUGINS_DEFAULT=false`.
 
 ## Gradle Tasks 
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -274,7 +274,7 @@ class AzBatchService implements Closeable {
             if (!config.batch().accountName)
                 throw new IllegalArgumentException("Missing Azure Batch account name -- Specify it in the nextflow.config file using the setting 'azure.batch.accountName'")
             if (!config.batch().accountKey)
-                throw new IllegalArgumentException("Missing Azure Batch account key -- Specify it in the nextflow.config file using the setting 'azure.batch.accountKet'")
+                throw new IllegalArgumentException("Missing Azure Batch account key -- Specify it in the nextflow.config file using the setting 'azure.batch.accountKey'")
 
             return new BatchSharedKeyCredentials(config.batch().endpoint, config.batch().accountName, config.batch().accountKey)
 
@@ -872,7 +872,7 @@ class AzBatchService implements Closeable {
         final listener = new EventListener<ExecutionAttemptedEvent<T>>() {
             @Override
             void accept(ExecutionAttemptedEvent<T> event) throws Throwable {
-                log.debug("Azure TooManyRequests reponse error - attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}")
+                log.debug("Azure TooManyRequests response error - attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}")
             }
         }
         return RetryPolicy.<T>builder()

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -652,7 +652,7 @@ class TowerClient implements TraceObserver {
             def map = obj as Map
             return map.collect { k,v -> "$k:$v" }.join(',')
         }
-        throw new IllegalArgumentException("Illegal container attribut type: ${obj.getClass().getName()} = ${obj}" )
+        throw new IllegalArgumentException("Illegal container attribute type: ${obj.getClass().getName()} = ${obj}" )
     }
 
     protected Map makeTaskMap0(TraceRecord trace) {


### PR DESCRIPTION
Replace typos in source code comments and output messages. I avoided changing outside comments/output messages as changing those could break code.