### PR TITLE
Support resource labels for Azure Batch

### DIFF
--- a/docs/executor.md
+++ b/docs/executor.md
@@ -28,6 +28,7 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-cpus`
 - {ref}`process-memory`
 - {ref}`process-queue`
+- {ref}`process-resourcelabels`
 - {ref}`process-time`
 
 See the {ref}`AWS Batch<aws-batch>` page for further configuration details.
@@ -55,6 +56,7 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-machineType`
 - {ref}`process-memory`
 - {ref}`process-queue`
+- {ref}`process-resourcelabels`
 - {ref}`process-time`
 
 See the {ref}`Azure Batch <azure-batch>` page for further configuration details.
@@ -191,8 +193,8 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-disk`
 - {ref}`process-machineType`
 - {ref}`process-memory`
-- {ref}`process-time`
 - {ref}`process-resourcelabels`
+- {ref}`process-time`
 
 See the {ref}`Google Cloud Batch <google-batch>` page for further configuration details.
 
@@ -218,6 +220,7 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-disk`
 - {ref}`process-machineType`
 - {ref}`process-memory`
+- {ref}`process-resourcelabels`
 - {ref}`process-time`
 
 See the {ref}`Google Life Sciences <google-lifesciences>` page for further configuration details.
@@ -312,6 +315,7 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-disk`
 - {ref}`process-memory`
 - {ref}`process-pod`
+- {ref}`process-resourcelabels`
 - {ref}`process-time`
 
 See the {ref}`Kubernetes <k8s-page>` page to learn how to set up a Kubernetes cluster to run Nextflow pipelines.

--- a/docs/process.md
+++ b/docs/process.md
@@ -2124,12 +2124,15 @@ The limits and the syntax of the corresponding cloud provider should be taken in
 Resource labels are currently supported by the following executors:
 
 - {ref}`awsbatch-executor`
-- {ref}`google-lifesciences-executor`
+- {ref}`azurebatch-executor`
 - {ref}`google-batch-executor`
+- {ref}`google-lifesciences-executor`
 - {ref}`k8s-executor`
 
 :::{versionadded} 23.09.0-edge
-Resource labels are supported for {ref}`azurebatch-executor`. However, because cost analysis in Azure is tied to pools, resource labels are applied to pools rather than jobs. Therefore, when using Azure Batch it is recommended that you define resource labels once for all processes, as each pool will use the resource labels of the first process that creates it.
+Resource labels are supported for Azure Batch when using automatic pool creation.
+
+Resource labels in Azure are added to pools, rather than jobs, in order to facilitate cost analysis. A new pool will be created for each new set of resource labels, therefore it is recommended to also set `azure.batch.deletePoolsOnCompletion = true` when using process-specific resource labels.
 :::
 
 See also: [label](#label)

--- a/docs/process.md
+++ b/docs/process.md
@@ -2121,8 +2121,15 @@ process my_task {
 
 The limits and the syntax of the corresponding cloud provider should be taken into consideration when using resource labels.
 
-:::{note}
-Resource labels are currently only supported by the {ref}`awsbatch-executor`, {ref}`google-lifesciences-executor`, Google Cloud Batch and {ref}`k8s-executor` executors.
+Resource labels are currently supported by the following executors:
+
+- {ref}`awsbatch-executor`
+- {ref}`google-lifesciences-executor`
+- {ref}`google-batch-executor`
+- {ref}`k8s-executor`
+
+:::{versionadded} 23.09.0-edge
+Resource labels are supported for {ref}`azurebatch-executor`. However, because cost analysis in Azure is tied to pools, resource labels are applied to pools rather than jobs. Therefore, when using Azure Batch it is recommended that you define resource labels once for all processes, as each pool will use the resource labels of the first process that creates it.
 :::
 
 See also: [label](#label)

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -564,8 +564,7 @@ class AzBatchService implements Closeable {
             throw new IllegalArgumentException(msg)
         }
 
-        def metadata = task.config.getResourceLabels()
-
+        final metadata = task.config.getResourceLabels()
         final key = CacheHelper.hasher([vmType.name, opts, metadata]).hash().toString()
         final poolId = "nf-pool-$key-$vmType.name"
         return new AzVmPoolSpec(poolId: poolId, vmType: vmType, opts: opts, metadata: metadata)

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzVmPoolSpec.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzVmPoolSpec.groovy
@@ -36,4 +36,5 @@ class AzVmPoolSpec {
     String poolId
     AzVmType vmType
     AzPoolOpts opts
+    Map<String,String> metadata
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -338,6 +338,7 @@ class AzBatchServiceTest extends Specification {
                 getMemory() >> MEM
                 getCpus() >> CPUS
                 getMachineType() >> TYPE
+                getResourceLabels() >> [foo: 'bar']
             }
         }
 
@@ -346,7 +347,8 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-ddb1223ab79edfe07c0af2be7fceeb13-Standard_X1'
+        spec.poolId == 'nf-pool-9022a3fbfb5f93028d78fefaea5e21ab-Standard_X1'
+        spec.metadata == [foo: 'bar']
 
     }
 


### PR DESCRIPTION
Close #3248 

Based on discussions in the issue and with Adam, it seems cost analysis in Azure is tied to pools, and job metadata is not propagated to VMs. As a result, this PR applies `resourceLabels` to the pool when it is created, and the docs make clear that resource labels in Azure should be defined once for all processes, or else they will be non-deterministic.

Happy to be proven wrong if anyone knows better. But this feature is still useful for pipeline-level labels, like pipeline name, user, project, etc.

@adamrtalbot can you test it?