### PR TITLE
Document error about trailing backslash with space

### DIFF
--- a/docs/script.md
+++ b/docs/script.md
@@ -223,6 +223,14 @@ result = myLongCmdline.execute().text
 
 In the preceding example, `blastp` and its `-in`, `-out`, `-db` and `-html` switches and their arguments are effectively a single line.
 
+:::{warning}
+When using backslashes to continue a multi-line command, make sure to not put any spaces after the backslash, otherwise it will be interpreted by the Groovy lexer as an escaped space instead of a backslash, which will make your script incorrect. It will also print this warning:
+
+```
+unknown recognition error type: groovyjarjarantlr4.v4.runtime.LexerNoViableAltException
+```
+:::
+
 (script-regexp)=
 
 ### Regular expressions


### PR DESCRIPTION
Close #3188 

Consider the following Groovy code:
```groovy
println """
  cat ${'foo.txt'} \ 
  | wc -l
  """
```

Because the backslash is followed by a space, apparently it is interpreted by Groovy as an escaped space rather than a backslash. For regular strings, this causes an "Unexpected token" error, but for GStrings, it simply prints a lexer warning and continues, but now the string is incorrect.

I couldn't find a way to intercept this error, since apparently it is just printed as a warning. So instead I added a blurb to a section in the docs about backslash continuations.