### PR TITLE
Add checks to dynamic trace logs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
@@ -342,7 +342,9 @@ class NextflowDSLImpl implements ASTTransformation {
          *
          */
         protected void convertWorkflowDef(MethodCallExpression methodCall, SourceUnit unit) {
-            log.trace "Convert 'workflow' ${methodCall.arguments}"
+            if( log.isTraceEnabled() ) {
+                log.trace "Convert 'workflow' ${methodCall.arguments}"
+            }
 
             assert methodCall.arguments instanceof ArgumentListExpression
             def args = (ArgumentListExpression)methodCall.arguments
@@ -383,7 +385,10 @@ class NextflowDSLImpl implements ASTTransformation {
             // as an extra item in the arguments list
             args = (ArgumentListExpression)nested.getArguments()
             len = args.size()
-            log.trace "Workflow name: $name with args: $args"
+
+            if( log.isTraceEnabled() ) {
+                log.trace "Workflow name: $name with args: $args"
+            }
 
             // make sure to add the 'name' after the map item
             // (which represent the named parameter attributes)
@@ -560,7 +565,9 @@ class NextflowDSLImpl implements ASTTransformation {
          * @param unit
          */
         protected void convertProcessBlock( MethodCallExpression methodCall, SourceUnit unit ) {
-            log.trace "Apply task closure transformation to method call: $methodCall"
+            if( log.isTraceEnabled() ) {
+                log.trace "Apply task closure transformation to method call: $methodCall"
+            }
 
             final args = methodCall.arguments as ArgumentListExpression
             final lastArg = args.expressions.size()>0 ? args.getExpression(args.expressions.size()-1) : null
@@ -928,7 +935,9 @@ class NextflowDSLImpl implements ASTTransformation {
          * handle *input* parameters
          */
         protected void convertInputMethod( Expression expression ) {
-            log.trace "convert > input expression: $expression"
+            if( log.isTraceEnabled() ) {
+                log.trace "convert > input expression: $expression"
+            }
 
             if( expression instanceof MethodCallExpression ) {
 
@@ -1006,7 +1015,9 @@ class NextflowDSLImpl implements ASTTransformation {
         }
 
         protected void convertOutputMethod( Expression expression ) {
-            log.trace "convert > output expression: $expression"
+            if( log.isTraceEnabled() ) {
+                log.trace "convert > output expression: $expression"
+            }
 
             if( !(expression instanceof MethodCallExpression) ) {
                 return
@@ -1276,7 +1287,9 @@ class NextflowDSLImpl implements ASTTransformation {
          * @param unit
          */
         protected void convertProcessDef( MethodCallExpression methodCall, SourceUnit unit ) {
-            log.trace "Converts 'process' ${methodCall.arguments}"
+            if( log.isTraceEnabled() ) {
+                log.trace "Converts 'process' ${methodCall.arguments}"
+            }
 
             assert methodCall.arguments instanceof ArgumentListExpression
             def list = (methodCall.arguments as ArgumentListExpression).getExpressions()
@@ -1301,7 +1314,10 @@ class NextflowDSLImpl implements ASTTransformation {
             // to the process definition, plus adding the process *name*
             // as an extra item in the arguments list
             def args = nested.getArguments() as ArgumentListExpression
-            log.trace "Process name: $name with args: $args"
+
+            if( log.isTraceEnabled() ) {
+                log.trace "Process name: $name with args: $args"
+            }
 
             // make sure to add the 'name' after the map item
             // (which represent the named parameter attributes)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -493,7 +493,7 @@ class Launcher {
             // launch the command
             command?.run()
 
-            if( log.isTraceEnabled())
+            if( log.isTraceEnabled() )
                 log.trace "Exit\n" + dumpThreads()
             return 0
         }

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -309,9 +309,11 @@ class CondaCache {
 
     @PackageScope
     int runCommand( String cmd ) {
-        log.trace """${binaryName} create
-                     command: $cmd
-                     timeout: $createTimeout""".stripIndent(true)
+        if( log.isTraceEnabled() )
+            log.trace """\
+                ${binaryName} create
+                command: $cmd
+                timeout: $createTimeout""".stripIndent(true)
 
         final max = createTimeout.toMillis()
         final builder = new ProcessBuilder(['bash','-c',cmd])

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -906,7 +906,8 @@ class ConfigBuilder {
         // compute config
         final result = toCanonicalString(config, false)
         // dump config for debugging
-        log.trace "Resolved config:\n${result.indent('\t')}"
+        if( log.isTraceEnabled() )
+            log.trace "Resolved config:\n${result.indent('\t')}"
         return result
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -280,7 +280,8 @@ abstract class AbstractGridExecutor extends Executor {
             final result = buf.toString()
 
             if( exit == 0 ) {
-                log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status > cmd exit: $exit\n$result"
+                if( log.isTraceEnabled() )
+                    log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status > cmd exit: $exit\n$result"
                 return parseQueueStatus(result)
             }
             else {
@@ -310,7 +311,8 @@ abstract class AbstractGridExecutor extends Executor {
         }
         Map<String,QueueStatus> status = Throttle.cache("${name}_${queue}", queueInterval) {
             final result = getQueueStatus0(queue)
-            log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status >\n" + dumpQueueStatus(result)
+            if( log.isTraceEnabled() )
+                log.trace "[${name.toUpperCase()}] queue ${queue?"($queue) ":''}status >\n" + dumpQueueStatus(result)
             return result
         }
         // track the last status for debugging purpose

--- a/modules/nextflow/src/main/groovy/nextflow/executor/Executor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/Executor.groovy
@@ -82,7 +82,9 @@ abstract class Executor {
      * @param task A {@code TaskRun} instance
      */
     final void submit( TaskRun task ) {
-        log.trace "Scheduling process: ${task}"
+        if( log.isTraceEnabled() ) {
+            log.trace "Scheduling process: ${task}"
+        }
 
         if( session.isTerminated() ) {
             new IllegalStateException("Session terminated - Cannot add process to execution queue: ${task}")

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -181,7 +181,9 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
         try {
             // -- forward the job launcher script to the command stdin if required
             if( pipeScript ) {
-                log.trace "[${executor.name.toUpperCase()}] Submit STDIN command ${task.name} >\n${pipeScript.indent()}"
+                if( log.isTraceEnabled() ) {
+                    log.trace "[${executor.name.toUpperCase()}] Submit STDIN command ${task.name} >\n${pipeScript.indent()}"
+                }
                 process.out << pipeScript
                 process.out.close()
             }

--- a/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
@@ -98,9 +98,9 @@ class FilePorter {
 
     void transfer(Batch batch) {
         if( batch.size() ) {
-            log.trace "Stage foreign files: $batch"
+            if( log.isTraceEnabled() ) log.trace "Stage foreign files: $batch"
             submitStagingActions(batch.foreignPaths)
-            log.trace "Stage foreign files completed: $batch"
+            if( log.isTraceEnabled() ) log.trace "Stage foreign files completed: $batch"
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/file/SortFileCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/SortFileCollector.groovy
@@ -234,7 +234,7 @@ class SortFileCollector extends FileCollector implements Closeable {
 
         Hasher hasher = cacheable ? CacheHelper.hasher( hashKeys, CacheHelper.HashMode.STANDARD ) : null
         if( hasher ) {
-            log.trace "  hasher: ${CacheHelper.hasher( hashKeys, CacheHelper.HashMode.STANDARD ) } \n"
+            log.trace "  hasher: ${hasher} \n"
         }
 
         // index route file

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sDriverLauncher.groovy
@@ -378,7 +378,9 @@ class K8sDriverLauncher {
         if( !config.libDir )
             config.remove('libDir')
 
-        log.trace "K8s config object:\n${ConfigHelper.toCanonicalString(config).indent('  ')}"
+        if( log.isTraceEnabled() )
+            log.trace "K8s config object:\n${ConfigHelper.toCanonicalString(config).indent('  ')}"
+
         return config
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/client/K8sClient.groovy
@@ -658,7 +658,9 @@ class K8sClient {
 
         if( !method ) method = body ? 'POST' : 'GET'
         conn.setRequestMethod(method)
-        log.trace "[K8s] API request $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
+
+        if( log.isTraceEnabled() )
+            log.trace "[K8s] API request $method $path ${body ? '\n'+prettyPrint(body).indent() : ''}"
 
         if( body ) {
             conn.setDoOutput(true);
@@ -676,7 +678,8 @@ class K8sClient {
     }
 
     static private void trace(String method, String path, String text) {
-        log.trace "[K8s] API response $method $path \n${prettyPrint(text).indent()}"
+        if( log.isTraceEnabled() )
+            log.trace "[K8s] API response $method $path \n${prettyPrint(text).indent()}"
     }
 
     protected K8sResponseApi get(String path) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/LocalPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/LocalPollingMonitor.groovy
@@ -175,7 +175,7 @@ class LocalPollingMonitor extends TaskPollingMonitor {
             throw new ProcessUnrecoverableException("Process requirement exceeds available memory -- req: ${new MemoryUnit(taskMemory)}; avail: ${new MemoryUnit(maxMemory)}")
 
         final result = super.canSubmit(handler) && taskCpus <= availCpus && taskMemory <= availMemory
-        if( !result && log.isTraceEnabled( ) ) {
+        if( !result && log.isTraceEnabled() ) {
             log.trace "Task `${handler.task.name}` cannot be scheduled -- taskCpus: $taskCpus <= availCpus: $availCpus && taskMemory: ${new MemoryUnit(taskMemory)} <= availMemory: ${new MemoryUnit(availMemory)}"
         }
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -441,7 +441,8 @@ class PublishDir {
 
     @CompileStatic
     protected void processFileImpl( Path source, Path destination ) {
-        log.trace "publishing file: $source -[$mode]-> $destination"
+        if( log.isTraceEnabled() )
+            log.trace "publishing file: $source -[$mode]-> $destination"
 
         if( !mode || mode == Mode.SYMLINK ) {
             Files.createSymbolicLink(destination, source)

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
@@ -79,7 +79,8 @@ class TaskContext implements Map<String,Object>, Cloneable {
             variableNames = variableNames - processor.getDeclaredNames()
         }
 
-        log.trace "Binding names for '$name' > $variableNames"
+        if( log.isTraceEnabled() )
+            log.trace "Binding names for '$name' > $variableNames"
     }
 
     protected TaskContext(Script script, Map holder, String name) {
@@ -88,7 +89,9 @@ class TaskContext implements Map<String,Object>, Cloneable {
         this.name = name
         def names = script.getBinding()?.getVariables()?.keySet()
         this.variableNames = names ? new HashSet<String>(names) : new HashSet<String>()
-        log.trace "Binding names for '$name' > $variableNames"
+
+        if( log.isTraceEnabled() )
+            log.trace "Binding names for '$name' > $variableNames"
     }
 
     /** ONLY FOR TEST PURPOSE -- do not use */
@@ -234,7 +237,10 @@ class TaskContext implements Map<String,Object>, Cloneable {
             def var = ( p == -1 ? it : it.substring(0,p) )
             checkAndSet(var, copy)
         }
-        log.trace "Delegate for $name > binding copy: ${copy}"
+
+        if( log.isTraceEnabled() )
+            log.trace "Delegate for $name > binding copy: ${copy}"
+
         kryo.writeObject(out, copy)
 
         out.flush()

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -198,7 +198,7 @@ abstract class TaskHandler {
                 // note: this may be override run time provided by the trace file (3rd line)
                 if( startTimeMillis ) {
                     record.realtime = completeTimeMillis - startTimeMillis
-                    log.trace "task stats: ${task.name}; start: ${startTimeMillis}; complete: ${completeTimeMillis}; realtime: ${completeTimeMillis - startTimeMillis} [${record.realtime}]; "
+                    log.trace "task stats: ${task.name}; start: ${startTimeMillis}; complete: ${completeTimeMillis}; realtime: ${record.realtime}; "
                 }
             }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -227,7 +227,9 @@ class TaskPollingMonitor implements TaskMonitor {
             pendingQueue << handler
             taskAvail.signal()  // signal that a new task is available for execution
             session.notifyTaskPending(handler)
-            log.trace "Scheduled task > $handler"
+
+            if( log.isTraceEnabled() )
+                log.trace "Scheduled task > $handler"
         }
         finally {
             pendingLock.unlock()
@@ -606,7 +608,8 @@ class TaskPollingMonitor implements TaskMonitor {
 
         // check if it is started
         if( handler.checkIfRunning() ) {
-            log.trace "Task started > $handler"
+            if( log.isTraceEnabled() )
+                log.trace "Task started > $handler"
             session.notifyTaskStart(handler)
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -431,7 +431,10 @@ class TaskProcessor {
         state = new Agent<>(new StateObj(name))
         state.addListener { StateObj old, StateObj obj ->
             try {
-                log.trace "<$name> Process state changed to: $obj -- finished: ${obj.isFinished()}"
+                if( log.isTraceEnabled() ) {
+                    log.trace "<$name> Process state changed to: $obj -- finished: ${obj.isFinished()}"
+                }
+
                 if( !completed && obj.isFinished() ) {
                     terminateProcess()
                     completed = true
@@ -582,7 +585,8 @@ class TaskProcessor {
         final values = (List) args[1]
 
         // create and initialize the task instance to be executed
-        log.trace "Invoking task > $name with params=$params; values=$values"
+        if( log.isTraceEnabled() )
+            log.trace "Invoking task > $name with params=$params; values=$values"
 
         // -- create the task run instance
         final task = createTaskRun(params)
@@ -773,7 +777,9 @@ class TaskProcessor {
                 if( resumeDir )
                     exists = resumeDir.exists()
 
-                log.trace "[${safeTaskName(task)}] Cacheable folder=${resumeDir?.toUriString()} -- exists=$exists; try=$tries; shouldTryCache=$shouldTryCache; entry=$entry"
+                if( log.isTraceEnabled() )
+                    log.trace "[${safeTaskName(task)}] Cacheable folder=${resumeDir?.toUriString()} -- exists=$exists; try=$tries; shouldTryCache=$shouldTryCache; entry=$entry"
+
                 def cached = shouldTryCache && exists && checkCachedOutput(task.clone(), resumeDir, hash, entry)
                 if( cached )
                     break
@@ -1356,7 +1362,8 @@ class TaskProcessor {
 
             switch( param ) {
             case StdOutParam:
-                log.trace "Process $name > normalize stdout param: $param"
+                if( log.isTraceEnabled() )
+                    log.trace "Process $name > normalize stdout param: $param"
                 value = value instanceof Path ? value.text : value?.toString()
 
             case OptionalParam:
@@ -1369,7 +1376,8 @@ class TaskProcessor {
             case EnvOutParam:
             case ValueOutParam:
             case DefaultOutParam:
-                log.trace "Process $name > collecting out param: ${param} = $value"
+                if( log.isTraceEnabled() )
+                    log.trace "Process $name > collecting out param: ${param} = $value"
                 tuples[param.index].add(value)
                 break
 
@@ -1426,13 +1434,15 @@ class TaskProcessor {
                 continue
             }
 
-            log.trace "Process $name > Binding out param: ${param} = ${outValue}"
+            if( log.isTraceEnabled() )
+                log.trace "Process $name > Binding out param: ${param} = ${outValue}"
             bindOutParam(param, outValue)
         }
     }
 
     protected void bindOutParam( OutParam param, List values ) {
-        log.trace "<$name> Binding param $param with $values"
+        if( log.isTraceEnabled() )
+            log.trace "<$name> Binding param $param with $values"
         final x = values.size() == 1 ? values[0] : values
         final ch = param.getOutChannel()
         if( ch != null ) {
@@ -1455,7 +1465,8 @@ class TaskProcessor {
      * @param task
      */
     final protected void collectOutputs( TaskRun task, Path workDir, def stdout, Map context ) {
-        log.trace "<$name> collecting output: ${task.outputs}"
+        if( log.isTraceEnabled() )
+            log.trace "<$name> collecting output: ${task.outputs}"
 
         for( OutParam param : task.outputs.keySet() ) {
 
@@ -1597,7 +1608,8 @@ class TaskProcessor {
             // set into the output set
             task.setOutput(param,val)
             // trace the result
-            log.trace "Collecting param: ${param.name}; value: ${val}"
+            if( log.isTraceEnabled() )
+                log.trace "Collecting param: ${param.name}; value: ${val}"
         }
         catch( MissingPropertyException e ) {
             throw new MissingValueException("Missing value declared as output parameter: ${e.property}")
@@ -2234,7 +2246,8 @@ class TaskProcessor {
      */
     @PackageScope
     final finalizeTask( TaskRun task ) {
-        log.trace "finalizing process > ${safeTaskName(task)} -- $task"
+        if( log.isTraceEnabled() )
+            log.trace "finalizing process > ${safeTaskName(task)} -- $task"
 
         def fault = null
         try {
@@ -2388,7 +2401,9 @@ class TaskProcessor {
 
         @Override
         List<Object> beforeRun(final DataflowProcessor processor, final List<Object> messages) {
-            log.trace "<${name}> Before run -- messages: ${messages}"
+            if( log.isTraceEnabled() ) {
+                log.trace "<${name}> Before run -- messages: ${messages}"
+            }
             // the counter must be incremented here, otherwise it won't be consistent
             state.update { StateObj it -> it.incSubmitted() }
             // task index must be created here to guarantee consistent ordering
@@ -2399,7 +2414,6 @@ class TaskProcessor {
             result[1] = messages
             return result
         }
-
 
         @Override
         void afterRun(DataflowProcessor processor, List<Object> messages) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskTemplateEngine.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskTemplateEngine.groovy
@@ -134,7 +134,9 @@ class TaskTemplateEngine extends TemplateEngine {
 
             // -- parse the template reader and create script string
             String script = parse(reader);
-            log.trace "\n-- script source --\n${script}\n-- script end --\n"
+
+            if( log.isTraceEnabled() )
+                log.trace "\n-- script source --\n${script}\n-- script end --\n"
 
             // -- finally create the Script object
             try {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
@@ -312,8 +312,10 @@ class ProviderConfig {
 
     static private void dumpScmContent(Path file, String content) {
         try {
-            log.trace "Parsing SCM config path: ${file.toUriString()}\n${StringUtils.stripSecrets(content)}\n"
-        }catch(Exception e){
+            if( log.isTraceEnabled() )
+                log.trace "Parsing SCM config path: ${file.toUriString()}\n${StringUtils.stripSecrets(content)}\n"
+        }
+        catch(Exception e){
             log.debug "Error dumping configuration ${file.toUriString()}", e
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowBinding.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowBinding.groovy
@@ -95,7 +95,9 @@ class WorkflowBinding extends Binding  {
     @Override
     Object invokeMethod(String name, Object args) {
         if( meta ) {
-            log.trace "Trying to invoke component: $name - args=${args}"
+            if( log.isTraceEnabled() )
+                log.trace "Trying to invoke component: $name - args=${args}"
+
             final component = getComponent0(name)
             if( component ) {
                 checkScope0(component)

--- a/modules/nextflow/src/main/groovy/nextflow/script/bundle/ResourcesBundle.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/bundle/ResourcesBundle.groovy
@@ -170,7 +170,10 @@ class ResourcesBundle {
                 regular ? attrs.size() : 0,
                 regular ? md5(file, attrs) : 0,
                 Integer.toOctalString(file.getPermissionsMode()) ]
-        log.trace "Module bundle entry=$meta"
+
+        if( log.isTraceEnabled() )
+            log.trace "Module bundle entry=$meta"
+
         return meta
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/spack/SpackCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/spack/SpackCache.groovy
@@ -310,9 +310,11 @@ class SpackCache {
 
     @PackageScope
     void runCommand( String cmd ) {
-        log.trace """spack env create
-                     command: $cmd
-                     timeout: $createTimeout""".stripIndent(true)
+        if( log.isTraceEnabled() )
+            log.trace """\
+                spack env create
+                command: $cmd
+                timeout: $createTimeout""".stripIndent(true)
 
         final max = createTimeout.toMillis()
         final builder = new ProcessBuilder(['bash','-c',cmd])

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
@@ -159,7 +159,9 @@ class ReportObserver implements TraceObserver {
      */
     @Override
     void onProcessSubmit(TaskHandler handler, TraceRecord trace) {
-        log.trace "Trace report - submit process > $handler"
+        if( log.isTraceEnabled() )
+            log.trace "Trace report - submit process > $handler"
+
         synchronized (records) {
             records[ trace.taskId ] = trace
         }
@@ -172,7 +174,9 @@ class ReportObserver implements TraceObserver {
      */
     @Override
     void onProcessStart(TaskHandler handler, TraceRecord trace) {
-        log.trace "Trace report - start process > $handler"
+        if( log.isTraceEnabled() )
+            log.trace "Trace report - start process > $handler"
+
         synchronized (records) {
             records[ trace.taskId ] = trace
         }
@@ -185,7 +189,9 @@ class ReportObserver implements TraceObserver {
      */
     @Override
     void onProcessComplete(TaskHandler handler, TraceRecord trace) {
-        log.trace "Trace report - complete process > $handler"
+        if( log.isTraceEnabled() )
+            log.trace "Trace report - complete process > $handler"
+
         if( !trace ) {
             log.debug "WARN: Unable to find trace record for task id=${handler.task?.id}"
             return
@@ -204,7 +210,8 @@ class ReportObserver implements TraceObserver {
      */
     @Override
     void onProcessCached(TaskHandler handler, TraceRecord trace) {
-        log.trace "Trace report - cached process > $handler"
+        if( log.isTraceEnabled() )
+            log.trace "Trace report - cached process > $handler"
 
         // event was triggered by a stored task, ignore it
         if( trace == null ) {

--- a/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
@@ -263,7 +263,9 @@ class PathSerializer extends Serializer<Path> {
     void write(Kryo kryo, Output output, Path target) {
         final scheme = target.getFileSystem().provider().getScheme()
         final path = target.toString()
-        log.trace "Path serialization > scheme: $scheme; path: $path"
+
+        if( log.isTraceEnabled() )
+            log.trace "Path serialization > scheme: $scheme; path: $path"
 
         output.writeString(scheme)
         output.writeString(path)
@@ -273,7 +275,9 @@ class PathSerializer extends Serializer<Path> {
     Path read(Kryo kryo, Input input, Class<Path> type) {
         final scheme = input.readString()
         final path = input.readString()
-        log.trace "Path de-serialization > scheme: $scheme; path: $path"
+
+        if( log.isTraceEnabled() )
+            log.trace "Path de-serialization > scheme: $scheme; path: $path"
 
         if( "file".equalsIgnoreCase(scheme) ) {
             return FileSystems.getDefault().getPath(path)
@@ -303,7 +307,9 @@ class GStringSerializer extends Serializer<GString> {
 
     @Override
     void write(Kryo kryo, Output stream, GString object) {
-        log.trace "GString serialization: values: ${object?.getValues()} - strings: ${object?.getStrings()}"
+        if( log.isTraceEnabled() )
+            log.trace "GString serialization: values: ${object?.getValues()} - strings: ${object?.getStrings()}"
+
         kryo.writeObject( stream, object.getValues() )
         kryo.writeObject( stream, object.getStrings() )
     }
@@ -312,7 +318,10 @@ class GStringSerializer extends Serializer<GString> {
     GString read(Kryo kryo, Input stream, Class<GString> type) {
         Object[] values = kryo.readObject(stream, OBJ_ARRAY_CLASS)
         String[] strings = kryo.readObject(stream, STR_ARRAY_CLASS)
-        log.trace "GString de-serialize: values: ${values} - strings: ${strings}"
+
+        if( log.isTraceEnabled() )
+            log.trace "GString de-serialize: values: ${values} - strings: ${strings}"
+
         new GStringImpl(values, strings)
     }
 }

--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -814,7 +814,9 @@ class FileHelper {
             FileVisitResult preVisitDirectory(Path fullPath, BasicFileAttributes attrs) throws IOException {
                 final int depth = fullPath.nameCount - folder.nameCount
                 final path = relativize0(folder, fullPath)
-                log.trace "visitFiles > dir=$path; depth=$depth; includeDir=$includeDir; matches=${matcher.matches(path)}; isDir=${attrs.isDirectory()}"
+
+                if( log.isTraceEnabled() )
+                    log.trace "visitFiles > dir=$path; depth=$depth; includeDir=$includeDir; matches=${matcher.matches(path)}; isDir=${attrs.isDirectory()}"
 
                 if (depth>0 && includeDir && matcher.matches(path) && attrs.isDirectory() && (includeHidden || !isHidden(fullPath))) {
                     def result = relative ? path : fullPath
@@ -827,7 +829,9 @@ class FileHelper {
             @Override
             FileVisitResult visitFile(Path fullPath, BasicFileAttributes attrs) throws IOException {
                 final path = folder.relativize(fullPath)
-                log.trace "visitFiles > file=$path; includeFile=$includeFile; matches=${matcher.matches(path)}; isRegularFile=${attrs.isRegularFile()}"
+
+                if( log.isTraceEnabled() )
+                    log.trace "visitFiles > file=$path; includeFile=$includeFile; matches=${matcher.matches(path)}; isRegularFile=${attrs.isRegularFile()}"
 
                 if (includeFile && matcher.matches(path) && (attrs.isRegularFile() || (options.followLinks == false && attrs.isSymbolicLink())) && (includeHidden || !isHidden(fullPath))) {
                     def result = relative ? path : fullPath

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -186,7 +186,9 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         }
 
         // retrieve the status for the specified job and along with the next batch
-        log.trace "[AWS BATCH] requesting describe jobs=${jobIdsToString(batchIds)}"
+        if( log.isTraceEnabled() )
+            log.trace "[AWS BATCH] requesting describe jobs=${jobIdsToString(batchIds)}"
+
         DescribeJobsResult resp = client.describeJobs(new DescribeJobsRequest().withJobs(batchIds))
         if( !resp.getJobs() ) {
             log.debug "[AWS BATCH] cannot retrieve running status for job=$jobId"
@@ -312,7 +314,9 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
          * create submit request
          */
         final req = newSubmitRequest(task)
-        log.trace "[AWS BATCH] new job request > $req"
+
+        if( log.isTraceEnabled() )
+            log.trace "[AWS BATCH] new job request > $req"
 
         /*
          * submit the task execution

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -131,7 +131,10 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
          * create submit request
          */
         final req = newSubmitRequest(task, spec0(launcher))
-        log.trace "[GOOGLE BATCH] new job request > $req"
+
+        if( log.isTraceEnabled() )
+            log.trace "[GOOGLE BATCH] new job request > $req"
+
         final resp = client.submitJob(jobId, req)
         this.uid = resp.getUid()
         this.status = TaskStatus.SUBMITTED

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -529,7 +529,10 @@ class TowerClient implements TraceObserver {
             // The actual HTTP request
             final String json = payload != null ? generator.toJson(payload) : null
             final String debug = json != null ? JsonOutput.prettyPrint(json).indent() : '-'
-            log.trace "HTTP url=$url; payload:\n${debug}\n"
+
+            if( log.isTraceEnabled() )
+                log.trace "HTTP url=$url; payload:\n${debug}\n"
+
             try {
                 if( refreshTries==1 ) {
                     refreshToken(currentRefresh)


### PR DESCRIPTION
Add `log.isTraceEnabled()` check to certain log messages with dynamic strings, so that the strings aren't evaluated when trace logging is disabled. Mainly for trace logs that occur often or print large data structures.