### PR TITLE
Fix `workflow.container` map resolution

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1268,7 +1268,14 @@ class Session implements ISession {
              * look for `container` definition at process level
              */
             config.process.each { String name, value ->
-                if( name.startsWith('$') && value instanceof Map && value.container ) {
+                if( name.startsWith('$') ) {
+                    name = name.substring(1)
+                }
+                else if( name.startsWith('withName:') ) {
+                    name = name.substring('withName:'.length())
+                }
+
+                if( value instanceof Map && value.container ) {
                     result[name] = resolveClosure(value.container)
                 }
             }

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -525,25 +525,25 @@ class SessionTest extends Specification {
         when:
         text = '''
                 process {
-                    $proc1 { container = 'alpha' }
-                    $proc2 { container ='beta' }
+                    withName:'proc1' { container = 'alpha' }
+                    withName:'proc2' { container = 'beta' }
                 }
                 '''
         then:
-        new Session(cfg(text)).fetchContainers() == ['$proc1': 'alpha', '$proc2': 'beta']
+        new Session(cfg(text)).fetchContainers() == ['proc1': 'alpha', 'proc2': 'beta']
 
 
         when:
         text = '''
                 process {
-                    $proc1 { container = 'alpha' }
-                    $proc2 { container ='beta' }
+                    withName:'proc1' { container = 'alpha' }
+                    withName:'proc2' { container = 'beta' }
                 }
 
                 process.container = 'gamma'
                 '''
         then:
-        new Session(cfg(text)).fetchContainers() == ['$proc1': 'alpha', '$proc2': 'beta', default: 'gamma']
+        new Session(cfg(text)).fetchContainers() == ['proc1': 'alpha', 'proc2': 'beta', 'default': 'gamma']
 
 
         when:


### PR DESCRIPTION
Close #3394 

Keeps the old `$<name>` syntax for backwards compatibility. See also: `Session::validateConfig()`