### PR TITLE
FIx nested InvocationTargetException

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1275,7 +1275,7 @@ class TaskProcessor {
 
 
     static String err0(Throwable e) {
-        final fail = e instanceof InvocationTargetException ? e.targetException : e
+        final fail = e instanceof InvocationTargetException ? e.cause : e
 
         if( fail instanceof NoSuchFileException ) {
             return "No such file or directory: $fail.message"

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1275,7 +1275,7 @@ class TaskProcessor {
 
 
     static String err0(Throwable e) {
-        final fail = e instanceof InvocationTargetException ? e.cause : e
+        final fail = e instanceof InvocationTargetException ? e.targetException : e
 
         if( fail instanceof NoSuchFileException ) {
             return "No such file or directory: $fail.message"

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -193,7 +193,10 @@ abstract class BaseScript extends Script implements ExecutionContext {
         }
         catch( InvocationTargetException e ) {
             // provide the exception cause which is more informative than InvocationTargetException
-            throw e.cause?.cause ?: e.cause ?: e
+            Throwable target = e
+            while( target.cause )
+                target = target.cause
+            throw target
         }
         finally {
             ExecutionStack.pop()

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -194,8 +194,8 @@ abstract class BaseScript extends Script implements ExecutionContext {
         catch( InvocationTargetException e ) {
             // provide the exception cause which is more informative than InvocationTargetException
             Throwable target = e
-            while( target.cause instanceof InvocationTargetException )
-                target = target.cause
+            do target = target.cause
+            while ( target instanceof InvocationTargetException )
             throw target
         }
         finally {

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -194,7 +194,7 @@ abstract class BaseScript extends Script implements ExecutionContext {
         catch( InvocationTargetException e ) {
             // provide the exception cause which is more informative than InvocationTargetException
             Throwable target = e
-            while( target.cause )
+            while( target.cause instanceof InvocationTargetException )
                 target = target.cause
             throw target
         }

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -191,9 +191,9 @@ abstract class BaseScript extends Script implements ExecutionContext {
         try {
             run0()
         }
-        catch(InvocationTargetException e) {
+        catch( InvocationTargetException e ) {
             // provide the exception cause which is more informative than InvocationTargetException
-            throw(e.cause ?: e)
+            throw e.cause?.cause ?: e.cause ?: e
         }
         finally {
             ExecutionStack.pop()


### PR DESCRIPTION
Close #3418 

When a method invoked via reflection throws an exception, the exception is wrapped in an `InvocationTargetException`. `BaseScript` already has a catch block to unwrap this exception, but for some reason there are some cases where the exception is wrapped twice, such as the linked issue.

I tried burying the user exception in more function calls and workflow calls, but it was only ever wrapped once or twice. So it does not seem to depend on the call depth, but I can't explain why it is wrapped sometimes once and sometimes twice. So I just check both cases.