### PR TITLE
Fix `executor.queueSize = 0` ignored

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -640,7 +640,7 @@ The following settings are available:
 : Determines how job status is retrieved. When `false` only the queue associated with the job execution is queried. When `true` the job status is queried globally i.e. irrespective of the submission queue (default: `false`).
 
 `executor.queueSize`
-: The number of tasks the executor will handle in a parallel manner. Default varies for each executor (see below).
+: The number of tasks the executor will handle in a parallel manner. A queue size of zero corresponds to no limit. Default varies for each executor (see below).
 
 `executor.queueStatInterval`
 : Determines how often to fetch the queue status from the scheduler (default: `1min`). Used only by grid executors.

--- a/modules/nextflow/src/main/groovy/nextflow/processor/ParallelPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/ParallelPollingMonitor.groovy
@@ -55,7 +55,7 @@ class ParallelPollingMonitor extends TaskPollingMonitor {
 
     @Override
     protected boolean canSubmit(TaskHandler handler) {
-        return super.canSubmit(handler) && semaphore.tryAcquire()
+        return super.canSubmit(handler) && semaphore?.tryAcquire()
     }
 
     protected RateLimiter createSubmitRateLimit() {
@@ -95,7 +95,7 @@ class ParallelPollingMonitor extends TaskPollingMonitor {
 
     @Override
     boolean evict(TaskHandler handler) {
-        semaphore.release()
+        semaphore?.release()
         return super.evict(handler)
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/util/ConfigHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/ConfigHelper.groovy
@@ -42,7 +42,7 @@ class ConfigHelper {
             result = config['$'+execName][propName]
         }
 
-        if( result==null && config instanceof Map && config[propName] ) {
+        if( result==null && config instanceof Map && config[propName] != null ) {
             result = config[propName]
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy
@@ -29,6 +29,21 @@ import spock.lang.Unroll
 class ConfigHelperTest extends Specification {
 
     @Unroll
+    def "get config property" () {
+
+        expect:
+        ConfigHelper.getConfigProperty(config, execName, 'foo') == value
+
+        where:
+        config               | execName | value
+        [foo: 0]             | null     | 0
+        [foo: 100]           | null     | 100
+        [foo: 'bar']         | null     | 'bar'
+        [$sge: [foo: 'bar']] | 'sge'    | 'bar'
+
+    }
+
+    @Unroll
     def "should parse string value: #str" () {
 
         expect:


### PR DESCRIPTION
Setting `executor.queueSize` to 0 is equivalent to having no limit. However, due to an incorrect null check, the queue size is ignored and falls back to the default value if it is set to 0 in the config. This PR fixes that, as well as a null reference error that happens when the queue size is 0.