### PR TITLE
Align Singularity experience with Docker

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1294,7 +1294,7 @@ The `singularity` scope controls how [Singularity](https://sylabs.io/singularity
 The following settings are available:
 
 `singularity.autoMounts`
-: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature to be enabled in your Singularity installation (default: `false`).
+: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature to be enabled in your Singularity installation. Note: as of version `23.09.0-edge` this feature is enabled by default.
 
 `singularity.cacheDir`
 : The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1294,7 +1294,10 @@ The `singularity` scope controls how [Singularity](https://sylabs.io/singularity
 The following settings are available:
 
 `singularity.autoMounts`
-: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature to be enabled in your Singularity installation. Note: as of version `23.09.0-edge` this feature is enabled by default.
+: When `true` Nextflow automatically mounts host paths in the executed container. It requires the `user bind control` feature to be enabled in your Singularity installation (default: `true`).
+: :::{versionchanged} 23.09.0-edge
+  Default value was changed from `false` to `true`.
+  :::
 
 `singularity.cacheDir`
 : The directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.

--- a/docs/container.md
+++ b/docs/container.md
@@ -587,6 +587,11 @@ Nextflow no longer mounts the home directory when launching a Singularity contai
 As of 23.09.0-edge, Nextflow automatically mounts the required host paths in the container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false` or set `singularity.autoMounts=false` in the Nextflow configuration file.
 :::
 
+:::{versionchanged} 23.09.0-edge
+As of 23.09.0-edge, Nextflow uses the command `run` to carry out the execution of Singularity containers instead of the `exec` command.
+To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_RUN_COMMAND` to `exec`.
+:::
+
 ### Multiple containers
 
 It is possible to specify a different Singularity image for each process definition in your pipeline script. For example, let's suppose you have two processes named `foo` and `bar`. You can specify two different Singularity images specifying them in the `nextflow.config` file as shown below:

--- a/docs/container.md
+++ b/docs/container.md
@@ -583,6 +583,10 @@ When a process input is a *symbolic link* file, make sure the linked file is sto
 Nextflow no longer mounts the home directory when launching a Singularity container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_HOME_MOUNT` to `true`.
 :::
 
+:::{versionchanged} 23.09.0-edge
+As of 23.09.0-edge, Nextflow automatically mounts the required host paths in the container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false` or set `singularity.autoMounts=false` in the Nextflow configuration file.
+:::
+
 ### Multiple containers
 
 It is possible to specify a different Singularity image for each process definition in your pipeline script. For example, let's suppose you have two processes named `foo` and `bar`. You can specify two different Singularity images specifying them in the `nextflow.config` file as shown below:

--- a/docs/container.md
+++ b/docs/container.md
@@ -584,11 +584,11 @@ Nextflow no longer mounts the home directory when launching a Singularity contai
 :::
 
 :::{versionchanged} 23.09.0-edge
-As of 23.09.0-edge, Nextflow automatically mounts the required host paths in the container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false` or set `singularity.autoMounts=false` in the Nextflow configuration file.
+Nextflow automatically mounts the required host paths in the container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false` or set `singularity.autoMounts=false` in the Nextflow configuration file.
 :::
 
 :::{versionchanged} 23.09.0-edge
-As of 23.09.0-edge, Nextflow uses the command `run` to carry out the execution of Singularity containers instead of the `exec` command.
+Nextflow uses the command `run` to carry out the execution of Singularity containers instead of the `exec` command.
 To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_RUN_COMMAND` to `exec`.
 :::
 

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityBuilder.groovy
@@ -37,10 +37,14 @@ class SingularityBuilder extends ContainerBuilder<SingularityBuilder> {
 
     private boolean newPidNamespace
 
+    private String runCmd0
+
     SingularityBuilder(String name) {
         this.image = name
         this.homeMount = defaultHomeMount()
+        this.autoMounts = defaultAutoMounts()
         this.newPidNamespace = defaultNewPidNamespace()
+        this.runCmd0 = defaultRunCommand()
     }
 
     private boolean defaultHomeMount() {
@@ -49,6 +53,17 @@ class SingularityBuilder extends ContainerBuilder<SingularityBuilder> {
 
     private boolean defaultNewPidNamespace() {
         SysEnv.get("NXF_${getBinaryName().toUpperCase()}_NEW_PID_NAMESPACE", 'true').toString() == 'true'
+    }
+
+    private boolean defaultAutoMounts() {
+        SysEnv.get("NXF_${getBinaryName().toUpperCase()}_AUTO_MOUNTS", 'true').toString() == 'true'
+    }
+
+    private String defaultRunCommand() {
+        final result = SysEnv.get("NXF_${getBinaryName().toUpperCase()}_RUN_COMMAND", 'run')
+        if( result !in ['run','exec'] )
+            throw new IllegalArgumentException("Invalid singularity launch command '$result' - it should be either 'run' or 'exec'")
+        return result
     }
 
     protected String getBinaryName() { 'singularity' }
@@ -68,7 +83,7 @@ class SingularityBuilder extends ContainerBuilder<SingularityBuilder> {
         if( params.containsKey('runOptions') )
             addRunOptions(params.runOptions.toString())
 
-        if( params.autoMounts )
+        if( params.autoMounts!=null )
             autoMounts = params.autoMounts.toString() == 'true'
 
         if( params.newPidNamespace!=null )
@@ -97,7 +112,7 @@ class SingularityBuilder extends ContainerBuilder<SingularityBuilder> {
         if( engineOptions )
             result << engineOptions.join(' ') << ' '
 
-        result << 'exec '
+        result << runCmd0 << ' '
 
         if( !homeMount )
             result << '--no-home '

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdInfoTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdInfoTest.groovy
@@ -17,6 +17,7 @@
 package nextflow.cli
 
 import nextflow.plugin.Plugins
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
@@ -31,6 +32,7 @@ import org.yaml.snakeyaml.Yaml
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
+@IgnoreIf({System.getenv('NXF_SMOKE')})
 @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})
 class CmdInfoTest extends Specification {
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/SingularityBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/SingularityBuilderTest.groovy
@@ -28,9 +28,10 @@ import spock.lang.Unroll
  */
 class SingularityBuilderTest extends Specification {
 
-    def 'should get the exec command line' () {
-
+    def 'should get the legacy exec command line' () {
         given:
+        SysEnv.push(NXF_SINGULARITY_RUN_COMMAND:'exec', NXF_SINGULARITY_AUTO_MOUNTS:'false')
+        and:
         def path1 = Paths.get('/foo/data/file1')
         def path2 = Paths.get('/bar/data/file2')
         def path3 = Paths.get('/bar/data file')
@@ -88,6 +89,71 @@ class SingularityBuilderTest extends Specification {
                 .build()
                 .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity exec --no-home ubuntu'
 
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should get the run command line' () {
+
+        given:
+        def path1 = Paths.get('/foo/data/file1')
+        def path2 = Paths.get('/bar/data/file2')
+        def path3 = Paths.get('/bar/data file')
+
+        expect:
+        new SingularityBuilder('busybox')
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B "$PWD" busybox'
+
+        new SingularityBuilder('busybox')
+                .params(engineOptions: '-q -v')
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity -q -v run --no-home --pid -B "$PWD" busybox'
+
+        new SingularityBuilder('busybox')
+                .params(runOptions: '--contain --writable')
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B "$PWD" --contain --writable busybox'
+
+        new SingularityBuilder('ubuntu')
+                .params(autoMounts: false)
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid ubuntu'
+
+        new SingularityBuilder('ubuntu')
+                .addMount(path1)
+                .addMount(path2)
+                .params(autoMounts: true)
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B /foo/data/file1 -B /bar/data/file2 -B "$PWD" ubuntu'
+
+        new SingularityBuilder('ubuntu')
+                .addMount(path1)
+                .addMount(path1)
+                .params(autoMounts: true)
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B /foo/data/file1 -B "$PWD" ubuntu'
+
+        new SingularityBuilder('ubuntu')
+                .addMount(path1)
+                .addMount(path1)
+                .params(autoMounts: true)
+                .params(readOnlyInputs: true)
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B /foo/data/file1:/foo/data/file1:ro -B "$PWD" ubuntu'
+
+        new SingularityBuilder('ubuntu')
+                .addMount(path3)
+                .params(autoMounts: true)
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B /bar/data\\ file -B "$PWD" ubuntu'
+
+        new SingularityBuilder('ubuntu')
+                .params(newPidNamespace: false)
+                .params(autoMounts: false)
+                .build()
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home ubuntu'
+
     }
 
     def 'should mount home directory if specified' () {
@@ -136,12 +202,12 @@ class SingularityBuilderTest extends Specification {
                 .addEnv('X=1')
                 .addEnv(ALPHA:'aaa', BETA: 'bbb')
                 .build()
-                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} SINGULARITYENV_X="1" SINGULARITYENV_ALPHA="aaa" SINGULARITYENV_BETA="bbb" singularity exec --no-home --pid busybox'
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} SINGULARITYENV_X="1" SINGULARITYENV_ALPHA="aaa" SINGULARITYENV_BETA="bbb" singularity run --no-home --pid -B "$PWD" busybox'
 
         new SingularityBuilder('busybox')
                 .addEnv('CUDA_VISIBLE_DEVICES')
                 .build()
-                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} ${CUDA_VISIBLE_DEVICES:+SINGULARITYENV_CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES"} singularity exec --no-home --pid busybox'
+                .runCommand == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} ${CUDA_VISIBLE_DEVICES:+SINGULARITYENV_CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES"} singularity run --no-home --pid -B "$PWD" busybox'
 
     }
 
@@ -151,17 +217,17 @@ class SingularityBuilderTest extends Specification {
         when:
         def cmd = new SingularityBuilder('ubuntu.img').build().getRunCommand()
         then:
-        cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity exec --no-home --pid ubuntu.img'
+        cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B "$PWD" ubuntu.img'
 
         when:
         cmd = new SingularityBuilder('ubuntu.img').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity exec --no-home --pid ubuntu.img bwa --this --that file.fastq'
+        cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B "$PWD" ubuntu.img bwa --this --that file.fastq'
 
         when:
         cmd = new SingularityBuilder('ubuntu.img').params(entry:'/bin/sh').build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity exec --no-home --pid ubuntu.img /bin/sh -c "cd $PWD; bwa --this --that file.fastq"'
+        cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} singularity run --no-home --pid -B "$PWD" ubuntu.img /bin/sh -c "cd $PWD; bwa --this --that file.fastq"'
     }
 
     @Unroll

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -977,7 +977,7 @@ class BashWrapperBuilderTest extends Specification {
                 containerConfig: [enabled: true, engine: 'singularity'] as ContainerConfig ).makeBinding()
 
         then:
-        binding.launch_cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} ${NXF_TASK_WORKDIR:+SINGULARITYENV_NXF_TASK_WORKDIR="$NXF_TASK_WORKDIR"} singularity exec --no-home --pid docker://ubuntu:latest /bin/bash -c "cd $PWD; eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"'
+        binding.launch_cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} ${NXF_TASK_WORKDIR:+SINGULARITYENV_NXF_TASK_WORKDIR="$NXF_TASK_WORKDIR"} singularity run --no-home --pid -B /work/dir docker://ubuntu:latest /bin/bash -c "cd $PWD; eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"'
         binding.cleanup_cmd == ""
         binding.kill_cmd == '[[ "$pid" ]] && nxf_kill $pid'
     }
@@ -991,7 +991,7 @@ class BashWrapperBuilderTest extends Specification {
                 containerConfig: [enabled: true, engine: 'singularity', entrypointOverride: true] as ContainerConfig ).makeBinding()
 
         then:
-        binding.launch_cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} ${NXF_TASK_WORKDIR:+SINGULARITYENV_NXF_TASK_WORKDIR="$NXF_TASK_WORKDIR"} singularity exec --no-home --pid docker://ubuntu:latest /bin/bash -c "cd $PWD; eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"'
+        binding.launch_cmd == 'set +u; env - PATH="$PATH" ${TMP:+SINGULARITYENV_TMP="$TMP"} ${TMPDIR:+SINGULARITYENV_TMPDIR="$TMPDIR"} ${NXF_TASK_WORKDIR:+SINGULARITYENV_NXF_TASK_WORKDIR="$NXF_TASK_WORKDIR"} singularity run --no-home --pid -B /work/dir docker://ubuntu:latest /bin/bash -c "cd $PWD; eval $(nxf_container_env); /bin/bash -ue /work/dir/.command.sh"'
         binding.cleanup_cmd == ""
         binding.kill_cmd == '[[ "$pid" ]] && nxf_kill $pid'
     }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/fusion/FusionHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/fusion/FusionHelperTest.groovy
@@ -68,9 +68,9 @@ class FusionHelperTest extends Specification {
         [engine:'docker']       | [FOO:'one']       | 'image:2'     | null          | ['echo', 'hello']     | "docker run -i -e \"FOO=one\" --rm --privileged image:2 echo 'hello'"
         [engine:'docker']       | [FOO:'one']       | 'image:2'     | '--this=that' | ['echo', 'hello']     | "docker run -i -e \"FOO=one\" --this=that --rm --privileged image:2 echo 'hello'"
         and:
-        [engine:'singularity']  | [:]               | 'image:1'     | null          | ['echo', 'hello']     | "set +u; env - PATH=\"\$PATH\" \${TMP:+SINGULARITYENV_TMP=\"\$TMP\"} \${TMPDIR:+SINGULARITYENV_TMPDIR=\"\$TMPDIR\"} singularity exec --no-home --pid image:1 echo 'hello'"
-        [engine:'singularity']  | [FOO:'one']       | 'image:1'     | null          | ['echo', 'hello']     | "set +u; env - PATH=\"\$PATH\" \${TMP:+SINGULARITYENV_TMP=\"\$TMP\"} \${TMPDIR:+SINGULARITYENV_TMPDIR=\"\$TMPDIR\"} SINGULARITYENV_FOO=\"one\" singularity exec --no-home --pid image:1 echo 'hello'"
-        [engine:'singularity']  | [FOO:'one']       | 'image:1'     | '--this=that' | ['echo', 'hello']     | "set +u; env - PATH=\"\$PATH\" \${TMP:+SINGULARITYENV_TMP=\"\$TMP\"} \${TMPDIR:+SINGULARITYENV_TMPDIR=\"\$TMPDIR\"} SINGULARITYENV_FOO=\"one\" singularity exec --no-home --pid --this=that image:1 echo 'hello'"
+        [engine:'singularity']  | [:]               | 'image:1'     | null          | ['echo', 'hello']     | "set +u; env - PATH=\"\$PATH\" \${TMP:+SINGULARITYENV_TMP=\"\$TMP\"} \${TMPDIR:+SINGULARITYENV_TMPDIR=\"\$TMPDIR\"} singularity run --no-home --pid image:1 echo 'hello'"
+        [engine:'singularity']  | [FOO:'one']       | 'image:1'     | null          | ['echo', 'hello']     | "set +u; env - PATH=\"\$PATH\" \${TMP:+SINGULARITYENV_TMP=\"\$TMP\"} \${TMPDIR:+SINGULARITYENV_TMPDIR=\"\$TMPDIR\"} SINGULARITYENV_FOO=\"one\" singularity run --no-home --pid image:1 echo 'hello'"
+        [engine:'singularity']  | [FOO:'one']       | 'image:1'     | '--this=that' | ['echo', 'hello']     | "set +u; env - PATH=\"\$PATH\" \${TMP:+SINGULARITYENV_TMP=\"\$TMP\"} \${TMPDIR:+SINGULARITYENV_TMPDIR=\"\$TMPDIR\"} SINGULARITYENV_FOO=\"one\" singularity run --no-home --pid --this=that image:1 echo 'hello'"
 
     }
 


### PR DESCRIPTION
This PR align the execution of Singularity (and Apptainer) containers to make experience more consistent with Docker containers. 

More in detail: 

- Use `singularity run` command in place of `singularity exec`. This allows the execution of the `%runscript`, when defined in the Singularityfile, which provides a behaviour similar to Docker entry-point. To rollback to the previous `exec` command the variable `NXF_SINGULARITY_RUN_COMMAND=exec` (or `NXF_APPTAINER_RUN_COMMAND=exec`).  
- Automatically mount the host path in the running container. This, along with the recent change of disabling the mount of the home dir by default (a0ee4657), makes the file system isolation of Singularity containers more singular to Docker. To rollback to the previous behavior use `singularity.autoMounts=false` in the nextlow config or the variable `NXF_SINGULARITY_AUTO_MOUNTS=false` in the launching environment.


See also https://github.com/nextflow-io/nextflow/issues/2348.  