### PR TITLE
Update AZ File share doc. [ci skip]

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -73,7 +73,7 @@ azure {
         // ...
 
         fileShares {
-          rnaseqresources38 {
+          rnaseqResources {
                 mountPath = "/mnt/mydata/myresources"
             }
         }

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -63,7 +63,7 @@ azure {
 }
 ```
 
-The files in the File share are available to the task in the directory: `<YOUR MOUNT DESTINATION>/<YOUR SOURCE FILE SHARE NAME>`.
+The files in the File share are available to the task in the directory: `<YOUR MOUNT DESTINATION>`.
 
 For instance, given the following configuration:
 
@@ -73,15 +73,20 @@ azure {
         // ...
 
         fileShares {
-            dir1 {
-                mountPath = "/mnt/mydata/"
+          rnaseqresources38 {
+                mountPath = "/mnt/mydata/myresources"
             }
         }
     }
 }
 ```
 
-The task can access the File share in `/mnt/mydata/dir1`.
+The task can access the File share in `/mnt/mydata/myresources`.
+
+:::{warning}
+Azure File shares do not support authentication and management with Active Directory. The storage account key must be 
+set in the configuration if a share is mounted.
+:::
 
 (azure-batch)=
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -81,7 +81,7 @@ azure {
 }
 ```
 
-The task can access the File share in `/mnt/mydata/myresources`.
+The task can access the File share in `/mnt/mydata/myresources`. Note: The string `rnaseqResources` in the above config can be any name of your choice, and it does not affect the underlying mount. 
 
 :::{warning}
 Azure File shares do not support authentication and management with Active Directory. The storage account key must be 


### PR DESCRIPTION
Fixing and updating File shares documentation.
I've asked clarifications to the Azure SDK team (see https://github.com/Azure/azure-sdk-for-java/issues/36546). They confirmed that authentication with AAD for Azure Files is not supported and not in their immediate roadmap.