### PR TITLE
More helpful warnings when publish fails to create parent directory.

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -483,6 +483,9 @@ class PublishDir {
         catch( FileAlreadyExistsException e ) {
             // ignore
         }
+        catch( Exception e ) {
+            log.warn "Failed to create directory for publishing file: ${dir.toUriString()}"
+        }
         finally {
             makeCache.put(dir,true)
         }


### PR DESCRIPTION
At the moment, if publishing a file fails because of permissions, Nextflow will return an error indicating the Access Denied exception, but will not indicate which file was the problem.

This commit adds the file name to the error message, so that the user can determine from the logs alone which file path was the problem. Catching this exception also triggers the safeProcessFile catch block which also gives the helpful message saying "Failed to publish file". It's not entirely clear to me why this catch block does not catch the Access Denied exception being thrown inside the `makeDirs` method.