### PR TITLE
make store public

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -238,7 +238,12 @@ class TraceRecord implements Serializable {
     }
 
 
-    public Map<String,Object> store
+    @PackageScope
+    Map<String,Object> store
+
+    Map<String,Object> getStore() {
+        new LinkedHashMap(store)
+    }
 
     @Memoized
     Set<String> keySet() {

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -238,8 +238,7 @@ class TraceRecord implements Serializable {
     }
 
 
-    @PackageScope
-    Map<String,Object> store
+    public Map<String,Object> store
 
     @Memoized
     Set<String> keySet() {

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
@@ -288,14 +288,14 @@ class TraceRecordTest extends Specification {
         when:
         rec.env = 'aws_key=1234'
         then:
-        rec.store.env == 'aws_key=[secure]'
+        rec.@store.env == 'aws_key=[secure]'
     }
 
     def 'should retrieve safe env' () {
         given:
         def rec = new TraceRecord()
         when:
-        rec.store.env = 'aws_key=1234'
+        rec.@store.env = 'aws_key=1234'
         then:
         rec.env == 'aws_key=[secure]'
     }


### PR DESCRIPTION
Went to give `nf-weblog` a go.

It blows up hard here: https://github.com/nextflow-io/nf-weblog/blob/4a6b16832252426851b3b015a2e46f6ba2fafe69/plugins/nf-weblog/src/main/nextflow/trace/WebLogObserver.groovy#L221

Hard enough that I didn't see any stacktrace in the logs - not sure why.

Anyway, I think I chased it down.

I'm not sure if the member should be public, or if there should be a getter, or other. First I tried to implement a getter, but it broke some other methods that rely on `store`.