### PR TITLE
Add task entry prefix to cloud cache

### DIFF
--- a/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy
+++ b/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy
@@ -162,6 +162,7 @@ class CloudCacheStore implements CacheStore {
     }
 
     private Path getCachePath(HashCode key) {
-        dataPath.resolve(key.toString())
+        final keyStr = key.toString()
+        dataPath.resolve(keyStr.substring(0, 2)).resolve(keyStr.substring(2))
     }
 }


### PR DESCRIPTION
Before we start pushing the cloud cache more... I am concerned that it will not perform optimally against object storage at scale. This PR is meant to address that concern.

My understanding is that when you request many S3 objects, each prefix is processed in parallel. So if you have many files then it is better to spread them across many prefixes, as we do for the work directory.

But a workflow run with 30,000 tasks will have an S3 directory with 30,000 objects... I suspect that will be hard to manage and hurt performance a little bit.

It may not be a huge issue for resuming, since usually you would resume a few tasks at a time rather than all at once. But if you ran e.g. 1,000 samples in parallel, then the resume would be fetching 1,000 objects at a time, from the same prefix.