### PR TITLE
Nullable input/output paths

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/params/ArityParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/ArityParam.groovy
@@ -56,14 +56,34 @@ trait ArityParam {
     }
 
     /**
+     * Determine whether a null file is allowed.
+     */
+    boolean isNullable() {
+        return arity && arity.min == 0 && arity.max == 1
+    }
+
+    /**
      * Determine whether a single output file should be unwrapped.
      */
     boolean isSingle() {
         return !arity || arity.max == 1
     }
 
-    boolean isValidArity(int size) {
-        return !arity || arity.contains(size)
+    /**
+     * Determine whether a collection of files has valid arity.
+     *
+     * If the param is nullable, there should be exactly one file (either
+     * a real file or a null file)
+     *
+     * @param files
+     */
+    boolean isValidArity(Collection files) {
+        if( !arity )
+            return true
+
+        return isNullable()
+            ? files.size() == 1
+            : arity.contains(files.size())
     }
 
     @EqualsAndHashCode
@@ -72,12 +92,10 @@ trait ArityParam {
         int max
 
         Range(int min, int max) {
-            if( min<0 )
-                throw new IllegalArityException("Path arity min value must be greater or equals to 0")
-            if( max<1 )
-                throw new IllegalArityException("Path arity max value must be greater or equals to 1")
-            if( min==0 && max==1 )
-                throw new IllegalArityException("Path arity 0..1 is not allowed")
+            if( min < 0 )
+                throw new IllegalArityException("Path arity min value must be at least 0")
+            if( max < 1 )
+                throw new IllegalArityException("Path arity max value must be at least 1")
             this.min = min
             this.max = max
         }

--- a/modules/nextflow/src/main/groovy/nextflow/util/NullPath.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/NullPath.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.util
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.PackageScope
+import groovy.util.logging.Slf4j
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@EqualsAndHashCode
+@Slf4j
+class NullPath implements Path {
+
+    @PackageScope
+    @Delegate
+    Path delegate
+
+    NullPath(String path) {
+        delegate = Paths.get(path)
+    }
+}

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -839,7 +839,7 @@ class TaskProcessorTest extends Specification {
         def proc = new TaskProcessor(); proc.executor = executor
 
         when:
-        def result = proc.normalizeInputToFiles(PATH.toString(), 0, true, batch)
+        def result = proc.normalizeInputToFiles(PATH.toString(), 0, true, false, batch)
         then:
         1 * executor.isForeignFile(PATH) >> false
         0 * batch.addToForeign(PATH) >> null
@@ -1043,7 +1043,7 @@ class TaskProcessorTest extends Specification {
 
         where:
         FILE_NAME       | FILE_VALUE                                | ARITY     | ERROR
-        'file.txt'      | []                                        | '0'       | 'Path arity max value must be greater or equals to 1'
+        'file.txt'      | []                                        | '0'       | 'Path arity max value must be at least 1'
         'file.txt'      | []                                        | '1'       | 'Incorrect number of input files for process `foo` -- expected 1, found 0'
         'f*'            | []                                        | '1..*'    | 'Incorrect number of input files for process `foo` -- expected 1..*, found 0'
         'f*'            | '/some/file.txt'                          | '2..*'    | 'Incorrect number of input files for process `foo` -- expected 2..*, found 1'

--- a/modules/nextflow/src/test/groovy/nextflow/script/params/ArityParamTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/ArityParamTest.groovy
@@ -37,13 +37,15 @@ class ArityParamTest extends Specification {
         then:
         param.arity.min == MIN
         param.arity.max == MAX
+        param.isNullable() == NULLABLE
         param.isSingle() == SINGLE
 
         where:
-        VALUE  | SINGLE | MIN | MAX
-        '1'    | true   | 1   | 1
-        '1..*' | false  | 1   | Integer.MAX_VALUE
-        '0..*' | false  | 0   | Integer.MAX_VALUE
+        VALUE  | NULLABLE | SINGLE | MIN | MAX
+        '1'    | false    | true   | 1   | 1
+        '0..1' | true     | true   | 0   | 1
+        '1..*' | false    | false  | 1   | Integer.MAX_VALUE
+        '0..*' | false    | false  | 0   | Integer.MAX_VALUE
     }
 
     @Unroll
@@ -58,6 +60,7 @@ class ArityParamTest extends Specification {
         where:
         MIN | MAX               | TWO   | STRING
         1   | 1                 | false | '1'
+        0   | 1                 | false | '0..1'
         1   | Integer.MAX_VALUE | true  | '1..*'
     }
 

--- a/tests/checks/process-arity-fails.nf/.checks
+++ b/tests/checks/process-arity-fails.nf/.checks
@@ -1,0 +1,18 @@
+set +e
+
+#
+# run normal mode
+#
+echo ''
+$NXF_RUN 
+[[ $? == 0 ]] && exit 1
+
+
+#
+# RESUME mode
+#
+echo ''
+$NXF_RUN -resume 
+[[ $? == 0 ]] && exit 1
+
+exit 0

--- a/tests/process-arity-fails.nf
+++ b/tests/process-arity-fails.nf
@@ -1,0 +1,19 @@
+#!/usr/bin/env nextflow
+
+process foo {
+  output:
+    path('output.txt', arity: '0..1')
+  script:
+    true
+}
+
+process bar {
+  input:
+    path(file)
+  script:
+    true
+}
+
+workflow {
+    foo | bar
+}

--- a/tests/process-arity.nf
+++ b/tests/process-arity.nf
@@ -5,6 +5,8 @@ process foo {
     path('one.txt', arity: '1')
     path('pair_*.txt', arity: '2')
     path('many_*.txt', arity: '1..*')
+    path('opt_one.txt', arity: '0..1')
+    path('opt_many_*.txt', arity: '0..*')
   script:
     """
     echo 'one' > one.txt
@@ -21,11 +23,15 @@ process bar {
     path('one.txt', arity: '1')
     path('pair_*.txt', arity: '2')
     path('many_*.txt', arity: '1..*')
+    path('opt_one.txt', arity: '0..1')
+    path('opt_many_*.txt', arity: '0..*')
   script:
     """
     cat one.txt
     cat pair_*.txt
     cat many_*.txt
+    cat opt_one.txt || true
+    cat opt_many_*.txt || true
     """
 }
 


### PR DESCRIPTION
Close #2678

This PR contains the support for nullable paths via `arity: '0..1'`, which was implemented in PR #3706 but ultimately excluded because it is tricky to implement.

With the new arity feature, you can set `arity: '0..*'` to specify that a path input/output should be a list and can be empty.

With this PR, you can also set `arity: '0..1'` to specify that a path input/output should be a single file but could also be null. Whereas `optional: true` emits nothing if no file is produced, this "nullable" path emits a null value which can be accepted by similarly nullable inputs.

The problem with the current implementation is that the null path is being passed through some code that it shouldn't, and produces this warning:
```
WARN: File system is unable to get file attributes file: nextflow.util.NullPath@7f -- Cause: java.nio.file.ProviderMismatchException
```

While it still works, ideally the null path should bypass any code that would try to use it like a real file.

Additionally, it should be considered whether nullable paths should be implemented with a separate option like `nullable: true` instead of adding it on to the arity feature, which might simplify the logic a bit.