### PR TITLE
Fix issues with workflow complete handler

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -764,6 +764,7 @@ class Session implements ISession {
                 log.debug(status)
             // force termination
             notifyError(null)
+            shutdown0()
             ansiLogObserver?.forceTermination()
             executorFactory?.signalExecutors()
             processesBarrier.forceTermination()

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -385,6 +385,7 @@ class WorkflowMetadata {
 
         onCompleteActions.each { Closure action ->
             try {
+                action.delegate = [log: log]
                 action.call()
             }
             catch (Exception e) {
@@ -402,6 +403,7 @@ class WorkflowMetadata {
         setErrorAttributes()
         onErrorActions.each { Closure action ->
             try {
+                action.delegate = [log: log]
                 action.call(trace)
             }
             catch (Exception e) {


### PR DESCRIPTION
Close #3129 

- Call workflow complete handler on all workflow errors, including session `abort()` (as well as other shutdown callbacks and observers)
- Add `log` to complete/error handler context so that they can use the logger when defined in a config file

For testing (1), see the reproducible example in the linked issue.

For testing (2), add the following to Nextflow config:

```groovy
workflow.onComplete = {
    log.info "~ config handler was also here ~"
}

workflow.onError = {
    log.error "~ config handler was also here ~"
}
```

I'm not 100% on either of these changes. Not sure if adding the shutdown callbacks to session `abort()` has other unintended side effects. And the delegate for the workflow handlers should probably be done more carefully to make sure that the handler can still access global variables in the pipeline script.