### PR TITLE
Removed allow_other vulnerability preventing google-batch submissions

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -134,7 +134,7 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
                             .setRemotePath(it)
                     )
                     .setMountPath( "${MOUNT_ROOT}/${it}".toString() )
-                    .addAllMountOptions( ['-o rw,allow_other', '-implicit-dirs'] )
+                    .addAllMountOptions( ['-o rw', '-implicit-dirs'] )
                     .build()
             )
         }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
@@ -71,10 +71,10 @@ class GoogleBatchScriptLauncherTest extends Specification{
         volumes.size() == 2
         volumes[0].getGcs().getRemotePath() == 'alpha'
         volumes[0].getMountPath() == '/mnt/disks/alpha'
-        volumes[0].getMountOptionsList() == ['-o rw,allow_other', '-implicit-dirs']
+        volumes[0].getMountOptionsList() == ['-o rw', '-implicit-dirs']
         volumes[1].getGcs().getRemotePath() == 'omega'
         volumes[1].getMountPath() == '/mnt/disks/omega'
-        volumes[1].getMountOptionsList() == ['-o rw,allow_other', '-implicit-dirs']
+        volumes[1].getMountOptionsList() == ['-o rw', '-implicit-dirs']
     }
 
 }


### PR DESCRIPTION
Fixes #4331

`-o allow_other` as a gcsfuse option creates a potential shell injection vulnerability.

As a result, current `process.executor = google-batch` submissions are being rejected with the error:

```
ERROR ~ Error executing process > 'splitLetters'

Caused by:
  INVALID_ARGUMENT: volume.mount_options field is invalid. mount_option -o rw,allow_other has potential shell injection, please check again.


 -- Check '.nextflow.log' file for details
```

Removing `allow_other` corrects this.
