### PR TITLE
Document source of `vol_ctxt` and `inv_ctxt` trace metrics

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -282,10 +282,10 @@ The following table shows the fields that can be included in the execution repor
 : Number of bytes the process originally dirtied in the page-cache (assuming they will go to disk later). This data is read from file `/proc/$pid/io`.
 
 `vol_ctxt`
-: Number of voluntary context switches.
+: Number of voluntary context switches. This data is read from field `voluntary_ctxt_switches` in `/proc/$pid/status` file.
 
 `inv_ctxt`
-: Number of involuntary context switches.
+: Number of involuntary context switches. This data is read from field `nonvoluntary_ctxt_switches` in `/proc/$pid/status` file.
 
 `env`
 : The variables defined in task execution environment.

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -98,8 +98,8 @@ class TraceRecord implements Serializable {
             time:       'time',
             env:        'str',
             error_action:'str',
-            vol_ctxt: 'num',
-            inv_ctxt: 'num',
+            vol_ctxt: 'num',        // -- /proc/$pid/status field 'voluntary_ctxt_switches'
+            inv_ctxt: 'num',        // -- /proc/$pid/status field 'nonvoluntary_ctxt_switches'
             hostname: 'str',
             cpu_model:  'str'
     ]


### PR DESCRIPTION
Based on a customer ticket where they asked about how these fields are defined, which is from the /proc filesystem.