### PR TITLE
Add support for Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [11, 17, 19]
+
     steps:
       - name: Environment
         run: env | sort
@@ -55,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: temurin
+          distribution: 'temurin'
           architecture: x64
           cache: gradle
 
@@ -118,7 +119,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: temurin
+          distribution: 'temurin'
           architecture: x64
           cache: gradle
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: 'oracle'
+          distribution: 'temurin'
           architecture: x64
           cache: gradle
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,13 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [11, 17, 21]
-
+        include:
+        - os: 11
+          distribution: temurin
+        - os: 17
+          distribution: temurin
+        - os: 21
+          distribution: oracle
     steps:
       - name: Environment
         run: env | sort
@@ -56,7 +62,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: 'temurin'
+          distribution: ${{matrix.distribution}}
           architecture: x64
           cache: gradle
 
@@ -119,7 +125,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: 'temurin'
+          distribution: ${{matrix.distribution}}
           architecture: x64
           cache: gradle
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [11, 17, 19]
+        java_version: [11, 17, 21]
 
     steps:
       - name: Environment
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: 'temurin'
+          distribution: 'oracle'
           architecture: x64
           cache: gradle
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [11, 17, 21]
-        include:
-        - os: 11
-          distribution: temurin
-        - os: 17
-          distribution: temurin
-        - os: 21
-          distribution: oracle
+        java_version: [11, 17, 19]
     steps:
       - name: Environment
         run: env | sort
@@ -62,7 +55,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: ${{matrix.distribution}}
+          distribution: temurin
           architecture: x64
           cache: gradle
 
@@ -125,7 +118,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{matrix.java_version}}
-          distribution: ${{matrix.distribution}}
+          distribution: temurin
           architecture: x64
           cache: gradle
 

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-Nextflow can be used on any POSIX compatible system (Linux, OS X, etc). It requires Bash 3.2 (or later) and [Java 11 (or later, up to 20)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to be installed.
+Nextflow can be used on any POSIX compatible system (Linux, OS X, etc). It requires Bash 3.2 (or later) and [Java 11 (or later, up to 21)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to be installed.
 
 For the execution in a cluster of computers, the use of a shared file system is required to allow the sharing of tasks input/output files.
 

--- a/launch.sh
+++ b/launch.sh
@@ -66,14 +66,15 @@ fi
 JAVA_VER=$(echo "$JAVA_VER" | awk '/version/ {gsub(/"/, "", $3); print $3}')
 major=${BASH_REMATCH[1]}
 minor=${BASH_REMATCH[2]}
-version_check="^(1.8|9|10|11|12|13|14|15|16|17|18|19|20)"
+version_check="^(1.8|9|10|11|12|13|14|15|16|17|18|19|20|21)"
 if [[ ! $JAVA_VER =~ $version_check ]]; then
     echo "Error: cannot find Java or it's a wrong version -- please make sure that Java 8 or higher is installed"
     exit 1
 fi
 JVM_ARGS+=" -Dfile.encoding=UTF-8 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-[[ $JAVA_VER =~ ^(9|10|11|12|13|14|15|16|17|18|19|20) ]] && JVM_ARGS+=" --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio.file.spi=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED"
-[[ $NXF_ENABLE_VIRTUAL_THREADS == 'true' ]] && JVM_ARGS+=" --enable-preview"
+[[ $JAVA_VER =~ ^(9|10|11|12|13|14|15|16|17|18|19|20|21) ]] && JVM_ARGS+=" --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio.file.spi=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED"
+[[ $NXF_ENABLE_VIRTUAL_THREADS == 'true' ]] && [[ "$JAVA_VER" =~ ^(19|20) ]] && JVM_ARGS+=" --enable-preview"
+[[ "$JAVA_VER" =~ ^(21) ]] && [[ ! "$NXF_ENABLE_VIRTUAL_THREADS" ]] && NXF_ENABLE_VIRTUAL_THREADS=true
 
 ## flight recorded -- http://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/run.htm
 ##JVM_ARGS+=" -XX:+UnlockCommercialFeatures -XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=myrecording.jfr"
@@ -89,6 +90,7 @@ export COLUMNS
 export NXF_PLUGINS_DIR
 export NXF_PLUGINS_MODE
 export NXF_PLUGINS_DEFAULT
+export NXF_ENABLE_VIRTUAL_THREADS
 
 # Yourkit profiling library
 YOURKIT_AGENT=${YOURKIT_AGENT:-/Applications/YourKit-Java-Profiler-2021.11.app/Contents/Resources/bin/mac/libyjpagent.dylib}

--- a/nextflow
+++ b/nextflow
@@ -305,8 +305,8 @@ else
     version_check="^(1.7|1.8)"
     version_message="Java 7 or 8"
   else
-    version_check="^(1.8|9|10|11|12|13|14|15|16|17|18|19|20)"
-    version_message="Java 8 or later (up to 20)"
+    version_check="^(1.8|9|10|11|12|13|14|15|16|17|18|19|20|21)"
+    version_message="Java 8 or later (up to 21)"
   fi
   if [[ ! $JAVA_VER =~ $version_check ]]; then
       echo_red "ERROR: Cannot find Java or it's a wrong version -- please make sure that $version_message is installed"
@@ -317,8 +317,8 @@ else
       fi
       exit 1
   fi
-  if [[ ! $JAVA_VER =~ ^(11|12|13|14|15|16|17|18|19|20) ]]; then
-      echo_yellow "NOTE: Nextflow is not tested with Java $JAVA_VER -- It's recommended the use of version 11 up to 20\n"
+  if [[ ! $JAVA_VER =~ ^(11|12|13|14|15|16|17|18|19|20|21) ]]; then
+      echo_yellow "NOTE: Nextflow is not tested with Java $JAVA_VER -- It's recommended the use of version 11 up to 21\n"
   fi
   mkdir -p $(dirname "$JAVA_KEY")
   [[ -f $JAVA_VER ]] && echo $JAVA_VER > "$JAVA_KEY"
@@ -340,6 +340,7 @@ if [[ $cmd == console ]]; then bg=1;
 else JAVA_OPTS+=(-Djava.awt.headless=true)
 fi
 
+[[ "$JAVA_VER" =~ ^(21) ]] && [[ ! "$NXF_ENABLE_VIRTUAL_THREADS" ]] && NXF_ENABLE_VIRTUAL_THREADS=true
 [[ "$JAVA_HOME" ]] && JAVA_OPTS+=(-Dcapsule.java.home="$JAVA_HOME")
 [[ "$CAPSULE_LOG" ]] && JAVA_OPTS+=(-Dcapsule.log=$CAPSULE_LOG)
 [[ "$CAPSULE_RESET" ]] && JAVA_OPTS+=(-Dcapsule.reset=true)
@@ -356,6 +357,7 @@ export NXF_PLUGINS_DIR
 export NXF_PLUGINS_MODE
 export NXF_PLUGINS_DEFAULT
 export NXF_PACK
+export NXF_ENABLE_VIRTUAL_THREADS
 
 # lookup the a `md5` command
 if hash md5sum 2>/dev/null; then MD5=md5sum;
@@ -409,7 +411,7 @@ else
     [[ "$NXF_JVM_ARGS" ]] && launcher+=($NXF_JVM_ARGS)
     [[ "$remote_debug" ]] && launcher+=(-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$NXF_REMOTE_DEBUG_PORT)
 
-    if [[ "$JAVA_VER" =~ ^(9|10|11|12|13|14|15|16|17|18|19|20) ]]; then
+    if [[ "$JAVA_VER" =~ ^(9|10|11|12|13|14|15|16|17|18|19|20|21) ]]; then
       launcher+=(--add-opens=java.base/java.lang=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.io=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.nio=ALL-UNNAMED)
@@ -428,7 +430,9 @@ else
       launcher+=(--add-opens=java.base/jdk.internal.vm=ALL-UNNAMED)
       launcher+=(--add-opens=java.base/java.util.regex=ALL-UNNAMED)
       if [[ "$NXF_ENABLE_VIRTUAL_THREADS" == 'true' ]]; then
-        [[ "$JAVA_VER" =~ ^(19|20) ]] && launcher+=(--enable-preview) || die "Virtual threads requires Java 19 or later - current version $JAVA_VER"
+        if [[ "$JAVA_VER" =~ ^(19|20) ]]; then launcher+=(--enable-preview)
+        elif [[ ! "$JAVA_VER" =~ ^(21) ]]; then die "Virtual threads require Java 19 or later - current version $JAVA_VER"
+        fi
       fi
       launcher+=("${cmd_tail[@]}")
     else


### PR DESCRIPTION
This PR adds support for Java 21. Moreover, it enables virtual threads by default when using Java 21. It's still possible to rollback to platform threads by setting the variable `NXF_ENABLE_VIRTUAL_THREADS=false`. 
