### PR TITLE
Pin only major/minor plugin version with `+` suffix

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1611,9 +1611,12 @@ The following environment variables control the configuration of the Nextflow ru
 : Allows the setting Java VM options. This is similar to `NXF_OPTS` however it's only applied the JVM running Nextflow and not to any java pre-launching commands.
 
 `NXF_OFFLINE`
-: When `true` disables the project automatic download and update from remote repositories (default: `false`).
+: When `true` prevents Nextflow from automatically downloading and updating remote project repositories (default: `false`).
 : :::{versionchanged} 23.09.0-edge
   This option also disables the automatic version check (see `NXF_DISABLE_CHECK_LATEST`).
+  :::
+: :::{versionchanged} 23.10.0
+  This option also prevents plugins from being automatically updated. If a plugin is specified in offline mode but a compatible plugin version is not locally available, Nextflow will fail.
   :::
 
 `NXF_OPTS`

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSpec.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSpec.groovy
@@ -62,7 +62,7 @@ class PluginSpec implements CacheFunnel, Comparable<PluginSpec> {
      * @param dir
      * @return A {@link PluginSpec} representing the plugin
      */
-    static PluginSpec parseDirectory(String dir) {
+    static PluginSpec parseDirName(String dir) {
         final index = dir.lastIndexOf('-')
         final id = dir.substring(0, index)
         final version = dir.substring(index + 1)

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSpec.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSpec.groovy
@@ -56,6 +56,19 @@ class PluginSpec implements CacheFunnel, Comparable<PluginSpec> {
         return new PluginSpec(id)
     }
 
+    /**
+     * Parse a plugin spec from a plugin directory name, e.g. nf-amazon-1.2.0
+     *
+     * @param dir
+     * @return A {@link PluginSpec} representing the plugin
+     */
+    static PluginSpec parseDirectory(String dir) {
+        final index = dir.lastIndexOf('-')
+        final id = dir.substring(0, index)
+        final version = dir.substring(index + 1)
+        return new PluginSpec(id, version)
+    }
+
     @Override
     Hasher funnel(Hasher hasher, CacheHelper.HashMode mode) {
         hasher.putUnencodedChars(id)

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -378,7 +378,7 @@ class PluginUpdater extends UpdateManager {
 
     private String getLastPluginReleaseOffline(String id) {
         final specs = FilesEx.list(pluginsStore)
-            .collect( dir -> PluginSpec.parseDirectory(dir) )
+            .collect( dir -> PluginSpec.parseDirName(dir) )
             .findAll( spec -> spec.id == id )
 
         if( !specs )

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -55,7 +55,7 @@ class PluginsFacade implements PluginStateListener {
     PluginsFacade() {
         mode = getPluginsMode()
         root = getPluginsDir()
-        if( mode=='dev' && root.toString()=='plugins' && !isRunningFromDistArchive() )
+        if( mode==DEV_MODE && root.toString()=='plugins' && !isRunningFromDistArchive() )
             root = detectPluginsDevRoot()
         System.setProperty('pf4j.mode', mode)
     }


### PR DESCRIPTION
Close #4329 

This PR changes the plugin system to not download plugins in offline mode (`NXF_OFFLINE`). Instead, Nextflow will search the plugins directory for the latest plugin version and use that one.

This change makes it possible to run a pipeline in offline mode without pinning the version of each plugin, which allows the pipeline to automatically receive plugin updates. The assumption is that users will download all the plugins they need beforehand and transfer them to the offline system, using these plugins as a local cache.

I tested this PR by installing nf-validation 0.3.0 (`nextflow plugin install nf-validation@0.3.0`) and running a script with the following config:
```groovy
plugins {
  id 'nf-validation'
}
```

Normally, Nextflow would automatically download the newest plugin version (currently 0.3.2), but now if you run Nextflow with `NXF_OFFLINE=true`, it will use the already downloaded version 0.3.0 and not download anything new. I even disabled my internet connection just to be sure 😉 

One limitation however is that the offline version checker doesn't verify that a plugin version is compatible with the current Nextflow version. We can get the version range from the plugin manifest file, but maybe there is some code somewhere that already does this?