### PR TITLE
Return -1 when exitcode file is empty

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -375,6 +375,7 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
             }
             catch( Exception e ) {
                 log.warn "Unable to parse process exit file: ${exitFile.toUriString()} -- bad value: '$status'"
+                return Integer.MAX_VALUE
             }
         }
 
@@ -400,9 +401,8 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
                 return null
             }
             log.warn "Unable to read command status from: ${exitFile.toUriString()} after $delta ms"
+            return -1
         }
-
-        return Integer.MAX_VALUE
     }
 
     @Override

--- a/modules/nextflow/src/test/groovy/nextflow/executor/GridExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/GridExecutorTest.groovy
@@ -129,8 +129,9 @@ class GridExecutorTest extends Specification {
         // now 'checkIfCompleted' returns true
         handler.checkIfCompleted()
         handler.status == TaskStatus.COMPLETED
-        // but the 'exitStatus' not ZERO
-        handler.task.exitStatus == Integer.MAX_VALUE
+        // but the 'exitStatus' is-1 to signal the '.exitcode' file was empty
+        // and allow the task to be retried
+        handler.task.exitStatus == -1
 
     }
 


### PR DESCRIPTION
This change modifies the exitStatus value from MAX_INTEGER to `-1` when the exitcode file exists but it's empty. 

This prevents interrupting the pipeline execution and allows instead to handle this condition as job error 