### PR TITLE
Add process programmatic configuration

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1071,6 +1071,19 @@ manifest {
 
 Read the {ref}`sharing-page` page to learn how to publish your pipeline to GitHub, BitBucket or GitLab.
 
+(config-nextflow)=
+
+### Scope `nextflow`
+
+The `nextflow` scope allows you to define some miscellaneous settings.
+
+The following settings are available:
+
+`nextflow.defaults.publishDir`
+: :::{versionadded} 23.10.0
+  :::
+: Default params for the {ref}`process-publishdir` directive. Every instance of this directive will use these defaults unless it overrides them for itself.
+
 (config-notification)=
 
 ### Scope `notification`

--- a/docs/dsl2.md
+++ b/docs/dsl2.md
@@ -183,6 +183,26 @@ workflow {
 Optional params for a process input/output are always prefixed with a comma, except for `stdout`. Because `stdout` does not have an associated name or value like other types, the first param should not be prefixed.
 :::
 
+### Process config
+
+:::{versionadded} 23.10.0
+:::
+
+A process can be configured with additional directives from a workflow by using the `config` attribute on a process. For example:
+
+```groovy
+include { foo ; foo as bar } from './module.nf'
+
+workflow {
+    foo()
+
+    bar.config.publishDir 'results', mode: 'copy'
+    bar()
+}
+```
+
+Process directives can be defined using the same syntax as in a process definition, and they are applied separately to different module aliases. In the above example, the `publishDir` directive is applied to process `bar` but not to process `foo`.
+
 ## Workflow
 
 ### Workflow definition

--- a/docs/dsl2.md
+++ b/docs/dsl2.md
@@ -183,6 +183,8 @@ workflow {
 Optional params for a process input/output are always prefixed with a comma, except for `stdout`. Because `stdout` does not have an associated name or value like other types, the first param should not be prefixed.
 :::
 
+(dsl2-process-config)=
+
 ### Process config
 
 :::{versionadded} 23.10.0

--- a/docs/process.md
+++ b/docs/process.md
@@ -1229,6 +1229,12 @@ By default, directives are evaluated when the process is defined. However, if th
 
 Some directives are generally available to all processes, while others depend on the `executor` currently defined.
 
+Process directives can also be defined in the Nextflow configuration using the {ref}`process <config-process>` scope.
+
+:::{versionadded} 23.10.0
+Process directives can also be defined for a particular process from the enclosing workflow. See {ref}`dsl2-process-config` for details.
+:::
+
 (process-accelerator)=
 
 ### accelerator

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -21,6 +21,8 @@ import java.util.regex.Pattern
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.Const
+import nextflow.Global
+import nextflow.Session
 import nextflow.NF
 import nextflow.ast.NextflowDSLImpl
 import nextflow.exception.ConfigParseException
@@ -842,7 +844,9 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             configProperties.put('publishDir', dirs)
         }
 
-        dirs.add(params)
+        final session = Global.session as Session
+        final defaults = session.config.navigate('nextflow.defaults.publishDir', [:]) as Map
+        dirs.add(defaults + params)
         return this
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -145,7 +145,10 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
 
     String getBaseName() { baseName }
 
-    ProcessConfig getProcessConfig() { processConfig }
+    ProcessConfig getConfig() {
+        if( processConfig == null ) initialize()
+        processConfig
+    }
 
     ChannelOut getOut() {
         if( output==null )
@@ -165,7 +168,8 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
     @Override
     Object run(Object[] args) {
         // initialise process config
-        initialize()
+        if( processConfig == null )
+            initialize()
 
         // get params 
         final params = ChannelOut.spread(args)

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -88,18 +88,20 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         this.simpleName = name
         this.processName = name
         this.baseName = name
+
+        this.initialize0()
     }
 
     static String stripScope(String str) {
         str.split(Const.SCOPE_SEP).last()
     }
 
-    protected void initialize() {
+    protected void initialize0() {
         log.trace "Process config > $processName"
-        assert processConfig==null
-
-        // the config object
         processConfig = new ProcessConfig(owner,processName)
+    }
+
+    protected void initialize1() {
 
         // Invoke the code block which will return the script closure to the executed.
         // As side effect will set all the property declarations in the 'taskConfig' object.
@@ -130,6 +132,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         def result = clone()
         result.@processName = name
         result.@simpleName = stripScope(name)
+        result.initialize0()
         return result
     }
 
@@ -145,10 +148,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
 
     String getBaseName() { baseName }
 
-    ProcessConfig getConfig() {
-        if( processConfig == null ) initialize()
-        processConfig
-    }
+    ProcessConfig getConfig() { processConfig }
 
     ChannelOut getOut() {
         if( output==null )
@@ -168,8 +168,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
     @Override
     Object run(Object[] args) {
         // initialise process config
-        if( processConfig == null )
-            initialize()
+        initialize1()
 
         // get params 
         final params = ChannelOut.spread(args)

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -89,20 +89,15 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         this.processName = name
         this.baseName = name
 
-        this.initialize0()
+        this.processConfig = new ProcessConfig(owner,processName)
     }
 
     static String stripScope(String str) {
         str.split(Const.SCOPE_SEP).last()
     }
 
-    protected void initialize0() {
+    protected void initialize() {
         log.trace "Process config > $processName"
-        processConfig = new ProcessConfig(owner,processName)
-    }
-
-    protected void initialize1() {
-
         // Invoke the code block which will return the script closure to the executed.
         // As side effect will set all the property declarations in the 'taskConfig' object.
         processConfig.throwExceptionOnMissingProperty(true)
@@ -123,6 +118,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         def result = (ProcessDef)super.clone()
         result.@taskBody = taskBody?.clone()
         result.@rawBody = (Closure)rawBody?.clone()
+        result.@processConfig = processConfig?.clone()
         return result
     }
 
@@ -132,7 +128,6 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         def result = clone()
         result.@processName = name
         result.@simpleName = stripScope(name)
-        result.initialize0()
         return result
     }
 
@@ -168,7 +163,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
     @Override
     Object run(Object[] args) {
         // initialise process config
-        initialize1()
+        initialize()
 
         // get params 
         final params = ChannelOut.spread(args)

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessDefTest.groovy
@@ -98,7 +98,7 @@ class ProcessDefTest extends Specification {
         def copy = proc.clone()
         copy.initialize()
         then:
-        def cfg1 = copy.processConfig.createTaskConfig()
+        def cfg1 = copy.config.createTaskConfig()
         cfg1.getCpus()==2           // taken from the generic config
         cfg1.getMemory().giga == 3  // taken from the `foo` config
 
@@ -106,7 +106,7 @@ class ProcessDefTest extends Specification {
         copy = proc.cloneWithName('flow1:bar')
         copy.initialize()
         then:
-        def cfg2 = copy.processConfig.createTaskConfig()
+        def cfg2 = copy.config.createTaskConfig()
         cfg2.getCpus()==4           // taken from the `bar` config
         cfg2.getMemory().giga == 4  // taken from the `bar` config
 
@@ -115,7 +115,7 @@ class ProcessDefTest extends Specification {
         copy = proc.cloneWithName('flow1:flow2:flow3:bar')
         copy.initialize()
         then:
-        def cfg3 = copy.processConfig.createTaskConfig()
+        def cfg3 = copy.config.createTaskConfig()
         cfg3.getCpus()==4           // <-- taken from `withName: foo`
         cfg3.getMemory().giga == 8  // <-- taken from `withName: 'flow1:flow2:flow3:bar'`
     }

--- a/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsDsl2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsDsl2Test.groovy
@@ -137,8 +137,8 @@ class ParamsDsl2Test extends Dsl2Spec {
         def process = ScriptMeta.get(script).getProcess('alpha'); process.initialize()
 
         then:
-        def inputs = process.processConfig.getInputs()
-        def outputs = process.processConfig.getOutputs()
+        def inputs = process.config.getInputs()
+        def outputs = process.config.getOutputs()
         and:
         inputs.size() == 1
         inputs[0] instanceof StdInParam
@@ -178,8 +178,8 @@ class ParamsDsl2Test extends Dsl2Spec {
         def process = ScriptMeta.get(script).getProcess('beta'); process.initialize()
 
         then:
-        def inputs = process.processConfig.getInputs()
-        def outputs = process.processConfig.getOutputs()
+        def inputs = process.config.getInputs()
+        def outputs = process.config.getOutputs()
         and:
         inputs.size() == 1
         and:


### PR DESCRIPTION
Close #4322 

Example test case:

```groovy
// main.nf

include { FOO ; FOO as BAR } from './module.nf'

params.outdir = 'results'
params.publish_dir_mode = 'copy'

workflow {

    FOO.config.ext.extension = 'foo'
    FOO( Channel.of('1', '2', '3') )
    FOO.out.view { "FOO: $it" }

    BAR.config.ext.extension = 'bar'
    BAR.config.publishDir params.outdir, mode: params.publish_dir_mode
    BAR( Channel.of('1', '2', '3') )
    BAR.out.view { "BAR: $it" }

}
```

```groovy
// module.nf

process FOO {
    input:
    val(id)

    output:
    tuple val(id), path("sample${id}.${task.ext.extension}")

    script:
    """
    echo '${id} was here' > sample${id}.${task.ext.extension}
    """
}
```

```console
$ ./launch.sh run main.nf
N E X T F L O W  ~  version 23.09.2-edge
Launching `main.nf` [astonishing_goldwasser] DSL2 - revision: 9b1341eb15
executor >  local (6)
[cd/f6fe43] process > FOO (3) [100%] 3 of 3 ✔
[16/d722fe] process > BAR (1) [100%] 3 of 3 ✔
BAR: [2, work/ad/d60943813d18751a8ded972ee9d798/sample2.bar]
BAR: [3, work/89/9295138db148949f054a22708895a4/sample3.bar]
FOO: [2, work/48/659fef3cb5e492e2f181c975ea232c/sample2.foo]
FOO: [1, work/db/43db80ff13d8d3c7301467e14184db/sample1.foo]
BAR: [1, work/16/d722fe4b621da24e9bd1e7f30cfd1e/sample1.bar]
FOO: [3, work/cd/f6fe432184777c0f08c9e5c1edee30/sample3.foo]

$ ls -al results/
total 1224
drwxr-xr-x  3 bent bent    4096 Oct  3 12:44 ./
drwxr-xr-x 88 bent bent   12288 Oct  3 12:38 ../
-rw-r--r--  1 bent bent      11 Oct  3 12:38 sample1.bar
-rw-r--r--  1 bent bent      11 Oct  3 12:38 sample2.bar
-rw-r--r--  1 bent bent      11 Oct  3 12:38 sample3.bar

$ cat results/*.bar
1 was here
2 was here
3 was here
```
```