### PR TITLE
Fix Google Batch do not stop running jobs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -117,6 +117,8 @@ abstract class TaskHandler {
 
     boolean isCompleted()  { return status == COMPLETED  }
 
+    boolean isActive() { status == SUBMITTED || status == RUNNING }
+
     protected StringBuilder toStringBuilder(StringBuilder builder) {
         builder << "id: ${task.id}; name: ${task.name}; status: $status; exit: ${task.exitStatus != Integer.MAX_VALUE ? task.exitStatus : '-'}; error: ${task.error ?: '-'}; workDir: ${task.workDir?.toUriString()}"
     }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskHandlerTest.groovy
@@ -228,4 +228,25 @@ class TaskHandlerTest extends Specification {
         timeout
 
     }
+
+    @Unroll
+    def 'should validate status' () {
+        given:
+        def handler = Spy(TaskHandler)
+        handler.status = STATUS
+
+        expect:
+        handler.isNew() == EXPECT_NEW
+        handler.isRunning() == EXPECT_RUNNING
+        handler.isSubmitted() == EXPECT_SUBMITTED
+        handler.isActive() == EXPECTED_ACTIVE
+        handler.isCompleted() == EXPECT_COMPLETE
+        
+        where:
+        STATUS              | EXPECT_NEW  | EXPECT_SUBMITTED | EXPECT_RUNNING | EXPECTED_ACTIVE | EXPECT_COMPLETE
+        TaskStatus.NEW      | true        | false            | false          | false           | false
+        TaskStatus.SUBMITTED| false       | true             | false          | true            | false
+        TaskStatus.RUNNING  | false       | false            | true           | true            | false
+        TaskStatus.COMPLETED| false       | false            | false          | false           | true
+    }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -356,10 +356,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         return jobState
     }
 
-    private List<String> RUNNING_AND_TERMINATED = ['RUNNING', 'SUCCEEDED', 'FAILED', 'DELETION_IN_PROGRESS']
+    static private List<String> RUNNING_AND_TERMINATED = ['RUNNING', 'SUCCEEDED', 'FAILED', 'DELETION_IN_PROGRESS']
 
-    private List<String> TERMINATED = ['SUCCEEDED', 'FAILED', 'DELETION_IN_PROGRESS']
-
+    static private List<String> TERMINATED = ['SUCCEEDED', 'FAILED', 'DELETION_IN_PROGRESS']
 
     @Override
     boolean checkIfRunning() {
@@ -408,7 +407,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     @Override
     void kill() {
-        if( isSubmitted() ) {
+        if( isActive() ) {
             log.trace "[GOOGLE BATCH] Process `${task.lazyName()}` - deleting job name=$jobId"
             client.deleteJob(jobId)
         }


### PR DESCRIPTION
This PR fixed an issue when terminating Google Batch execution that prevented the termination of running jobs. 

The task handle should check also the status `RUNNING` other the status `SUBMITTED`

Closes #4378 