### PR TITLE
Add some details about what a workflow can contain

### DIFF
--- a/docs/dsl2.md
+++ b/docs/dsl2.md
@@ -187,7 +187,7 @@ Optional params for a process input/output are always prefixed with a comma, exc
 
 ### Workflow definition
 
-The `workflow` keyword allows the definition of sub-workflow components that enclose the invocation of one or more processes and operators:
+The `workflow` keyword allows the definition of sub-workflow components that enclose the invocation of one or more processes and/or operators:
 
 ```groovy
 workflow my_pipeline {


### PR DESCRIPTION
A workflow can contains no process or no operator, I'd say even none of them, but that'll be useless. But at least we can specify in the docs that it can be one or the other.