### PR TITLE
Conceptual error in process selector documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1195,7 +1195,7 @@ process {
 ```
 
 :::{note}
-The `withName` selector applies to a process even when it is included from a module under an alias. For example, `withName: hello` will apply to any process originally defined as `hello`, regardless of whether it is included under an alias. Similarly, it will not apply to any process not originally defined as `hello`, even if it is included under the alias `hello`.
+The `withName` selector applies to a process even when it is included from a module under an alias. For example, `withName: hello` will apply to any process originally defined as `hello`, regardless of whether it is included under an alias. However, a selector referring to the alias of a process will also be applied.
 :::
 
 :::{tip}


### PR DESCRIPTION
Hi, the documentation for this seems inaccurate to me. While the first part is true that the withName selector applies also to the original name of a module, not only the import name, in my usage experience it does also apply to the import name. For example if I have a process named FOO and I import it with import FOO as BAR, a withName:BAR selector will work, and also a withName:FOO selector will. The documentation suggests that only withName:FOO works, which I believe to be incorrect.