### PR TITLE
Reflect current macOS naming convention

### DIFF
--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-Nextflow can be used on any POSIX compatible system (Linux, OS X, etc). It requires Bash 3.2 (or later) and [Java 11 (or later, up to 21)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to be installed.
+Nextflow can be used on any POSIX compatible system (Linux, macOS, etc). It requires Bash 3.2 (or later) and [Java 11 (or later, up to 21)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to be installed.
 
 For the execution in a cluster of computers, the use of a shared file system is required to allow the sharing of tasks input/output files.
 


### PR DESCRIPTION
OS X has been officially known as macOS since 2016.
I think it would be a good idea to use the official naming convention to avoid user confusion. 
Might need to consider updating the [Nextflow home page](https://www.nextflow.io/) as well