### PR TITLE
Allow to add custom traces and use them as metadata

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -323,6 +323,9 @@ class BashWrapperBuilder {
         // patch root ownership problem on files created with docker
         binding.fix_ownership = fixOwnership() ? "[ \${NXF_OWNER:=''} ] && (shopt -s extglob; GLOBIGNORE='..'; chown -fR --from root \$NXF_OWNER ${workDir}/{*,.*}) || true" : null
 
+        binding.custom_trace_collect = getCustomTraceCollect()
+        binding.custom_trace_write = getCustomTraceWrite()
+
         binding.trace_script = isTraceRequired() ? getTraceScript(binding) : null
         
         return binding
@@ -424,6 +427,26 @@ class BashWrapperBuilder {
         String result=''
         for( String it : moduleNames) {
             result += moduleLoad(it) + ENDL
+        }
+        return result
+    }
+
+    private String getCustomTraceCollect() {
+        if( !customTraces )
+            return null
+        String result=''
+        for( String key : customTraces.keySet() ) {
+            result += "local custom_${key}=\$(${customTraces.get(key)})"
+        }
+        return result
+    }
+
+    private String getCustomTraceWrite() {
+        if( !customTraces )
+            return null
+        String result=''
+        for( String key : customTraces.keySet() ) {
+            result += "echo \"custom_${key}=\$custom_${key}\" >> \$trace_file"
         }
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -51,6 +51,8 @@ class TaskBean implements Serializable, Cloneable {
 
     List<String> moduleNames
 
+    Map<String,String> customTraces
+
     Path workDir
 
     Path targetDir
@@ -156,6 +158,7 @@ class TaskBean implements Serializable, Cloneable {
         this.stageOutMode = task.config.getStageOutMode()
 
         this.resourceLabels = task.config.getResourceLabels()
+        this.customTraces = task.config.getCustomTraces()
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -206,6 +206,19 @@ class TaskConfig extends LazyMap implements Cloneable {
         return get('stageOutMode')
     }
 
+    Map<String, String> getCustomTraces() {
+        def value = get('customTraces')
+        if( value == null )
+            return null
+
+        if( value instanceof Map ) {
+            //TODO validate key names
+            return (Map) value
+        }
+
+        throw new IllegalArgumentException("Not a valid `customTraces` value: ${value}")
+    }
+
     boolean getDebug() {
         // check both `debug` and `echo` for backward
         // compatibility until `echo` is not removed

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -91,7 +91,8 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             'stdout',
             'stageInMode',
             'stageOutMode',
-            'resourceLabels'
+            'resourceLabels',
+            'customTraces'
     ]
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.script
 
+import nextflow.trace.TraceRecord
+
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.OffsetDateTime
@@ -206,6 +208,11 @@ class WorkflowMetadata {
      * The workflow manifest
      */
     Manifest manifest
+
+    /**
+     * The workflow completed traces
+     */
+    List<TraceRecord> traces = []
 
     private Session session
 

--- a/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
@@ -25,6 +25,7 @@ class DefaultObserverFactory implements TraceObserverFactory {
         createTimelineObserver(result)
         createDagObserver(result)
         createAnsiLogObserver(result)
+        createTraceMetadataObserver(result)
         return result
     }
 
@@ -99,6 +100,10 @@ class DefaultObserverFactory implements TraceObserverFactory {
         config.navigate('trace.fields') { observer.setFieldsAndFormats(it) }
         config.navigate('trace.overwrite') { observer.overwrite = it }
         result << observer
+    }
+
+    protected void createTraceMetadataObserver(Collection<TraceObserver> result) {
+        result << new TraceMetadataObserver(session)
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceMetadataObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceMetadataObserver.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.trace
+
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+import groovy.util.logging.Slf4j
+import groovyx.gpars.agent.Agent
+import nextflow.ISession
+import nextflow.Session
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskId
+import nextflow.processor.TaskProcessor
+import nextflow.script.WorkflowMetadata
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+@Slf4j
+@CompileStatic
+class TraceMetadataObserver implements TraceObserver {
+
+    Session session
+
+    TraceMetadataObserver(Session session) {
+        this.session = session
+    }
+
+    @Override
+    void onProcessComplete(TaskHandler handler, TraceRecord trace) {
+        final taskId = handler.task.id
+        if( !trace ) {
+            log.debug "[WARN] Unable to find record for task run with id: ${taskId}"
+            return
+        }
+
+        session.workflowMetadata.traces.add(trace)
+    }
+
+    @Override
+    void onProcessCached(TaskHandler handler, TraceRecord trace) {
+        onProcessComplete(handler, trace)
+    }
+
+    @Override
+    boolean enableMetrics() {
+        return true
+    }
+}

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -170,6 +170,10 @@ nxf_trace_linux() {
     local cpu_time0=$(2> /dev/null < /proc/$pid/stat awk '{printf "%.0f", ($16+$17)*10 }' || echo -n 'X')
     local io_stat0=($(2> /dev/null < /proc/$pid/io sed 's/^.*:\s*//' | head -n 6 | tr '\n' ' ' || echo -n '0 0 0 0 0 0'))
     local start_millis=$(nxf_date)
+
+    ## collect custom traces
+    {{custom_trace_collect}}
+
     ## capture error and kill mem watcher
     trap 'kill $mem_proc' ERR
     
@@ -209,6 +213,7 @@ nxf_trace_linux() {
     echo "syscw=${io_stat1[3]}"        >> $trace_file
     echo "read_bytes=${io_stat1[4]}"   >> $trace_file
     echo "write_bytes=${io_stat1[5]}"  >> $trace_file
+    {{custom_trace_write}}
 
     ## join nxf_mem_watch
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true


### PR DESCRIPTION
# Description 

This PR allows the user to add custom traces on each process. Also exposes them as workflow metadata, so the user can use them without any extra channel.

This is a more generic approach to solve the version tracking problem described at #4386 

The idea is to allow the user to collect custom traces before running the command. The custom traces is a map where the key is the name of the custom trace and the value is an string with the bash script to run to collect that trace. The output is always parsed as an string.

Then all the traces of the completed and resumed tasks are available as workflow metadata at `workflow.traces`. If `workflow.traces` is used as part of a process script it will contain all the traces of completed task just before submitting that process.

You can use `workflow.traces` at `workflow.onComplete` if you want to store custom traces into a file or do something else.

# Example pipeline

See the whole pipeline [here](https://github.com/jordeu/nf-tests/tree/versions) 

**main.nf**
```nextflow
def parseVersions(traces) {
  result = ''
  for( t in traces ) {
    v = t.getStore().keySet().findAll{ it.startsWith('custom_version_') }.collect{ "$it: ${t.getStore().get(it)}" }
    if( v ) { 
      result += t.processName + ":\n    " + v.join("\n    ") + "\n"
    }
  } 
  return result
}


process FASTQC {
  conda "bioconda::fastqc=0.11.9"
  customTraces version_fastqc: "fastqc --version | sed -e 's/FastQC v//g'"

  output:
    path 'output.txt'

  """
  echo "FASTQC" > output.txt
  """
}


process BAMTOOLS {
  conda "bioconda::bamtools=2.5.2"
  customTraces version_bamtools: "bamtools --version | grep -e 'bamtools' | sed 's/^.*bamtools //'"

  output:
    path 'output.txt'

  """
  echo "BAMTOOLS" > output.txt
  """
}


process MULTIQC {

  input:
    path 'fastqc.txt'
    path 'bamtools.txt'

  script:
    versions = parseVersions(workflow.traces)
    """
    cat <<-END_VERSIONS > versions.yml
${versions}
END_VERSIONS

    cat fastqc.txt bamtools.txt > result.txt
    """
}

workflow {

  FASTQC()
  BAMTOOLS()

  MULTIQC(FASTQC.out, BAMTOOLS.out)
}

workflow.onComplete {
  println "EXAMPLE VERSIONS YAML:\n${parseVersions(workflow.traces)}"   
}
```

# Notes

- This is still a PoC, open to discuss this approach and alternatives.
- The `workflow.traces` is an array of `TraceRecord` of the completed tasks
- Maybe instead of using directly `TraceRecord` to expose traces to the user, would be better to expose them using a custom class more user friendly. 
