### PR TITLE
Document `emit` option in process outputs

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1193,8 +1193,8 @@ process FOO {
 }
 
 workflow {
-  ch = FOO()
-  ch[1].view()
+  FOO()
+  FOO.out[1].view()
 }
 ```
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1212,8 +1212,8 @@ process FOO {
 }
 
 workflow {
-  ch = FOO()
-  ch.hi_file.view()
+  FOO()
+  FOO.out.hi_file.view()
 }
 ```
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1177,6 +1177,46 @@ output:
 
 In this example, the process is normally expected to produce an `output.txt` file, but in the cases where the file is legitimately missing, the process does not fail. The output channel will only contain values for those processes that produce `output.txt`.
 
+### Multiple outputs and the `emit` option
+
+When you have multiple outputs in your process, you can access any of them individually in the output channel through their position in the process output block. The script below will print the location of the file of the second output. Remember indexes in Nextflow start with `0`.
+
+```
+process FOO {
+  output:
+    path 'bye_file.txt'
+    path 'hi_file.txt'
+  """
+  echo "bye" > bye_file.txt
+  echo "hi" > hi_file.txt
+  """
+}
+
+workflow {
+  ch = FOO()
+  ch[1].view()
+}
+```
+
+You can refer to these outputs through a mnemonic using the `emit` option, as in the following example:
+
+```
+process FOO {
+  output:
+    path 'bye_file.txt', emit: bye_file
+    path 'hi_file.txt',  emit: hi_file
+  """
+  echo "bye" > bye_file.txt
+  echo "hi" > hi_file.txt
+  """
+}
+
+workflow {
+  ch = FOO()
+  ch.hi_file.view()
+}
+```
+
 ## When
 
 The `when` block allows you to define a condition that must be satisfied in order to execute the process. The condition can be any expression that returns a boolean value.

--- a/docs/process.md
+++ b/docs/process.md
@@ -1177,45 +1177,51 @@ output:
 
 In this example, the process is normally expected to produce an `output.txt` file, but in the cases where the file is legitimately missing, the process does not fail. The output channel will only contain values for those processes that produce `output.txt`.
 
-### Multiple outputs and the `emit` option
+(process-multiple-outputs)=
 
-When you have multiple outputs in your process, you can access any of them individually in the output channel through their position in the process output block. The script below will print the location of the file of the second output. Remember indexes in Nextflow start with `0`.
+### Multiple outputs
 
-```
+When a process declares multiple outputs, each output can be accessed by index. The following example prints the second process output (indexes start at zero):
+
+```groovy
 process FOO {
-  output:
+    output:
     path 'bye_file.txt'
     path 'hi_file.txt'
-  """
-  echo "bye" > bye_file.txt
-  echo "hi" > hi_file.txt
-  """
+
+    """
+    echo "bye" > bye_file.txt
+    echo "hi" > hi_file.txt
+    """
 }
 
 workflow {
-  FOO()
-  FOO.out[1].view()
+    FOO()
+    FOO.out[1].view()
 }
 ```
 
-You can refer to these outputs through a mnemonic using the `emit` option, as in the following example:
+You can also use the `emit` option to assign a name to each output and access them by name:
 
-```
+```groovy
 process FOO {
-  output:
+    output:
     path 'bye_file.txt', emit: bye_file
     path 'hi_file.txt',  emit: hi_file
-  """
-  echo "bye" > bye_file.txt
-  echo "hi" > hi_file.txt
-  """
+
+    """
+    echo "bye" > bye_file.txt
+    echo "hi" > hi_file.txt
+    """
 }
 
 workflow {
-  FOO()
-  FOO.out.hi_file.view()
+    FOO()
+    FOO.out.hi_file.view()
 }
 ```
+
+See {ref}`workflow-process-invocation` for more details.
 
 ## When
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -41,6 +41,8 @@ The `main:` label can be omitted if there are no `take:` or `emit:` blocks.
 Workflows were introduced in DSL2. If you are still using DSL1, see the {ref}`dsl1-page` page to learn how to migrate your Nextflow pipelines to DSL2.
 :::
 
+(workflow-process-invocation)=
+
 ## Process invocation
 
 A process can be invoked like a function in a workflow definition, passing the expected input channels like function arguments. For example:
@@ -141,6 +143,8 @@ workflow {
     ch_samples = foo().samples_bam
 }
 ```
+
+See {ref}`process-multiple-outputs` for more details.
 
 ### Process named stdout
 


### PR DESCRIPTION
Update process.md to document the `emit` option in process outputs.