### PR TITLE
Fix errors when NXF_HOME contains spaces

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -320,7 +320,7 @@ else
   if [[ ! $JAVA_VER =~ ^(11|12|13|14|15|16|17|18|19|20|21) ]]; then
       echo_yellow "NOTE: Nextflow is not tested with Java $JAVA_VER -- It's recommended the use of version 11 up to 21\n"
   fi
-  mkdir -p $(dirname "$JAVA_KEY")
+  mkdir -p "$(dirname "$JAVA_KEY")"
   [[ -f $JAVA_VER ]] && echo $JAVA_VER > "$JAVA_KEY"
 fi
 
@@ -405,7 +405,7 @@ else
     cmd_pattern='"([^"]*)"(.*)'
     [[ "${cli[@]}" =~ $cmd_pattern ]]
     cmd_base=(${BASH_REMATCH[1]})
-    cmd_tail=(${BASH_REMATCH[2]})
+    declare -a cmd_tail="(${BASH_REMATCH[2]})"
 
     launcher="${cmd_base[@]}"
     [[ "$NXF_JVM_ARGS" ]] && launcher+=($NXF_JVM_ARGS)
@@ -443,7 +443,7 @@ else
     if mkdir -p "${NXF_LAUNCHER}" 2>/dev/null; then
         STR=''
         for x in "${launcher[@]}"; do
-        [[ "$x" != "\"-Duser.dir=$PWD\"" ]] && [[ ! "$x" == *"-agentlib:jdwp"* ]] && STR+="$x "
+        [[ "$x" != "\"-Duser.dir=$PWD\"" ]] && [[ ! "$x" == *"-agentlib:jdwp"* ]] && STR+=$(printf '%q ' "$x")
         done
         printf "$STR">"$LAUNCH_FILE"
     else

--- a/nextflow
+++ b/nextflow
@@ -404,7 +404,7 @@ else
     # we extract first part into `cmd_base`` and remainder into `cmd_tail`` and convert them to array as previous version
     cmd_pattern='"([^"]*)"(.*)'
     [[ "${cli[@]}" =~ $cmd_pattern ]]
-    cmd_base=(${BASH_REMATCH[1]})
+    declare -a cmd_base="(${BASH_REMATCH[1]})"
     declare -a cmd_tail="(${BASH_REMATCH[2]})"
 
     launcher="${cmd_base[@]}"


### PR DESCRIPTION
Close #4360 

This PR applies the changes suggested in the original issue, basically ensures that any variables based on `NXF_HOME` are correctly quoted to prevent argument splitting.

Note the caveat from the original issue:
> It is worth noting that although the %q conversion operator appears to be well supported, it is not portable according to POSIX. In practice, I have not found this to be a problem, but I don't like it. Hopefully someone with more sh-fu than me has a better idea.

I do not have more bash-fu, so I did not try to find a better solution...

By the way, a helpful thing I found was to install the shellcheck extension in VS Code (should be an equivalent in IntelliJ) which provides lots of hints for these problems.