### PR TITLE
Add support for FUSION_AWS_REGION 

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsConfig.groovy
@@ -20,6 +20,7 @@ package nextflow.cloud.aws.config
 import java.nio.file.Path
 import java.nio.file.Paths
 
+import com.amazonaws.regions.Regions
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Global
@@ -78,6 +79,12 @@ class AwsConfig {
 
     Map<String,?> getS3LegacyClientConfig() {
         return s3Legacy.getAwsClientConfig()
+    }
+
+    String getS3GlobalRegion() {
+        return !region || !s3Config.endpoint || s3Config.endpoint.contains(".amazonaws.com")
+            ? Regions.US_EAST_1.getName()   // always use US_EAST_1 as global region for AWS endpoints
+            : region                        // for custom endpoint use the config provided region
     }
 
     static protected String getAwsProfile0(Map env, Map<String,Object> config) {

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
@@ -114,4 +114,8 @@ class AwsS3Config {
     Boolean getAnonymous() {
         return anonymous
     }
+
+    boolean isCustomEndpoint() {
+        endpoint && !endpoint.contains(".amazonaws.com")
+    }
 }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
@@ -46,6 +46,8 @@ class AwsFusionEnv implements FusionEnv {
         }
         if( endpoint )
             result.AWS_S3_ENDPOINT = endpoint
+        if( awsConfig.region && awsConfig.s3Config.isCustomEndpoint() )
+            result.FUSION_AWS_REGION = awsConfig.region
         if( awsConfig.s3Config.storageEncryption )
             result.FUSION_AWS_SERVER_SIDE_ENCRYPTION = awsConfig.s3Config.storageEncryption
         if( awsConfig.s3Config.storageKmsKeyId )

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
@@ -836,7 +836,7 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
 
 		final String bucketName = S3Path.bucketName(uri);
 		final boolean global = bucketName!=null;
-		final AwsClientFactory factory = new AwsClientFactory(awsConfig, Regions.US_EAST_1.getName());
+		final AwsClientFactory factory = new AwsClientFactory(awsConfig, globalRegion(awsConfig));
 		client = new S3Client(factory.getS3Client(clientConfig, global));
 
 		// set the client acl
@@ -851,6 +851,12 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
 
 		return new S3FileSystem(this, client, uri, props);
 	}
+
+    protected String globalRegion(AwsConfig awsConfig) {
+        return awsConfig.getRegion() != null && awsConfig.getS3Config().isCustomEndpoint()
+                ? awsConfig.getRegion()
+                : Regions.US_EAST_1.getName();
+    }
 
 	protected String getProp(Properties props, String... keys) {
 		for( String k : keys ) {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsS3ConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsS3ConfigTest.groovy
@@ -39,6 +39,7 @@ class AwsS3ConfigTest extends Specification {
         !client.s3Acl
         !client.pathStyleAccess
         !client.anonymous
+        !client.isCustomEndpoint()
     }
 
     def 'should set config' () {
@@ -138,5 +139,20 @@ class AwsS3ConfigTest extends Specification {
         cleanup:
         SysEnv.pop()
 
+    }
+
+    @Unroll
+    def 'should check is custom endpoint' () {
+        given:
+        def config = new AwsS3Config(CONFIG)
+
+        expect:
+        config.isCustomEndpoint() == EXPECTED
+
+        where:
+        EXPECTED    | CONFIG
+        false       | [:]
+        false       | [endpoint: 'https://s3.us-east-2.amazonaws.com']
+        true        | [endpoint: 'https://foo.com']
     }
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3FileSystemProviderTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3FileSystemProviderTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.aws.nio
+
+import nextflow.cloud.aws.config.AwsConfig
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class S3FileSystemProviderTest extends Specification {
+
+    @Unroll
+    def 'should get global region' () {
+        given:
+        def provider = Spy(S3FileSystemProvider)
+
+        expect:
+        provider.globalRegion(new AwsConfig(CONFIG)) == EXPECTED
+
+        where:
+        EXPECTED    | CONFIG
+        'us-east-1' | [:]
+        'us-east-1' | [region:'foo']
+        'us-east-1' | [region:'foo', client:[endpoint: 'http://s3.us-east-2.amazonaws.com']]
+        'foo'       | [region:'foo', client:[endpoint: 'http://bar.com']]        
+
+    }
+
+}


### PR DESCRIPTION
This PR adds support for passing the AWS region to Fusion when using a custom endpoint. 

