### PR TITLE
Add support for K8s pod schedulerName

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -2075,6 +2075,9 @@ The following options are available:
 `runAsUser: '<uid>'`
 : Specifies the user ID with which to run the container. Shortcut for the `securityContext` option.
 
+`schedulerName: '<name>'`
+: Specifies which [scheduler](https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/#specify-schedulers-for-pods) is used to schedule the container. 
+
 `secret: '<secret>/<key>', mountPath: '</absolute/path>'`
 : *Can be specified multiple times*
 : Mounts a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with name and optional key to the given path. If the key is omitted, the path is interpreted as a directory and all entries in the `Secret` are exposed in that path.
@@ -2115,9 +2118,6 @@ The following options are available:
 : Mounts a [Persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) with the given name to the given path.
 : The `subPath` option can be used to mount a sub-directory of the volume instead of its root.
 : The `readOnly` option can be used to mount the volume as read-only (default: `false`)
-
-`schedulerName: '<name>'`
-: Specifies which [scheduler](https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/#specify-schedulers-for-pods) is used to schedule the container. 
 
 (process-publishdir)=
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -2116,6 +2116,9 @@ The following options are available:
 : The `subPath` option can be used to mount a sub-directory of the volume instead of its root.
 : The `readOnly` option can be used to mount the volume as read-only (default: `false`)
 
+`schedulerName: '<name>'`
+: Specifies which [scheduler](https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/#specify-schedulers-for-pods) is used to schedule the container. 
+
 (process-publishdir)=
 
 ### publishDir

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sConfig.groovy
@@ -70,6 +70,10 @@ class K8sConfig implements Map<String,Object> {
             podOptions.securityContext = new PodSecurityContext(target.runAsUser)
         else if( target.securityContext instanceof Map )
             podOptions.securityContext = new PodSecurityContext(target.securityContext as Map)
+
+        // -- shortcut to pod image scheduler name
+        if ( target.schedulerName != null )
+            podOptions.schedulerName = target.schedulerName.toString()
     }
 
     private PodOptions createPodOptions( value ) {

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sConfig.groovy
@@ -70,10 +70,6 @@ class K8sConfig implements Map<String,Object> {
             podOptions.securityContext = new PodSecurityContext(target.runAsUser)
         else if( target.securityContext instanceof Map )
             podOptions.securityContext = new PodSecurityContext(target.securityContext as Map)
-
-        // -- shortcut to pod image scheduler name
-        if ( target.schedulerName != null )
-            podOptions.schedulerName = target.schedulerName.toString()
     }
 
     private PodOptions createPodOptions( value ) {

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -67,6 +67,8 @@ class PodOptions {
     private List<Map> tolerations
 
     private Boolean privileged
+
+    private String schedulerName
     
     PodOptions( List<Map> options=null ) {
         int size = options ? options.size() : 0
@@ -156,6 +158,9 @@ class PodOptions {
         else if( entry.privileged instanceof Boolean ) {
             this.privileged = entry.privileged as Boolean
         }
+        else if( entry.schedulerName ) {
+            this.schedulerName = entry.schedulerName
+        }
         else
             throw new IllegalArgumentException("Unknown pod options: $entry")
     }
@@ -217,6 +222,8 @@ class PodOptions {
     }
 
     String getPriorityClassName() { priorityClassName }
+
+    String getSchedulerName() { schedulerName }
 
     List<Map> getTolerations() { tolerations }
 
@@ -296,6 +303,9 @@ class PodOptions {
 
         //  privileged execution
         result.privileged = other.privileged!=null ? other.privileged : this.privileged
+
+        // schedulerName
+        result.schedulerName = other.schedulerName ?: this.schedulerName
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodOptions.groovy
@@ -304,7 +304,7 @@ class PodOptions {
         //  privileged execution
         result.privileged = other.privileged!=null ? other.privileged : this.privileged
 
-        // schedulerName
+        // scheduler name
         result.schedulerName = other.schedulerName ?: this.schedulerName
 
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -118,6 +118,8 @@ class PodSpecBuilder {
 
     Map<String,?> resourcesLimits
 
+    String schedulerName
+
     /**
      * @return A sequential volume unique identifier
      */
@@ -374,6 +376,9 @@ class PodSpecBuilder {
             tolerations.addAll(opts.tolerations)
         // -- privileged
         privileged = opts.privileged
+        // -- schedulerName
+        if ( opts.schedulerName )
+            schedulerName = opts.schedulerName
 
         return this
     }
@@ -435,6 +440,9 @@ class PodSpecBuilder {
 
         if( nodeSelector )
             spec.nodeSelector = nodeSelector.toSpec()
+
+        if( schedulerName )
+            spec.schedulerName = schedulerName
 
         if( affinity )
             spec.affinity = affinity

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -376,9 +376,8 @@ class PodSpecBuilder {
             tolerations.addAll(opts.tolerations)
         // -- privileged
         privileged = opts.privileged
-        // -- schedulerName
-        if ( opts.schedulerName )
-            schedulerName = opts.schedulerName
+        // -- scheduler name
+        schedulerName = opts.schedulerName
 
         return this
     }

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
@@ -553,4 +553,21 @@ class PodOptionsTest extends Specification {
         then:
         opts.getPrivileged()
     }
+
+    def 'should set pod schedulerName' () {
+        when:
+        def opts = new PodOptions()
+        then:
+        opts.getSchedulerName() == null
+
+        when:
+        opts = new PodOptions([ [schedulerName:'foo-scheduler'] ])
+        then:
+        opts.getSchedulerName() == 'foo-scheduler'
+
+        when:
+        opts = new PodOptions([ [schedulerName:'bar-scheduler'] ])
+        then:
+        opts.getSchedulerName() == 'bar-scheduler'
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodOptionsTest.groovy
@@ -561,13 +561,8 @@ class PodOptionsTest extends Specification {
         opts.getSchedulerName() == null
 
         when:
-        opts = new PodOptions([ [schedulerName:'foo-scheduler'] ])
+        opts = new PodOptions([ [schedulerName:'my-scheduler'] ])
         then:
-        opts.getSchedulerName() == 'foo-scheduler'
-
-        when:
-        opts = new PodOptions([ [schedulerName:'bar-scheduler'] ])
-        then:
-        opts.getSchedulerName() == 'bar-scheduler'
+        opts.getSchedulerName() == 'my-scheduler'
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -581,6 +581,21 @@ class PodSpecBuilderTest extends Specification {
 
     }
 
+    def 'should create pod spec with schedulerName' () {
+
+        when:
+        def pod = new PodSpecBuilder()
+                .withPodName('foo')
+                .withImageName('busybox')
+                .withCommand(['echo', 'hello'])
+                .withPodOptions(new PodOptions(schedulerName: 'my-scheduler'))
+                .build()
+
+        then:
+        pod.spec.schedulerName == 'my-scheduler'
+
+    }
+
     def 'should create image pull request map' () {
         given:
         def builder = new PodSpecBuilder(imagePullSecret: 'MySecret')


### PR DESCRIPTION
For my master thesis I needed a way to specify which scheduler is used to schedule nextflow tasks. Maybe it could be useful for others as well. This adds a `schedulerName` field to `PodOptions` and a shortcut to it via `K8sConfig`.

K8s docs reference: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/#specify-schedulers-for-pods

Given I already had the code, I opted to create a PR directly instead of creating an issue first. If this is not needed or already worked on, feel free to close :)

