### PR TITLE
Update logging filter for Google Batch provider

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/logging/BatchLogging.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/logging/BatchLogging.groovy
@@ -70,7 +70,7 @@ class BatchLogging implements Closeable {
         final stdout = new StringBuilder()
         final stderr = new StringBuilder()
         // use logging here
-        final filter = "resource.type=generic_task AND logName=\"projects/${projectId}/logs/batch_task_logs\" AND labels.job_uid=$uid"
+        final filter = "resource.type=generic_task OR resource.type=\"batch.googleapis.com/Job\" AND logName=\"projects/${projectId}/logs/batch_task_logs\" AND labels.job_uid=$uid"
         final entries = loggingService().listLogEntries(
                 Logging.EntryListOption.filter(filter),
                 Logging.EntryListOption.pageSize(1000) )


### PR DESCRIPTION
Batch used to use generic_task as monitored resource type. However, the type is not only for Batch. Google Batch is planning to switch it's own monitored resource type which is "batch.googleapis.com/Job". To have a smooth changing, add a OR filter to have the new monitored resource type included. After we finished transition, the generic_task filter could be removed.