### PR TITLE
Fix doc tests to fail on test failure

### DIFF
--- a/docs/snippets/test.sh
+++ b/docs/snippets/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit_status=0
+
 NXF_CMD=${NXF_CMD:-nextflow}
 NXF_FILES=${*:-'*.nf'}
 
@@ -17,6 +19,7 @@ for pipeline in $NXF_FILES ; do
         sort "$outfile" > a.out
         sort .out > b.out
         diff a.out b.out
+        status=$? ; [ $status -eq 0 ] || exit_status=$status
     else
         echo "> $outfile not found, skipping"
     fi
@@ -24,3 +27,5 @@ for pipeline in $NXF_FILES ; do
 done
 
 rm -rf .nextflow* work .out a.out b.out
+
+[ $exit_status -eq 0 ] || false


### PR DESCRIPTION
This PR adds some logic to the doc tests so that a failing test actually causes the test suite to fail, without aborting the remaining tests.