### PR TITLE
Makefile clean to also remove buildSrc/build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ clean:
 	rm -rf modules/nextflow/.nextflow*
 	rm -rf modules/nextflow/work
 	rm -rf build
+	rm -rf buildSrc/build
 	rm -rf modules/*/build
 	rm -rf plugins/*/build
 	./gradlew clean


### PR DESCRIPTION
@pditommaso  this should fix weird behaviours observed when testing Nextflow builds with source modifications.
A while ago the fix you handed me was:
```
find . -name MANIFEST.MF | grep build/tmp | xargs rm
```

Upon inspection, the command above reduces to the `Makefile` change in this PR.