### PR TITLE
Add "fusion.cacheSize" config option

### DIFF
--- a/docs/fusion.md
+++ b/docs/fusion.md
@@ -212,3 +212,6 @@ The following configuration options are available:
 
 `fusion.tagsPattern`
 : The pattern that determines how tags are applied to files created via the Fusion client (default: `[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)`)
+
+`fusion.cacheSize`
+: The maximum size of the local cache used by the Fusion client.

--- a/docs/fusion.md
+++ b/docs/fusion.md
@@ -184,14 +184,19 @@ The following configuration options are available:
 `fusion.enabled`
 : Enable/disable the use of Fusion file system.
 
+`fusion.cacheSize`
+: :::{versionadded} 23.11.0-edge
+:::
+: The maximum size of the local cache used by the Fusion client.
+
+`fusion.containerConfigUrl`
+: The URL from where the container layer provisioning the Fusion client is downloaded.
+
 `fusion.exportStorageCredentials`
 : :::{versionadded} 23.05.0-edge
   This option was previously named `fusion.exportAwsAccessKeys`.
   :::
 : When `true` the access credentials required by the underlying object storage are exported the pipeline jobs execution environment.
-
-`fusion.containerConfigUrl`
-: The URL from where the container layer provisioning the Fusion client is downloaded. 
 
 `fusion.logLevel`
 : The level of logging emitted by the Fusion client.
@@ -212,8 +217,3 @@ The following configuration options are available:
 
 `fusion.tagsPattern`
 : The pattern that determines how tags are applied to files created via the Fusion client (default: `[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)`)
-
-`fusion.cacheSize`
-: :::{versionadded} 23.11.0-edge
-  :::
-: The maximum size of the local cache used by the Fusion client.

--- a/docs/fusion.md
+++ b/docs/fusion.md
@@ -214,4 +214,6 @@ The following configuration options are available:
 : The pattern that determines how tags are applied to files created via the Fusion client (default: `[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)`)
 
 `fusion.cacheSize`
+: :::{versionadded} 23.11.0-edge
+  :::
 : The maximum size of the local cache used by the Fusion client.

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
@@ -21,6 +21,8 @@ import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import nextflow.Global
 import nextflow.SysEnv
+import nextflow.util.MemoryUnit
+
 /**
  * Model Fusion config options
  *
@@ -44,6 +46,7 @@ class FusionConfig {
     final private boolean tagsEnabled
     final private String tagsPattern
     final private boolean privileged
+    final private MemoryUnit cacheSize
 
     boolean enabled() { enabled }
 
@@ -63,6 +66,8 @@ class FusionConfig {
 
     String tagsPattern() { tagsPattern }
 
+    MemoryUnit cacheSize() { cacheSize }
+
     URL containerConfigUrl() {
         this.containerConfigUrl ? new URL(this.containerConfigUrl) : null
     }
@@ -81,6 +86,7 @@ class FusionConfig {
         this.tagsEnabled = opts.tags==null || opts.tags.toString()!='false'
         this.tagsPattern = (opts.tags==null || (opts.tags instanceof Boolean && opts.tags)) ? DEFAULT_TAGS : ( opts.tags !instanceof Boolean ? opts.tags as String : null )
         this.privileged = opts.privileged==null || opts.privileged.toString()=='true'
+        this.cacheSize = opts.cacheSize as MemoryUnit
         if( containerConfigUrl && !validProtocol(containerConfigUrl))
             throw new IllegalArgumentException("Fusion container config URL should start with 'http:' or 'https:' protocol prefix - offending value: $containerConfigUrl")
     }

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionEnvProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionEnvProvider.groovy
@@ -42,6 +42,8 @@ class FusionEnvProvider {
             result.FUSION_LOG_OUTPUT = config.logOutput()
         if( config.logLevel() )
             result.FUSION_LOG_LEVEL = config.logLevel()
+        if( config.cacheSize() )
+            result.FUSION_CACHE_SIZE = "${config.cacheSize().toMega()}M"
         return result
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/fusion/FusionConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/fusion/FusionConfigTest.groovy
@@ -17,7 +17,7 @@
 
 package nextflow.fusion
 
-
+import nextflow.util.MemoryUnit
 import spock.lang.Specification
 import spock.lang.Unroll
 /**
@@ -84,6 +84,21 @@ class FusionConfigTest extends Specification {
         [logLevel: 'trace']             | 'trace'   | null
         [logOutput: 'stdout']           | null      | 'stdout'
     }
+
+    def 'should configure cache size' () {
+        given:
+        def opts = new FusionConfig(OPTS)
+        expect:
+        opts.cacheSize() == SIZE
+
+        where:
+        OPTS                            | SIZE
+        [:]                             | null
+        [cacheSize: 100]                | MemoryUnit.of(100)
+        [cacheSize: '100']              | MemoryUnit.of(100)
+        [cacheSize: '100.MB']           | MemoryUnit.of('100.MB')
+    }
+
 
     @Unroll
     def 'should configure tags' () {


### PR DESCRIPTION
## Description

Add `cacheSize` Fusion configuration option that allows to limit the size of the local cache that creates Fusion.