### PR TITLE
Add Retry policy to Google Storage

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -751,7 +751,9 @@ The `google` scope allows you to configure the interactions with Google Cloud, i
 
 Read the {ref}`google-page` page for more information.
 
-The following settings are available:
+#### Cloud Batch
+
+The following settings are available for Google Cloud Batch:
 
 `google.enableRequesterPaysBuckets`
 : When `true` uses the given Google Cloud project ID as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`).
@@ -771,14 +773,6 @@ The following settings are available:
 
 `google.project`
 : The Google Cloud project ID to use for pipeline execution
-
-`google.region`
-: *Available only for Google Life Sciences*
-: The Google Cloud region where jobs are executed. Multiple regions can be provided as a comma-separated list. Cannot be used with the `google.zone` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
-
-`google.zone`
-: *Available only for Google Life Sciences*
-: The Google Cloud zone where jobs are executed. Multiple zones can be provided as a comma-separated list. Cannot be used with the `google.region` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
 
 `google.batch.allowedLocations`
 : :::{versionadded} 22.12.0-edge
@@ -817,6 +811,50 @@ The following settings are available:
 
 `google.batch.usePrivateAddress`
 : When `true` the VM will NOT be provided with a public IP address, and only contain an internal IP. If this option is enabled, the associated job can only load docker images from Google Container Registry, and the job executable cannot use external services other than Google APIs (default: `false`).
+
+`google.storage.maxAttempts`
+: :::{versionadded} 23.11.0-edge
+  :::
+: Max attempts when retrying failed API requests to Cloud Storage (default: `10`).
+
+`google.storage.maxDelay`
+: :::{versionadded} 23.11.0-edge
+  :::
+: Max delay when retrying failed API requests to Cloud Storage (default: `'90s'`).
+
+`google.storage.multiplier`
+: :::{versionadded} 23.11.0-edge
+  :::
+: Delay multiplier when retrying failed API requests to Cloud Storage (default: `2.0`).
+
+#### Cloud Life Sciences
+
+The following settings are available for Cloud Life Sciences:
+
+`google.enableRequesterPaysBuckets`
+: When `true` uses the given Google Cloud project ID as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`).
+
+`google.httpConnectTimeout`
+: :::{versionadded} 23.06.0-edge
+  :::
+: Defines the HTTP connection timeout for Cloud Storage API requests (default: `'60s'`).
+
+`google.httpReadTimeout`
+: :::{versionadded} 23.06.0-edge
+  :::
+: Defines the HTTP read timeout for Cloud Storage API requests (default: `'60s'`).
+
+`google.location`
+: The Google Cloud location where jobs are executed (default: `us-central1`).
+
+`google.project`
+: The Google Cloud project ID to use for pipeline execution
+
+`google.region`
+: The Google Cloud region where jobs are executed. Multiple regions can be provided as a comma-separated list. Cannot be used with the `google.zone` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
+
+`google.zone`
+: The Google Cloud zone where jobs are executed. Multiple zones can be provided as a comma-separated list. Cannot be used with the `google.region` option. See the [Google Cloud documentation](https://cloud.google.com/compute/docs/regions-zones/) for a list of available regions and zones.
 
 `google.lifeSciences.bootDiskSize`
 : Set the size of the virtual machine boot disk e.g `50.GB` (default: none).

--- a/plugins/nf-google/src/main/nextflow/cloud/google/config/GoogleRetryOpts.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/config/GoogleRetryOpts.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.google.config
+
+import groovy.transform.CompileStatic
+import nextflow.util.Duration
+
+/**
+ * Model Google storage retry settings
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class GoogleRetryOpts {
+
+    final int maxAttempts
+    final double multiplier
+    final Duration maxDelay
+
+    GoogleRetryOpts(Map opts) {
+        maxAttempts = opts.maxAttempts ? opts.maxAttempts as int : 10
+        multiplier = opts.multiplier ? opts.multiplier as double : 2d
+        maxDelay = opts.maxDelay ? opts.maxDelay as Duration : Duration.of('90s')
+    }
+
+    long maxDelaySecs() {
+        return maxDelay.seconds
+    }
+}

--- a/plugins/nf-google/src/main/nextflow/cloud/google/config/GoogleStorageOpts.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/config/GoogleStorageOpts.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.google.config
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class GoogleStorageOpts {
+
+    final GoogleRetryOpts retryPolicy
+
+    GoogleStorageOpts(Map opts) {
+        retryPolicy = new GoogleRetryOpts( opts.retryPolicy as Map ?: Map.of()  )
+    }
+
+}

--- a/plugins/nf-google/src/main/nextflow/cloud/google/util/GsPathFactory.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/util/GsPathFactory.groovy
@@ -73,7 +73,8 @@ class GsPathFactory extends FileSystemPathFactory {
                 .setTotalTimeout(org.threeten.bp.Duration.ofSeconds(opts.storageOpts.retryPolicy.maxDelaySecs()))
                 .build()
 
-        return StorageOptions.getDefaultInstance().toBuilder()
+        return StorageOptions.getDefaultInstance()
+            .toBuilder()
             .setTransportOptions(transportOptions.build())
             .setRetrySettings(retrySettings)
             .build()

--- a/plugins/nf-google/src/main/nextflow/cloud/google/util/GsPathFactory.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/util/GsPathFactory.groovy
@@ -18,6 +18,7 @@ package nextflow.cloud.google.util
 
 import java.nio.file.Path
 
+import com.google.api.gax.retrying.RetrySettings
 import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
@@ -57,15 +58,24 @@ class GsPathFactory extends FileSystemPathFactory {
         return builder.build()
     }
 
-    static protected StorageOptions getCloudStorageOptions(GoogleOpts googleOpts) {
+    static protected StorageOptions getCloudStorageOptions(GoogleOpts opts) {
         final transportOptions = StorageOptions.getDefaultHttpTransportOptions().toBuilder()
-        if( googleOpts.httpConnectTimeout )
-            transportOptions.setConnectTimeout( (int)googleOpts.httpConnectTimeout.toMillis() )
-        if( googleOpts.httpReadTimeout )
-            transportOptions.setReadTimeout( (int)googleOpts.httpReadTimeout.toMillis() )
+        if( opts.httpConnectTimeout )
+            transportOptions.setConnectTimeout( (int)opts.httpConnectTimeout.toMillis() )
+        if( opts.httpReadTimeout )
+            transportOptions.setReadTimeout( (int)opts.httpReadTimeout.toMillis() )
+
+        RetrySettings retrySettings =
+            StorageOptions.getDefaultRetrySettings()
+                .toBuilder()
+                .setMaxAttempts(opts.storageOpts.retryPolicy.maxAttempts)
+                .setRetryDelayMultiplier(opts.storageOpts.retryPolicy.multiplier)
+                .setTotalTimeout(org.threeten.bp.Duration.ofSeconds(opts.storageOpts.retryPolicy.maxDelaySecs()))
+                .build()
 
         return StorageOptions.getDefaultInstance().toBuilder()
             .setTransportOptions(transportOptions.build())
+            .setRetrySettings(retrySettings)
             .build()
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/config/GoogleRetryOptsTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/config/GoogleRetryOptsTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.google.config
+
+import nextflow.util.Duration
+import spock.lang.Specification
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class GoogleRetryOptsTest extends Specification {
+
+    def 'should get retry opts' () {
+        when:
+        def opts1 = new GoogleRetryOpts([:])
+        then:
+        opts1.maxAttempts == 10
+        opts1.multiplier == 2.0d
+        opts1.maxDelay ==  Duration.of('90s')
+
+        when:
+        def opts2 = new GoogleRetryOpts([maxAttempts: 5, maxDelay: '5s', multiplier: 10])
+        then:
+        opts2.maxAttempts == 5
+        opts2.multiplier == 10d
+        opts2.maxDelay ==  Duration.of('5s')
+    }
+}

--- a/plugins/nf-google/src/test/nextflow/cloud/google/util/GsPathFactoryTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/util/GsPathFactoryTest.groovy
@@ -20,6 +20,7 @@ import com.google.cloud.storage.StorageOptions
 import nextflow.Global
 import nextflow.Session
 import nextflow.cloud.google.GoogleOpts
+import nextflow.cloud.google.config.GoogleRetryOpts
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -87,6 +88,14 @@ class GsPathFactoryTest extends Specification {
             getConfig() >> [google:[httpConnectTimeout: CONNECT, httpReadTimeout: READ]]
         }
         and:
+        def policy = new GoogleRetryOpts([:])
+        def retrySettings = StorageOptions.getDefaultRetrySettings()
+            .toBuilder()
+            .setMaxAttempts(policy.maxAttempts)
+            .setRetryDelayMultiplier(policy.multiplier)
+            .setTotalTimeout(org.threeten.bp.Duration.ofSeconds(policy.maxDelaySecs()))
+            .build()
+        and:
         def opts = GoogleOpts.fromSession(session)
         and:
         def storageOptions = GsPathFactory.getCloudStorageOptions(opts)
@@ -98,6 +107,7 @@ class GsPathFactoryTest extends Specification {
         expect:
         storageOptions == StorageOptions.getDefaultInstance().toBuilder()
             .setTransportOptions(transportOptions.build())
+            .setRetrySettings(retrySettings)
             .build()
 
         where:
@@ -105,5 +115,20 @@ class GsPathFactoryTest extends Specification {
         null    | 60000          | null  | 60000
         '30s'   | 30000          | '30s' | 30000
         '60s'   | 60000          | '60s' | 60000
+    }
+
+    def 'should apply retry settings' () {
+        given:
+        def session = Mock(Session) {
+            getConfig() >> [google:[storage:[retryPolicy: [maxAttempts: 5, maxDelay:'50s', multiplier: 500]]]]
+        }
+
+        when:
+        def opts = GoogleOpts.fromSession(session)
+        then:
+        opts.storageOpts.retryPolicy.maxAttempts == 5
+        opts.storageOpts.retryPolicy.maxDelaySecs() == 50
+        opts.storageOpts.retryPolicy.multiplier == 500d
+
     }
 }

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -567,6 +567,8 @@ class WaveClient {
             return false
         if( value.startsWith('http://') || value.startsWith('https://') )
             return false
+        if( value.startsWith('/') && !value.contains('/n') )
+            return true
         return value.endsWith('.yaml') || value.endsWith('.yml') || value.endsWith('.txt')
     }
 

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -33,7 +33,6 @@ import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.SysEnv
 import nextflow.container.inspect.ContainerInspectMode
-import nextflow.container.inspect.ContainersInspector
 import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.processor.TaskRun
@@ -1215,6 +1214,7 @@ class WaveClientTest extends Specification {
         'foo'               | false
         'foo.yml'           | true
         'foo.txt'           | true
+        '/foo/bar'          | true
         'foo\nbar.yml'      | false
         'http://foo.com'    | false
     }


### PR DESCRIPTION
This adds support for retry settings for Google Storage operations. By default it uses 10 retries up to 90 seconds. 

The policy can be customised by using those settings 

```
google.storage.retryPolicy.maxAttempts = <number>
google.storage.retryPolicy.maxDelay = '<duration>'
google.storage.retryPolicy.multiplier = <decimal>
```
