### PR TITLE
Add support for Azure low-priority VMs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -366,6 +366,10 @@ The following settings are available:
 : *New in `nf-azure` version `0.11.0`*
 : If mounting File Shares, this is the internal root mounting point. Must be `/mnt/resource/batch/tasks/fsmounts` for CentOS nodes or `/mnt/batch/tasks/fsmounts` for Ubuntu nodes (default is for CentOS).
 
+`azure.batch.pools.<name>.lowPriority`
+: *New in `nf-azure` version `1.4.0`*
+: Enable the use of low-priority VMs (default: `false`).
+
 `azure.batch.pools.<name>.maxVmCount`
 : Specify the max of virtual machine when using auto scale option.
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -764,23 +764,24 @@ class AzBatchService implements Closeable {
     }
 
     protected String scaleFormula(AzPoolOpts opts) {
+        final target = opts.lowPriority ? 'TargetLowPriorityNodes' : 'TargetDedicatedNodes'
         // https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling
-        def DEFAULT_FORMULA = '''
+        final DEFAULT_FORMULA = """
             // Get pool lifetime since creation.
             lifespan = time() - time("{{poolCreationTime}}");
             interval = TimeInterval_Minute * {{scaleInterval}};
             
             // Compute the target nodes based on pending tasks.
-            // $PendingTasks == The sum of $ActiveTasks and $RunningTasks
-            $samples = $PendingTasks.GetSamplePercent(interval);
-            $tasks = $samples < 70 ? max(0, $PendingTasks.GetSample(1)) : max( $PendingTasks.GetSample(1), avg($PendingTasks.GetSample(interval)));
-            $targetVMs = $tasks > 0 ? $tasks : max(0, $TargetDedicatedNodes/2);
-            targetPoolSize = max(0, min($targetVMs, {{maxVmCount}}));
+            // \$PendingTasks == The sum of \$ActiveTasks and \$RunningTasks
+            \$samples = \$PendingTasks.GetSamplePercent(interval);
+            \$tasks = \$samples < 70 ? max(0, \$PendingTasks.GetSample(1)) : max( \$PendingTasks.GetSample(1), avg(\$PendingTasks.GetSample(interval)));
+            \$targetVMs = \$tasks > 0 ? \$tasks : max(0, \$TargetDedicatedNodes/2);
+            targetPoolSize = max(0, min(\$targetVMs, {{maxVmCount}}));
             
             // For first interval deploy 1 node, for other intervals scale up/down as per tasks.
-            $TargetDedicatedNodes = lifespan < interval ? {{vmCount}} : targetPoolSize;
-            $NodeDeallocationOption = taskcompletion;
-            '''.stripIndent(true)
+            \$${target} = lifespan < interval ? {{vmCount}} : targetPoolSize;
+            \$NodeDeallocationOption = taskcompletion;
+            """.stripIndent(true)
 
         final scaleFormula = opts.scaleFormula ?: DEFAULT_FORMULA
         final vars = poolCreationBindings(opts, Instant.now())

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -749,7 +749,12 @@ class AzBatchService implements Closeable {
                     .withAutoScaleEvaluationInterval( new Period().withSeconds(interval) )
                     .withAutoScaleFormula(scaleFormula(spec.opts))
         }
-        else {
+        else if( spec.opts.lowPriority ) {
+            log.debug "Creating low-priority pool with id: ${spec.poolId}; vmCount=${spec.opts.vmCount};"
+            poolParams
+                .withTargetLowPriorityNodes(spec.opts.vmCount)
+        }
+        else  {
             log.debug "Creating fixed pool with id: ${spec.poolId}; vmCount=${spec.opts.vmCount};"
             poolParams
                     .withTargetDedicatedNodes(spec.opts.vmCount)

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -66,6 +66,7 @@ class AzPoolOpts implements CacheFunnel {
     String password
 
     String virtualNetwork
+    boolean lowPriority
 
     AzPoolOpts() {
         this(Collections.emptyMap())
@@ -89,6 +90,7 @@ class AzPoolOpts implements CacheFunnel {
         this.userName = opts.userName
         this.password = opts.password
         this.virtualNetwork = opts.virtualNetwork
+        this.lowPriority = opts.lowPriority as boolean
     }
 
     @Override
@@ -108,6 +110,7 @@ class AzPoolOpts implements CacheFunnel {
         hasher.putUnencodedChars(scaleFormula ?: '')
         hasher.putUnencodedChars(schedulePolicy ?: '')
         hasher.putUnencodedChars(virtualNetwork ?: '')
+        hasher.putBoolean(lowPriority)
         return hasher
     }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -347,7 +347,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-9022a3fbfb5f93028d78fefaea5e21ab-Standard_X1'
+        spec.poolId == 'nf-pool-6e9cf97d3d846621464131d3842265ce-Standard_X1'
         spec.metadata == [foo: 'bar']
 
     }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -237,6 +237,18 @@ class AzBatchServiceTest extends Specification {
         formula.contains '$TargetDedicatedNodes = lifespan < interval ? 3 : targetPoolSize;'
     }
 
+    def 'should check scaling formula for low-priority' () {
+        given:
+        def exec = Mock(AzBatchExecutor) { getConfig() >> new AzConfig([:]) }
+        def svc = new AzBatchService(exec)
+
+        when:
+        def formula = svc.scaleFormula( new AzPoolOpts(lowPriority: true, vmCount: 3, maxVmCount: 10, scaleInterval: Duration.of('5 min')) )
+        then:
+        formula.contains 'interval = TimeInterval_Minute * 5;'
+        formula.contains '$TargetLowPriorityNodes = lifespan < interval ? 3 : targetPoolSize;'
+    }
+
     def 'should  check formula vars' () {
         given:
         def exec = Mock(AzBatchExecutor) { getConfig() >> new AzConfig([:]) }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.azure.config
+
+import nextflow.util.Duration
+import spock.lang.Specification
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class AzPoolOptsTest extends Specification {
+
+    def 'should create pool options' () {
+        when:
+        def opts = new AzPoolOpts()
+        then:
+        !opts.runAs
+        !opts.privileged
+        opts.publisher == AzPoolOpts.DEFAULT_PUBLISHER
+        opts.offer == AzPoolOpts.DEFAULT_OFFER
+        opts.sku == AzPoolOpts.DEFAULT_SKU
+        opts.vmType == AzPoolOpts.DEFAULT_VM_TYPE
+        opts.fileShareRootPath == '/mnt/batch/tasks/fsmounts'
+        opts.vmCount == 1
+        !opts.autoScale
+        !opts.scaleFormula
+        !opts.schedulePolicy
+        opts.scaleInterval == AzPoolOpts.DEFAULT_SCALE_INTERVAL
+        opts.maxVmCount == opts.vmCount *3
+        !opts.registry
+        !opts.userName
+        !opts.password
+        !opts.virtualNetwork
+        !opts.lowPriority
+    }
+
+    def 'should create pool with custom options' () {
+        when:
+        def opts = new AzPoolOpts([
+            runAs:'foo',
+            privileged: true,
+            publisher: 'some-pub',
+            offer: 'some-offer',
+            sku: 'some-sku',
+            vmType: 'some-vmtype',
+            vmCount: 10,
+            autoScale: true,
+            scaleFormula: 'some-formula',
+            schedulePolicy: 'some-policy',
+            scaleInterval: Duration.of('10s'),
+            maxVmCount: 100,
+            registry: 'some-reg',
+            userName: 'some-user',
+            password: 'some-pwd',
+            virtualNetwork: 'some-vnet',
+            lowPriority: true
+        ])
+        then:
+        opts.runAs == 'foo'
+        opts.privileged
+        opts.publisher == 'some-pub'
+        opts.offer == 'some-offer'
+        opts.sku == 'some-sku'
+        opts.vmType == 'some-vmtype'
+        opts.fileShareRootPath == ''
+        opts.vmCount == 10
+        opts.autoScale
+        opts.scaleFormula == 'some-formula'
+        opts.schedulePolicy == 'some-policy'
+        opts.scaleInterval == Duration.of('10s')
+        opts.maxVmCount == 100
+        opts.registry == 'some-reg'
+        opts.userName == 'some-user'
+        opts.password == 'some-pwd'
+        opts.virtualNetwork == 'some-vnet'
+        opts.lowPriority
+    }
+
+}


### PR DESCRIPTION
This PR adds initial support for Azure Low-priority VMs by adding a new `lowPriority` boolean option to the azure pool settings 

