### PR TITLE
Fix the missing labels field in Job request for Google Batch

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -347,6 +347,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                 LogsPolicy.newBuilder()
                     .setDestination(LogsPolicy.Destination.CLOUD_LOGGING)
             )
+            .putAllLabels(task.config.getResourceLabels())
             .build()
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -217,6 +217,9 @@ class GoogleBatchTaskHandlerTest extends Specification {
         networkInterface.getNoExternalIpAddress() == true
         and:
         req.getLogsPolicy().getDestination().toString() == 'CLOUD_LOGGING'
+        and:
+        req.getLabelsMap() == [foo: 'bar']
+
 
         when:
         req = handler.newSubmitRequest(task, launcher)


### PR DESCRIPTION
This change will add the missing labels to Batch Job request.
Without some of the labels, some Batch side optimization is not recognized.