### PR TITLE
Harden regular expression to used to strip secrets in logs

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/StringUtils.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/StringUtils.groovy
@@ -56,7 +56,7 @@ class StringUtils {
         return m.matches() ? m.group(1).toLowerCase() : null
     }
 
-    static private Pattern multilinePattern = ~/"?(password|token|secret|license)"?\s?[:=]\s?"?(\w+)"?/
+    static private Pattern multilinePattern = ~/["']?(password|token|secret|license)["']?\s?[:=]\s?["']?(\w+)["']?/
 
     static String stripSecrets(String message) {
         if (message == null) {

--- a/modules/nf-commons/src/test/nextflow/util/StringUtilsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/StringUtilsTest.groovy
@@ -100,13 +100,15 @@ class StringUtilsTest extends Specification {
         StringUtils.stripSecrets(SECRET) == EXPECTED
 
         where:
-        SECRET                                  | EXPECTED
-        'Hi\n here is the "password" : "1234"'  | 'Hi\n here is the "password" : "********"'
-        'Hi\n here is the password : "1"'       | 'Hi\n here is the password : "********"'
-        'Hi\n here is the password : "1"'       | 'Hi\n here is the password : "********"'
-        'Hi\n "password" :"1" \n "token": "123"'| 'Hi\n "password" :"********" \n "token": "********"'
-        'Hi\n password :"1"\nsecret: "345"'     | 'Hi\n password :"********"\nsecret: "********"'
-        'secret="abc" password:"1" more text'   | 'secret="********" password:"********" more text'
+        SECRET                                          | EXPECTED
+        'Hi\n here is the "password" : "1234"'          | 'Hi\n here is the "password" : "********"'
+        'Hi\n here is the password : "1"'               | 'Hi\n here is the password : "********"'
+        'Hi\n here is the password : \'1\''             | 'Hi\n here is the password : \'********\''
+        'Hi\n "password" :"1" \n "token": "123"'        | 'Hi\n "password" :"********" \n "token": "********"'
+        'Hi\n "password" :\'1\' \n "token": "123"'      | 'Hi\n "password" :\'********\' \n "token": "********"'
+        'Hi\n \'password\' :\'1\' \n \'token\': \'123\''| 'Hi\n \'password\' :\'********\' \n \'token\': \'********\''
+        'Hi\n password :"1"\nsecret: "345"'             | 'Hi\n password :"********"\nsecret: "********"'
+        'secret="abc" password:"1" more text'           | 'secret="********" password:"********" more text'
     }
 
     @Unroll


### PR DESCRIPTION
Include option to strip secrets from single-quoted strings.

Closes https://github.com/nextflow-io/nextflow/issues/4562