### PR TITLE
Build optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,15 @@ clean:
 	rm -rf plugins/*/build
 	./gradlew clean
 
+compileCore:
+	BUILD_PLUGINS=0 ./gradlew compile exportClasspath
+
 compile:
 	./gradlew compile exportClasspath
 	@echo "DONE `date`"
 
 assemble:
-	./gradlew compile assemble
+	./gradlew buildInfo compile assemble
 
 check:
 	./gradlew check

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,6 @@ clean:
 	rm -rf plugins/*/build
 	./gradlew clean
 
-compileCore:
-	BUILD_PLUGINS=0 ./gradlew compile exportClasspath
-
 compile:
 	./gradlew compile exportClasspath
 	@echo "DONE `date`"

--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,6 @@ task buildInfo { doLast {
  * Compile sources and copies all libs to target directory
  */
 task compile {
-    dependsOn buildInfo
     dependsOn allprojects.classes
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,15 +31,13 @@ rootProject.children.each { prj ->
     prj.projectDir = new File("$rootDir/modules/$prj.name")
 }
 
-if( System.getenv('BUILD_PLUGINS') !in ['0', 'false'] ) {
-    include 'plugins'
-    include 'plugins:nf-amazon'
-    include 'plugins:nf-google'
-    include 'plugins:nf-ga4gh'
-    include 'plugins:nf-tower'
-    include 'plugins:nf-console'
-    include 'plugins:nf-azure'
-    include 'plugins:nf-codecommit'
-    include 'plugins:nf-wave'
-    include 'plugins:nf-cloudcache'
-}
+include 'plugins'
+include 'plugins:nf-amazon'
+include 'plugins:nf-google'
+include 'plugins:nf-ga4gh'
+include 'plugins:nf-tower'
+include 'plugins:nf-console'
+include 'plugins:nf-azure'
+include 'plugins:nf-codecommit'
+include 'plugins:nf-wave'
+include 'plugins:nf-cloudcache'

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,13 +31,15 @@ rootProject.children.each { prj ->
     prj.projectDir = new File("$rootDir/modules/$prj.name")
 }
 
-include 'plugins'
-include 'plugins:nf-amazon'
-include 'plugins:nf-google'
-include 'plugins:nf-ga4gh'
-include 'plugins:nf-tower'
-include 'plugins:nf-console'
-include 'plugins:nf-azure'
-include 'plugins:nf-codecommit'
-include 'plugins:nf-wave'
-include 'plugins:nf-cloudcache'
+if( System.getenv('BUILD_PLUGINS') !in ['0', 'false'] ) {
+    include 'plugins'
+    include 'plugins:nf-amazon'
+    include 'plugins:nf-google'
+    include 'plugins:nf-ga4gh'
+    include 'plugins:nf-tower'
+    include 'plugins:nf-console'
+    include 'plugins:nf-azure'
+    include 'plugins:nf-codecommit'
+    include 'plugins:nf-wave'
+    include 'plugins:nf-cloudcache'
+}


### PR DESCRIPTION
This PR includes two improvements:
- Remove `buildInfo` as a dependency of `compile` and add it as a dependency of `make assemble`, since the build info is only needed when building a release
- Add a make rule `make compileCore` which compiles only Nextflow without the plugins. Useful when testing core features that don't depend on the plugins

The first optimization alone brings my cached build time from ~45s to ~3s