### PR TITLE
Add AWS_SESSION_TOKEN when exporting credentials for Fusion

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
@@ -43,6 +43,9 @@ class AwsFusionEnv implements FusionEnv {
         if( creds ) {
             result.AWS_ACCESS_KEY_ID = creds[0]
             result.AWS_SECRET_ACCESS_KEY = creds[1]
+
+            if( creds.size() > 2 )
+                result.AWS_SESSION_TOKEN = creds[2]
         }
         if( endpoint )
             result.AWS_S3_ENDPOINT = endpoint
@@ -59,6 +62,10 @@ class AwsFusionEnv implements FusionEnv {
         final result = awsConfig.getCredentials()
         if( result )
             return result
+
+        if( SysEnv.get('AWS_ACCESS_KEY_ID') && SysEnv.get('AWS_SECRET_ACCESS_KEY') && SysEnv.get('AWS_SESSION_TOKEN') )
+            return List.<String>of(SysEnv.get('AWS_ACCESS_KEY_ID'), SysEnv.get('AWS_SECRET_ACCESS_KEY'), SysEnv.get('AWS_SESSION_TOKEN'))
+
         if( SysEnv.get('AWS_ACCESS_KEY_ID') && SysEnv.get('AWS_SECRET_ACCESS_KEY') )
             return List.<String>of(SysEnv.get('AWS_ACCESS_KEY_ID'), SysEnv.get('AWS_SECRET_ACCESS_KEY'))
         else

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/fusion/AwsFusionEnvTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/fusion/AwsFusionEnvTest.groovy
@@ -77,4 +77,28 @@ class AwsFusionEnvTest extends Specification {
         cleanup:
         Global.config = null
     }
+
+    def 'should return env environment with session token' () {
+        given:
+        SysEnv.push([AWS_ACCESS_KEY_ID: 'x1', AWS_SECRET_ACCESS_KEY: 'y1', AWS_S3_ENDPOINT: 'http://my-host.com', AWS_SESSION_TOKEN: 'z1'])
+        and:
+
+        when:
+        def config = Mock(FusionConfig)
+        def env = new AwsFusionEnv().getEnvironment('s3', Mock(FusionConfig))
+        then:
+        env == [AWS_S3_ENDPOINT:'http://my-host.com']
+
+        when:
+        config = Mock(FusionConfig) { exportStorageCredentials() >> true }
+        env = new AwsFusionEnv().getEnvironment('s3', config)
+        then:
+        env == [AWS_ACCESS_KEY_ID: 'x1',
+                AWS_SECRET_ACCESS_KEY: 'y1',
+                AWS_S3_ENDPOINT:'http://my-host.com',
+                AWS_SESSION_TOKEN: 'z1']
+
+        cleanup:
+        SysEnv.pop()
+    }
 }


### PR DESCRIPTION
## Description

In some scenarios the `AWS_SESSION_TOKEN` variable is also needed by Fusion to authenticate AWS. 

This PR exports this variable if exists and `fusion.exportStorageCredentials` is set to `true`.