### PR TITLE
Improve logging of task progress

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -964,6 +964,17 @@ class Session implements ISession {
         }
     }
 
+    void notifyProcessClose(TaskProcessor process) {
+        for( def observer : observers ) {
+            try {
+                observer.onProcessClose(process)
+            }
+            catch( Exception e ) {
+                log.debug(e.getMessage(), e)
+            }
+        }
+    }
+
     void notifyProcessTerminate(TaskProcessor process) {
         for( int i=0; i<observers.size(); i++ ) {
             final observer = observers.get(i)

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -2341,6 +2341,10 @@ class TaskProcessor {
         state.update { StateObj it -> it.incCompleted() }
     }
 
+    protected void closeProcess() {
+        session.notifyProcessClose(this)
+    }
+
     protected void terminateProcess() {
         log.trace "<${name}> Sending poison pills and terminating process"
         sendPoisonPill()
@@ -2493,6 +2497,7 @@ class TaskProcessor {
             // apparently auto if-guard instrumented by @Slf4j is not honoured in inner classes - add it explicitly
             if( log.isTraceEnabled() )
                 log.trace "<${name}> After stop"
+            closeProcess()
         }
 
         /**

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ProgressRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ProgressRecord.groovy
@@ -43,6 +43,7 @@ class ProgressRecord implements Cloneable {
     int stored
     int ignored
     int retries
+    boolean closed
     boolean terminated
     boolean errored
 
@@ -63,11 +64,11 @@ class ProgressRecord implements Cloneable {
 
     int getTotalCount() {
         pending+ submitted+ running+
-           succeeded+ failed+ cached+ stored
+           succeeded+ cached+ stored
     }
 
     int getCompletedCount() {
-        succeeded+ failed+ cached+ stored
+        succeeded+ cached+ stored
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
@@ -50,6 +50,11 @@ trait TraceObserver {
      */
     void onProcessCreate( TaskProcessor process ){}
 
+    /**
+     * Invoked when the process is closed (all tasks have been created).
+     */
+    void onProcessClose( TaskProcessor process ){}
+
     /*
       * Invoked when all tak have been executed and process ends.
       */

--- a/modules/nextflow/src/main/groovy/nextflow/trace/WorkflowStats.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/WorkflowStats.groovy
@@ -288,6 +288,13 @@ class WorkflowStats implements Cloneable {
         this.changeTimestamp = System.currentTimeMillis()
     }
 
+    void markClosed(TaskProcessor process) {
+        final pid = process.getId()
+        final state = records.get(pid)
+        state.closed = true
+        this.changeTimestamp = System.currentTimeMillis()
+    }
+
     void markSubmitted(TaskRun task) {
         final state = getOrCreateRecord(task.processor)
         state.hash = task.hashLog

--- a/modules/nextflow/src/main/groovy/nextflow/trace/WorkflowStatsObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/WorkflowStatsObserver.groovy
@@ -55,6 +55,12 @@ class WorkflowStatsObserver implements TraceObserver {
     }
 
     @Override
+    void onProcessClose(TaskProcessor process){
+        log.trace "== event close pid=${process.id}"
+        agent.send { data.markClosed(process) }
+    }
+
+    @Override
     void onProcessTerminate( TaskProcessor processor ) {
         log.trace "== event terminated pid=${processor.id}"
         agent.send { data.markTerminated(processor) }

--- a/modules/nextflow/src/test/groovy/nextflow/trace/AnsiLogObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/AnsiLogObserverTest.groovy
@@ -36,6 +36,7 @@ class AnsiLogObserverTest extends Specification {
         stats.cached    = CACHE
         stats.stored    = STORE
         stats.terminated = DONE
+        stats.closed = CLOSED
         stats.errored = ERR
         stats.hash = HASH
 
@@ -45,18 +46,21 @@ class AnsiLogObserverTest extends Specification {
         observer.line(stats) == EXPECTED
 
         where:
-        HASH        | SUBMIT  | SUCCEEDED | CACHE | STORE | DONE  | ERR   | EXPECTED
-        null        | 0       | 0         | 0     | 0     | false | false | '[-        ] process > foo -'
-        '4e/486876' | 1       | 0         | 0     | 0     | false | false | '[4e/486876] process > foo [  0%] 0 of 1'
-        '4e/486876' | 0       | 1         | 0     | 0     | false | false | '[4e/486876] process > foo [100%] 1 of 1'
-        '4e/486876' | 1       | 1         | 0     | 0     | false | false | '[4e/486876] process > foo [ 50%] 1 of 2'
-        '4e/486876' | 5       | 5         | 0     | 0     | false | false | '[4e/486876] process > foo [ 50%] 5 of 10'
-        '4e/486876' | 0       | 0         | 5     | 0     | false | false | '[4e/486876] process > foo [100%] 5 of 5, cached: 5'
-        '4e/486876' | 1       | 1         | 3     | 0     | false | false | '[4e/486876] process > foo [ 80%] 4 of 5, cached: 3'
-        'skipped'   | 0       | 0         | 0     | 5     | false | false | '[skipped  ] process > foo [100%] 5 of 5, stored: 5'
-        'skipped'   | 1       | 1         | 0     | 3     | false | false | '[skipped  ] process > foo [ 80%] 4 of 5, stored: 3'
-        'ab/123456' | 0       | 2         | 0     | 0     | true  | false | '[ab/123456] process > foo [100%] 2 of 2 ✔'
-        'ef/987654' | 0       | 2         | 0     | 0     | true  | true  | '[ef/987654] process > foo [100%] 2 of 2 ✘'
+        HASH        | SUBMIT  | SUCCEEDED | CACHE | STORE | CLOSED | DONE  | ERR   | EXPECTED
+        null        | 0       | 0         | 0     | 0     | false  | false | false | '[-        ] process > foo -'
+        '4e/486876' | 1       | 0         | 0     | 0     | false  | false | false | '[4e/486876] process > foo [  ?%] 0 of 1'
+        '4e/486876' | 1       | 0         | 0     | 0     | true   | false | false | '[4e/486876] process > foo [  0%] 0 of 1'
+        '4e/486876' | 0       | 1         | 0     | 0     | false  | false | false | '[4e/486876] process > foo [  ?%] 1 of 1'
+        '4e/486876' | 0       | 1         | 0     | 0     | true   | false | false | '[4e/486876] process > foo [100%] 1 of 1'
+        '4e/486876' | 1       | 1         | 0     | 0     | false  | false | false | '[4e/486876] process > foo [  ?%] 1 of 2'
+        '4e/486876' | 1       | 1         | 0     | 0     | true   | false | false | '[4e/486876] process > foo [ 50%] 1 of 2'
+        '4e/486876' | 5       | 5         | 0     | 0     | true   | false | false | '[4e/486876] process > foo [ 50%] 5 of 10'
+        '4e/486876' | 0       | 0         | 5     | 0     | true   | false | false | '[4e/486876] process > foo [100%] 5 of 5, cached: 5'
+        '4e/486876' | 1       | 1         | 3     | 0     | true   | false | false | '[4e/486876] process > foo [ 80%] 4 of 5, cached: 3'
+        'skipped'   | 0       | 0         | 0     | 5     | true   | false | false | '[skipped  ] process > foo [100%] 5 of 5, stored: 5'
+        'skipped'   | 1       | 1         | 0     | 3     | true   | false | false | '[skipped  ] process > foo [ 80%] 4 of 5, stored: 3'
+        'ab/123456' | 0       | 2         | 0     | 0     | true   | true  | false | '[ab/123456] process > foo [100%] 2 of 2 ✔'
+        'ef/987654' | 0       | 2         | 0     | 0     | true   | true  | true  | '[ef/987654] process > foo [100%] 2 of 2 ✘'
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ProgressRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ProgressRecordTest.groovy
@@ -73,8 +73,8 @@ class ProgressRecordTest extends Specification {
         rec.stored =STORED
 
         then:
-        rec.getCompletedCount() == SUCCEEDED+ FAILED+ CACHED+ STORED
-        rec.getTotalCount() == PENDING+ SUBMITTED+ RUNNING + SUCCEEDED+ FAILED+ CACHED+ STORED
+        rec.getCompletedCount() == SUCCEEDED+ CACHED+ STORED
+        rec.getTotalCount() == PENDING+ SUBMITTED+ RUNNING + SUCCEEDED+ CACHED+ STORED
     }
 
 


### PR DESCRIPTION
Spun off from https://github.com/nextflow-io/nextflow/pull/4573#issuecomment-1852025912 and below

This PR contains two improvements to the progress logging:

- Don't show the percentage until the process is "closed", i.e. all tasks have been received. This prevents Nextflow from overestimating the progress before it knows the total task count of a process. Instead a question mark is shown.

  This requires a new lifecycle event `onProcessClosed()`, which is also needed to implement array jobs, task grouping, and automatic cleanup, all for the same reason -- to know how many tasks a process will execute

- Don't include the failed task count in the percentage or the complete/total counts. This prevents the percentage from increasing when a task fails even though no progress was made, and it allows the process to reach 100% if the tasks are successfully retried/ignored.

As an example, consider a process that executes 4 tasks with 1 task that fails on the first attempt.

Before all tasks are received (i.e. process is still "open"):
```
[70/0de758] process > bar (3) [  ?%] 1 of 3
```

A task fails and is retried, and succeeds on the second attempt:
```
[70/0de758] process > bar (3) [ 75%] 3 of 4, retries: 1
[70/0de758] process > bar (3) [100%] 4 of 4, retries: 1 ✔
```

If instead the failed task is ignored, it simply reduces the number of total tasks, allowing the process to reach 100% while still noting the number of ignored tasks:
```
[f2/decd6c] process > bar (4) [ 75%] 2 of 3, ignored: 1
[98/47ff99] process > bar (4) [100%] 3 of 3, ignored: 1 ✔
```