### PR TITLE
Fix bug with Fusion symlink resolution

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -294,6 +294,7 @@ class PublishDir {
         this.sourceDir = task.targetDir
         this.sourceFileSystem = sourceDir.fileSystem
         this.stageInMode = task.config.stageInMode
+        this.task = task
 
         apply0(files)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -134,7 +134,7 @@ class PublishDir {
     }
 
     protected Map<String,Path> getTaskInputs() {
-        return task?.getInputFilesMap()
+        return task ? task.getInputFilesMap() : Map.<String,Path>of()
     }
 
     void setPath( def value ) {

--- a/tests/checks/fusion-symlink.nf/.checks
+++ b/tests/checks/fusion-symlink.nf/.checks
@@ -10,6 +10,7 @@ fi
 # normal run
 #
 echo initial run
+$NXF_CMD fs rm s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt || true
 $NXF_RUN -c .config
 
 $NXF_CMD fs cp s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt data.txt
@@ -19,6 +20,7 @@ cmp data.txt .expected || false
 # resume run
 #
 echo resumed run
+$NXF_CMD fs rm s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt || true
 $NXF_RUN -c .config -resume
 
 $NXF_CMD fs cp s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt data.txt


### PR DESCRIPTION
Follow up to #4348 , based on multiple customer reports that Fusion symlinks are still not being published correctly.

It looks like some last minute changes on the original PR introduced a bug, but the integration test was not robust enough to catch it.

While I'm confident that this PR will fix the bug, I haven't been able to make the integration test fail. Whenever I run `fusion-symlink.nf` locally, the `data.txt` output in each task directory is a copy instead of a symlink, so it is not actually testing the symlink resolution.