### PR TITLE
fix: workaround for bitbucket bug related to branch names with slash

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
@@ -50,7 +50,14 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
 
     @Override
     String getContentUrl( String path ) {
-        final ref = revision ?: getMainBranch()
+        def ref
+        if (!revision){
+            ref = getMainBranch()
+        } else if (revision.contains('/')){
+            ref = getCommitIdForRevision()
+        } else {
+            ref = revision
+        }
         return "${config.endpoint}/api/2.0/repositories/$project/src/$ref/$path"
     }
 
@@ -60,6 +67,11 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
 
     String getMainBranch() {
         invokeAndParseResponse(getMainBranchUrl()) ?. mainbranch ?. name
+    }
+
+    String getCommitIdForRevision(){
+        def resp = invokeAndParseResponse("${config.endpoint}/api/2.0/repositories/$project/refs/branches/$revision")
+        return resp?.target?.hash
     }
 
     @Memoized

--- a/modules/nextflow/src/test/groovy/nextflow/scm/BitbucketRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/BitbucketRepositoryProviderTest.groovy
@@ -114,4 +114,28 @@ class BitbucketRepositoryProviderTest extends Specification {
                 .getContentUrl('main.nf') == 'https://bitbucket.org/api/2.0/repositories/pditommaso/hello/src/foo/main.nf'
 
     }
+
+    def 'readbytes' () {
+        given:
+        String CONFIG = '''
+        providers {
+            mybitbucket {
+                server = 'https://bitbucket.org'
+                endpoint = 'https://bitbucket.org'
+                platform = 'bitbucket'
+            }
+        }
+        '''
+
+        def config = new ConfigSlurper().parse(CONFIG)
+        def obj = new ProviderConfig('bitbucket', config.providers.mybitbucket as ConfigObject)
+
+        expect:
+        def bitBucketProvider = new BitbucketRepositoryProvider('endre-seqera-testing/nextflow-hello', obj)
+        bitBucketProvider.setRevision('master')
+        bitBucketProvider.readText('nextflow.config') == "process.container = 'quay.io/nextflow/bash'\n"
+
+        bitBucketProvider.setRevision('feature/1234')
+        bitBucketProvider.readText('nextflow.config') == "process.container = 'quay.io/nextflow/bash'\n"
+    }
 }


### PR DESCRIPTION
Fix for #4599.

### Tested

```
rm -rf ~/.nextflow/assets/endre-seqera-testing
make compile
./launch.sh run https://bitbucket.org/endre-seqera-testing/nextflow-hello -r feature/1234
N E X T F L O W  ~  version 23.11.0-edge
Pulling endre-seqera-testing/nextflow-hello ...
 downloaded from https://bitbucket.org/endre-seqera-testing/nextflow-hello.git
Launching `https://bitbucket.org/endre-seqera-testing/nextflow-hello` [compassionate_easley] DSL2 - revision: e12ed7715d [feature/1234]
executor >  local (4)
[83/11cc9e] process > sayHello (2) [100%] 4 of 4 ✔
Bonjour world!

Hello world!

Hola world!

Ciao world!
```