### PR TITLE
Fix fusion symlink test

### DIFF
--- a/tests/checks/fusion-symlink.nf/.checks
+++ b/tests/checks/fusion-symlink.nf/.checks
@@ -10,7 +10,6 @@ fi
 # normal run
 #
 echo initial run
-$NXF_CMD fs rm s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt || true
 $NXF_RUN -c .config
 
 $NXF_CMD fs cp s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt data.txt
@@ -20,7 +19,6 @@ cmp data.txt .expected || false
 # resume run
 #
 echo resumed run
-$NXF_CMD fs rm s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt || true
 $NXF_RUN -c .config -resume
 
 $NXF_CMD fs cp s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt data.txt


### PR DESCRIPTION
This PR should fix the fusion symlink test which can fail sometimes if multiple instances are running at the same time and clobber each other's results.

A more robust solution would be if every CI test instance used a unique S3 work directory.