### PR TITLE
Add ability to disable Cloudinfo service

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -21,6 +21,7 @@ import java.nio.file.Path
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.SysEnv
 import nextflow.cloud.google.batch.client.BatchConfig
 import nextflow.cloud.google.batch.client.BatchClient
 import nextflow.cloud.google.batch.logging.BatchLogging
@@ -123,5 +124,9 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint {
     @Override
     boolean isFusionEnabled() {
         return FusionHelper.isFusionEnabled(session)
+    }
+
+    boolean isCloudinfoEnabled() {
+        return Boolean.parseBoolean(SysEnv.get('NXF_CLOUDINFO_ENABLED', 'true') )
     }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -17,7 +17,6 @@
 
 package nextflow.cloud.google.batch
 
-
 import java.nio.file.Path
 
 import com.google.cloud.batch.v1.AllocationPolicy
@@ -286,7 +285,11 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                 log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - adding local volume as fusion scratch: $disk"
             }
 
-            final machineType = findBestMachineType(task.config, disk?.type == 'local-ssd')
+            def machineType = findBestMachineType(task.config, disk?.type == 'local-ssd')
+            if( !machineType ) {
+
+            }
+
             if( machineType ) {
                 instancePolicy.setMachineType(machineType.type)
                 machineInfo = new CloudMachineInfo(
@@ -494,32 +497,38 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         return result
     }
 
+    protected GoogleBatchMachineTypeSelector.MachineType bestMachineType0(int cpus, int memory, String location, boolean spot, boolean localSSD, List<String> families) {
+        return GoogleBatchMachineTypeSelector.INSTANCE.bestMachineType(cpus, memory, location, spot, localSSD, families)
+    }
+
     protected GoogleBatchMachineTypeSelector.MachineType findBestMachineType(TaskConfig config, boolean localSSD) {
         final location = client.location
         final cpus = config.getCpus()
         final memory = config.getMemory() ? config.getMemory().toMega().toInteger() : 1024
         final spot = executor.config.spot ?: executor.config.preemptible
-        final families = config.getMachineType() ? config.getMachineType().tokenize(',') : []
+        final machineType = config.getMachineType()
+        final families = machineType ? machineType.tokenize(',') : List.<String>of()
         final priceModel = spot ? PriceModel.spot : PriceModel.standard
 
         try {
-            return GoogleBatchMachineTypeSelector.INSTANCE.bestMachineType(cpus, memory, location, spot, localSSD, families)
+            if( executor.isCloudinfoEnabled() ) {
+                return bestMachineType0(cpus, memory, location, spot, localSSD, families)
+            }
         }
         catch (Exception e) {
-            log.debug "[GOOGLE BATCH] Cannot select machine type using cloud info for task: `${task.lazyName()}` - ${e.message}"
-
-            // Check if a specific machine type was provided by the user
-            if( config.getMachineType() && !config.getMachineType().contains(',') && !config.getMachineType().contains('*') )
-                return new GoogleBatchMachineTypeSelector.MachineType(
-                        type: config.getMachineType(),
-                        location: location,
-                        priceModel: priceModel
-                )
-
-            // Fallback to Google Batch automatically deduce from requested resources
-            return null
+            log.debug "[GOOGLE BATCH] Cannot select machine type using Seqera Cloudinfo for task: `${task.lazyName()}` - ${e.message}"
         }
 
+        // Check if a specific machine type was provided by the user
+        if( machineType && !machineType.contains(',') && !machineType.contains('*') )
+            return new GoogleBatchMachineTypeSelector.MachineType(
+                type: machineType,
+                location: location,
+                priceModel: priceModel
+            )
+
+        // Fallback to Google Batch automatically deduce from requested resources
+        return null
     }
 
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -285,10 +285,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                 log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - adding local volume as fusion scratch: $disk"
             }
 
-            def machineType = findBestMachineType(task.config, disk?.type == 'local-ssd')
-            if( !machineType ) {
-
-            }
+            final machineType = findBestMachineType(task.config, disk?.type == 'local-ssd')
 
             if( machineType ) {
                 instancePolicy.setMachineType(machineType.type)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
@@ -10,6 +10,8 @@ package nextflow.cloud.google.batch
 import nextflow.Session
 import nextflow.SysEnv
 import spock.lang.Specification
+import spock.lang.Unroll
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -38,7 +40,26 @@ class GoogleBatchExecutorTest extends Specification {
         [fusion:[enabled: false]]   | [FUSION_ENABLED:'true']   | false     // <-- config has priority
         [:]                         | [FUSION_ENABLED:'true']   | true
         [:]                         | [FUSION_ENABLED:'false']  | false
-
     }
 
+    @Unroll
+    def 'should check cloudinfo enabled' () {
+        given:
+        SysEnv.push(ENV)
+        and:
+        def sess = Mock(Session) { getConfig() >> [:] }
+        def executor = new GoogleBatchExecutor(session: sess)
+
+        expect:
+        executor.isCloudinfoEnabled() == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        ENV                             | EXPECTED
+        [:]                             | true
+        [NXF_CLOUDINFO_ENABLED:'true']  | true
+        [NXF_CLOUDINFO_ENABLED:'false'] | false
+    }
 }


### PR DESCRIPTION
This PR adds the ability to disable the use of Cloudinfo service by setting the env variable

```
export NXF_CLOUDINFO_ENABLED=false
```
