### PR TITLE
Update support for local TES executor with GA4GH TES Plugin

### DIFF
--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesFileCopyStrategy.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesFileCopyStrategy.groovy
@@ -113,6 +113,7 @@ class TesFileCopyStrategy implements ScriptFileCopyStrategy {
             copy.remove('PATH')
         // when a remote bin directory is provide managed it properly
         if( remoteBinDir ) {
+            result << "mkdir \$PWD/nextflow-bin/\n"
             result << "cp -r ${remoteBinDir}/* \$PWD/nextflow-bin/\n"
             result << "chmod +x \$PWD/nextflow-bin/* || true\n"
             result << "export PATH=\$PWD/nextflow-bin:\$PATH\n"

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -23,6 +23,7 @@ import static nextflow.processor.TaskStatus.COMPLETED
 import static nextflow.processor.TaskStatus.RUNNING
 
 import java.nio.file.Path
+import java.nio.file.Files
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -190,6 +191,9 @@ class TesTaskHandler extends TaskHandler {
         body.addInputsItem(inItem(scriptFile))
         body.addInputsItem(inItem(wrapperFile))
 
+        Path remoteBinDir = executor.getRemoteBinDir()
+        body.addInputsItem(inItem(remoteBinDir, remoteBinDir.toString(), true))
+
         // add task input files
         if(inputFile.exists()) body.addInputsItem(inItem(inputFile))
 
@@ -234,11 +238,12 @@ class TesTaskHandler extends TaskHandler {
         return size != null ? ((double)size.bytes)/1073741824 : null
     }
 
-    private TesInput inItem( Path realPath, String fileName = null) {
+    private TesInput inItem( Path realPath, String fileName = null, Boolean isBin = false) {
         def result = new TesInput()
         result.url = realPath.toUriString()
         result.path = fileName ? "$WORK_DIR/$fileName" : "$WORK_DIR/${realPath.getName()}"
         log.trace "[TES] Adding INPUT file: $result"
+        result.path = isBin ? realPath : result.path
         return result
     }
 

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -23,7 +23,6 @@ import static nextflow.processor.TaskStatus.COMPLETED
 import static nextflow.processor.TaskStatus.RUNNING
 
 import java.nio.file.Path
-import java.nio.file.Files
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j

--- a/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
+++ b/plugins/nf-ga4gh/src/main/nextflow/ga4gh/tes/executor/TesTaskHandler.groovy
@@ -192,7 +192,9 @@ class TesTaskHandler extends TaskHandler {
         body.addInputsItem(inItem(wrapperFile))
 
         Path remoteBinDir = executor.getRemoteBinDir()
-        body.addInputsItem(inItem(remoteBinDir, remoteBinDir.toString(), true))
+        if (remoteBinDir) {
+            body.addInputsItem(inItem(remoteBinDir, null, true))
+        }
 
         // add task input files
         if(inputFile.exists()) body.addInputsItem(inItem(inputFile))
@@ -238,7 +240,7 @@ class TesTaskHandler extends TaskHandler {
         return size != null ? ((double)size.bytes)/1073741824 : null
     }
 
-    private TesInput inItem( Path realPath, String fileName = null, Boolean isBin = false) {
+    private TesInput inItem( Path realPath, String fileName = null, boolean isBin = false) {
         def result = new TesInput()
         result.url = realPath.toUriString()
         result.path = fileName ? "$WORK_DIR/$fileName" : "$WORK_DIR/${realPath.getName()}"


### PR DESCRIPTION
# Overview

This PR includes updates to the GA4GH TES plugin to allow successfully communication between it and a local TES executor, specifically by passing the contents of the working directory's `bin` directory as TES inputs. 

Nextflow's [default behavior](https://www.nextflow.io/docs/latest/faq.html#how-do-i-invoke-custom-scripts-and-tools) is to add the contents of the `bin` directory to a process and automatically update the $PATH variable to allow workflows to run with dependencies:

> Nextflow will automatically add the directory bin into the PATH environmental variable. So therefore any executable in the bin folder of a Nextflow pipeline can be called without the need to reference the full path.

# Related Issues/PRs

- https://github.com/nextflow-io/nextflow/pull/4195
- https://github.com/nextflow-io/nextflow/issues/3040

# Tests

Tested using the `./gradlew :plugins:nf-ga4gh:test` command in the IntelliJ terminal:

```sh
./gradlew :plugins:nf-ga4gh:test

BUILD SUCCESSFUL in 4s
29 actionable tasks: 2 executed, 27 up-to-date
```

<img alt="Gradle Test Results" width="75%" src="https://github.com/nextflow-io/nextflow/assets/15309567/efd8df52-8908-463a-92a2-2ea3974a9ee0"/>

## Funnel

An updated [Funnel release candidate](https://github.com/ohsu-comp-bio/funnel/releases) is being created that includes updated support for this feature. While that's being created its possible to pull in the updates and compile Funnel locally by running the following:

```sh
git clone https://github.com/ohsu-comp-bio/funnel -b feature/nextflow-tests

cd funnel

make

./funnel server --Server.HTTPPort 8000 --LocalStorage.AllowedDirs $HOME run
```

Funnel's [documentation page](https://ohsu-comp-bio.github.io/funnel/docs/) is also being updated and will reflect the latest steps for interoperability with Nextflow and Azure.

## Nextflow

To install the changes in this PR to a local instance of Nextflow run the following:

```sh
git clone https://github.com/nextflow-io/nextflow -b tes-update-1.1

cd nextflow

make compile
```

This will create a new `launch.sh` file that can be used in the **nf-canary** tests below.

Add the following to your `nextflow.config` in order to use the GA4GH TES plugin:

```groovy
plugins {
  id 'nf-ga4gh'
}

process.executor = 'tes'
tes.endpoint = 'http://localhost:8000'
```

## nf-canary

[nf-canary](https://github.com/seqeralabs/nf-canary) is a "A minimal Nextflow workflow for testing infrastructure" that can be used to check compliance with Nextflow workflows.

To use it to test the changes included in this PR run the following:

```sh
git clone https://github.com/seqeralabs/nf-canary

cd nf-canary

alias nextflow=~/nextflow/launch.sh  # <--- Change this line to match your local nextflow directory

nextflow run main.nf -c nextflow.config
```

A successful run will show all tests passed (including one test meant to ignore a simulated test "failure"):

```
N E X T F L O W  ~  version 23.08.0-edge
Launching `main.nf` [pedantic_archimedes] DSL2 - revision: da205cac0c
Uploading local `bin` scripts folder to $HOME/nf-canary/work/tmp/0d/7632584dabcba30575be6513304d96/bin
executor >  tes [http://localhost:8000] (12)
[e3/ae33dc] process > NF_CANARY:TEST_SUCCESS            [100%] 1 of 1 ✔
[a8/2b4e53] process > NF_CANARY:TEST_CREATE_FILE        [100%] 1 of 1 ✔
[fe/920b2d] process > NF_CANARY:TEST_CREATE_FOLDER      [100%] 1 of 1 ✔
[0c/3104c6] process > NF_CANARY:TEST_INPUT (1)          [100%] 1 of 1 ✔
[83/333e1c] process > NF_CANARY:TEST_BIN_SCRIPT         [100%] 1 of 1 ✔
[-        ] process > NF_CANARY:TEST_STAGE_REMOTE       -
[e6/1152f4] process > NF_CANARY:TEST_PASS_FILE          [100%] 1 of 1 ✔
[92/7f8c7b] process > NF_CANARY:TEST_PASS_FOLDER        [100%] 1 of 1 ✔
[81/c3ba84] process > NF_CANARY:TEST_PUBLISH_FILE       [100%] 1 of 1 ✔
[cd/ce8fb7] process > NF_CANARY:TEST_PUBLISH_FOLDER     [100%] 1 of 1 ✔
[8a/c31c60] process > NF_CANARY:TEST_IGNORED_FAIL       [100%] 1 of 1, failed: 1 ✔
[fb/ae45eb] process > NF_CANARY:TEST_MV_FILE            [100%] 1 of 1 ✔
[65/39eb16] process > NF_CANARY:TEST_MV_FOLDER_CONTENTS [100%] 1 of 1 ✔
[8a/c31c60] NOTE: Process `NF_CANARY:TEST_IGNORED_FAIL` terminated for an unknown reason -- Likely it has been terminated by the external system -- Error is ignored
```