### PR TITLE
fixed output typo, OCI, in ContainerConfig.groovy

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerConfig.groovy
@@ -84,7 +84,7 @@ class ContainerConfig extends LinkedHashMap {
             return false
         }
         if( get('oci')?.toString()=='true' ) {
-            log.warn "The setting `singularity.oci` is deprecated - use `singularity.ociNative` instead"
+            log.warn "The setting `singularity.oci` is deprecated - use `singularity.ociMode` instead"
             return true
         }
         if( get('ociMode')?.toString()=='true' )


### PR DESCRIPTION
as per PR title, just a small typo in an output message.