### PR TITLE
Add unwrap option to groupTuple

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -692,6 +692,11 @@ Available options:
   - `'deep'`: Similar to the previous, but the hash number is created on actual entries content e.g. when the item is a file, the hash is created on the actual file content.
   - A custom sorting criteria used to order the nested list elements of each tuple. It can be a {ref}`Closure <script-closure>` or a [Comparator](http://docs.oracle.com/javase/7/docs/api/java/util/Comparator.html) object.
 
+`unwrap`
+: :::{versionadded} 24.01.0-edge
+  :::
+: If the key is wrapped with `groupKey()`, unwrap the group key when the group is emitted (default: `false`).
+
 (operator-ifempty)=
 
 ## ifEmpty

--- a/modules/nextflow/src/test/groovy/nextflow/extension/GroupTupleOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/GroupTupleOpTest.groovy
@@ -17,10 +17,8 @@
 package nextflow.extension
 
 import nextflow.Channel
-
-import spock.lang.Specification
-
 import nextflow.Session
+import spock.lang.Specification
 
 /**
  *
@@ -100,7 +98,6 @@ class GroupTupleOpTest extends Specification {
         0       | []
     }
 
-
     def 'should group items using dyn group size' () {
         given:
         def k1 = new GroupKey("k1", 2)
@@ -129,7 +126,6 @@ class GroupTupleOpTest extends Specification {
         result.val == [k2, ['x', 'y', 'z'] ]
         result.val == Channel.STOP
 
-
         when:
         result = tuples.channel().groupTuple(remainder: true)
         then:
@@ -138,6 +134,17 @@ class GroupTupleOpTest extends Specification {
         result.val == [k2, ['x', 'y', 'z'] ]
         result.val == [k3, ['q']]
         result.val == [k1, ['f']]
+        result.val == Channel.STOP
+
+        when:
+        // unwrap the group key if specified
+        result = tuples.channel().groupTuple(remainder: true, unwrap: true)
+        then:
+        result.val == [k1.target, ['a', 'b'] ]
+        result.val == [k1.target, ['d', 'c'] ]
+        result.val == [k2.target, ['x', 'y', 'z'] ]
+        result.val == [k3.target, ['q']]
+        result.val == [k1.target, ['f']]
         result.val == Channel.STOP
     }
 }


### PR DESCRIPTION
Close #4104 and #4637 

I would prefer to be aggressive here and unwrap the group key by default because it will almost always be the desired behavior. But I will leave that decision up to you. We could add the option now and change the default later.