### PR TITLE
LocalSecretsProvider: invalid permissions tests made more robust

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ NEXTFLOW CHANGE-LOG
 - Fix bug with Fusion symlink resolution (#4593) [f28c9e48]
 - Fix Fusion symlinks when publishing files (#4348) [1fa5878a]
 - Fix Inspect command fails with Singularity [25883df3]
-- Fix Allow the use of error build-in function in onComplete handler (#4458) [ci fast] [4be10cd3]
+- Fix Allow the use of error built-in function in onComplete handler (#4458) [ci fast] [4be10cd3]
 - Fix Harden regular expression to used to strip secrets in logs (#4563) [ci fast] [0102d4d6]
 - Fix custom notification template [40980bcb]
 - Fix container environment with special chars (#4594) [f4e00601]

--- a/modules/nextflow/src/test/groovy/nextflow/secret/LocalSecretsProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/secret/LocalSecretsProviderTest.groovy
@@ -106,6 +106,8 @@ class LocalSecretsProviderTest extends Specification {
         and:
         Files.write(secretFile, json.getBytes('utf-8'), StandardOpenOption.CREATE_NEW)
         and:
+        secretFile.setPermissions('rw-r-----')
+        and:
         def provider = new LocalSecretsProvider(storeFile: secretFile)
 
         when:


### PR DESCRIPTION
This PR fixes a unit test failure that happens if the machine you run on has tight default file permissions (e.g. as obtained via `umask`, for instance `umask 067`).   

The error reads:
```
LocalSecretsProviderTest > should fail with invalid permissions FAILED
    org.spockframework.runtime.WrongExceptionThrownError at LocalSecretsProviderTest.groovy:114
```

To succeed, this tests is expected to raise an exception as a result of the permissions of a created file being different from `rw-------`.  If this configuration is the default in the machine (more secure),  the test will fail. 

The PR explicitly sets the file permissions for the test to something different, i.e. `rw-r-----` , instead of relying on the machine default.