### PR TITLE
Set scratch default to false when using Fusion

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionScriptLauncher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionScriptLauncher.groovy
@@ -62,7 +62,7 @@ class FusionScriptLauncher extends BashWrapperBuilder {
         bean.headerScript = headerScript(bean)
         // enable use of local scratch dir
         if( bean.scratch==null )
-            bean.scratch = true
+            bean.scratch = false
 
         return new FusionScriptLauncher(bean, scheme, remoteWorkDir)
     }


### PR DESCRIPTION
I spoke to Jordi and found that we originally defaulted scratch to true with Fusion at a time when Fusion was only staging input data. But now that Fusion handles both inputs and outputs staging, it makes no sense to ever use scratch=true with Fusion because it eliminates the performance benefit of Fusion. I think we can safely set the default to false now.