### PR TITLE
Fix error text alignment

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
@@ -471,9 +471,9 @@ class NextflowDSLImpl implements ASTTransformation {
                         }
                         body.add(stm)
                 }
-
-                readSource(stm, source, unit)
             }
+            // read the closure source
+            readSource(closure, source, unit)
 
             final bodyClosure = closureX(null, block(scope, body))
             final invokeBody = makeScriptWrapper(bodyClosure, source.toString(), 'workflow', unit)
@@ -759,21 +759,35 @@ class NextflowDSLImpl implements ASTTransformation {
                 final line = unit.source.getLine(i, null)
 
                 // prepend first-line indent
-                def indent = ''
                 if( i == first ) {
                     int k = 0
                     while( k < line.size() && line[k] == ' ' )
                         k++
-                    indent = line.substring(0, k)
+                    buffer.append( line.substring(0, k) )
                 }
-
-                // prepend statement label
-                if( node.statementLabel )
-                    buffer.append(indent).append(node.statementLabel).append(':\n')
 
                 final begin = (i == first) ? colx - 1 : 0
                 final end = (i == last) ? colz - 1 : line.size()
-                buffer.append(indent).append( line.substring(begin, end) ).append('\n')
+                buffer.append( line.substring(begin, end) ).append('\n')
+            }
+        }
+
+        private void readSource( ClosureExpression node, StringBuilder buffer, SourceUnit unit ) {
+            final colx = node.getColumnNumber()
+            final colz = node.getLastColumnNumber()
+            final first = node.getLineNumber()
+            final last = node.getLastLineNumber()
+            for( int i=first; i<=last; i++ ) {
+                def line = unit.source.getLine(i, null)
+                if( i==last ) {
+                    line = line.substring(0,colz-1).replaceFirst(/}.*$/,'')
+                    if( !line.trim() ) continue
+                }
+                if( i==first ) {
+                    line = line.substring(colx-1).replaceFirst(/^.*\{/,'').trim()
+                    if( !line ) continue
+                }
+                buffer.append(line) .append('\n')
             }
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
@@ -471,9 +471,9 @@ class NextflowDSLImpl implements ASTTransformation {
                         }
                         body.add(stm)
                 }
+
+                readSource(stm, source, unit)
             }
-            // read the closure source
-            readSource(closure, source, unit, true)
 
             final bodyClosure = closureX(null, block(scope, body))
             final invokeBody = makeScriptWrapper(bodyClosure, source.toString(), 'workflow', unit)
@@ -750,28 +750,25 @@ class NextflowDSLImpl implements ASTTransformation {
          * @param buffer
          * @param unit
          */
-        private void readSource( ASTNode node, StringBuilder buffer, SourceUnit unit, stripBrackets=false ) {
+        private void readSource( Statement node, StringBuilder buffer, SourceUnit unit ) {
             final colx = node.getColumnNumber()
             final colz = node.getLastColumnNumber()
             final first = node.getLineNumber()
             final last = node.getLastLineNumber()
-            for( int i=first; i<=last; i++ ) {
-                def line = unit.source.getLine(i, null)
-                if( i==last ) {
-                    line = line.substring(0,colz-1)
-                    if( stripBrackets ) {
-                        line = line.replaceFirst(/}.*$/,'')
-                        if( !line.trim() ) continue
-                    }
+            for( int i = first; i <= last; i++ ) {
+                final line = unit.source.getLine(i, null)
+
+                // prepend first-line indent
+                if( i == first ) {
+                    int k = 0
+                    while( k < line.size() && line[k] == ' ' )
+                        k++
+                    buffer.append( line.substring(0, k) )
                 }
-                if( i==first ) {
-                    line = line.substring(colx-1)
-                    if( stripBrackets ) {
-                        line = line.replaceFirst(/^.*\{/,'').trim()
-                        if( !line.trim() ) continue
-                    }
-                }
-                buffer.append(line) .append('\n')
+
+                final begin = (i == first) ? colx - 1 : 0
+                final end = (i == last) ? colz - 1 : line.size()
+                buffer.append( line.substring(begin, end) ).append('\n')
             }
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
@@ -759,16 +759,21 @@ class NextflowDSLImpl implements ASTTransformation {
                 final line = unit.source.getLine(i, null)
 
                 // prepend first-line indent
+                def indent = ''
                 if( i == first ) {
                     int k = 0
                     while( k < line.size() && line[k] == ' ' )
                         k++
-                    buffer.append( line.substring(0, k) )
+                    indent = line.substring(0, k)
                 }
+
+                // prepend statement label
+                if( node.statementLabel )
+                    buffer.append(indent).append(node.statementLabel).append(':\n')
 
                 final begin = (i == first) ? colx - 1 : 0
                 final end = (i == last) ? colz - 1 : line.size()
-                buffer.append( line.substring(begin, end) ).append('\n')
+                buffer.append(indent).append( line.substring(begin, end) ).append('\n')
             }
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1265,8 +1265,16 @@ class TaskProcessor {
         else {
             if( task?.source )  {
                 message << "Source block:"
-                task.source.stripIndent(true).eachLine {
-                    message << "  $it"
+                def ws_check = task.source =~ /\n(\s+)['"]{3}\n/
+                if( ws_check.find() ){
+                    def whitespace = ws_check[0][1]
+                    task.source.eachLine {
+                        message << "  ${it.startsWith(whitespace) ? it.substring(whitespace.size()) : it}"
+                    }
+                } else {
+                    task.source.eachLine {
+                        message << "  $it"
+                    }
                 }
             }
 
@@ -1328,9 +1336,10 @@ class TaskProcessor {
         else
             message = err0(error.cause)
 
+        message.eachLine {
+            result << '  ' << it << '\n'
+        }
         result
-            .append('  ')
-            .append(message)
             .append('\n')
             .toString()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1265,14 +1265,8 @@ class TaskProcessor {
         else {
             if( task?.source )  {
                 message << "Source block:"
-                // Trim indentation
-                def ws_size = []
-                task.source.eachLine {
-                    ws_size << it.indexOf(it.trim())
-                }
-                def min_ws_size = ws_size.findAll{ it > 0 }.min()
-                task.source.eachLine {
-                    message << "  ${min_ws_size && it.startsWith(" ") ? it.substring(min_ws_size) : it}"
+                task.source.stripIndent(true).eachLine {
+                    message << "  $it"
                 }
             }
 
@@ -1334,8 +1328,8 @@ class TaskProcessor {
         else
             message = err0(error.cause)
 
-        message.eachLine {
-            result << '  ' << it << '\n'
+        message.eachLine { line ->
+            result << '  ' << line << '\n'
         }
         result
             .append('\n')

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1265,16 +1265,14 @@ class TaskProcessor {
         else {
             if( task?.source )  {
                 message << "Source block:"
-                def ws_check = task.source =~ /\n(\s+)['"]{3}\n/
-                if( ws_check.find() ){
-                    def whitespace = ws_check[0][1]
-                    task.source.eachLine {
-                        message << "  ${it.startsWith(whitespace) ? it.substring(whitespace.size()) : it}"
-                    }
-                } else {
-                    task.source.eachLine {
-                        message << "  $it"
-                    }
+                // Trim indentation
+                def ws_size = []
+                task.source.eachLine {
+                    ws_size << it.indexOf(it.trim())
+                }
+                def min_ws_size = ws_size.findAll{ it > 0 }.min()
+                task.source.eachLine {
+                    message << "  ${min_ws_size && it.startsWith(" ") ? it.substring(min_ws_size) : it}"
                 }
             }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
@@ -91,27 +91,27 @@ class WorkflowDefTest extends Dsl2Spec {
         meta.getWorkflow('bravo') .declaredInputs == ['foo', 'bar']
         meta.getWorkflow('bravo') .declaredVariables == ['$out0']
         meta.getWorkflow('bravo') .source.stripIndent(true) == '''\
-              take:
-              foo
-              take:
-              bar
-              main:
-              print foo
-              print bar
-              emit:
-              foo+bar
-              '''.stripIndent(true)
+            take:
+            foo
+            take:
+            bar
+            main:
+            print foo
+            print bar
+            emit:
+            foo+bar
+            '''.stripIndent(true)
 
         meta.getWorkflow('delta') .declaredInputs == ['foo','bar']
         meta.getWorkflow('delta') .declaredVariables == [] 
         meta.getWorkflow('delta') .source.stripIndent(true) == '''\
-                take:
-                foo
-                take:
-                bar
-                main:
-                println foo+bar
-                '''.stripIndent(true)
+            take:
+            foo
+            take:
+            bar
+            main:
+            println foo+bar
+            '''.stripIndent(true)
 
         meta.getWorkflow('empty') .source == ''
         meta.getWorkflow('empty') .declaredInputs == []
@@ -328,11 +328,11 @@ class WorkflowDefTest extends Dsl2Spec {
                     
             workflow alpha {
               take:
-                foo
+              foo
               main:
-                print x 
+              print x 
               emit: 
-                foo  
+              foo  
             }
         '''
 
@@ -342,13 +342,13 @@ class WorkflowDefTest extends Dsl2Spec {
         def workflow = ScriptMeta.get(script).getWorkflow('alpha')
         then:
         workflow.getSource().stripIndent(true) == '''\
-                            take:
-                              foo
-                            main:
-                              print x 
-                            emit: 
-                              foo  
-                            '''.stripIndent(true)
+            take:
+            foo
+            main:
+            print x 
+            emit: 
+            foo  
+            '''.stripIndent(true)
     }
 
     def 'should capture empty workflow code'  () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
@@ -62,10 +62,10 @@ class WorkflowDefTest extends Dsl2Spec {
               take: foo
               take: bar
               main:
-              print foo
-              print bar
-              emit:
-              foo+bar
+                print foo
+                print bar
+              emit: 
+                foo+bar
             }
             
             workflow delta() {
@@ -91,27 +91,23 @@ class WorkflowDefTest extends Dsl2Spec {
         meta.getWorkflow('bravo') .declaredInputs == ['foo', 'bar']
         meta.getWorkflow('bravo') .declaredVariables == ['$out0']
         meta.getWorkflow('bravo') .source.stripIndent(true) == '''\
-            take:
-            foo
-            take:
-            bar
-            main:
-            print foo
-            print bar
-            emit:
-            foo+bar
-            '''.stripIndent(true)
+              take: foo
+              take: bar
+              main:
+                print foo
+                print bar
+              emit: 
+                foo+bar
+              '''.stripIndent(true)
 
         meta.getWorkflow('delta') .declaredInputs == ['foo','bar']
         meta.getWorkflow('delta') .declaredVariables == [] 
         meta.getWorkflow('delta') .source.stripIndent(true) == '''\
-            take:
-            foo
-            take:
-            bar
-            main:
-            println foo+bar
-            '''.stripIndent(true)
+                take: foo
+                take: bar
+                main:
+                println foo+bar
+                '''.stripIndent(true)
 
         meta.getWorkflow('empty') .source == ''
         meta.getWorkflow('empty') .declaredInputs == []
@@ -328,11 +324,11 @@ class WorkflowDefTest extends Dsl2Spec {
                     
             workflow alpha {
               take:
-              foo
+                foo
               main:
-              print x 
+                print x 
               emit: 
-              foo  
+                foo  
             }
         '''
 
@@ -342,13 +338,13 @@ class WorkflowDefTest extends Dsl2Spec {
         def workflow = ScriptMeta.get(script).getWorkflow('alpha')
         then:
         workflow.getSource().stripIndent(true) == '''\
-            take:
-            foo
-            main:
-            print x 
-            emit: 
-            foo  
-            '''.stripIndent(true)
+                            take:
+                              foo
+                            main:
+                              print x 
+                            emit: 
+                              foo  
+                            '''.stripIndent(true)
     }
 
     def 'should capture empty workflow code'  () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
@@ -62,10 +62,10 @@ class WorkflowDefTest extends Dsl2Spec {
               take: foo
               take: bar
               main:
-                print foo
-                print bar
-              emit: 
-                foo+bar
+              print foo
+              print bar
+              emit:
+              foo+bar
             }
             
             workflow delta() {
@@ -91,20 +91,24 @@ class WorkflowDefTest extends Dsl2Spec {
         meta.getWorkflow('bravo') .declaredInputs == ['foo', 'bar']
         meta.getWorkflow('bravo') .declaredVariables == ['$out0']
         meta.getWorkflow('bravo') .source.stripIndent(true) == '''\
-              take: foo
-              take: bar
+              take:
+              foo
+              take:
+              bar
               main:
-                print foo
-                print bar
-              emit: 
-                foo+bar
+              print foo
+              print bar
+              emit:
+              foo+bar
               '''.stripIndent(true)
 
         meta.getWorkflow('delta') .declaredInputs == ['foo','bar']
         meta.getWorkflow('delta') .declaredVariables == [] 
         meta.getWorkflow('delta') .source.stripIndent(true) == '''\
-                take: foo
-                take: bar
+                take:
+                foo
+                take:
+                bar
                 main:
                 println foo+bar
                 '''.stripIndent(true)


### PR DESCRIPTION
Fixes https://github.com/nextflow-io/nextflow/issues/4585

## Input output

Using this toy:
```nextflow
workflow {
    TASK(Channel.of('a')).view()
}

process TASK {
    input:
    val letter

    script:
    assert letter.isUpperCase()
    def puzzle = null
    if ( puzzle ) {
        println "Puzzled"
    } else {
        println "LGTM"
    }
    """
    echo $letter
    """

    output:
    stdout
}
```
I now get a properly formatted error:
```
N E X T F L O W  ~  version 23.12.0-edge
Launching `../main.test.nf` [spontaneous_galileo] DSL2 - revision: 81c47780ef
[-        ] process > TASK -
ERROR ~ Error executing process > 'TASK (1)'

Caused by:
  assert letter.isUpperCase()
         |      |
         'a'    false -- Check script '/workspace/main.test.nf' at line: 10


Source block:
  assert letter.isUpperCase()
  def puzzle = null
  if ( puzzle ) {
      println "Puzzled"
  } else {
      println "LGTM"
  }
  """
  echo $letter
  """

Tip: view the complete command output by changing to the process work dir and entering the command `cat .command.out`

 -- Check '.nextflow.log' file for details
```


## Additional notes

`task.source` seems to be formatted strangely such `stripIndent` doesn't work. As soon as it encounters indented code, all indentation is preserved. E.g.
```nextflow
    script:
    if (meta.id) {
        args = "-f $meta.id"
    } else {
        args = "-f $bam.baseName"
    } 
```
becomes:
```nextflow
if (meta.id) {
        args = "-f $meta.id"
    } else {
        args = "-f $bam.baseName"
    } 
```