### PR TITLE
Add pip attribute to conda directive

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/res/CondaResource.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/res/CondaResource.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.executor.res
+
+
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+/**
+ * Model Conda packaging tool resource
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+@ToString(includeNames = true, includePackage = false)
+@EqualsAndHashCode
+class CondaResource {
+    final String packages
+    final String pip
+
+    private CondaResource(String conda, String pip) {
+        this.packages = conda
+        this.pip = pip
+    }
+
+    static CondaResource ofCondaPackages(CharSequence packages) {
+        new CondaResource(packages.toString(), null)
+    }
+
+    static CondaResource ofPipPackages(CharSequence packages) {
+        new CondaResource(null, packages.toString())
+    }
+
+    static CondaResource of(Map<String,?> values) {
+        if( !values )
+            throw new IllegalArgumentException("Conda directive cannot be empty")
+        for( String k in values.keySet()) {
+            if( k != 'packages' && k != 'pip' )
+                throw new IllegalArgumentException("Not a valid Conda directive attribute: '$k'")
+        }
+        new CondaResource(values.packages?.toString(), values.pip?.toString())
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/executor/res/CondaResource.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/res/CondaResource.groovy
@@ -38,7 +38,7 @@ class CondaResource {
 
     private CondaResource(String conda, String pip) {
         if( pip && conda && isFilePath(conda) )
-            throw new IllegalArgumentException("Conda environment file and Pip packages conflict each other - offending enviroment: '$conda'")
+            throw new IllegalArgumentException("Conda environment file and Pip packages conflict each other - offending environment: '$conda'")
         this.packages = conda
         this.pip = pip
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.processor
 
+import nextflow.executor.res.CondaResource
 import nextflow.util.CmdLineOptionMap
 
 import static nextflow.processor.TaskProcessor.*
@@ -444,6 +445,26 @@ class TaskConfig extends LazyMap implements Cloneable {
         if( value != null )
             throw new IllegalArgumentException("Invalid `accelerator` directive value: $value [${value.getClass().getName()}]")
         return null
+    }
+
+    String getConda() {
+        final result = get('conda')
+        if( result instanceof CondaResource )
+            return (result as CondaResource).packages 
+        // this may be needed for backward compatibility with serialised objects
+        if( result instanceof CharSequence )
+            return result
+        throw new IllegalArgumentException("Invalid `conda` directive value: $result [${result.getClass().getName()}]")
+    }
+
+    CondaResource getCondaResource() {
+        final result = get('conda')
+        if( result instanceof CondaResource )
+            return result as CondaResource
+        // this may be needed for backward compatibility with serialised objects
+        if( result instanceof CharSequence )
+            return CondaResource.ofCondaPackages(result)
+        throw new IllegalArgumentException("Invalid `conda` directive value: $result [${result.getClass().getName()}]")
     }
 
     String getMachineType() {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -451,6 +451,8 @@ class TaskConfig extends LazyMap implements Cloneable {
         final result = get('conda')
         if( result instanceof CondaResource )
             return (result as CondaResource).packages 
+        if( result instanceof Map )
+            return (result as Map).packages as String
         // this may be needed for backward compatibility with serialised objects
         if( result instanceof CharSequence )
             return result
@@ -463,6 +465,8 @@ class TaskConfig extends LazyMap implements Cloneable {
         final result = get('conda')
         if( result instanceof CondaResource )
             return result as CondaResource
+        if( result instanceof Map )
+            return CondaResource.of(result)
         // this may be needed for backward compatibility with serialised objects
         if( result instanceof CharSequence )
             return CondaResource.ofCondaPackages(result)

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -454,7 +454,9 @@ class TaskConfig extends LazyMap implements Cloneable {
         // this may be needed for backward compatibility with serialised objects
         if( result instanceof CharSequence )
             return result
-        throw new IllegalArgumentException("Invalid `conda` directive value: $result [${result.getClass().getName()}]")
+        if( result != null )
+            throw new IllegalArgumentException("Invalid `conda` directive value: $result [${result.getClass().getName()}]")
+        return null
     }
 
     CondaResource getCondaResource() {
@@ -464,7 +466,9 @@ class TaskConfig extends LazyMap implements Cloneable {
         // this may be needed for backward compatibility with serialised objects
         if( result instanceof CharSequence )
             return CondaResource.ofCondaPackages(result)
-        throw new IllegalArgumentException("Invalid `conda` directive value: $result [${result.getClass().getName()}]")
+        if( result != null )
+            throw new IllegalArgumentException("Invalid `conda` directive value: $result [${result.getClass().getName()}]")
+        return null
     }
 
     String getMachineType() {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -16,22 +16,39 @@
 
 package nextflow.script
 
+import static nextflow.util.CacheHelper.*
+
 import java.util.regex.Pattern
 
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.Const
-import nextflow.NF
 import nextflow.ast.NextflowDSLImpl
 import nextflow.exception.ConfigParseException
 import nextflow.exception.IllegalConfigException
 import nextflow.exception.IllegalDirectiveException
 import nextflow.executor.BashWrapperBuilder
+import nextflow.executor.res.CondaResource
 import nextflow.processor.ConfigList
 import nextflow.processor.ErrorStrategy
 import nextflow.processor.TaskConfig
-import static nextflow.util.CacheHelper.HashMode
-import nextflow.script.params.*
+import nextflow.script.params.DefaultInParam
+import nextflow.script.params.DefaultOutParam
+import nextflow.script.params.EachInParam
+import nextflow.script.params.EnvInParam
+import nextflow.script.params.EnvOutParam
+import nextflow.script.params.FileInParam
+import nextflow.script.params.FileOutParam
+import nextflow.script.params.InParam
+import nextflow.script.params.InputsList
+import nextflow.script.params.OutParam
+import nextflow.script.params.OutputsList
+import nextflow.script.params.StdInParam
+import nextflow.script.params.StdOutParam
+import nextflow.script.params.TupleInParam
+import nextflow.script.params.TupleOutParam
+import nextflow.script.params.ValueInParam
+import nextflow.script.params.ValueOutParam
 
 /**
  * Holds the process configuration properties
@@ -918,6 +935,27 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
         else if( value != null )
             throw new IllegalArgumentException("Not a valid `accelerator` directive value: $value [${value.getClass().getName()}]")
         return this
+    }
+
+    ProcessConfig conda( value ) {
+        if( value instanceof CharSequence ) {
+            configProperties.put('conda', CondaResource.ofCondaPackages(value))
+        }
+        else if( value instanceof Map ) {
+            configProperties.put('conda', CondaResource.of(value))
+        }
+        else if( value != null )
+            throw new IllegalArgumentException("Not a valid `conda` directive value: $value [${value.getClass().getName()}]")
+        return this
+    }
+
+    ProcessConfig conda( Map params, value ) {
+        if( value instanceof CharSequence ) {
+            params.packages = value
+        }
+        else if( value != null )
+            throw new IllegalArgumentException("Not a valid `conda` directive value: $value [${value.getClass().getName()}]")
+        return conda(params)
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/executor/res/CondaResourceTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/res/CondaResourceTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.executor.res
+
+
+import spock.lang.Specification
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class CondaResourceTest extends Specification {
+
+    def 'should create conda resource' () {
+        expect:
+        CondaResource.ofCondaPackages('foo bar').packages == 'foo bar'
+        CondaResource.ofPipPackages('foo bar').pip == 'foo bar'
+        CondaResource.of([packages: 'foo', pip: 'bar']).packages == 'foo'
+        CondaResource.of([packages: 'foo', pip: 'bar']).pip == 'bar'
+    }
+
+    def 'should validate equals and hashcode' () {
+        given:
+        def c1 = CondaResource.of([packages: 'foo', pip: 'bar'])
+        def c2 = CondaResource.of([packages: 'foo', pip: 'bar'])
+        def c3 = CondaResource.of([packages: 'foo', pip: 'baz'])
+
+        expect:
+        c1 == c2
+        c1 != c3
+        and:
+        c1.hashCode() == c2.hashCode()
+        c1.hashCode() != c3.hashCode()
+    }
+
+    def 'should return extended syntax' () {
+        expect:
+        CondaResource.of(VALUE).getExtendedPackages() == EXPECTED
+
+        where:
+        VALUE                           | EXPECTED
+        [packages:'foo']                | 'foo'
+        [packages:'foo bar']            | 'foo bar'
+        and:
+        [pip:'foo']                     | 'pip:foo'
+        [pip:'foo bar']                 | 'pip:foo pip:bar'
+        and:
+        [packages:'one', pip:'two three' ]    | 'one pip:two pip:three'
+
+    }
+
+    def "should check if it's a file" () {
+        expect:
+        CondaResource.isFilePath(VALUE)  == EXPECTED
+        where:
+        VALUE                   | EXPECTED
+        null                    | false
+        '/foo'                  | true
+        'this/that'             | true
+        'foo.yaml'              | true
+        'foo.yml'               | true
+        'http://foo.com'        | true
+        'https://foo.com'       | true
+        and:
+        'foo bar'               | false
+    }
+
+    def 'should report and error' () {
+        when:
+        CondaResource.of([:])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Conda directive cannot be empty'
+
+        when:
+        CondaResource.of([foo:'value'])
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message == "Not a valid Conda directive attribute: 'foo'"
+
+        when:
+        CondaResource.of([packages:'/file.txt', pip:'x y'])
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message == "Conda environment file and Pip packages conflict each other - offending enviroment: '/file.txt'"
+    }
+}

--- a/modules/nextflow/src/test/groovy/nextflow/executor/res/CondaResourceTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/res/CondaResourceTest.groovy
@@ -96,6 +96,6 @@ class CondaResourceTest extends Specification {
         CondaResource.of([packages:'/file.txt', pip:'x y'])
         then:
         e = thrown(IllegalArgumentException)
-        e.message == "Conda environment file and Pip packages conflict each other - offending enviroment: '/file.txt'"
+        e.message == "Conda environment file and Pip packages conflict each other - offending environment: '/file.txt'"
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -619,6 +619,21 @@ class TaskConfigTest extends Specification {
 
     }
 
+    def 'should get conda resources with map' () {
+        when:
+        def process = new ProcessConfig([conda: CONFIG])
+        then:
+        process.createTaskConfig().getConda() == CONDA
+        process.createTaskConfig().getCondaResource() == RESOURCES
+
+        where:
+        CONFIG                              | CONDA                 | RESOURCES
+        'foo bar'                           | 'foo bar'             | CondaResource.ofCondaPackages('foo bar')
+        [packages:'foo bar', pip: 'pandas'] | 'foo bar'             | CondaResource.of([packages:'foo bar', pip: 'pandas'])
+        [pip: 'pandas']                     | null                  | CondaResource.ofPipPackages('pandas')
+
+    }
+
     def 'should configure secrets'()  {
 
         given:

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -18,6 +18,7 @@ package nextflow.processor
 import java.nio.file.Paths
 
 import nextflow.exception.FailedGuardException
+import nextflow.executor.res.CondaResource
 import nextflow.k8s.model.PodOptions
 import nextflow.script.BaseScript
 import nextflow.script.ProcessConfig
@@ -589,6 +590,33 @@ class TaskConfigTest extends Specification {
         res.request == 5
         res.limit == 10
         res.type == 'nvidia'
+    }
+
+    def 'should get conda resources' () {
+        given:
+        def script = Mock(BaseScript)
+
+        when:
+        def process = new ProcessConfig(script)
+        process.conda 'foo bar'
+        then:
+        process.createTaskConfig().getConda() == 'foo bar'
+        process.createTaskConfig().getCondaResource() == CondaResource.ofCondaPackages('foo bar')
+
+        when:
+        process = new ProcessConfig(script)
+        process.conda 'foo bar', pip: 'pandas'
+        then:
+        process.createTaskConfig().getConda() == 'foo bar'
+        process.createTaskConfig().getCondaResource() == CondaResource.of([packages:'foo bar', pip: 'pandas'])
+
+        when:
+        process = new ProcessConfig(script)
+        process.conda pip: 'pandas'
+        then:   
+        process.createTaskConfig().getConda() == null
+        process.createTaskConfig().getCondaResource() == CondaResource.ofPipPackages('pandas')
+
     }
 
     def 'should configure secrets'()  {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -18,6 +18,7 @@ package nextflow.script
 
 import java.nio.file.Files
 
+import nextflow.executor.res.CondaResource
 import nextflow.scm.ProviderConfig
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -676,6 +677,26 @@ class ProcessConfigTest extends Specification {
         process.accelerator 5, request: 1
         then:
         process.accelerator == [request: 1, limit:5]
+    }
+
+    def 'should apply conda config' () {
+        given:
+        def process = new ProcessConfig(Mock(BaseScript))
+
+        when:
+        process.conda 'foo bar'
+        then:
+        process.conda == CondaResource.of([packages: 'foo bar'])
+
+        when:
+        process.conda 'foo bar', pip: 'pandas'
+        then:
+        process.conda == CondaResource.of([packages: 'foo bar', pip: 'pandas'])
+
+        when:
+        process.conda packages: 'foo bar', pip: 'pandas'
+        then:
+        process.conda == CondaResource.of([packages: 'foo bar', pip: 'pandas'])
     }
 
     def 'should apply disk config' () {

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.google.code.gson:gson:2.10.1'
     api 'org.yaml:snakeyaml:2.0'
-    api 'io.seqera:wave-utils:0.8.1'
+    api 'io.seqera:wave-utils:0.11.0'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.codehaus.groovy:groovy:3.0.19"

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -407,7 +407,7 @@ class WaveClient {
         // compose the request attributes
         def attrs = new HashMap<String,String>()
         attrs.container = containerImage
-        attrs.conda = task.config.conda as String
+        attrs.conda = task.config.getCondaResource()?.extendedPackages
         attrs.spack = task.config.spack as String
         if( bundle!=null && bundle.dockerfile ) {
             attrs.dockerfile = bundle.dockerfile.text

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,3 +41,4 @@ include 'plugins:nf-azure'
 include 'plugins:nf-codecommit'
 include 'plugins:nf-wave'
 include 'plugins:nf-cloudcache'
+//includeBuild('../libseqera')


### PR DESCRIPTION
This PR adds `pip` attribute to the `conda` directive to allow specifying pip packages as part of the conda packages specification. For example 


```
process Hello {
  conda 'multiqc', pip: 'pandas numpy'

  ''' 
  command_here
  '''
}
```

In the config it should be provided in the form 

```
process.conda = [packages: 'multiqc', pip: 'pandas numpy']
```