### PR TITLE
Improve handling of publish error

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -504,7 +504,14 @@ class PublishDir {
     }
 
     protected void createPublishDir() {
-        makeDirs(this.path)
+        try {
+            makeDirs(path)
+        }
+        catch( Throwable e ) {
+            log.warn "Failed to create publish directory: ${path.toUriString()} -- See log file for details", e
+            if( NF.strictMode || failOnError )
+                session?.abort(e)
+        }
     }
 
     protected void makeDirs(Path dir) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -508,9 +508,7 @@ class PublishDir {
             makeDirs(path)
         }
         catch( Throwable e ) {
-            log.warn "Failed to create publish directory: ${path.toUriString()} -- See log file for details", e
-            if( NF.strictMode || failOnError )
-                session?.abort(e)
+            session?.abort(new IllegalStateException("Failed to create publish directory: ${path.toUriString()}", e))
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -508,7 +508,7 @@ class PublishDir {
             makeDirs(path)
         }
         catch( Throwable e ) {
-            session?.abort(new IllegalStateException("Failed to create publish directory: ${path.toUriString()}", e))
+            throw new IllegalStateException("Failed to create publish directory: ${path.toUriString()}", e)
         }
     }
 


### PR DESCRIPTION
Close #4639 

If the creation of the base publish directory fails, the error message is misleading and vague. This PR makes this error handling consistent with other publish errors. If the publish directory cannot be created, it logs a specific warning and fails the pipeline only if `failOnError` is true (or strict mode is enabled).

Test case:
```groovy
process foo {
  publishDir 's3://<my-bucket>/results'

  output:
  path 'result.txt'

  script:
  """
  echo foo > result.txt
  """
}

workflow {
  foo()
}
```

Set the publishDir to any S3 bucket for which you don't have access.