### PR TITLE
Architecture update: dockerArch to dockerPlat

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy
@@ -35,7 +35,7 @@ class Architecture {
  * example of notation in process: arch 'linux/x86_64', target: 'haswell'
  * example of notation in config:  arch = [name: 'linux/x86_64', target: 'haswell']
  * 
- * where dockerArch = 'linux/x86_64'
+ * where dockerPlat = 'linux/x86_64'
  *       spackArch = target ?: arch  // plus some validation for Spack syntax
  * 
  *       platform = 'linux'
@@ -45,7 +45,7 @@ class Architecture {
  * [alternate example: 'arch linux/arm/v8', where platform = 'linux' and arch = 'arm/v8']
  */
     // used in Nextflow
-    final String dockerArch
+    final String dockerPlat
     final String spackArch
 
     // defined, but currently not used
@@ -73,7 +73,7 @@ class Architecture {
             return chunks[0]
     }
 
-    static private String validateArchToDockerArch( Map res ) {
+    static private String validateArchTomodules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy( Map res ) {
         def value = getArch(res.name as String)
         def name = res.name as String
         if( value == 'x86_64' || value == 'amd64' )
@@ -115,7 +115,6 @@ class Architecture {
         this.dockerArch = validateArchToDockerArch(res)
         this.platform = getPlatform(res.name as String)
         this.arch = getArch(res.name as String)
-
         if( res.target != null )
             this.target = res.target as String
         if( res.name!=null || res.target!=null )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy
@@ -73,7 +73,7 @@ class Architecture {
             return chunks[0]
     }
 
-    static private String validateArchTomodules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy( Map res ) {
+    static private String validateArchToDockerArch( Map res ) {
         def value = getArch(res.name as String)
         def name = res.name as String
         if( value == 'x86_64' || value == 'amd64' )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/Architecture.groovy
@@ -73,7 +73,7 @@ class Architecture {
             return chunks[0]
     }
 
-    static private String validateArchToDockerArch( Map res ) {
+    static private String validateArchToDockerPlat( Map res ) {
         def value = getArch(res.name as String)
         def name = res.name as String
         if( value == 'x86_64' || value == 'amd64' )
@@ -112,7 +112,7 @@ class Architecture {
         if( !res.name )
             throw new IllegalArgumentException("Missing architecture `name` attribute")
 
-        this.dockerArch = validateArchToDockerArch(res)
+        this.dockerPlat = validateArchToDockerPlat(res)
         this.platform = getPlatform(res.name as String)
         this.arch = getArch(res.name as String)
         if( res.target != null )

--- a/modules/nextflow/src/test/groovy/nextflow/processor/ArchitectureTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/ArchitectureTest.groovy
@@ -34,7 +34,7 @@ class ArchitectureTest extends Specification {
         arch.platform == PLAT
         arch.arch == ARCH
         arch.target == TAR
-        arch.dockerArch == DOCK
+        arch.dockerPlat == DOCK
         arch.spackArch == SPACK
 
         where:
@@ -55,7 +55,7 @@ class ArchitectureTest extends Specification {
         arch.platform == PLAT
         arch.arch == ARCH
         arch.target == TAR
-        arch.dockerArch == DOCK
+        arch.dockerPlat == DOCK
         arch.spackArch == SPACK
 
         where:

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -403,7 +403,7 @@ class WaveClient {
         // get the Spack architecture
         final arch = task.config.getArchitecture()
         final spackArch = arch ? arch.spackArch : DEFAULT_SPACK_ARCH
-        final dockerArch = arch? arch.dockerArch : DEFAULT_DOCKER_PLATFORM
+        final dockerPlat = arch? arch.dockerPlat : DEFAULT_DOCKER_PLATFORM
         // compose the request attributes
         def attrs = new HashMap<String,String>()
         attrs.container = containerImage
@@ -424,10 +424,10 @@ class WaveClient {
             checkConflicts(attrs, task.lazyName())
 
         //  resolve the wave assets
-        return resolveAssets0(attrs, bundle, singularity, dockerArch, spackArch)
+        return resolveAssets0(attrs, bundle, singularity, dockerPlat, spackArch)
     }
 
-    protected WaveAssets resolveAssets0(Map<String,String> attrs, ResourcesBundle bundle, boolean singularity, String dockerArch, String spackArch) {
+    protected WaveAssets resolveAssets0(Map<String,String> attrs, ResourcesBundle bundle, boolean singularity, String dockerPlat, String spackArch) {
 
         final scriptType = singularity ? 'singularityfile' : 'dockerfile'
         String containerScript = attrs.get(scriptType)
@@ -507,7 +507,7 @@ class WaveClient {
         /*
          * the container platform to be used
          */
-        final platform = dockerArch
+        final platform = dockerPlat
 
         // check is a valid container image
         WaveAssets.validateContainerName(containerImage)


### PR DESCRIPTION
This PR internally renames `dockerArch` to `dockerPlat`, for better jargon consistency in the codebase and docs. This variable specifies the platform to build containers via Wave, ie X86 or ARM.

Spun out of #4701 