### PR TITLE
nf-wave WaveClient: fix for s5cmdConfigUrl

### DIFF
--- a/modules/nf-commons/src/main/nextflow/extension/Bolts.groovy
+++ b/modules/nf-commons/src/main/nextflow/extension/Bolts.groovy
@@ -443,6 +443,12 @@ class Bolts {
         else if( type == RateUnit ) {
             return new RateUnit(self)
         }
+        else if ( type == URL ) {
+            return new URL(self)
+        }
+        else if ( type == URI ) {
+            return URI.create(self)
+        }
 
         StringGroovyMethods.asType(self, type);
     }
@@ -463,6 +469,12 @@ class Bolts {
         }
         else if( type == MemoryUnit ) {
             return new MemoryUnit(self.toString())
+        }
+        else if ( type == URL ) {
+            return new URL(self.toString())
+        }
+        else if ( type == URI ) {
+            return URI.create(self.toString())
         }
 
         StringGroovyMethods.asType(self, type);

--- a/modules/nf-commons/src/test/nextflow/extension/BoltsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/extension/BoltsTest.groovy
@@ -145,6 +145,18 @@ class BoltsTest extends Specification {
         "$x MB" as MemoryUnit == MemoryUnit.of('5 MB')
     }
 
+    def testAsURL() {
+        expect: 
+        'http://foo.com' as URL == new URL('http://foo.com')
+        'http://foo.com/some/file.txt' as URL == new URL('http://foo.com/some/file.txt')
+    }
+
+    def testAsURI() {
+        expect:
+        'http://foo.com' as URI == URI.create('http://foo.com')
+        'http://foo.com/some/file.txt' as URI == URI.create('http://foo.com/some/file.txt')
+    }
+
     def testConfigToMap  () {
 
         setup:

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -125,7 +125,7 @@ class WaveClient {
         this.fusion = new FusionConfig(session.config.fusion as Map ?: Collections.emptyMap(), SysEnv.get())
         this.tower = new TowerConfig(session.config.tower as Map ?: Collections.emptyMap(), SysEnv.get())
         this.awsFargate = WaveFactory.isAwsBatchFargateMode(session.config)
-        this.s5cmdConfigUrl = session.config.navigate('wave.s5cmdConfigUrl') as URL
+        this.s5cmdConfigUrl = parseUrl(session.config.navigate('wave.s5cmdConfigUrl') as String)
         this.endpoint = config.endpoint()
         this.condaChannels = session.getCondaConfig()?.getChannels() ?: DEFAULT_CONDA_CHANNELS
         log.debug "Wave config: $config"
@@ -140,6 +140,10 @@ class WaveClient {
         cookieManager = new CookieManager()
         // create http client
         this.httpClient = newHttpClient()
+    }
+
+    private URL parseUrl(String value) {
+        return value ? new URL(value) : null
     }
 
     protected HttpClient newHttpClient() {

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -125,7 +125,7 @@ class WaveClient {
         this.fusion = new FusionConfig(session.config.fusion as Map ?: Collections.emptyMap(), SysEnv.get())
         this.tower = new TowerConfig(session.config.tower as Map ?: Collections.emptyMap(), SysEnv.get())
         this.awsFargate = WaveFactory.isAwsBatchFargateMode(session.config)
-        this.s5cmdConfigUrl = parseUrl(session.config.navigate('wave.s5cmdConfigUrl') as String)
+        this.s5cmdConfigUrl = session.config.navigate('wave.s5cmdConfigUrl') as URL
         this.endpoint = config.endpoint()
         this.condaChannels = session.getCondaConfig()?.getChannels() ?: DEFAULT_CONDA_CHANNELS
         log.debug "Wave config: $config"

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -142,10 +142,6 @@ class WaveClient {
         this.httpClient = newHttpClient()
     }
 
-    private URL parseUrl(String value) {
-        return value ? new URL(value) : null
-    }
-
     protected HttpClient newHttpClient() {
         final builder = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -1248,6 +1248,15 @@ class WaveClientTest extends Specification {
         'linux/arm64/v8'    | 'https://nf-xpack.seqera.io/s5cmd/linux_arm64_2.0.0.json'
     }
 
+    def 'should configure custom s5cmd' () {
+        given:
+        def sess = Mock(Session) {getConfig() >> [wave:[s5cmdConfigUrl: 'http://host.com/s5cmd.zip']] }
+        when:
+        def wave = Spy(new WaveClient(sess))
+        then:
+        wave.@s5cmdConfigUrl == new URL('http://host.com/s5cmd.zip')
+    }
+
     def 'should check is local conda file' () {
         expect:
         WaveClient.isCondaLocalFile(CONTENT) == EXPECTED


### PR DESCRIPTION
This PR adds a small fix in WaveClient, to better handle `s5cmdConfigUrl`.

This is spun out of #4701, and comes from original Paolo's PR #4554.

internally renames `dockerArch` to `dockerPlat`, for better jargon consistency in the codebase and docs. This variable specifies the platform to build containers via Wave, ie X86 or ARM.

