### PR TITLE
Save built-in reports as Tower reports

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -390,8 +390,8 @@ class TowerClient implements TraceObserver {
     void onFlowComplete() {
         // submit the record
         events << new ProcessEvent(completed: true)
-        // send any runtime reports that are enabled
-        reports.sendRuntimeReports()
+        // publish runtime reports
+        reports.publishRuntimeReports()
         // wait the submission of pending events
         sender.join()
         // wait and flush reports content

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -390,6 +390,8 @@ class TowerClient implements TraceObserver {
     void onFlowComplete() {
         // submit the record
         events << new ProcessEvent(completed: true)
+        // send any runtime reports that are enabled
+        reports.sendRuntimeReports()
         // wait the submission of pending events
         sender.join()
         // wait and flush reports content

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerReports.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerReports.groovy
@@ -204,35 +204,6 @@ class TowerReports {
         return false
     }
 
-    /**
-     * Send any built-in reports that are enabled to the reports file.
-     */
-    void sendRuntimeReports() {
-        final config = session.config
-        final Map<String,Map<String,String>> entries = [:]
-        if( config.navigate('report.enabled') ) {
-            final reportFile = config.navigate('report.file', ReportObserver.DEF_FILE_NAME) as String
-            entries[reportFile] = Map.of('display', 'Nextflow execution report')
-        }
-        if( config.navigate('timeline.enabled') ) {
-            final reportFile = config.navigate('timeline.file', TimelineObserver.DEF_FILE_NAME) as String
-            entries[reportFile] = Map.of('display', 'Nextflow timeline report')
-        }
-        if( config.navigate('trace.enabled') ) {
-            final reportFile = config.navigate('trace.file', TraceFileObserver.DEF_FILE_NAME) as String
-            entries[reportFile] = Map.of('display', 'Nextflow trace report')
-        }
-        if( config.navigate('dag.enabled') ) {
-            final reportFile = config.navigate('dag.file', GraphObserver.DEF_FILE_NAME) as String
-            entries[reportFile] = Map.of('display', 'Nextflow workflow diagram')
-        }
-
-        for( def entry : entries ) {
-            final destination = (entry.key as Path).complete()
-            writer.send((PrintWriter it) -> writeRecord(it, entry, destination))
-        }
-    }
-
     private writeRecord(PrintWriter it, Map.Entry<String,Map<String,String>> reportEntry, Path destination) {
         try {
             final target = destination.toUriString()
@@ -252,5 +223,28 @@ class TowerReports {
     protected static String convertToGlobPattern(String reportKey) {
         final prefix = reportKey.startsWith("**/") ? "" : "**/"
         return "glob:${prefix}${reportKey}"
+    }
+
+    /**
+     * Publish any built-in reports that are enabled to the reports file.
+     */
+    void publishRuntimeReports() {
+        final config = session.config
+        final files = []
+
+        if( config.navigate('report.enabled') )
+            files << config.navigate('report.file', ReportObserver.DEF_FILE_NAME)
+
+        if( config.navigate('timeline.enabled') )
+            files << config.navigate('timeline.file', TimelineObserver.DEF_FILE_NAME)
+
+        if( config.navigate('trace.enabled') )
+            files << config.navigate('trace.file', TraceFileObserver.DEF_FILE_NAME)
+
+        if( config.navigate('dag.enabled') )
+            files << config.navigate('dag.file', GraphObserver.DEF_FILE_NAME)
+
+        for( def file : files )
+            filePublish( (file as Path).complete() )
     }
 }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerReports.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerReports.groovy
@@ -32,6 +32,10 @@ import groovy.yaml.YamlSlurper
 import groovyx.gpars.agent.Agent
 import nextflow.Session
 import nextflow.file.FileHelper
+import nextflow.trace.GraphObserver
+import nextflow.trace.ReportObserver
+import nextflow.trace.TimelineObserver
+import nextflow.trace.TraceFileObserver
 /**
  * If reports are defined at `nf-<workflow_id>-tower.yml`, collects all published files
  * that are reports and writes `nf-<workflow_id>-reports.tsv` file with all the paths.
@@ -198,6 +202,35 @@ class TowerReports {
             }
         }
         return false
+    }
+
+    /**
+     * Send any built-in reports that are enabled to the reports file.
+     */
+    void sendRuntimeReports() {
+        final config = session.config
+        final Map<String,Map<String,String>> entries = [:]
+        if( config.navigate('report.enabled') ) {
+            final reportFile = config.navigate('report.file', ReportObserver.DEF_FILE_NAME) as String
+            entries[reportFile] = Map.of('display', 'Nextflow execution report')
+        }
+        if( config.navigate('timeline.enabled') ) {
+            final reportFile = config.navigate('timeline.file', TimelineObserver.DEF_FILE_NAME) as String
+            entries[reportFile] = Map.of('display', 'Nextflow timeline report')
+        }
+        if( config.navigate('trace.enabled') ) {
+            final reportFile = config.navigate('trace.file', TraceFileObserver.DEF_FILE_NAME) as String
+            entries[reportFile] = Map.of('display', 'Nextflow trace report')
+        }
+        if( config.navigate('dag.enabled') ) {
+            final reportFile = config.navigate('dag.file', GraphObserver.DEF_FILE_NAME) as String
+            entries[reportFile] = Map.of('display', 'Nextflow workflow diagram')
+        }
+
+        for( def entry : entries ) {
+            final destination = (entry.key as Path).complete()
+            writer.send((PrintWriter it) -> writeRecord(it, entry, destination))
+        }
     }
 
     private writeRecord(PrintWriter it, Map.Entry<String,Map<String,String>> reportEntry, Path destination) {


### PR DESCRIPTION
Close #3460 

This PR saves the built-in reports as Tower reports by inspecting the Nextflow config. If a report is enabled, it will be eagerly sent to the reports file on workflow completion.

Note that if a report fails to create for some reason, it will be displayed in the platform run page but will not load since the file doesn't exist. In this case, the failure will have been logged as a warning to the console output.