### PR TITLE
Always emit publish event for symlinks on resume

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -385,6 +385,7 @@ class PublishDir {
             processFileImpl(source, destination)
         }
         catch( FileAlreadyExistsException e ) {
+            // don't copy source path if target is identical, but still emit publish event
             final sameRealPath = checkIsSameRealPath(source, destination)
             // make sure destination and source does not overlap
             // see https://github.com/nextflow-io/nextflow/issues/2177

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -385,14 +385,13 @@ class PublishDir {
             processFileImpl(source, destination)
         }
         catch( FileAlreadyExistsException e ) {
-            if( checkIsSameRealPath(source, destination) )
-                return 
+            final sameRealPath = checkIsSameRealPath(source, destination)
             // make sure destination and source does not overlap
             // see https://github.com/nextflow-io/nextflow/issues/2177
-            if( checkSourcePathConflicts(destination))
+            if( !sameRealPath && checkSourcePathConflicts(destination))
                 return
             
-            if( overwrite ) {
+            if( !sameRealPath && overwrite ) {
                 FileHelper.deletePath(destination)
                 processFileImpl(source, destination)
             }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -385,8 +385,10 @@ class PublishDir {
             processFileImpl(source, destination)
         }
         catch( FileAlreadyExistsException e ) {
-            // don't copy source path if target is identical, but still emit publish event
+            // don't copy source path if target is identical, but still emit the publish event
+            // see also https://github.com/nextflow-io/nf-prov/issues/22
             final sameRealPath = checkIsSameRealPath(source, destination)
+
             // make sure destination and source does not overlap
             // see https://github.com/nextflow-io/nextflow/issues/2177
             if( !sameRealPath && checkSourcePathConflicts(destination))


### PR DESCRIPTION
Close https://github.com/nextflow-io/nf-prov/issues/22

When publishing a symlink for a cached task, the publish event is normally skipped because the source and target paths are the same "real path". This PR adjusts the logic to ensure that the publish event is still emitted.

Symlink is the default publish mode, and nf-prov depends on publish events to generate the provenance manifest, so this is causing some confusing behavior for new users of nf-prov.

This fix was tested with Rob's minimal example in the linked issue and works.