### PR TITLE
Encode S3 Path URI

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Path.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Path.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.S3ObjectId;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.Tag;
@@ -410,12 +411,12 @@ public class S3Path implements Path, TagAwareFile {
 		builder.append("s3://");
 		if (fileSystem.getEndpoint() != null) {
 			builder.append(fileSystem.getEndpoint());
-		}
-		builder.append("/");
+            builder.append("/");
+        }
 		builder.append(bucket);
 		builder.append(PATH_SEPARATOR);
 		builder.append(Joiner.on(PATH_SEPARATOR).join(parts));
-		return URI.create(builder.toString());
+        return new AmazonS3URI(builder.toString()).getURI();
 	}
 
 	@Override

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3PathTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3PathTest.groovy
@@ -43,6 +43,17 @@ class S3PathTest extends Specification {
 
     }
 
+    @Unroll
+    def 'should convert to encoded URI' () {
+        expect:
+        FileHelper.asPath(PATH).toUri() == URI.create(STR)
+
+        where:
+        _ | PATH                                 | STR
+        _ | 's3://foo/some/file with spaces.txt' | 's3://foo/some/file%20with%20spaces.txt'
+        _ | 's3://foo/some/file+with+pluses.txt' | 's3://foo/some/file%2Bwith%2Bpluses.txt'
+    }
+
     def 'should check equals and hashcode' () {
         given:
         def path1 = FileHelper.asPath('s3://foo/some/foo.txt')


### PR DESCRIPTION
Closes #4778

> [!NOTE]
> Using AmazonS3URI since it already provides extra replacements on top of the Java URLEncoder (e.g. making sure spaces are encoded with `%20` instead of `+`).

> [!WARNING]
> Nesting `builder.append("/");` inside the condition as I believe it's related, and avoids the extra slash when the filesystem endpoint is `null`. AmazonS3URI does not deal so well with that extra slash.