### PR TITLE
Remove square brackets from job name in LSF executor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -114,10 +114,10 @@ class LsfExecutor extends AbstractGridExecutor {
 
     @Override
     String sanitizeJobName( String name ) {
-        // some implementations do not allow square brackets in the job name -- see #271
+        // LSF does not allow square brackets in job names except for job arrays
         name = name.replace('[','').replace(']','')
-        // LSF does not allow more than 4094 characters for the job name string
-        name.size()>4094 ? name.substring(0,4094) : name
+        // Old LSF versions do not allow job names longer than 511 chars
+        name.size()>511 ? name.substring(0,511) : name
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -112,6 +112,13 @@ class LsfExecutor extends AbstractGridExecutor {
         return result
     }
 
+    @Override
+    String sanitizeJobName( String name ) {
+        // some implementations do not allow square brackets in the job name -- see #271
+        name = name.replace('[','').replace(']','')
+        // LSF does not allow more than 4094 characters for the job name string
+        name.size()>4094 ? name.substring(0,4094) : name
+    }
 
     /**
      * The command line to submit this job

--- a/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -717,7 +717,7 @@ class LsfExecutorTest extends Specification {
         name             | expected
         'hello'          | 'nf-hello'
         '12 45'          | 'nf-12_45'
-        'hello[123]'     | 'nf-hello123'
+        'hello[123]-[xyz]'     | 'nf-hello123-xyz'
         'a'.repeat(4095) | 'nf-'.concat("a".repeat(4091))
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -714,11 +714,11 @@ class LsfExecutorTest extends Specification {
         executor.getJobNameFor(task).size() <= 4094
 
         where:
-        name             | expected
-        'hello'          | 'nf-hello'
-        '12 45'          | 'nf-12_45'
-        'hello[123]-[xyz]'     | 'nf-hello123-xyz'
-        'a'.repeat(4095) | 'nf-'.concat("a".repeat(4091))
+        name               | expected
+        'hello'            | 'nf-hello'
+        '12 45'            | 'nf-12_45'
+        'hello[123]-[xyz]' | 'nf-hello123-xyz'
+        'a'.repeat(509)    | 'nf-'.concat("a".repeat(508))
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -25,6 +25,8 @@ import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import spock.lang.Specification
+import spock.lang.Unroll
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -699,4 +701,25 @@ class LsfExecutorTest extends Specification {
         config.RESOURCE_RESERVE_PER_TASK == 'Y'
     }
 
+    // Adapted from PbsExecutorTest.groovy
+    @Unroll
+    def 'should return valid job name given #name'() {
+        given:
+        def executor = [:] as LsfExecutor
+        def task = Mock(TaskRun)
+        task.getName() >> name
+
+        expect:
+        executor.getJobNameFor(task) == expected
+        executor.getJobNameFor(task).size() <= 4094
+
+        where:
+        name             | expected
+        'hello'          | 'nf-hello'
+        '12 45'          | 'nf-12_45'
+        'hello[123]'     | 'nf-hello123'
+        'a'.repeat(4095) | 'nf-'.concat("a".repeat(4091))
+    }
+
 }
+


### PR DESCRIPTION
When there is a task name with square brackets, it fails on my LSF cluster:

```
-[nf-core/differentialabundance] Pipeline completed with errors-
ERROR ~ Error executing process > 'NFCORE_DIFFERENTIALABUNDANCE:DIFFERENTIALABUNDANCE:CUSTOM_MATRIXFILTER ([id:study])'

Caused by:
  Failed to submit process to grid scheduler for execution

Command executed [/hpc/users/goateomics/.nextflow/assets/nf-core/differentialabundance/./workflows/../modules/nf-core/custom/matrixfilter/templates/matrixfilter.R]:

  cat << 'LAUNCH_COMMAND_EOF' | bsub
  #!/bin/bash
  #BSUB -o /sc/arion/projects/load/users/goateomics/garretti_francesca/20240305.THP1_siRNA_bulkRNAseqDGE/work/8e/b989526c492d2818e8d2991b54110b/.command.log
  #BSUB -q express
  #BSUB -W 04:00
  #BSUB -M 6144
  #BSUB -R "select[mem>=6144] rusage[mem=6144]"
  #BSUB -J "nf-NFCORE_DIFFERENTIALABUNDANCE_DIFFERENTIALABUNDANCE_CUSTOM_MATRIXFILTER_([id_study])"
  #BSUB -P acc_LOAD
  #BSUB -R himem
  NXF_CHDIR=/sc/arion/projects/load/users/goateomics/garretti_francesca/20240305.THP1_siRNA_bulkRNAseqDGE/work/8e/b989526c492d2818e8d2991b54110b
  # NEXTFLOW TASK: NFCORE_DIFFERENTIALABUNDANCE:DIFFERENTIALABUNDANCE:CUSTOM_MATRIXFILTER ([id:study])
  set -e
  set -u
  NXF_DEBUG=${NXF_DEBUG:=0}; [[ $NXF_DEBUG > 1 ]] && set -x
  NXF_ENTRY=${1:-nxf_main}
```
...

```
Command exit status:
  255

Command output:
  Warning: Number of processor was not specified using bsub -n. Default value <1> was used.
  Bad job name. Job not submitted.
```

The brackets are responsible for that error. Therefore, I have modified `sanitizeJobName()` from the PBS executor to fix this.
