### PR TITLE
Google Batch: improve job naming convention

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -118,10 +118,11 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         // -- if not available fallback on a custom naming strategy
         final result = new StringBuilder("nf-")
         final name = task.getName()
-        for( int i=0; i<name.size(); i++ ) {
-            final ch = name[i]
-            result.append( INVALID_NAME_CHARS.contains(ch) ? "_" : ch )
-        }
+        if ( name )
+            for( int i=0; i<name.size(); i++ ) {
+                final ch = name[i]
+                result.append( INVALID_NAME_CHARS.contains(ch) ? "_" : ch )
+            }
         // sanitize to len = 242 = 256 minus the prefix "-" and the output of currentTimeMillis()
         return sanitizeJobName(result.toString(), 242) + "-${System.currentTimeMillis()}"
     }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -111,20 +111,14 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
      */
     protected String getJobNameFor(TaskRun task) {
         // -- check for a custom `jobName` defined in the nextflow config file
-         def customName = resolveCustomJobName(task)
-         if( customName )
-             return sanitizeJobName(customName, 256)
+        def customName = resolveCustomJobName(task)
+        if( customName )
+            return sanitizeJobName(customName, 256)
 
         // -- if not available fallback on a custom naming strategy
-        final result = new StringBuilder("nf-")
-        final name = task.getName()
-        if ( name )
-            for( int i=0; i<name.size(); i++ ) {
-                final ch = name[i]
-                result.append( INVALID_NAME_CHARS.contains(ch) ? "_" : ch )
-            }
+        def defaultName = "nf-${task.hashLog.replace('/','')}-${System.currentTimeMillis()}"
         // sanitize to len = 242 = 256 minus the prefix "-" and the output of currentTimeMillis()
-        return sanitizeJobName(result.toString(), 242) + "-${System.currentTimeMillis()}"
+        return sanitizeJobName(defaultName, 242) + "-${System.currentTimeMillis()}"
     }
 
     protected String sanitizeJobName(String name, Integer max) {


### PR DESCRIPTION
This PR comes out of #4714, and hence aims to update the job naming convention on Google Batch, by rendering it more human readable, and also customisable.

Key design choices:
* [updated] IGNORE THIS Updated default naming from `nf-<task-hashLog>-<system-time>` to a sanitised `nf-<task-name>-<system-time>` (similar to default for `executor.jobName`)
* Retained original default naming `nf-<task-hashLog>-<system-time>` 
* Added possibility to leverage `executor.jobName` config option to customise naming convention

TO DO:
- [ ] Update Google Batch documentation
- [x] Fix existing unit tests
- [ ] Add unit test in `GoogleBatchTaskHandlerTest`
- [ ] ? Run integration test
- [ ] ? Customise also for Google Life Sciences (see https://github.com/nextflow-io/nextflow/blob/master/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy#L341)