### PR TITLE
Improve control on azcopy install

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -341,7 +341,7 @@ The following settings are available:
 : Enable the automatic creation of batch pools depending on the pipeline resources demand (default: `true`).
 
 `azure.batch.copyToolInstallMode`
-: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution (default: `node`).
+: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution. Finally when `none` is specified, the `azcopy` tool is not installed (default: `node`).
 
 `azure.batch.deleteJobsOnCompletion`
 : Delete all jobs when the workflow completes (default: `false`).

--- a/docs/config.md
+++ b/docs/config.md
@@ -341,7 +341,7 @@ The following settings are available:
 : Enable the automatic creation of batch pools depending on the pipeline resources demand (default: `true`).
 
 `azure.batch.copyToolInstallMode`
-: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution. Finally when `none` is specified, the `azcopy` tool is not installed (default: `node`).
+: Specify where the `azcopy` tool used by Nextflow. When `node` is specified it's copied once during the pool creation. When `task` is provider, it's installed for each task execution. Finally when `off` is specified, the `azcopy` tool is not installed (default: `node`).
 
 `azure.batch.deleteJobsOnCompletion`
 : Delete all jobs when the workflow completes (default: `false`).

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -21,7 +21,10 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 import groovy.transform.CompileStatic
+import nextflow.Global
+import nextflow.Session
 import nextflow.cloud.CloudTransferOptions
+import nextflow.fusion.FusionHelper
 import nextflow.util.Duration
 import nextflow.util.StringUtils
 
@@ -136,10 +139,12 @@ class AzBatchOpts implements CloudTransferOptions {
     CopyToolInstallMode getCopyToolInstallMode() {
         // if the `installAzCopy` is not specified
         // `true` is returned when the pool is not create by Nextflow
-        // since it can be a pol provided by the user which does not
+        // since it can be a pool provided by the user which does not
         // provide the required `azcopy` tool
         if( copyToolInstallMode )
             return copyToolInstallMode
+        if( FusionHelper.isFusionEnabled((Session) Global.session) )
+            return CopyToolInstallMode.none
         canCreatePool() ? CopyToolInstallMode.node : CopyToolInstallMode.task
     }
 }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -144,7 +144,7 @@ class AzBatchOpts implements CloudTransferOptions {
         if( copyToolInstallMode )
             return copyToolInstallMode
         if( FusionHelper.isFusionEnabled((Session) Global.session) )
-            return CopyToolInstallMode.none
+            return CopyToolInstallMode.off
         canCreatePool() ? CopyToolInstallMode.node : CopyToolInstallMode.task
     }
 }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/CopyToolInstallMode.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/CopyToolInstallMode.groovy
@@ -23,5 +23,6 @@ package nextflow.cloud.azure.config
  */
 enum CopyToolInstallMode {
     node,
-    task
+    task,
+    none
 }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/CopyToolInstallMode.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/CopyToolInstallMode.groovy
@@ -24,5 +24,5 @@ package nextflow.cloud.azure.config
 enum CopyToolInstallMode {
     node,
     task,
-    none
+    off
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzBatchOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzBatchOptsTest.groovy
@@ -1,5 +1,7 @@
 package nextflow.cloud.azure.config
 
+import nextflow.Global
+import nextflow.Session
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -67,20 +69,23 @@ class AzBatchOptsTest extends Specification {
     @Unroll
     def 'should check azcopy install' () {
         given:
+        Global.session = Mock(Session) { getConfig()>>[fusion:[enabled: FUSION]] }
         AzBatchOpts opts = Spy(AzBatchOpts, constructorArgs: [ CONFIG,[:] ])
 
         expect:
         opts.getCopyToolInstallMode() == EXPECTED
 
         where:
-        EXPECTED                    | CONFIG
-        CopyToolInstallMode.task    | [:]
-        CopyToolInstallMode.node    | [allowPoolCreation: true]
-        CopyToolInstallMode.node    | [autoPoolMode: true]
-        CopyToolInstallMode.node    | [allowPoolCreation: true, copyToolInstallMode: 'node']
-        CopyToolInstallMode.task    | [allowPoolCreation: true, copyToolInstallMode: 'task']
-        CopyToolInstallMode.task    | [copyToolInstallMode: 'task']
-        CopyToolInstallMode.node    | [copyToolInstallMode: 'node']
+        EXPECTED                    | CONFIG                                                    | FUSION
+        CopyToolInstallMode.task    | [:]                                                       | false
+        CopyToolInstallMode.node    | [allowPoolCreation: true]                                 | false
+        CopyToolInstallMode.node    | [autoPoolMode: true]                                      | false
+        CopyToolInstallMode.node    | [allowPoolCreation: true, copyToolInstallMode: 'node']    | false
+        CopyToolInstallMode.task    | [allowPoolCreation: true, copyToolInstallMode: 'task']    | false
+        CopyToolInstallMode.task    | [copyToolInstallMode: 'task']                             | false
+        CopyToolInstallMode.node    | [copyToolInstallMode: 'node']                             | false
+        CopyToolInstallMode.none    | [copyToolInstallMode: 'none']                             | false
+        CopyToolInstallMode.none    | [:]                                                       | true
 
     }
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzBatchOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzBatchOptsTest.groovy
@@ -84,8 +84,8 @@ class AzBatchOptsTest extends Specification {
         CopyToolInstallMode.task    | [allowPoolCreation: true, copyToolInstallMode: 'task']    | false
         CopyToolInstallMode.task    | [copyToolInstallMode: 'task']                             | false
         CopyToolInstallMode.node    | [copyToolInstallMode: 'node']                             | false
-        CopyToolInstallMode.none    | [copyToolInstallMode: 'none']                             | false
-        CopyToolInstallMode.none    | [:]                                                       | true
+        CopyToolInstallMode.off     | [copyToolInstallMode: 'off']                              | false
+        CopyToolInstallMode.off     | [:]                                                       | true
 
     }
 }


### PR DESCRIPTION
This PR improves the control over the installation of the `azcopy` tool used by Azure batch execution by adding the ability to disable its installation using the `none` option or when Fusion is enabled. 

Moveover it prevents the installation in the compute node when the `task` mode is specified 