### PR TITLE
Hyperqueue breaking change (memory request)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -64,7 +64,7 @@ class HyperQueueExecutor extends AbstractGridExecutor {
 
         // No enforcement, Hq just makes sure that the allocated value is below the limit
         if( task.config.getMemory() )
-            result << '--resource' << "mem=${task.config.getMemory().toBytes()}".toString()
+            result << '--resource' << "mem=${task.config.getMemory().toBytes()/ (1024 * 1024)}".toString()
         if( task.config.hasCpus() )
             result << '--cpus'<< task.config.getCpus().toString()
         if( task.config.getTime() )


### PR DESCRIPTION
Hyperqueue version ≥ 0.17 needs memory requested in megabytes, not bytes. 
(https://github.com/It4innovations/hyperqueue/blob/main/CHANGELOG.md#breaking-change-1)
Worth adding a hyperqueue version check somehow??