### PR TITLE
Fix eval output type via bash -c wrapping

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -235,7 +235,7 @@ class BashWrapperBuilder {
         // out eval
         for( Map.Entry<String,String> eval : outEvals ) {
             result << "#\n"
-            result <<"nxf_eval_cmd STDOUT STDERR ${eval.value}\n"
+            result <<"nxf_eval_cmd STDOUT STDERR bash -c \"${eval.value}\"\n"
             result << 'status=$?\n'
             result << 'if [ $status -eq 0 ]; then\n'
             result << "  echo $eval.key=\"\$STDOUT\" >> ${TaskRun.CMD_ENV}\n"

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -1176,7 +1176,7 @@ class BashWrapperBuilderTest extends Specification {
             echo FOO="${FOO[@]}" >> .command.env
             echo /FOO/ >> .command.env
             #
-            nxf_eval_cmd STDOUT STDERR this --cmd
+            nxf_eval_cmd STDOUT STDERR bash -c "this --cmd"
             status=$?
             if [ $status -eq 0 ]; then
               echo THIS="$STDOUT" >> .command.env
@@ -1186,7 +1186,7 @@ class BashWrapperBuilderTest extends Specification {
               echo /THIS/=exit:$status >> .command.env
             fi
             #
-            nxf_eval_cmd STDOUT STDERR other --cmd
+            nxf_eval_cmd STDOUT STDERR bash -c "other --cmd"
             status=$?
             if [ $status -eq 0 ]; then
               echo THAT="$STDOUT" >> .command.env


### PR DESCRIPTION
This PR stems from issue #4870 , and fixes the shell implementation of the `eval` output type by wrapping the command within a `bash -c "<cmd>"` expression.  In this way, for instance, piping of commands becomes supported (see issue). 

Unit tests have been updated accordingly.

Note at this stage there is no special treatment of quote characters, may require double escaping in the input with this implementation.  @bentsherman have you any seen specific needs/use cases in this space?

