### PR TITLE
Do not print a new line when stdout is empty

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
@@ -120,7 +120,7 @@ class AnsiLogObserver implements TraceObserver {
     }
 
     synchronized void appendInfo(String message) {
-        if( message==null )
+        if( message==null || message.isEmpty() )
             return
         boolean warn
         if( isHashLogPrefix(message) && !(warn=message.indexOf('NOTE:')>0) )


### PR DESCRIPTION
## Description

When using `process.debug = true`, even if any process generates `stdout`, a new line is printed to `stdout` for each executed task.

I was expecting that if the process does not generate any `stdout`, then Nextflow does not print anything to `stdout`.

## Example
![Screenshot from 2024-04-06 06-48-51](https://github.com/nextflow-io/nextflow/assets/1315429/83bed581-d1a8-4e26-9a85-ff7e1c0e8b7a)

## With the fix in this pull request
![Screenshot from 2024-04-06 07-06-27](https://github.com/nextflow-io/nextflow/assets/1315429/54717f29-43e0-41e6-8480-046dd65d4f37)

**NOTE:** If ANSI is disabled, this will not happen.