### PR TITLE
Updated docs on Google Cloud setup and credentials

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -857,6 +857,9 @@ The following settings are available for Google Cloud Batch:
 `google.batch.serviceAccountEmail`
 : Define the Google service account email to use for the pipeline execution. If not specified, the default Compute Engine service account for the project will be used.
 
+  Note that the `google.batch.serviceAccountEmail` service account will only be used for spawned jobs, not for the Nextflow process itself. 
+  See the [Google Cloud](https://www.nextflow.io/docs/latest/google.html#credentials) documentation for more information on credentials.
+
 `google.batch.spot`
 : When `true` enables the usage of *spot* virtual machines or `false` otherwise (default: `false`).
 

--- a/docs/google.md
+++ b/docs/google.md
@@ -35,6 +35,9 @@ Then, define the following variable replacing the path in the example with the o
 export GOOGLE_APPLICATION_CREDENTIALS="/path/your/file/creds.json"
 ```
 
+See [Get started with Nextflow on Google Cloud Batch](https://www.nextflow.io/blog/2023/nextflow-with-gbatch.html) for more information on how to use Google Cloud Batch, 
+including how to set the required roles for your service account.
+
 (google-batch)=
 
 ## Cloud Batch


### PR DESCRIPTION
Updated docs on Google Cloud setup, in regards to credentials (e.g., setting service account roles).

This PR is specifically dealing with https://github.com/nextflow-io/nextflow/issues/4603 and [this slack thread](https://nextflow.slack.com/archives/C02TLU7U57F/p1712683379535059?thread_ts=1712517797.743939&cid=C02TLU7U57F).