### PR TITLE
Fix coloured ANSI log bug

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
@@ -419,7 +419,7 @@ class AnsiLogObserver implements TraceObserver {
         final labelSpaces = tagMatch ? tagMatch.group(2) : ''
         final labelNoTag = LBL_REPLACE.matcher(label).replaceFirst("")
         final labelFinalProcess = labelNoTag.tokenize(':')[-1]
-        final labelNoFinalProcess = labelFinalProcess.length() > 0 ? labelNoTag - labelFinalProcess : labelNoTag
+        final labelNoFinalProcess = labelNoTag.dropRight(labelFinalProcess.length())
         final hh = (stats.hash && tot>0 ? stats.hash : '-').padRight(9)
 
         final x = tot ? Math.floor(com / tot * 100f).toInteger() : 0


### PR DESCRIPTION
Truncation of the fully qualified process name was being too aggressive when the subworkflows included the process name as a substring.

Changed this to remove the process name by number of characters instead of by subtracting the string, now works as expected.