### PR TITLE
fix: remove commented out test lines in Azure Batch Pool opts tests.

### DIFF
--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
@@ -47,8 +47,8 @@ class AzPoolOptsTest extends Specification {
         !opts.password
         !opts.virtualNetwork
         !opts.lowPriority
-        // !opts.startTask
-        // !opts.startTaskPrivileged
+        !opts.startTask.script
+        !opts.startTask.privileged
     }
 
     def 'should create pool with custom options' () {


### PR DESCRIPTION
Some commented out lines were leftover from https://github.com/nextflow-io/nextflow/commit/27d01e3a2de65bb02d32a0240180c85b7507d03f in Azure Batch pool setup tests. This PR uncomments them so they are explicit.

Signed-off-by: Adam Talbot <12817534+adamrtalbot@users.noreply.github.com>
