### PR TITLE
Docs: Version switcher dropdown link fix

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -2,15 +2,15 @@
 
 {% block sidebartitle %}
     {{ super() }}
-    {%- set version_selected = "latest" -%}
+    {%- set version_selected = "stable" -%}
     {%- if "edge" in release %}{%- set version_selected = "edge" -%}{%- endif %}
     {%- if "dev" in release %}{%- set version_selected = "dev" -%}{%- endif %}
     <div class="sidebar_version">
         <span class="version">Version {{ release }} {{ release_checked_out }}</span>
         <select onchange="window.location = this.value;">
-            <option value="/docs/latest/index.html" {% if version_selected == 'latest' %}selected{% endif %}>Latest</option>
+            <option value="/docs/stable/index.html" {% if version_selected == 'stable' %}selected{% endif %}>Stable</option>
             <option value="/docs/edge/index.html" {% if version_selected == 'edge' %}selected{% endif %}>Edge</option>
-            <option value="/docs/master/index.html" {% if version_selected == 'dev' %}selected{% endif %}>Development</option>
+            <option value="/docs/latest/index.html" {% if version_selected == 'dev' %}selected{% endif %}>Development</option>
         </select>
         </select>
     </div>


### PR DESCRIPTION
We switched from using /master/ to using /latest/ - update the quick switch dropdown.

Ties together with https://github.com/nextflow-io/website/pull/198 - forgot that these links are also hardcoded into the Nextflow repo itself 🙈 