### PR TITLE
Fix semaphore in parallel polling monitor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/ParallelPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/ParallelPollingMonitor.groovy
@@ -55,7 +55,7 @@ class ParallelPollingMonitor extends TaskPollingMonitor {
 
     @Override
     protected boolean canSubmit(TaskHandler handler) {
-        return super.canSubmit(handler) && semaphore?.tryAcquire()
+        return super.canSubmit(handler) && (semaphore == null || semaphore.tryAcquire())
     }
 
     protected RateLimiter createSubmitRateLimit() {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/ParallelPollingMonitorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/ParallelPollingMonitorTest.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.processor
 
+
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -23,6 +24,7 @@ import nextflow.Session
 import nextflow.util.Duration
 import nextflow.util.ThrottlingExecutor
 import spock.lang.Specification
+import spock.lang.Unroll
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -69,6 +71,50 @@ class ParallelPollingMonitorTest extends Specification {
         failure.get() == 0
         change.get() == 1
 
+    }
+
+    @Unroll
+    def 'should validate can submit method' () {
+        given:
+        def success = new AtomicInteger()
+        def failure = new AtomicInteger()
+        def count = new AtomicInteger()
+        def change = new AtomicInteger()
+        def retry = new AtomicInteger()
+
+        def session = Mock(Session)
+        def handler = Mock(TaskHandler)
+
+        def opts = new ThrottlingExecutor.Options()
+            .retryOn(IllegalArgumentException)
+            .withRateLimit('10/sec')
+            .withErrorBurstDelay(Duration.of('5sec'))
+            .withAutoThrottle()
+            .onSuccess { success.incrementAndGet() }
+            .onRetry { retry.incrementAndGet() }
+            .onFailure { failure.incrementAndGet() }
+            .onRateLimitChange { change.incrementAndGet() }
+
+        def exec = ThrottlingExecutor.create(opts)
+        def mon = Spy(new ParallelPollingMonitor(exec, [capacity:CAPACITY, session:session, name:'foo', pollInterval:'1sec']))
+        and:
+        SUBMIT.times { mon.runningQueue.add(Mock(TaskHandler))  }
+
+        when:
+        def result = mon.canSubmit(handler)
+        then:
+        handler.canForkProcess() >> FORK
+        and:
+        result == EXPECTED
+
+        where:
+        CAPACITY    | SUBMIT | FORK  | EXPECTED
+        0           |   5    | true  | true
+        10          |   5    | true  | true
+        10          |   10   | true  | false
+        and:
+        0           |   1    | false | false
+        10          |   1    | false | false
     }
 
 }


### PR DESCRIPTION
In #4228 I made some changes to ensure that `executor.queueSize = 0` corresponds to no queue limit, and fixed a null reference error in the parallel polling monitor.

I made a small mistake which causes `executor.queueSize = 0` to mean "limit jobs to zero" instead of "no limit". Setting this in AWS Batch will cause no jobs to run. This PR corrects the mistake.