### PR TITLE
Guarantees K8s pod name is unique on resume

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
@@ -160,7 +160,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
 
     protected String getSyntheticPodName(TaskRun task) {
         final suffix = System.currentTimeMillis().toString().md5()[-5..-1]
-        return "nf-${task.hash}-$suffix"
+        return "nf-${task.hash}-${suffix}"
     }
 
     protected String getOwner() { OWNER }

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
@@ -159,7 +159,8 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     protected String getSyntheticPodName(TaskRun task) {
-        "nf-${task.hash}"
+        final suffix = System.currentTimeMillis().toString().md5()[-5..-1]
+        return "nf-${task.hash}-$suffix"
     }
 
     protected String getOwner() { OWNER }


### PR DESCRIPTION
This PR guarantees that a pod name is unique so that when resuming there is going to be no conflict 