### PR TITLE
Job array refactor 

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -31,6 +31,7 @@ import nextflow.container.ContainerBuilder
 import nextflow.container.DockerBuilder
 import nextflow.container.SingularityBuilder
 import nextflow.exception.ProcessException
+import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.processor.TaskBean
 import nextflow.processor.TaskProcessor
@@ -465,22 +466,22 @@ class BashWrapperBuilder {
     protected String getTaskMetadata() {
         final lines = new StringBuilder()
         lines << '### ---\n'
-        lines << "### name: '${name}'\n"
-        if( arrayIndexName ) {
+        lines << "### name: '${bean.name}'\n"
+        if( bean.arrayIndexName ) {
             lines << '### array:\n'
-            lines << "###   index-name: ${arrayIndexName}\n"
-            lines << "###   index-start: ${arrayIndexStart}\n"
+            lines << "###   index-name: ${bean.arrayIndexName}\n"
+            lines << "###   index-start: ${bean.arrayIndexStart}\n"
             lines << "###   work-dirs:\n"
-            for( String workDir : arrayWorkDirs )
-                lines << "###   - ${Escape.path(workDir)}\n"
+            for( Path it : bean.arrayWorkDirs )
+                lines << "###   - ${Escape.path(FilesEx.toUriString(it))}\n"
         }
 
         if( containerConfig?.isEnabled() )
-            lines << "### container: '${containerImage}'\n"
+            lines << "### container: '${bean.containerImage}'\n"
 
         if( outputFiles.size() > 0 ) {
             lines << '### outputs:\n'
-            for( final output : outputFiles )
+            for( final output : bean.outputFiles )
                 lines << "### - '${output}'\n"
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -117,9 +117,15 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
 
     @Override
     List<String> getLaunchCommand() {
+        // final launcher command
+        return fusionEnabled()
+            ? fusionSubmitCli()
+            : classicSubmitCli()
+    }
+
+    private List<String> classicSubmitCli() {
         final workDir = Escape.path(getWorkDir())
         final cmd = "bash ${workDir}/${TaskRun.CMD_RUN} 2>&1 | tee ${workDir}/${TaskRun.CMD_LOG}"
-
         List.of('bash', '-o', 'pipefail', '-c', cmd.toString())
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -44,7 +44,6 @@ import nextflow.processor.TaskRun
 import nextflow.trace.TraceRecord
 import nextflow.util.CmdLineHelper
 import nextflow.util.Duration
-import nextflow.util.Escape
 import nextflow.util.Throttle
 /**
  * Handles a job execution in the underlying grid platform
@@ -106,27 +105,6 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
     void prepareLauncher() {
         // -- create the wrapper script
         createTaskWrapper(task).build()
-    }
-
-    @Override
-    String getWorkDir() {
-        fusionEnabled()
-            ? FusionHelper.toContainerMount(task.workDir).toString()
-            : task.workDir.toString()
-    }
-
-    @Override
-    List<String> getLaunchCommand() {
-        // final launcher command
-        return fusionEnabled()
-            ? fusionSubmitCli()
-            : classicSubmitCli()
-    }
-
-    private List<String> classicSubmitCli() {
-        final workDir = Escape.path(getWorkDir())
-        final cmd = "bash ${workDir}/${TaskRun.CMD_RUN} 2>&1 | tee ${workDir}/${TaskRun.CMD_LOG}"
-        List.of('bash', '-o', 'pipefail', '-c', cmd.toString())
     }
 
     protected ProcessBuilder createProcessBuilder() {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -320,12 +320,19 @@ class LsfExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     }
 
     @Override
-    String getArrayIndexName() { 'LSB_JOBINDEX' }
+    String getArrayIndexName() {
+        return 'LSB_JOBINDEX'
+    }
 
     @Override
-    int getArrayIndexStart() { 1 }
+    int getArrayIndexStart() {
+        return 1
+    }
 
     @Override
-    String getArrayTaskId(String jobId, int index) { "${jobId}[${index + 1}]" }
+    String getArrayTaskId(String jobId, int index) {
+        assert jobId, "Missing 'jobId' argument"
+        return "${jobId}[${index + 1}]"
+    }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -182,14 +182,19 @@ class PbsExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     }
 
     @Override
-    String getArrayIndexName() { 'PBS_ARRAY_INDEX' }
+    String getArrayIndexName() {
+        return 'PBS_ARRAY_INDEX'
+    }
 
     @Override
-    int getArrayIndexStart() { 0 }
+    int getArrayIndexStart() {
+        return 0
+    }
 
     @Override
     String getArrayTaskId(String jobId, int index) {
-        jobId.replace('[]', "[$index]")
+        assert jobId, "Missing 'jobId' argument"
+        return jobId.replace('[]', "[$index]")
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
@@ -199,12 +199,18 @@ class SgeExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     }
 
     @Override
-    String getArrayIndexName() { 'SGE_TASK_ID' }
+    String getArrayIndexName() {
+        return 'SGE_TASK_ID'
+    }
 
     @Override
-    int getArrayIndexStart() { 1 }
+    int getArrayIndexStart() {
+        return 1
+    }
 
     @Override
-    String getArrayTaskId(String jobId, int index) { "${jobId}.${index}" }
+    String getArrayTaskId(String jobId, int index) {
+        return "${jobId}.${index}"
+    }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -220,12 +220,19 @@ class SlurmExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     }
 
     @Override
-    String getArrayIndexName() { 'SLURM_ARRAY_TASK_ID' }
+    String getArrayIndexName() {
+        return 'SLURM_ARRAY_TASK_ID'
+    }
 
     @Override
-    int getArrayIndexStart() { 0 }
+    int getArrayIndexStart() {
+        return 0
+    }
 
     @Override
-    String getArrayTaskId(String jobId, int index) { "${jobId}_${index}" }
+    String getArrayTaskId(String jobId, int index) {
+        assert jobId, "Missing 'jobId' argument"
+        return "${jobId}_${index}"
+    }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/TaskArrayExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/TaskArrayExecutor.groovy
@@ -61,6 +61,12 @@ interface TaskArrayExecutor {
         getWorkDir().fileSystem== FileSystems.default
     }
 
+    /**
+     * Get a {@link TaskHandler} work directory for the task array resolution
+     *
+     * @param handler
+     * @return
+     */
     default String getArrayWorkDir(TaskHandler handler) {
         return isFusionEnabled()
             ? FusionHelper.toContainerMount(handler.task.workDir).toString()

--- a/modules/nextflow/src/main/groovy/nextflow/executor/TaskArrayExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/TaskArrayExecutor.groovy
@@ -16,16 +16,19 @@
 
 package nextflow.executor
 
+import java.nio.file.FileSystems
 import java.nio.file.Path
 
+import groovy.transform.CompileStatic
+import nextflow.fusion.FusionHelper
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskRun
-
 /**
  * Interface for executors that support job arrays.
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
+@CompileStatic
 interface TaskArrayExecutor {
 
     String getName()
@@ -54,4 +57,25 @@ interface TaskArrayExecutor {
      */
     String getArrayTaskId(String jobId, int index)
 
+    default boolean isWorkDirDefaultFS() {
+        getWorkDir().fileSystem== FileSystems.default
+    }
+
+    default String getArrayWorkDir(TaskHandler handler) {
+        return isFusionEnabled()
+            ? FusionHelper.toContainerMount(handler.task.workDir).toString()
+            : handler.task.workDir.toUriString()
+    }
+
+    default String getArrayLaunchCommand(String taskDir) {
+        if( isFusionEnabled() ) {
+            return "bash ${taskDir}/${TaskRun.CMD_RUN}"
+        }
+        else if( isWorkDirDefaultFS() ) {
+            return "bash ${taskDir}/${TaskRun.CMD_RUN} 2>&1 > ${taskDir}/${TaskRun.CMD_LOG}"
+        }
+        else {
+            throw new IllegalStateException("Executor ${getName()} does not support array jobs")
+        }
+    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -25,11 +25,8 @@ import groovy.util.logging.Slf4j
 import nextflow.executor.Executor
 import nextflow.executor.TaskArrayExecutor
 import nextflow.file.FileHelper
-import nextflow.fusion.FusionAwareTask
-import nextflow.fusion.FusionHelper
 import nextflow.util.CacheHelper
 import nextflow.util.Escape
-
 /**
  * Task monitor that batches tasks and submits them as job arrays
  * to an underlying task monitor.
@@ -151,7 +148,8 @@ class TaskArrayCollector {
 
         // create wrapper script
         final script = createTaskArrayScript(handlers)
-
+        log.debug "Creating task array run >> $workDir\n$script"
+        
         // create config for job array
         final rawConfig = new HashMap<String,Object>(ARRAY_DIRECTIVES.size())
         for( final key : ARRAY_DIRECTIVES ) {
@@ -188,30 +186,19 @@ class TaskArrayCollector {
      */
     protected String createTaskArrayScript(List<TaskHandler> array) {
         // get work directory and launch command for each task
-        final workDirs = array.collect( h -> workDir(h) )
-        final args = array.first().getLaunchCommand().toArray() as String[]
-        final cmd = Escape.cli(args).replaceAll(workDirs.first(), '\\${nxf_array_task_dir}')
-
-        // create wrapper script
-        final indexName = executor.getArrayIndexName()
-        final indexStart = executor.getArrayIndexStart()
-        final arrayIndex = indexStart > 0
-            ? "${indexName} - ${indexStart}"
-            : "${indexName}"
-
+        final workDirs = array.collect( h -> executor.getArrayWorkDir(h) )
         """
         array=( ${workDirs.collect( p -> Escape.path(p) ).join(' ')} )
-        export nxf_array_task_dir=\${array[${arrayIndex}]}
-        ${cmd}
+        export nxf_array_task_dir=${getArrayIndexRef()}
+        ${executor.getArrayLaunchCommand('$nxf_array_task_dir')}
         """.stripIndent().leftTrim()
     }
 
-    protected String workDir(TaskHandler h) {
-        if( h instanceof FusionAwareTask && h.fusionEnabled() ) {
-            return FusionHelper.toContainerMount(h.task.workDir).toString()
-        }
-        else
-            return h.task.workDir.toUriString()
+    protected String getArrayIndexRef() {
+        final name = executor.getArrayIndexName()
+        final start = executor.getArrayIndexStart()
+        final index = start > 0 ? "${name} - ${start}" : name
+        return '${array[' + index + "]}"
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -147,7 +147,7 @@ class TaskArrayCollector {
         Files.createDirectories(workDir)
 
         // create wrapper script
-        final script = createTaskArrayScript(handlers)
+        final script = createArrayTaskScript(handlers)
         log.debug "Creating task array run >> $workDir\n$script"
         
         // create config for job array
@@ -184,7 +184,7 @@ class TaskArrayCollector {
      *
      * @param array
      */
-    protected String createTaskArrayScript(List<TaskHandler> array) {
+    protected String createArrayTaskScript(List<TaskHandler> array) {
         // get work directory and launch command for each task
         final workDirs = array.collect( h -> executor.getArrayWorkDir(h) )
         """

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -108,7 +108,7 @@ class TaskBean implements Serializable, Cloneable {
 
     Integer arrayIndexStart
 
-    List<String> arrayWorkDirs
+    List<Path> arrayWorkDirs
 
     @PackageScope
     TaskBean() {
@@ -169,7 +169,7 @@ class TaskBean implements Serializable, Cloneable {
             final executor = (TaskArrayExecutor)task.getProcessor().getExecutor()
             this.arrayIndexName = executor.getArrayIndexName()
             this.arrayIndexStart = executor.getArrayIndexStart()
-            this.arrayWorkDirs = task.children.collect( h -> h.getWorkDir() )
+            this.arrayWorkDirs = task.children.collect( h -> h.task.workDir )
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -97,16 +97,6 @@ abstract class TaskHandler {
     void prepareLauncher() {}
 
     /**
-     * Get the work directory as it will be seen from the launcher script.
-     */
-    String getWorkDir() { null }
-
-    /**
-     * Get the command to execute the launcher script.
-     */
-    List<String> getLaunchCommand() { null }
-
-    /**
      * Task status attribute setter.
      *
      * @param status The sask status as defined by {@link TaskStatus}

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -344,7 +344,7 @@ class BashWrapperBuilderTest extends Specification {
             name: 'foo',
             arrayIndexName: 'SLURM_ARRAY_TASK_ID',
             arrayIndexStart: 0,
-            arrayWorkDirs: [ '/work/01', '/work/02', '/work/03' ],
+            arrayWorkDirs: [ Path.of('/work/01'), Path.of('/work/02'), Path.of('/work/03') ],
             containerConfig: [enabled: true],
             containerImage: 'quay.io/nextflow:bash',
             outputFiles: ['foo.txt', '*.bar', '**/baz']
@@ -401,7 +401,7 @@ class BashWrapperBuilderTest extends Specification {
             name: 'task2',
             arrayIndexName: 'SLURM_ARRAY_TASK_ID',
             arrayIndexStart: 0,
-            arrayWorkDirs: [ '/work/01', '/work/02', '/work/03' ],
+            arrayWorkDirs: [ Path.of('/work/01'), Path.of('/work/02'), Path.of('/work/03') ],
             containerConfig: [enabled: true],
             containerImage: 'quay.io/nextflow:bash',
             outputFiles: ['foo.txt', '*.bar', '**/baz']

--- a/modules/nextflow/src/test/groovy/nextflow/executor/GridTaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/GridTaskHandlerTest.groovy
@@ -144,21 +144,4 @@ class GridTaskHandlerTest extends Specification {
                 '''.stripIndent()
     }
 
-    def 'should get launch command' () {
-        given:
-        def task = Mock(TaskRun) {
-            workDir >> Path.of('/work/dir')
-        }
-        def exec = Mock(AbstractGridExecutor)
-        def handler = Spy(new GridTaskHandler(task, exec)) {
-            fusionEnabled() >> false
-        }
-
-        expect:
-        handler.getLaunchCommand() == [
-            'bash',
-            '-o', 'pipefail',
-            '-c', 'bash /work/dir/.command.run 2>&1 > /work/dir/.command.log'
-        ]
-    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/GridTaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/GridTaskHandlerTest.groovy
@@ -158,7 +158,7 @@ class GridTaskHandlerTest extends Specification {
         handler.getLaunchCommand() == [
             'bash',
             '-o', 'pipefail',
-            '-c', 'bash /work/dir/.command.run 2>&1 | tee /work/dir/.command.log'
+            '-c', 'bash /work/dir/.command.run 2>&1 > /work/dir/.command.log'
         ]
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -724,5 +724,26 @@ class LsfExecutorTest extends Specification {
         'a'.repeat(509)    | 'nf-'.concat("a".repeat(508))
     }
 
+    def 'should get array index name and start' () {
+        given:
+        def executor = Spy(LsfExecutor)
+        expect:
+        executor.getArrayIndexName() == 'LSB_JOBINDEX'
+        executor.getArrayIndexStart() == 1
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(LsfExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo'       | 1             | 'foo[2]'
+        'bar'       | 2             | 'bar[3]'
+    }
+
 }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/PbsExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/PbsExecutorTest.groovy
@@ -312,4 +312,24 @@ class PbsExecutorTest extends Specification {
         !PbsExecutor.matchOptions('-x-l foo')
     }
 
+    def 'should get array index name and start' () {
+        given:
+        def executor = Spy(PbsExecutor)
+        expect:
+        executor.getArrayIndexName() == 'PBS_ARRAY_INDEX'
+        executor.getArrayIndexStart() == 0
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(PbsExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo[]'     | 1             | 'foo[1]'
+        'bar[]'     | 2             | 'bar[2]'
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/PbsProExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/PbsProExecutorTest.groovy
@@ -23,6 +23,8 @@ import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import spock.lang.Specification
+import spock.lang.Unroll
+
 /**
  *
  * @author Lorenz Gerber <lorenzottogerber@gmail.com>
@@ -264,4 +266,24 @@ class PbsProExecutorTest extends Specification {
                 .stripIndent().leftTrim()
     }
 
+    def 'should get array index name and start' () {
+        given:
+        def executor = Spy(PbsProExecutor)
+        expect:
+        executor.getArrayIndexName() == 'PBS_ARRAY_INDEX'
+        executor.getArrayIndexStart() == 0
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(PbsProExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo[]'     | 1             | 'foo[1]'
+        'bar[]'     | 2             | 'bar[2]'
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SgeExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SgeExecutorTest.groovy
@@ -22,6 +22,8 @@ import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import spock.lang.Specification
+import spock.lang.Unroll
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -385,4 +387,24 @@ class SgeExecutorTest extends Specification {
 
     }
 
+    def 'should get array index name and start' () {
+        given:
+        def executor = Spy(SgeExecutor)
+        expect:
+        executor.getArrayIndexName() == 'SGE_TASK_ID'
+        executor.getArrayIndexStart() == 1
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(SgeExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo'       | 1             | 'foo.1'
+        'bar'       | 2             | 'bar.2'
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -287,6 +287,27 @@ class SlurmExecutorTest extends Specification {
         usr
         exec.queueStatusCommand(null) == ['squeue','--noheader','-o','%i %t','-t','all','-u', usr]
         exec.queueStatusCommand('xxx') == ['squeue','--noheader','-o','%i %t','-t','all','-p','xxx','-u', usr]
-
     }
+
+    def 'should get array index name and start' () {
+        given:
+        def executor = Spy(SlurmExecutor)
+        expect:
+        executor.getArrayIndexName() == 'SLURM_ARRAY_TASK_ID'
+        executor.getArrayIndexStart() == 0
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(SlurmExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo'       | 1             | 'foo_1'
+        'bar'       | 2             | 'bar_2'
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
@@ -139,7 +139,7 @@ class TaskArrayCollectorTest extends Specification {
         then:
         3 * exec.createTaskHandler(task) >> handler
         3 * handler.prepareLauncher()
-        1 * collector.createTaskArrayScript([handler,handler,handler]) >> 'the-task-array-script'
+        1 * collector.createArrayTaskScript([handler, handler, handler]) >> 'the-task-array-script'
         and:
         taskArray.name == 'PROC (1)'
         taskArray.config.cpus == 4
@@ -152,4 +152,47 @@ class TaskArrayCollectorTest extends Specification {
         taskArray.isContainerEnabled() == false
     }
 
+    def 'should get array ref' () {
+        given:
+        def processor = Mock(TaskProcessor)
+        def executor = Mock(DummyExecutor) {
+            getArrayIndexName() >> NAME
+            getArrayIndexStart() >> START
+        }
+        def collector = Spy(new TaskArrayCollector(processor, executor, 10))
+        expect:
+        collector.getArrayIndexRef() == EXPECTED
+
+        where:
+        NAME        | START     | EXPECTED
+        'INDEX'     | 0         | '${array[INDEX]}'
+        'INDEX'     | 1         | '${array[INDEX - 1]}'
+        'OTHER'     | 99        | '${array[OTHER - 99]}'
+    }
+
+    def 'should get array launch script' () {
+        given:
+        def processor = Mock(TaskProcessor)
+        def executor = Spy(DummyExecutor) { isWorkDirDefaultFS()>>true }
+        def collector = Spy(new TaskArrayCollector(processor, executor, 10))
+        and:
+        def h1 = Mock(TaskHandler)
+        def h2 = Mock(TaskHandler)
+        def h3 = Mock(TaskHandler)
+
+        when:
+        def result = collector.createArrayTaskScript([h1,h2,h3])
+        then:
+        executor.getArrayWorkDir(h1) >> '/work/dir/1'
+        executor.getArrayWorkDir(h2) >> '/work/dir/2'
+        executor.getArrayWorkDir(h3) >> '/work/dir/3'
+        and:
+        collector.getArrayIndexRef() >> '$array[INDEX]'
+        then:
+        result == '''\
+                array=( /work/dir/1 /work/dir/2 /work/dir/3 )
+                export nxf_array_task_dir=$array[INDEX]
+                bash $nxf_array_task_dir/.command.run 2>&1 > $nxf_array_task_dir/.command.log
+                '''.stripIndent(true)
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
@@ -128,6 +128,7 @@ class TaskArrayCollectorTest extends Specification {
         def task = Mock(TaskRun) {
             index >> 1
             getHash() >> HashCode.fromString('0123456789abcdef')
+            getWorkDir() >> Paths.get('/work/foo')
         }
         def handler = Mock(TaskHandler) {
             getTask() >> task

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
@@ -343,7 +343,9 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint, TaskArrayExec
     int getArrayIndexStart() { 0 }
 
     @Override
-    String getArrayTaskId(String jobId, int index) { "${jobId}:${index}" }
+    String getArrayTaskId(String jobId, int index) {
+        return "${jobId}:${index}"
+    }
 
     @Override
     String getArrayLaunchCommand(String taskDir) {

--- a/plugins/nf-amazon/src/test/nextflow/executor/AwsBatchExecutorTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/AwsBatchExecutorTest.groovy
@@ -7,11 +7,18 @@
 
 package nextflow.executor
 
+import java.nio.file.Path
+
 import nextflow.Session
 import nextflow.SysEnv
 import nextflow.cloud.aws.batch.AwsBatchExecutor
+import nextflow.cloud.aws.batch.AwsOptions
+import nextflow.cloud.aws.util.S3PathFactory
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskRun
 import nextflow.util.ThrottlingExecutor
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  *
@@ -63,6 +70,74 @@ class AwsBatchExecutorTest extends Specification {
         executor.killTask('array-job-id:1')
         then:
         1 * executor.killTask0('array-job-id') >> null
+    }
+
+    def 'should get array index variable and start' () {
+        given:
+        def executor = Spy(AwsBatchExecutor)
+        expect:
+        executor.getArrayIndexName() == 'AWS_BATCH_JOB_ARRAY_INDEX'
+        executor.getArrayIndexStart() == 0
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(AwsBatchExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo'       | 1             | 'foo:1'
+        'bar'       | 2             | 'bar:2'
+    }
+
+    protected Path s3(String path) {
+        S3PathFactory.parse('s3:/' + path)
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(AwsBatchExecutor) {
+            isFusionEnabled()>>FUSION
+            isWorkDirDefaultFS()>>DEFAULT_FS
+        }
+        and:
+        def handler = Mock(TaskHandler) {
+            getTask() >> Mock(TaskRun) { getWorkDir() >> WORK_DIR }
+        }
+        expect:
+        executor.getArrayWorkDir(handler) == EXPECTED
+
+        where:
+        FUSION  | DEFAULT_FS  | WORK_DIR              | EXPECTED
+        false   | false       | s3('/foo/work/dir')   | 's3://foo/work/dir'
+        true    | false       | s3('/foo/work/dir')   | '/fusion/s3/foo/work/dir'
+        false   | true        | Path.of('/nfs/work')  | '/nfs/work'
+    }
+
+    def 'should get array launch command' (){
+        given:
+        def executor = Spy(AwsBatchExecutor) {
+            isFusionEnabled()>>FUSION
+            isWorkDirDefaultFS()>>DEFAULT_FS
+            getAwsOptions() >> Mock(AwsOptions) {
+                getS5cmdPath() >> { S5CMD ? 's5cmd' : null }
+                getAwsCli() >> { 'aws' }
+            }
+        }
+        expect:
+        executor.getArrayLaunchCommand(TASK_DIR) == EXPECTED
+
+        where:
+        FUSION  | DEFAULT_FS  | S5CMD   | TASK_DIR            | EXPECTED
+        false   | false       | false   | 's3://foo/work/dir' | 'bash -o pipefail -c \'trap "{ ret=$?; aws s3 cp --only-show-errors .command.log s3://foo/work/dir/.command.log||true; exit $ret; }" EXIT; aws s3 cp --only-show-errors s3://foo/work/dir/.command.run - | bash 2>&1 | tee .command.log\''
+        false   | false       | true    | 's3://foo/work/dir' | 'bash -o pipefail -c \'trap "{ ret=$?; s5cmd cp .command.log s3://foo/work/dir/.command.log||true; exit $ret; }" EXIT; s5cmd cat s3://foo/work/dir/.command.run | bash 2>&1 | tee .command.log\''
+        and:
+        true    | false       | false   | '/fusion/work/dir'  | 'bash /fusion/work/dir/.command.run'
+        false   | true        | false   | '/nfs/work/dir'     | 'bash /nfs/work/dir/.command.run 2>&1 > /nfs/work/dir/.command.log'
     }
 
 }

--- a/plugins/nf-amazon/src/test/nextflow/executor/TaskArrayExecutorTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/TaskArrayExecutorTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.executor
+
+import java.nio.file.Path
+
+import nextflow.file.http.XPath
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskRun
+import spock.lang.Specification
+import spock.lang.Unroll
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class TaskArrayExecutorTest extends Specification {
+
+    static abstract class TestArrayExecutor implements TaskArrayExecutor {
+
+    }
+
+    @Unroll
+    def 'should get array work dir' () {
+        given:
+        def task = Mock(TaskRun) {  getWorkDir() >> WORK_DIR }
+        def handler = Mock(TaskHandler) { getTask()>>task }
+        and:
+        def executor = Spy(TestArrayExecutor) { isFusionEnabled() >> FUSION }
+        when:
+        def result = executor.getArrayWorkDir(handler)
+        then:
+        result == EXPECTED
+        
+        where:
+        FUSION  | WORK_DIR                           |  EXPECTED
+        false   | Path.of('/work/dir')               | '/work/dir'
+        false   | XPath.get('http://foo.com/work')   | 'http://foo.com/work'
+        true    | XPath.get('http://foo.com/work')   | '/fusion/http/foo.com/work'
+    }
+
+    @Unroll
+    def 'should get array launch command' () {
+        given:
+        def executor = Spy(TestArrayExecutor) {
+            isFusionEnabled() >> FUSION
+            isWorkDirDefaultFS() >> !FUSION
+        }
+
+        expect:
+        executor.getArrayLaunchCommand(WORK_DIR) == EXPECTED
+
+        where:
+        FUSION      | WORK_DIR              | EXPECTED
+        false       | '/work/dir'           | 'bash /work/dir/.command.run 2>&1 > /work/dir/.command.log'
+        true        | '/fusion/work/dir'    | 'bash /fusion/work/dir/.command.run'
+    }
+
+}

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -21,6 +21,7 @@ import static nextflow.cloud.google.batch.GoogleBatchScriptLauncher.*
 
 import java.nio.file.Path
 
+import com.google.cloud.storage.contrib.nio.CloudStoragePath
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.SysEnv
@@ -160,13 +161,11 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
         return index.toString()
     }
 
+    @Override
     String getArrayWorkDir(TaskHandler handler) {
-        if( isFusionEnabled() || isWorkDirDefaultFS() ) {
-            return TaskArrayExecutor.super.getArrayWorkDir(handler)
-        }
-        else {
-            return (handler as GoogleBatchTaskHandler).getWorkDirContainerMount()
-        }
+        return isFusionEnabled() || isWorkDirDefaultFS()
+            ? TaskArrayExecutor.super.getArrayWorkDir(handler)
+            : containerMountPath(handler.task.workDir as CloudStoragePath)
     }
 
     @Override

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -64,6 +64,12 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
         bean.workDir = toContainerMount(bean.workDir)
         bean.targetDir = toContainerMount(bean.targetDir)
 
+        // add all children work dir 
+        if( bean.arrayWorkDirs ) {
+            for( Path it : bean.arrayWorkDirs )
+                toContainerMount(it)
+        }
+
         // remap input files to container mounted paths
         for( Map.Entry<String,Path> entry : new HashMap<>(bean.inputFiles).entrySet() ) {
             bean.inputFiles.put( entry.key, toContainerMount(entry.value, true) )
@@ -113,7 +119,7 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
 
     @Override
     String runCommand() {
-        "trap \"{ cp ${TaskRun.CMD_LOG} ${workDirMount}/${TaskRun.CMD_LOG}; }\" ERR; /bin/bash ${workDirMount}/${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}"
+        launchCommand(workDirMount)
     }
 
     @Override
@@ -171,4 +177,7 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
         return this
     }
 
+    static String launchCommand( String workDir ) {
+        "trap \"{ cp ${TaskRun.CMD_LOG} ${workDir}/${TaskRun.CMD_LOG}; }\" ERR; /bin/bash ${workDir}/${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}"
+    }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -108,7 +108,7 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
         if( path instanceof CloudStoragePath ) {
             buckets.add(path.bucket())
             pathTrie.add( (parent ? "/${path.bucket()}${path.parent}" : "/${path.bucket()}${path}").toString() )
-            final containerMount = "$MOUNT_ROOT/${path.bucket()}${path}"
+            final containerMount = containerMountPath(path)
             log.trace "Path ${FilesEx.toUriString(path)} to container mount: $containerMount"
             return Paths.get(containerMount)
         }
@@ -179,5 +179,9 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
 
     static String launchCommand( String workDir ) {
         "trap \"{ cp ${TaskRun.CMD_LOG} ${workDir}/${TaskRun.CMD_LOG}; }\" ERR; /bin/bash ${workDir}/${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}"
+    }
+
+    static String containerMountPath(CloudStoragePath path) {
+        return "$MOUNT_ROOT/${path.bucket()}${path}"
     }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -156,15 +156,6 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         launcher.build()
     }
 
-    Path getWorkDirContainerMount() {
-        if( launcher instanceof GoogleBatchScriptLauncher )
-            return launcher.toContainerMount(task.workDir)
-        // this method is only expected to be accessed by the job array collector
-        // when using Google Storage as work directory
-        // it should not be invoked when using Fusion or a NFS shared file system
-        throw new IllegalStateException("Unexpected access to getWorkDirContainerMount method")
-    }
-
     @Override
     void submit() {
         /*

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
@@ -7,12 +7,16 @@
 
 package nextflow.cloud.google.batch
 
+import java.nio.file.Path
+
+import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
 import nextflow.Session
 import nextflow.SysEnv
 import nextflow.cloud.google.batch.client.BatchClient
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskRun
 import spock.lang.Specification
 import spock.lang.Unroll
-
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -74,5 +78,69 @@ class GoogleBatchExecutorTest extends Specification {
         executor.killTask('job-id')
         then:
         1 * client.deleteJob('job-id')
+    }
+
+    def 'should get array index variable and start' () {
+        given:
+        def executor = Spy(GoogleBatchExecutor)
+        expect:
+        executor.getArrayIndexName() == 'BATCH_TASK_INDEX'
+        executor.getArrayIndexStart() == 0
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(GoogleBatchExecutor)
+        expect:
+        executor.getArrayTaskId(JOB_ID, TASK_INDEX) == EXPECTED
+
+        where:
+        JOB_ID      | TASK_INDEX    | EXPECTED
+        'foo'       | 1             | '1'
+        'bar'       | 2             | '2'
+    }
+
+    protected Path gs(String str) {
+        def b = str.tokenize('/')[0]
+        def p = str.tokenize('/')[1..-1].join('/')
+        CloudStorageFileSystem.forBucket(b).getPath('/'+p)
+    }
+
+    @Unroll
+    def 'should get array task id' () {
+        given:
+        def executor = Spy(GoogleBatchExecutor) {
+            isFusionEnabled()>>FUSION
+            isWorkDirDefaultFS()>>DEFAULT_FS
+        }
+        and:
+        def handler = Mock(TaskHandler) {
+            getTask() >> Mock(TaskRun) { getWorkDir() >> WORK_DIR }
+        }
+        expect:
+        executor.getArrayWorkDir(handler) == EXPECTED
+
+        where:
+        FUSION  | DEFAULT_FS  | WORK_DIR              | EXPECTED
+        false   | false       | gs('/foo/work/dir')   | '/mnt/disks/foo/work/dir'
+        true    | false       | gs('/foo/work/dir')   | '/fusion/gs/foo/work/dir'
+        false   | true        | Path.of('/nfs/work')  | '/nfs/work'
+    }
+
+    def 'should get array launch command' (){
+        given:
+        def executor = Spy(GoogleBatchExecutor) {
+            isFusionEnabled()>>FUSION
+            isWorkDirDefaultFS()>>DEFAULT_FS
+        }
+        expect:
+        executor.getArrayLaunchCommand(TASK_DIR) == EXPECTED
+
+        where:
+        FUSION  | DEFAULT_FS  | TASK_DIR            | EXPECTED
+        false   | false       | 'gs://foo/work/dir' | '/bin/bash -o pipefail -c \'trap "{ cp .command.log gs://foo/work/dir/.command.log; }" ERR; /bin/bash gs://foo/work/dir/.command.run 2>&1 | tee .command.log\''
+        true    | false       | '/fusion/work/dir'  | 'bash /fusion/work/dir/.command.run'
+        false   | true        | '/nfs/work/dir'     | 'bash /nfs/work/dir/.command.run 2>&1 > /nfs/work/dir/.command.log'
     }
 }


### PR DESCRIPTION
This PR refactor the support for job array provided by #3892. Main changes 

* Remove the need for `getWorkDir` and `getLaunchCommand` in `TaskHandler` 
* Add similar methods to TaskArrayExecutor providing default implementation 
* Fix support for Fusion 
* Add tests   