### PR TITLE
Improve error message for image pull time-out for Singularity/Apptainer/Charliecloud

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -240,7 +240,7 @@ class CharliecloudCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (default is $DEFAULT_PULLTIMEOUT_DURATION)\n  message:\n"
+            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (default is "${DEFAULT_PULLTIMEOUT_DURATION}")\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -39,8 +39,6 @@ import nextflow.util.Duration
 @CompileStatic
 class CharliecloudCache {
 
-    static final private Duration DEFAULT_PULLTIMEOUT_DURATION = Duration.of('20min')
-
     static final private Map<String,DataflowVariable<Path>> localImageNames = new ConcurrentHashMap<>()
 
     private ContainerConfig config
@@ -49,7 +47,7 @@ class CharliecloudCache {
 
     private boolean missingCacheDir
 
-    private Duration pullTimeout
+    private Duration pullTimeout = Duration.of('20min')
 
     private String registry
 
@@ -124,7 +122,8 @@ class CharliecloudCache {
     @PackageScope
     Path getCacheDir() {
 
-        pullTimeout = config.pullTimeout ? config.pullTimeout as Duration : DEFAULT_PULLTIMEOUT_DURATION
+        if( config.pullTimeout )
+            pullTimeout = config.pullTimeout as Duration
 
         def str = config.cacheDir as String
         if( str )

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -240,7 +240,7 @@ class CharliecloudCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (default is \"${DEFAULT_PULLTIMEOUT_DURATION}\")\n  message:\n"
+            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (current is \"${pullTimeout}\")\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -240,7 +240,7 @@ class CharliecloudCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (default is "${DEFAULT_PULLTIMEOUT_DURATION}")\n  message:\n"
+            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (default is \"${DEFAULT_PULLTIMEOUT_DURATION}\")\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -39,6 +39,8 @@ import nextflow.util.Duration
 @CompileStatic
 class CharliecloudCache {
 
+    static final private Duration DEFAULT_PULLTIMEOUT_DURATION = Duration.of('20min')
+
     static final private Map<String,DataflowVariable<Path>> localImageNames = new ConcurrentHashMap<>()
 
     private ContainerConfig config
@@ -47,7 +49,7 @@ class CharliecloudCache {
 
     private boolean missingCacheDir
 
-    private Duration pullTimeout = Duration.of('20min')
+    private Duration pullTimeout
 
     private String registry
 
@@ -122,8 +124,7 @@ class CharliecloudCache {
     @PackageScope
     Path getCacheDir() {
 
-        if( config.pullTimeout )
-            pullTimeout = config.pullTimeout as Duration
+        pullTimeout = config.pullTimeout ? config.pullTimeout as Duration : DEFAULT_PULLTIMEOUT_DURATION
 
         def str = config.cacheDir as String
         if( str )
@@ -239,7 +240,7 @@ class CharliecloudCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  message:\n"
+            def msg = "Charliecloud failed to pull image\n  command: $cmd\n  status : $status\n  hint   : Try and increase charliecloud.pullTimeout in the config (default is $DEFAULT_PULLTIMEOUT_DURATION)\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -42,8 +42,6 @@ import nextflow.util.Escape
 @CompileStatic
 class SingularityCache {
 
-    static final private Duration DEFAULT_PULLTIMEOUT_DURATION = Duration.of('20min')
-
     static final private Map<String,DataflowVariable<Path>> localImageNames = new ConcurrentHashMap<>()
 
     private ContainerConfig config
@@ -52,7 +50,7 @@ class SingularityCache {
 
     private boolean missingCacheDir
 
-    private Duration pullTimeout
+    private Duration pullTimeout = Duration.of('20min')
 
     /** Only for debugging purpose - do not use */
     @PackageScope
@@ -141,7 +139,8 @@ class SingularityCache {
     @PackageScope
     Path getCacheDir() {
 
-        pullTimeout = config.pullTimeout ? config.pullTimeout as Duration : DEFAULT_PULLTIMEOUT_DURATION
+        if( config.pullTimeout )
+            pullTimeout = config.pullTimeout as Duration
 
         def str = config.cacheDir as String
         if( str )

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -42,6 +42,8 @@ import nextflow.util.Escape
 @CompileStatic
 class SingularityCache {
 
+    static final private Duration DEFAULT_PULLTIMEOUT_DURATION = Duration.of('20min')
+
     static final private Map<String,DataflowVariable<Path>> localImageNames = new ConcurrentHashMap<>()
 
     private ContainerConfig config
@@ -50,12 +52,12 @@ class SingularityCache {
 
     private boolean missingCacheDir
 
-    private Duration pullTimeout = Duration.of('20min')
+    private Duration pullTimeout
 
     /** Only for debugging purpose - do not use */
     @PackageScope
     SingularityCache() {}
-
+z
     protected String getBinaryName() { return 'singularity' }
 
     protected String getAppName() { getBinaryName().capitalize() }
@@ -139,8 +141,7 @@ class SingularityCache {
     @PackageScope
     Path getCacheDir() {
 
-        if( config.pullTimeout )
-            pullTimeout = config.pullTimeout as Duration
+        pullTimeout = config.pullTimeout ? config.pullTimeout as Duration : DEFAULT_PULLTIMEOUT_DURATION
 
         def str = config.cacheDir as String
         if( str )
@@ -303,7 +304,7 @@ class SingularityCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  message:\n"
+            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase $binaryName.pullTimeout in the config (default is $DEFAULT_PULLTIMEOUT_DURATION)\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -304,7 +304,7 @@ class SingularityCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase $binaryName.pullTimeout in the config (default is $DEFAULT_PULLTIMEOUT_DURATION)\n  message:\n"
+            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase ${binaryName}.pullTimeout in the config (default is "${DEFAULT_PULLTIMEOUT_DURATION}")\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -304,7 +304,7 @@ class SingularityCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase ${binaryName}.pullTimeout in the config (default is \"${DEFAULT_PULLTIMEOUT_DURATION}\")\n  message:\n"
+            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase ${binaryName}.pullTimeout in the config (current is \"${pullTimeout}\")\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -57,7 +57,7 @@ class SingularityCache {
     /** Only for debugging purpose - do not use */
     @PackageScope
     SingularityCache() {}
-z
+
     protected String getBinaryName() { return 'singularity' }
 
     protected String getAppName() { getBinaryName().capitalize() }

--- a/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/SingularityCache.groovy
@@ -304,7 +304,7 @@ class SingularityCache {
         def status = proc.exitValue()
         if( status != 0 ) {
             consumer.join()
-            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase ${binaryName}.pullTimeout in the config (default is "${DEFAULT_PULLTIMEOUT_DURATION}")\n  message:\n"
+            def msg = "Failed to pull singularity image\n  command: $cmd\n  status : $status\n  hint   : Try and increase ${binaryName}.pullTimeout in the config (default is \"${DEFAULT_PULLTIMEOUT_DURATION}\")\n  message:\n"
             msg += err.toString().trim().indent('    ')
             throw new IllegalStateException(msg)
         }


### PR DESCRIPTION
Closes #4823  by adding an explicit suggestion in the error message, to increase the `pullTimeout` config for the relevant container runtime.