### PR TITLE
Add account config option for grid executors

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -646,6 +646,12 @@ The `executor` scope controls various executor behaviors.
 
 The following settings are available:
 
+`executor.account`
+: :::{versionadded} 24.04.0
+  :::
+: *Used only by the {ref}`slurm-executor`, {ref}`lsf-executor`, {ref}`pbs-executor` and {ref}`pbspro-executor` executor.*
+: Allows specifying the project or organisation account that should be charged for running the pipeline jobs.
+
 `executor.cpus`
 : The maximum number of CPUs made available by the underlying system. Used only by the `local` executor.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -649,7 +649,7 @@ The following settings are available:
 `executor.account`
 : :::{versionadded} 24.04.0
   :::
-: *Used only by the {ref}`slurm-executor`, {ref}`lsf-executor`, {ref}`pbs-executor` and {ref}`pbspro-executor` executor.*
+: *Used only by the {ref}`slurm-executor`, {ref}`lsf-executor`, {ref}`pbs-executor` and {ref}`pbspro-executor` executors.*
 : Allows specifying the project or organisation account that should be charged for running the pipeline jobs.
 
 `executor.cpus`

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -109,6 +109,12 @@ class LsfExecutor extends AbstractGridExecutor {
         // -- at the end append the command script wrapped file name
         result.addAll( task.config.getClusterOptionsAsList() )
 
+        // add account from config
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        if( account ) {
+            result << '-G' << account
+        }
+
         return result
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -110,7 +110,7 @@ class LsfExecutor extends AbstractGridExecutor {
         result.addAll( task.config.getClusterOptionsAsList() )
 
         // add account from config
-        final account = session.getExecConfigProp(name, 'account', null) as String
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
         if( account ) {
             result << '-G' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -110,7 +110,7 @@ class LsfExecutor extends AbstractGridExecutor {
         result.addAll( task.config.getClusterOptionsAsList() )
 
         // add account from config
-        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        final account = session.getExecConfigProp(name, 'account', null) as String
         if( account ) {
             result << '-G' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -79,6 +79,12 @@ class PbsExecutor extends AbstractGridExecutor {
             result << task.config.getClusterOptions() << ''
         }
 
+        // add account from config
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        if( account ) {
+            result << '-P' << account
+        }
+
         return result
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -80,7 +80,7 @@ class PbsExecutor extends AbstractGridExecutor {
         }
 
         // add account from config
-        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        final account = session.getExecConfigProp(name, 'account', null) as String
         if( account ) {
             result << '-P' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -80,7 +80,7 @@ class PbsExecutor extends AbstractGridExecutor {
         }
 
         // add account from config
-        final account = session.getExecConfigProp(name, 'account', null) as String
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
         if( account ) {
             result << '-P' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -84,6 +84,12 @@ class PbsProExecutor extends PbsExecutor {
             result << "-l" << "walltime=${duration.format('HH:mm:ss')}".toString()
         }
 
+        // add account from config
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        if( account ) {
+            result << '-P' << account
+        }
+
         return result
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -85,7 +85,7 @@ class PbsProExecutor extends PbsExecutor {
         }
 
         // add account from config
-        final account = session.getExecConfigProp(name, 'account', null) as String
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
         if( account ) {
             result << '-P' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -85,7 +85,7 @@ class PbsProExecutor extends PbsExecutor {
         }
 
         // add account from config
-        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        final account = session.getExecConfigProp(name, 'account', null) as String
         if( account ) {
             result << '-P' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -97,7 +97,7 @@ class SlurmExecutor extends AbstractGridExecutor {
         }
 
         // add slurm account from config
-        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        final account = session.getExecConfigProp(name, 'account', null) as String
         if( account ) {
             result << '-A' << account
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -91,6 +91,12 @@ class SlurmExecutor extends AbstractGridExecutor {
             result << '-p' << (task.config.queue.toString())
         }
 
+        // add slurm account from config
+        final account = session.getConfigAttribute('slurm.account', null) as String
+        if( account ) {
+            result << '-A' << account
+        }
+
         // -- at the end append the command script wrapped file name
         if( task.config.getClusterOptions() ) {
             result << task.config.getClusterOptions() << ''

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -91,15 +91,15 @@ class SlurmExecutor extends AbstractGridExecutor {
             result << '-p' << (task.config.queue.toString())
         }
 
-        // add slurm account from config
-        final account = session.getConfigAttribute('slurm.account', null) as String
-        if( account ) {
-            result << '-A' << account
-        }
-
         // -- at the end append the command script wrapped file name
         if( task.config.getClusterOptions() ) {
             result << task.config.getClusterOptions() << ''
+        }
+
+        // add slurm account from config
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
+        if( account ) {
+            result << '-A' << account
         }
 
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -97,7 +97,7 @@ class SlurmExecutor extends AbstractGridExecutor {
         }
 
         // add slurm account from config
-        final account = session.getExecConfigProp(name, 'account', null) as String
+        final account = session.getExecConfigProp(getName(), 'account', null) as String
         if( account ) {
             result << '-A' << account
         }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -290,7 +290,8 @@ class SlurmExecutorTest extends Specification {
         and:
         def executor = Spy(SlurmExecutor)
         executor.getJobNameFor(_) >> 'foo'
-        executor.getSession() >> Mock(Session) { getConfigAttribute('slurm.account',null)>>ACCOUNT }
+        executor.getName() >> 'slurm'
+        executor.getSession() >> Mock(Session) { getExecConfigProp('slurm', 'account',null)>>ACCOUNT }
 
         when:
         def result = executor.getDirectives(task, [])

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -15,6 +15,7 @@
  */
 
 package nextflow.executor
+
 import java.nio.file.Paths
 
 import nextflow.Session
@@ -23,7 +24,6 @@ import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import spock.lang.Specification
 import spock.lang.Unroll
-
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -82,6 +82,7 @@ class SlurmExecutorTest extends Specification {
         setup:
         // SLURM executor
         def executor = [:] as SlurmExecutor
+        executor.session = Mock(Session)
 
         // mock process
         def proc = Mock(TaskProcessor)
@@ -210,6 +211,7 @@ class SlurmExecutorTest extends Specification {
         setup:
         // LSF executor
         def executor = Spy(SlurmExecutor)
+        executor.session = Mock(Session)
 
         // mock process
         def proc = Mock(TaskProcessor)
@@ -274,5 +276,30 @@ class SlurmExecutorTest extends Specification {
         exec.queueStatusCommand(null) == ['squeue','--noheader','-o','%i %t','-t','all','-u', usr]
         exec.queueStatusCommand('xxx') == ['squeue','--noheader','-o','%i %t','-t','all','-p','xxx','-u', usr]
 
+    }
+
+    @Unroll
+    def 'should set slurm account' () {
+        given:
+        // task
+        def task = new TaskRun()
+        task.workDir = Paths.get('/work/dir')
+        task.processor = Mock(TaskProcessor)
+        task.processor.getSession() >> Mock(Session)
+        task.config = Mock(TaskConfig)
+        and:
+        def executor = Spy(SlurmExecutor)
+        executor.getJobNameFor(_) >> 'foo'
+        executor.getSession() >> Mock(Session) { getConfigAttribute('slurm.account',null)>>ACCOUNT }
+
+        when:
+        def result = executor.getDirectives(task, [])
+        then:
+        result == EXPECTED
+
+        where:
+        ACCOUNT             | EXPECTED
+        null                | ['-J', 'foo', '-o', '/work/dir/.command.log', '--no-requeue', '', '--signal', 'B:USR2@30']
+        'project-123'       | ['-J', 'foo', '-o', '/work/dir/.command.log', '--no-requeue', '', '--signal', 'B:USR2@30', '-A', 'project-123']
     }
 }


### PR DESCRIPTION
This PR adds the ability to define a Slurm account in the nextflow config. For example: 

```
executor {
  account = 'some-project-xyz'
}
```


Solve https://github.com/nextflow-io/nextflow/issues/4921

Updated to use `executor` instead of `slurm` on 7th May  