### PR TITLE
Update operator return types

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -21,7 +21,7 @@ This page is a comprehensive reference for all Nextflow operators. However, if y
 :::{versionadded} 19.08.0-edge
 :::
 
-*Returns: map of queue channels*
+*Returns: multiple queue channels or value channels, matching the source type*
 
 The `branch` operator forwards each item from a source channel to one of multiple output channels, based on a selection criteria.
 
@@ -486,7 +486,7 @@ See also: [combine](#combine)
 
 ## distinct
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `distinct` operator forwards a source channel with *consecutively* repeated items removed, such that each emitted item is different from the preceding one:
 
@@ -514,7 +514,7 @@ See also: [unique](#unique)
 
 ## dump
 
-*Returns: queue channel or value channel, depending on the input*
+*Returns: queue channel or value channel, matching the source type*
 
 The `dump` operator prints each item in a source channel when the pipeline is executed with the `-dump-channels` command-line option, otherwise it does nothing. It is a useful way to inspect and debug channels quickly without having to modify the pipeline script.
 
@@ -538,7 +538,7 @@ Available options:
 
 ## filter
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `filter` operator emits the items from a source channel that satisfy a condition, discarding all other items. The filter condition can be a literal value, a {ref}`regular expression <script-regexp>`, a type qualifier (i.e. Java class), or a boolean predicate.
 
@@ -696,7 +696,7 @@ Available options:
 
 ## ifEmpty
 
-*Returns: value channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `ifEmpty` operator emits a source channel, or a default value if the source channel is *empty* (doesn't emit any value):
 
@@ -788,7 +788,7 @@ The `last` operator emits the last item from a source channel:
 
 ## map
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `map` operator applies a *mapping function* to each item from a source channel:
 
@@ -840,7 +840,7 @@ The following examples show how to find the longest string in a channel:
 
 ## merge
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `merge` operator joins the items from two or more channels into a new channel:
 
@@ -861,6 +861,12 @@ An optional closure can be used to control how two items are merged:
 ```{literalinclude} snippets/merge-with-mapper.out
 :language: console
 ```
+
+The `merge` operator may return a queue channel or value channel depending on the inputs:
+
+- If the first argument is a queue channel, the `merge` operator will return a queue channel merging as many values as are available for all inputs. Value channels will be re-used for each merged value.
+
+- If the first argument is a value channel, the `merge` operator will return a value channel merging the first value from each input, regardless of whether there are queue channel inputs with additional values.
 
 :::{danger}
 In general, the use of the `merge` operator is discouraged. Processes and channel operators are not guaranteed to emit items in the order that they were received, as they are executed concurrently. Therefore, if you try to merge output channels from different processes, the resulting channel may be different on each run, which will cause resumed runs to {ref}`not work properly <cache-nondeterministic-inputs>`.
@@ -940,7 +946,7 @@ See also: [concat](#concat)
 :::{versionadded} 19.11.0-edge
 :::
 
-*Returns: map of queue channels*
+*Returns: multiple queue channels or value channels, matching the source type*
 
 The `multiMap` operator applies a set of mapping functions to a source channel, producing a separate output channel for each mapping function.
 
@@ -1488,7 +1494,7 @@ See also: [until](#until)
 
 ## tap
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `tap` operator assigns a source channel to a variable, and emits the source channel. It is a useful way to extract intermediate output channels from a chain of operators. For example:
 
@@ -1504,7 +1510,7 @@ See also: [set](#set)
 
 ## toInteger
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `toInteger` operator converts string values from a source channel to integer values:
 
@@ -1641,7 +1647,7 @@ See also: [groupTuple](#grouptuple)
 
 ## unique
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `unique` operator emits the unique items from a source channel:
 
@@ -1671,7 +1677,7 @@ See also: [distinct](#distinct)
 
 ## until
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `until` operator emits each item from a source channel until a stopping condition is satisfied:
 
@@ -1689,7 +1695,7 @@ See also: [take](#take)
 
 ## view
 
-*Returns: queue channel*
+*Returns: queue channel or value channel, matching the source type*
 
 The `view` operator prints each item from a source channel to standard output:
 


### PR DESCRIPTION
Update operator docs to distinguish between operators that always return a queue channel and operators that may return a queue or value channel matching the source channel type.