### PR TITLE
Fix missing include error message

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/exception/MissingModuleComponentException.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/exception/MissingModuleComponentException.groovy
@@ -19,7 +19,7 @@ class MissingModuleComponentException extends ProcessException {
     @PackageScope
     static String message(ScriptMeta meta, String name) {
         def result = "Cannot find a component with name '$name' in module: $meta.scriptPath"
-        def names = meta.getDefinitions().collect { it.name }
+        def names = meta.getDefinitions().findAll { it.name }.collect { it.name }
         def matches = names.closest(name)
         if( matches )
             result += "\n\nDid you mean any of these?\n" + matches.collect { "  $it"}.join('\n') + '\n'


### PR DESCRIPTION
Close #4980 

The problem is that the anonymous workflow is included in the script meta and it's name is null. A more radical solution would be to not add the anonymous workflow to the script meta, since I don't think it is ever retrieved from the script meta