### PR TITLE
Add 'preview' to workflow runtime metadata

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -74,6 +74,8 @@ The following table lists the properties that can be accessed on the `workflow` 
 : Entries of the workflow manifest.
 
 `workflow.preview`
+: :::{versionadded} 24.04.0
+  :::
 : Returns `true` whenever the current instance is a preview execution.
 
 `workflow.profile`

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -73,6 +73,9 @@ The following table lists the properties that can be accessed on the `workflow` 
 `workflow.manifest`
 : Entries of the workflow manifest.
 
+`workflow.preview`
+: Returns `true` whenever the current instance is a preview execution.
+
 `workflow.profile`
 : Used configuration profile.
 

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -154,6 +154,11 @@ class Session implements ISession {
     boolean stubRun
 
     /**
+     * Enable preview mode
+     */
+    boolean preview
+
+    /**
      * Folder(s) containing libs and classes to be added to the classpath
      */
     List<Path> libDir
@@ -344,6 +349,9 @@ class Session implements ISession {
 
         // -- dry run
         this.stubRun = config.stubRun
+
+        // -- preview
+        this.preview = config.preview
 
         // -- normalize taskConfig object
         if( config.process == null ) config.process = [:]

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -545,6 +545,9 @@ class ConfigBuilder {
         if( cmdRun.stubRun )
             config.stubRun = cmdRun.stubRun
 
+        if( cmdRun.preview )
+            config.preview = cmdRun.preview
+
         // -- sets the working directory
         if( cmdRun.workDir )
             config.workDir = cmdRun.workDir

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -190,6 +190,11 @@ class WorkflowMetadata {
     boolean stubRun
 
     /**
+     * Returns ``true`` whenever the current instance is in preview mode
+     */
+    boolean preview
+
+    /**
      * Which container engine was used to execute the workflow
      */
     String containerEngine
@@ -253,6 +258,7 @@ class WorkflowMetadata {
         this.sessionId = session.uniqueId
         this.resume = session.resumeMode
         this.stubRun = session.stubRun
+        this.preview = session.preview
         this.runName = session.runName
         this.containerEngine = containerEngine0(session)
         this.configFiles = session.configFiles?.collect { it.toAbsolutePath() }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -1873,7 +1873,22 @@ class ConfigBuilderTest extends Specification {
         then:
         config.stubRun == true
     }
-    
+
+    def 'should configure preview mode' () {
+        given:
+        Map config
+
+        when:
+        config = new ConfigBuilder().setCmdRun(new CmdRun()).build()
+        then:
+        !config.preview
+
+        when:
+        config = new ConfigBuilder().setCmdRun(new CmdRun(preview: true)).build()
+        then:
+        config.preview == true
+    }
+
     def 'should merge profiles' () {
         given:
         def ENV = [:]

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
@@ -96,6 +96,7 @@ class WorkflowMetadataTest extends Specification {
         metadata.configFiles == [Paths.get('foo').toAbsolutePath(), Paths.get('bar').toAbsolutePath()]
         metadata.resume == false
         metadata.stubRun == false
+        metadata.preview == false
         metadata.userName == System.getProperty('user.name')
         metadata.homeDir == Paths.get(System.getProperty('user.home'))
         metadata.manifest.version == '1.0.0'
@@ -114,11 +115,13 @@ class WorkflowMetadataTest extends Specification {
         session.profile >> 'foo_profile'
         session.resumeMode >> true
         session.stubRun >> true
+        session.preview >> true
         metadata = new WorkflowMetadata(session, script)
         then:
         metadata.profile == 'foo_profile'
         metadata.resume
         metadata.stubRun
+        metadata.preview
     }
 
     def foo_test_method() {


### PR DESCRIPTION
This addresses #4478. I more-or-less copied the implementation of the `stubRun` property.