### PR TITLE
Fix console "Plugin manager not initialised" warn

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -682,9 +682,6 @@ class Session implements ISession {
             // -- close db
             cache?.close()
 
-            // -- shutdown plugins
-            Plugins.stop()
-
             // -- cleanup script classes dir
             classesDir?.deleteDir()
         }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
@@ -47,6 +47,8 @@ class CmdPlugin extends CmdBase {
             throw new AbortOperationException("Missing plugin command - usage: nextflow plugin install <pluginId,..>")
         // setup plugins system
         Plugins.init()
+        Runtime.addShutdownHook((it)-> Plugins.stop())
+        
         // check for the plugins install
         if( args[0] == 'install' ) {
             if( args.size()!=2 )

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
@@ -27,6 +27,7 @@ import nextflow.Global
 import nextflow.Session
 import nextflow.exception.AbortOperationException
 import nextflow.exception.AbortRunException
+import nextflow.plugin.Plugins
 import nextflow.util.HistoryFile
 /**
  * Run a nextflow script file
@@ -257,6 +258,7 @@ class ScriptRunner {
 
     protected shutdown() {
         session.destroy()
+        Plugins.stop()
         session.cleanup()
         Global.cleanUp()
         log.debug "> Execution complete -- Goodbye"


### PR DESCRIPTION
This PR fixed the warning reported by the Console when running a script more then one time 

> WARN: Plugin manager not initialised -- Using built-in executors