### PR TITLE
Implements clusterOptions as a list

### DIFF
--- a/docs/executor.md
+++ b/docs/executor.md
@@ -412,12 +412,20 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-queue`
 - {ref}`process-time`
 
-### Known Limitations
+When specifying `clusterOptions` as a string, multiple options must be separated by semicolons to ensure that the job script is formatted correctly:
+```groovy
+clusterOptions = '-t besteffort;--project myproject'
+```
 
-- Multiple `clusterOptions` should be semicolon-separated to ensure that the OAR job script is accurately formatted:
-  ```groovy
-  clusterOptions = '-t besteffort;--project myproject'
-  ```
+:::{versionadded} 24.04.0
+:::
+
+The same behavior can now be achieved using a string list:
+```groovy
+clusterOptions = [ '-t besteffort', '--project myproject' ]
+```
+
+See {ref}`process-clusteroptions` for details.
 
 (pbs-executor)=
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1450,6 +1450,30 @@ The following options are available:
 
 The `clusterOptions` directive allows the usage of any native configuration option accepted by your cluster submit command. You can use it to request non-standard resources or use settings that are specific to your cluster and not supported out of the box by Nextflow.
 
+The cluster options can be a string:
+
+```groovy
+process foo {
+  clusterOptions '-x 1 -y 2'
+  // ...
+}
+```
+
+:::{versionchanged} 24.04.0
+Prior to this version, grid executors that require each option to be on a separate line in the job script would attempt to split multiple options using a variety of different conventions. Multiple options can now be specified more clearly using a string list as shown below.
+:::
+
+The cluster options can also be a string list:
+
+```groovy
+process foo {
+  clusterOptions '-x 1', '-y 2', '--flag'
+  // ...
+}
+```
+
+Grid executors that require one option per line will write each option to a separate line, while grid executors that allow multiple options per line will write all options to a single line, the same as with a string. This form is useful to control how the options are split across lines when it is required by the scheduler.
+
 :::{note}
 This directive is only used by grid executors. Refer to the {ref}`executor-page` page to see which executors support this directive.
 :::

--- a/modules/nextflow/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -21,6 +21,7 @@ import java.nio.file.Path
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
+import nextflow.processor.TaskConfig
 import nextflow.processor.TaskMonitor
 import nextflow.processor.TaskPollingMonitor
 import nextflow.processor.TaskProcessor
@@ -134,6 +135,23 @@ abstract class AbstractGridExecutor extends Executor {
      * @return A list of directives for this task used for the job submission
      */
     abstract protected List<String> getDirectives(TaskRun task, List<String> initial)
+
+    protected void addClusterOptionsDirective(TaskConfig config, List<String> result) {
+        final opts = config.getClusterOptions()
+        if( opts instanceof Collection ) {
+            for( String it : opts ) {
+                result.add(it)
+                result.add('')
+            }
+        }
+        else if( opts instanceof CharSequence ) {
+            result.add(opts.toString())
+            result.add('')
+        }
+        else if( opts != null ) {
+            throw new IllegalArgumentException("Unexpected value for clusterOptions process directive - offending value: $opts")
+        }
+    }
 
     /**
      * Given a task returns a *clean* name used to submit the job to the grid engine.

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BridgeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BridgeExecutor.groovy
@@ -76,9 +76,7 @@ class BridgeExecutor extends AbstractGridExecutor {
         }
 
         // other cluster options 
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/CrgExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/CrgExecutor.groovy
@@ -105,9 +105,7 @@ class CrgExecutor extends SgeExecutor {
         }
 
         // -- at the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
@@ -20,6 +20,7 @@ import java.util.regex.Pattern
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.processor.TaskConfig
 import nextflow.processor.TaskRun
 /**
  * Processor for Flux Framework executor
@@ -90,18 +91,25 @@ class FluxExecutor extends AbstractGridExecutor {
         }
 
         // Any extra cluster options the user wants!
-        // Options tokenized with ; akin to OarExecutor
-        if( task.config.getClusterOptions() ) {
+        addClusterOptionsDirective(task.config, result)
 
+        result << '/bin/bash' << scriptFile.getName()
+        return result
+    }
+
+    @Override
+    protected void addClusterOptionsDirective(TaskConfig config, List<String> result) {
+        final opts = config.getClusterOptions()
+        final str = opts instanceof Collection ? opts.join(' ') : opts?.toString()
+
+        if( str ) {
             // Split by space
-            for (String item : task.config.getClusterOptions().tokenize(' ')) {
+            for (String item : str.tokenize(' ')) {
                 if ( item ) {
                     result << item.stripIndent(true).trim()
                 }
             }
         }
-        result << '/bin/bash' << scriptFile.getName()
-        return result
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -73,9 +73,7 @@ class HyperQueueExecutor extends AbstractGridExecutor {
             result << '--resource' << "gpus=${task.config.getAccelerator().limit}".toString()
 
         // -- At the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/MoabExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/MoabExecutor.groovy
@@ -73,9 +73,7 @@ class MoabExecutor extends AbstractGridExecutor {
         }
 
         // -- at the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/NqsiiExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/NqsiiExecutor.groovy
@@ -71,9 +71,7 @@ class NqsiiExecutor extends AbstractGridExecutor {
         }
 
         // -- at the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/OarExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/OarExecutor.groovy
@@ -20,6 +20,7 @@ import java.util.regex.Pattern
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.processor.TaskConfig
 import nextflow.processor.TaskRun
 /**
  * Processor for OAR resource manager
@@ -80,14 +81,25 @@ class OarExecutor extends AbstractGridExecutor {
         }
 
         // -- at the end append the command script wrapped file name
-        // Options need to be semicolon ";" separated, if several are needed
-        if( task.config.getClusterOptions() ) {
-          for (String item : task.config.getClusterOptions().tokenize(';')) {
-            result << item << ''
-          }
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
+    }
+
+    @Override
+    void addClusterOptionsDirective(TaskConfig config, List result) {
+        final opts = config.getClusterOptions()
+        if( opts instanceof Collection ) {
+            for( String it in opts ) {
+                result << it << ''
+            }
+        }
+        // Options need to be semicolon ";" separated, if several are needed
+        else if( opts instanceof CharSequence ) {
+            for (String item : opts.toString().tokenize(';')) {
+                result << item << ''
+            }
+        }
     }
 
     String getHeaderToken() { '#OAR' }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -63,7 +63,7 @@ class PbsExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
 
         // task cpus
         if( task.config.getCpus() > 1 ) {
-            if( matchOptions(task.config.getClusterOptions()) ) {
+            if( matchOptions(task.config.getClusterOptionsAsString()) ) {
                 log.warn1 'cpus directive is ignored when clusterOptions contains -l option\ntip: clusterOptions = { "-l nodes=1:ppn=${task.cpus}:..." }'
             }
             else {
@@ -83,16 +83,14 @@ class PbsExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
             result << "-l" << "mem=${task.config.getMemory().toString().replaceAll(/[\s]/,'').toLowerCase()}".toString()
         }
 
-        // -- at the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
-
         // add account from config
         final account = session.getExecConfigProp(getName(), 'account', null) as String
         if( account ) {
             result << '-P' << account
         }
+
+        // -- at the end append the command script wrapped file name
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -54,9 +54,7 @@ class PbsProExecutor extends PbsExecutor {
         // when multiple competing directives are provided, only the first one will take effect
         // therefore clusterOptions is added as first to give priority over other options as expected
         // by the clusterOptions semantics -- see https://github.com/nextflow-io/nextflow/pull/2036
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         result << '-N' << getJobNameFor(task)
 
@@ -79,7 +77,7 @@ class PbsProExecutor extends PbsExecutor {
             res << "mem=${task.config.getMemory().getMega()}mb".toString()
         }
         if( res ) {
-            if( matchOptions(task.config.getClusterOptions()) ) {
+            if( matchOptions(task.config.getClusterOptionsAsString()) ) {
                 log.warn1 'cpus and memory directives are ignored when clusterOptions contains -l option\ntip: clusterOptions = { "-l select=1:ncpus=${task.cpus}:mem=${task.memory.toMega()}mb:..." }'
             }
             else {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
@@ -84,9 +84,7 @@ class SgeExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
         }
 
         // -- at the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -42,10 +42,9 @@ class SlurmExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     private boolean perCpuMemAllocation
 
     private boolean hasSignalOpt(TaskConfig config) {
-        def opts = config.getClusterOptions()
+        final opts = config.getClusterOptionsAsString()
         return opts ? opts.contains('--signal ') || opts.contains('--signal=') : false
     }
-
 
     /**
      * Gets the directives to submit the specified task to the cluster for execution
@@ -103,9 +102,7 @@ class SlurmExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
         }
 
         // -- at the end append the command script wrapped file name
-        if( task.config.getClusterOptions() ) {
-            result << task.config.getClusterOptions() << ''
-        }
+        addClusterOptionsDirective(task.config, result)
 
         // add slurm account from config
         final account = session.getExecConfigProp(getName(), 'account', null) as String

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -16,8 +16,6 @@
 
 package nextflow.processor
 
-import nextflow.util.CmdLineOptionMap
-
 import static nextflow.processor.TaskProcessor.*
 
 import java.nio.file.Path
@@ -33,6 +31,7 @@ import nextflow.executor.res.DiskResource
 import nextflow.k8s.model.PodOptions
 import nextflow.script.TaskClosure
 import nextflow.util.CmdLineHelper
+import nextflow.util.CmdLineOptionMap
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
 /**
@@ -414,10 +413,6 @@ class TaskConfig extends LazyMap implements Cloneable {
         throw new IllegalArgumentException("Not a valid PublishDir collection [${dirs.getClass().getName()}] $dirs")
     }
 
-    String getClusterOptions() {
-        return get('clusterOptions')
-    }
-    
     def getContainer() {
         return get('container')
     }
@@ -433,6 +428,21 @@ class TaskConfig extends LazyMap implements Cloneable {
         return null
     }
 
+    def getClusterOptions() {
+        return get('clusterOptions')
+    }
+
+    String getClusterOptionsAsString() {
+        final opts = getClusterOptions()
+        if( opts instanceof CharSequence )
+            return opts.toString()
+        if( opts instanceof Collection )
+            return CmdLineHelper.toLine(opts as List<String>)
+        if( opts != null )
+            throw new IllegalArgumentException("Unexpected value for clusterOptions process directive - offending value: $opts")
+        return null
+    }
+    
     /**
      * @return Parse the {@code clusterOptions} configuration option and return the entries as a list of values
      */

--- a/modules/nextflow/src/test/groovy/nextflow/executor/AbstractGridExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/AbstractGridExecutorTest.groovy
@@ -19,6 +19,7 @@ package nextflow.executor
 import java.nio.file.Path
 
 import nextflow.Session
+import nextflow.processor.TaskConfig
 import nextflow.processor.TaskRun
 import nextflow.util.Duration
 import spock.lang.Specification
@@ -160,6 +161,24 @@ class AbstractGridExecutorTest extends Specification {
         1 * exec.getQueueStatus0(null) >> STATUS
         and:
         result == STATUS
+    }
+
+    def 'should add cluster options' () {
+        given:
+        def exec = Spy(AbstractGridExecutor)
+
+        when:
+        def result = []
+        exec.addClusterOptionsDirective(new TaskConfig(clusterOptions: OPTS), result)
+        then:
+        result == EXPECTED
+
+        where:
+        OPTS                    | EXPECTED
+        null                    | []
+        '-foo 1'                | ['-foo 1', '']
+        '-foo 1 --bar 2'        | ['-foo 1 --bar 2', '']
+        ['-foo 1','--bar 2']    | ['-foo 1', '', '--bar 2', '']
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -178,6 +178,28 @@ class LsfExecutorTest extends Specification {
 
         when:
         task.config = new TaskConfig()
+        task.config.queue = 'bsc_ls'
+        task.config.clusterOptions = ['-x 1', '-R "span[ptile=2]"']
+        task.config.cpus = '2'
+        task.config.time = '1h 30min'
+        task.config.memory = '8GB'
+        then:
+        executor.getHeaders(task) == '''
+                #BSUB -o /scratch/.command.log
+                #BSUB -q bsc_ls
+                #BSUB -n 2
+                #BSUB -R "span[hosts=1]"
+                #BSUB -W 01:30
+                #BSUB -M 4096
+                #BSUB -R "select[mem>=8192] rusage[mem=8192]"
+                #BSUB -J nf-mapping_hola
+                #BSUB -x 1
+                #BSUB -R "span[ptile=2]"
+                '''
+            .stripIndent().leftTrim()
+
+        when:
+        task.config = new TaskConfig()
         task.config.queue = 'alpha'
         task.config.cpus = 1
         then:

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -150,6 +150,23 @@ class SlurmExecutorTest extends Specification {
 
         when:
         task.config = new TaskConfig()
+        task.config.time = '1h'
+        task.config.memory = '50 M'
+        task.config.clusterOptions = ['-a 1','--signal=KILL']
+        then:
+        executor.getHeaders(task) == '''
+                #SBATCH -J nf-the_task_name
+                #SBATCH -o /work/path/.command.log
+                #SBATCH --no-requeue
+                #SBATCH -t 01:00:00
+                #SBATCH --mem 50M
+                #SBATCH -a 1
+                #SBATCH --signal=KILL
+                '''
+            .stripIndent().leftTrim()
+
+        when:
+        task.config = new TaskConfig()
         task.config.cpus = 2
         task.config.time = '2h'
         task.config.memory = '200 M'

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -337,6 +337,21 @@ class TaskConfigTest extends Specification {
 
     }
 
+    def testClusterOptionsAsString() {
+        when:
+        def config = new TaskConfig()
+        config.clusterOptions = VALUE
+
+        then:
+        config.getClusterOptionsAsString() == EXPECTED
+
+        where:
+        EXPECTED                            || VALUE
+        null                                || null
+        '-queue alpha'                      || ['-queue','alpha']
+        '-queue alpha'                      || '-queue alpha'
+        "-queue 'alpha and beta'"           || ['-queue', 'alpha and beta']
+    }
 
     def testGetClusterOptionsAsList() {
 


### PR DESCRIPTION
This PR adds the ability to define process `clusterOptions` as a list of values other than a string. 

Solves https://github.com/nextflow-io/nextflow/issues/4935


