### PR TITLE
Remove `seqera` and `defaults` from Conda default channels

### DIFF
--- a/docs/wave.md
+++ b/docs/wave.md
@@ -99,8 +99,8 @@ Some configuration options in the `conda` scope are used when Wave is used to bu
 For example, the Conda channels and their priority can be set with `conda.channels`:
 
 ```groovy
-wave.strategy = ['conda']
-conda.channels = 'seqera,conda-forge,bioconda,defaults'
+wave.strategy = 'conda'
+conda.channels = 'conda-forge,bioconda'
 ```
 :::
 

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -78,7 +78,7 @@ class WaveClient {
 
     private static Logger log = LoggerFactory.getLogger(WaveClient)
 
-    public static final List<String> DEFAULT_CONDA_CHANNELS = ['conda-forge','bioconda','defaults']
+    public static final List<String> DEFAULT_CONDA_CHANNELS = ['conda-forge','bioconda']
 
     private static final String DEFAULT_SPACK_ARCH = 'x86_64'
 

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -78,7 +78,7 @@ class WaveClient {
 
     private static Logger log = LoggerFactory.getLogger(WaveClient)
 
-    public static final List<String> DEFAULT_CONDA_CHANNELS = ['seqera','conda-forge','bioconda','defaults']
+    public static final List<String> DEFAULT_CONDA_CHANNELS = ['conda-forge','bioconda','defaults']
 
     private static final String DEFAULT_SPACK_ARCH = 'x86_64'
 


### PR DESCRIPTION
This PR removes `seqera` from the Conda default channels as it's not going to be maintained anymore 