### PR TITLE
Add enabled property to output DSL

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -84,7 +84,7 @@ class PublishOp {
     }
 
     protected void onComplete(nope) {
-        if( indexOpts && indexRecords.size() > 0 ) {
+        if( indexOpts && indexRecords.size() > 0 && publisher.enabled ) {
             log.trace "Saving records to index file: ${indexRecords}"
             new CsvWriter(header: indexOpts.header, sep: indexOpts.sep).apply(indexRecords, indexOpts.path)
             session.notifyFilePublish(indexOpts.path)

--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -17,7 +17,6 @@
 package nextflow.script
 
 import java.nio.file.Path
-import java.nio.file.Paths
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -27,7 +26,6 @@ import nextflow.extension.CH
 import nextflow.extension.MixOp
 import nextflow.extension.PublishOp
 import nextflow.file.FileHelper
-
 /**
  * Implements the DSL for publishing workflow outputs
  *
@@ -81,6 +79,10 @@ class OutputDsl {
 
     void tags(Map value) {
         setDefault('tags', value)
+    }
+
+    void enabled( boolean value ) {
+        setDefault('enabled', value)
     }
 
     private void setDefault(String name, Object value) {
@@ -203,6 +205,10 @@ class OutputDsl {
             setOption('tags', value)
         }
 
+        void enabled( boolean value ) {
+            setOption('enabled', value)
+        }
+
         private void setOption(String name, Object value) {
             if( opts.containsKey(name) )
                 throw new ScriptRuntimeException("Publish option `${name}` cannot be defined more than once for a given target")
@@ -210,7 +216,7 @@ class OutputDsl {
         }
 
         Map getOptions() {
-            opts
+            return opts
         }
 
     }
@@ -246,7 +252,7 @@ class OutputDsl {
         }
 
         Map getOptions() {
-            opts
+            return opts
         }
 
     }

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -82,4 +82,60 @@ class OutputDslTest extends Specification {
         root?.deleteDir()
     }
 
+    def 'should set options' () {
+        when:
+        def dsl1 = new OutputDsl()
+        then:
+        dsl1.@defaults == [:]
+
+        when:
+        def dsl2 = new OutputDsl()
+        and:
+        dsl2.contentType('simple/text')
+        dsl2.ignoreErrors(true)
+        dsl2.mode('someMode')
+        dsl2.overwrite(true)
+        dsl2.storageClass('someClass')
+        dsl2.tags([foo:'1',bar:'2'])
+        dsl2.enabled(true)
+        then:
+        dsl2.@defaults == [
+            contentType:'simple/text',
+            ignoreErrors: true,
+            mode: 'someMode',
+            overwrite: true,
+            storageClass: 'someClass',
+            tags: [foo:'1',bar:'2'],
+            enabled: true
+        ]
+    }
+
+    def 'should set target dsl' () {
+        when:
+        def dsl1 = new OutputDsl.TargetDsl()
+        then:
+        dsl1.getOptions() == [:]
+
+        when:
+        def dsl2 = new OutputDsl.TargetDsl()
+        and:
+        dsl2.contentType('simple/text')
+        dsl2.ignoreErrors(true)
+        dsl2.mode('someMode')
+        dsl2.overwrite(true)
+        dsl2.storageClass('someClass')
+        dsl2.tags([foo:'1',bar:'2'])
+        dsl2.enabled(true)
+        then:
+        dsl2.getOptions() == [
+            contentType:'simple/text',
+            ignoreErrors: true,
+            mode: 'someMode',
+            overwrite: true,
+            storageClass: 'someClass',
+            tags: [foo:'1',bar:'2'],
+            enabled: true
+        ]
+    }
+
 }


### PR DESCRIPTION
This PR adds the `enabled` option to output DSL that allows to turn it on/off specific publish targets.