### PR TITLE
Fix the default for async finalizer

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -118,7 +118,7 @@ class TaskPollingMonitor implements TaskMonitor {
     @Lazy
     private ExecutorService finalizerPool = { session.taskFinalizerExecutorService() }()
 
-    private boolean enableAsyncFinalizer = SysEnv.get('NXF_ENABLE_ASYNC_FINALIZER','false') as boolean
+    private boolean enableAsyncFinalizer = SysEnv.getBool('NXF_ENABLE_ASYNC_FINALIZER',false)
 
     /**
      * Create the task polling monitor with the provided named parameters object.

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -118,7 +118,7 @@ class TaskPollingMonitor implements TaskMonitor {
     @Lazy
     private ExecutorService finalizerPool = { session.taskFinalizerExecutorService() }()
 
-    private boolean enableAsyncFinalizer = SysEnv.getBool('NXF_ENABLE_ASYNC_FINALIZER',false)
+    private boolean enableAsyncFinalizer = SysEnv.getBool('NXF_ENABLE_ASYNC_FINALIZER',true)
 
     /**
      * Create the task polling monitor with the provided named parameters object.

--- a/modules/nf-commons/src/main/nextflow/SysEnv.groovy
+++ b/modules/nf-commons/src/main/nextflow/SysEnv.groovy
@@ -49,6 +49,11 @@ class SysEnv {
         return holder.containsKey(name) ? holder.get(name) : defValue
     }
 
+    static boolean getBool(String name, boolean defValue) {
+        final result = get(name,String.valueOf(defValue))
+        return Boolean.parseBoolean(result)
+    }
+
     static void push(Map<String,String> env) {
         history.push(holder.getTarget())
         holder.setTarget(env)

--- a/modules/nf-commons/src/test/nextflow/SysEnvTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/SysEnvTest.groovy
@@ -18,6 +18,7 @@
 package nextflow
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  *
@@ -52,6 +53,26 @@ class SysEnvTest extends Specification {
         SysEnv.pop()
         then:
         SysEnv.get('HOME') == System.getenv('HOME')
+
+    }
+
+    @Unroll
+    def 'should get bool value' () {
+        given:
+        SysEnv.push(STATE)
+
+        expect:
+        SysEnv.getBool('FOO', DEF) == EXPECTED
+
+        where:
+        STATE           | DEF       | EXPECTED
+        [:]             | false     | false
+        [FOO:'false']   | false     | false
+        [FOO:'true']    | false     | true
+        and:
+        [:]             | true      | true
+        [FOO:'false']   | false     | false
+        [FOO:'true']    | true      | true
 
     }
 }


### PR DESCRIPTION
The PR fixes the setting for the `NXF_ENABLE_ASYNC_FINALIZER` env variable. 

The expression `'some string' as boolean` is always true unless the string is null or empty. 

Therefore the setting is always enabled unless `NXF_ENABLE_ASYNC_FINALIZER` is set to an empty string. 