### PR TITLE
Charliecloud: registry, docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -476,6 +476,7 @@ The following settings are available:
 ### Scope `charliecloud`
 
 The `charliecloud` scope controls how [Charliecloud](https://hpc.github.io/charliecloud/) containers are executed by Nextflow.
+If `charliecloud.writeFake` is unset / `false`, charliecloud will create a copy of the container in the process working directory.
 
 The following settings are available:
 
@@ -496,6 +497,15 @@ The following settings are available:
 
 `charliecloud.temp`
 : Mounts a path of your choice as the `/tmp` directory in the container. Use the special value `auto` to create a temporary directory each time a container is created.
+
+`charliecloud.registry`
+: The registry from where images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
+
+`charliecloud.writeFake`
+: Enable `writeFake` with charliecloud. This allows to run containers from storage in writeable mode, using overlayfs, see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details 
+
+`charliecloud.useSquash`
+: Create a temporary squashFS container image in the process work directory instead of a folder.
 
 Read the {ref}`container-charliecloud` page to learn more about how to use Charliecloud containers with Nextflow.
 

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudBuilder.groovy
@@ -27,6 +27,7 @@ import groovy.util.logging.Slf4j
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
  * @author Laurent Modolo <laurent.modolo@ens-lyon.fr>
+ * @author Niklas Schandry <niklas@bio.lmu.de>
  */
 @CompileStatic
 @Slf4j

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -86,7 +86,7 @@ class CharliecloudCache {
             if( !registry.endsWith('/') ) {
                 registry += '/'
             }
-            name += registry
+            name = registry + name
         }
 
         name = name.replace(':','+').replace('/','%')

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -86,7 +86,7 @@ class CharliecloudCache {
             if( !registry.endsWith('/') ) {
                 registry += '/'
             }
-            imageUrl = registry + imageUrl
+            name = registry + name
         }
         name = name.replace(':','+').replace('/','%')
         return name 

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -86,8 +86,9 @@ class CharliecloudCache {
             if( !registry.endsWith('/') ) {
                 registry += '/'
             }
-            name = registry + name
+            name += registry
         }
+
         name = name.replace(':','+').replace('/','%')
         return name 
     }

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -34,6 +34,7 @@ import nextflow.util.Duration
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  * @author Patrick Hüther <patrick.huether@gmail.com>
+ * @author Niklas Schandry <niklas@bio.lmu.de>
  */
 @Slf4j
 @CompileStatic
@@ -79,11 +80,14 @@ class CharliecloudCache {
     String simpleName(String imageUrl) {
         def p = imageUrl.indexOf('://')
         def name = p != -1 ? imageUrl.substring(p+3) : imageUrl
-
-        // add registry
-        if( registry )
-            name = registry + name
         
+        // add registry
+        if( registry ) {
+            if( !registry.endsWith('/') ) {
+                registry += '/'
+            }
+            imageUrl = registry + imageUrl
+        }
         name = name.replace(':','+').replace('/','%')
         return name 
     }
@@ -207,8 +211,9 @@ class CharliecloudCache {
         if( missingCacheDir )
             log.warn1 "Charliecloud cache directory has not been defined -- Remote image will be stored in the path: $targetPath.parent.parent -- Use the charliecloud.cacheDir config option or set the NXF_CHARLIECLOUD_CACHEDIR variable to specify a different location"
 
+        
         log.info "Charliecloud pulling image $imageUrl [cache $targetPath]"
-
+            
         String cmd = "ch-image pull -s $targetPath.parent.parent $imageUrl > /dev/null"
         try {
             runCommand( cmd, targetPath )

--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerHandler.groovy
@@ -287,18 +287,24 @@ class ContainerHandler {
             return null
 
         // when starts with `/` it's an absolute image file path, just return it
-        if( img.startsWith("/") )
-            return img
-
-        // check if matches a protocol scheme such as `docker://xxx`
-        if( img =~ IMAGE_URL_PREFIX ) {
+        if( img.startsWith("/") ) {
             return img
         }
+        // remove docker:// if present
+        if( img.startsWith("docker://") ) {
+            img = img.minus("docker://")
+        }
+        // if no tag, add :latest
+        if( !img.contains(':') ) {
+            img += ':latest'
+        }
+
         // if it's the path of an existing image file return it
         def imagePath = baseDir.resolve(img)
         if( imagePath.exists() ) {
             return imagePath.toString()
         }
+
         // in all other case it's supposed to be the name of an image
         return "${normalizeDockerImageName(img)}"
     }

--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerHandler.groovy
@@ -88,12 +88,15 @@ class ContainerHandler {
             return Escape.path(result)
         }
         if( engine == 'charliecloud' ) {
+            final normalizedImageName = normalizeCharliecloudImageName(imageName)
+            if( !config.isEnabled() || !normalizedImageName )
+                return normalizedImageName
             // if the imagename starts with '/' it's an absolute path
             // otherwise we assume it's in a remote registry and pull it from there
             final requiresCaching = !imageName.startsWith('/')
             if( ContainerInspectMode.active() && requiresCaching )
                 return imageName
-            final result = requiresCaching ? createCharliecloudCache(this.config, imageName) : imageName
+            final result = requiresCaching ? createCharliecloudCache(this.config, normalizedImageName) : normalizedImageName
             return Escape.path(result)
         }
         // fallback to docker
@@ -270,5 +273,33 @@ class ContainerHandler {
         // in all other case it's supposed to be the name of an image in the docker hub
         // prefix it with the `docker://` pseudo protocol used by apptainer to download it
         return "docker://${normalizeDockerImageName(img)}"
+    }
+
+    /**
+     * Normalize charliecloud image name resolving the absolute path
+     *
+     * @param imageName The container image name
+     * @return Image name in canonical format
+     */
+     @PackageScope
+     String normalizeCharliecloudImageName(String img) {
+        if( !img )
+            return null
+
+        // when starts with `/` it's an absolute image file path, just return it
+        if( img.startsWith("/") )
+            return img
+
+        // check if matches a protocol scheme such as `docker://xxx`
+        if( img =~ IMAGE_URL_PREFIX ) {
+            return img
+        }
+        // if it's the path of an existing image file return it
+        def imagePath = baseDir.resolve(img)
+        if( imagePath.exists() ) {
+            return imagePath.toString()
+        }
+        // in all other case it's supposed to be the name of an image
+        return "${normalizeDockerImageName(img)}"
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
@@ -29,7 +29,6 @@ import spock.lang.Unroll
  * @author Patrick Hüther <patrick.huether@gmail.com>
  */
 class CharliecloudCacheTest extends Specification {
-
     @Unroll
     def 'should return a simple name given an image url'() {
 
@@ -46,6 +45,21 @@ class CharliecloudCacheTest extends Specification {
         'shub://hello/world'        | 'hello%world'
         'ftp://hello/world'         | 'hello%world'
         'foo:bar'                   | 'foo+bar'
+    }
+
+    @Unroll
+    def 'should return a path with registry'() {
+
+        given:
+        def helper = new CharliecloudCache([registry: registry])
+
+        expect:
+        helper.simpleName(url) == expected
+
+        where:
+        url                      | registry   | expected
+        'foo:2.0'                | 'my.reg'   | 'my.reg%foo+2.0'
+        'foo:2.0'                | 'my.reg/'  | 'my.reg%foo+2.0'
     }
 
     def 'should return the cache dir from the config file' () {

--- a/modules/nextflow/src/test/groovy/nextflow/container/ContainerHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ContainerHandlerTest.groovy
@@ -200,6 +200,7 @@ class ContainerHandlerTest extends Specification {
         result == 'shifter://image'
             
     }
+
     @Unroll
     def 'test normalize method for charliecloud' () {
 

--- a/modules/nextflow/src/test/groovy/nextflow/container/ContainerHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/ContainerHandlerTest.groovy
@@ -200,6 +200,34 @@ class ContainerHandlerTest extends Specification {
         result == 'shifter://image'
             
     }
+    @Unroll
+    def 'test normalize method for charliecloud' () {
+
+       given:
+        def n = new ContainerHandler([registry: registry])
+
+        expect:
+        n.normalizeCharliecloudImageName(image) == expected
+
+        where:
+        image                      | registry   | expected
+        null                       | null       | null
+        ''                         | null       | null
+        '/abs/path/bar.img'        | null       | '/abs/path/bar.img'
+        'docker://library/busybox' | null       | 'library/busybox:latest'
+        'shub://busybox'           | null       | 'shub://busybox'
+        'foo://busybox'            | null       | 'foo://busybox'
+        'foo'                      | null       | 'foo:latest'
+        'foo:2.0'                  | null       | 'foo:2.0'
+        'foo.img'                  | null       | 'foo.img:latest'
+        'quay.io/busybox'          | null       | 'quay.io/busybox:latest'
+        'http://reg.io/v1/alpine:latest'        | null       | 'http://reg.io/v1/alpine:latest'
+        'https://reg.io/v1/alpine:latest'       | null       | 'https://reg.io/v1/alpine:latest'
+        and:
+        '/abs/path/bar.img'        | 'my.reg'  | '/abs/path/bar.img'
+        'busybox'                  | 'my.reg'  | 'my.reg/busybox:latest'
+        'foo:2.0'                  | 'my.reg'  | 'my.reg/foo:2.0'
+    }
 
     @Unroll
     def 'test normalize method for singularity' () {


### PR DESCRIPTION
Hi,

I noticed that my previous attempt (https://github.com/nextflow-io/nextflow/pull/4879) at making charliecloud handle the registry does not work. This PR fixes this by following the general approach of other container engines: letting normalizeDockerImageName handle this.
I also realized that my previous PR added three new options for charliecloud, but these were not documented, so this also updates the docs accordingly. This is identical to #5017, except that here I signed off the commits.