### PR TITLE
LocalSecretsProvider: escapes dollar char

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/secret/LocalSecretsProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/secret/LocalSecretsProvider.groovy
@@ -32,6 +32,7 @@ import nextflow.SysEnv
 import nextflow.exception.AbortOperationException
 import nextflow.exception.ProcessUnrecoverableException
 import nextflow.util.CacheHelper
+import nextflow.util.Escape
 /**
  * Implements a secrets store that saves secrets into a JSON file save into the
  * nextflow home. The file can be relocated using the env variable {@code NXF_SECRETS_FILE}.
@@ -207,7 +208,7 @@ class LocalSecretsProvider implements SecretsProvider, Closeable {
 
         def result = ''
         for( Secret s : secretsMap.values() ) {
-            result += /export ${s.name}="${s.value}"/
+            result += /export ${s.name}="${Escape.variable(s.value)}"/
             result += '\n'
         }
         Files.createFile(path)

--- a/modules/nextflow/src/test/groovy/nextflow/secret/LocalSecretsProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/secret/LocalSecretsProviderTest.groovy
@@ -236,4 +236,31 @@ class LocalSecretsProviderTest extends Specification {
         cleanup:
         folder?.deleteDir()
     }
+
+    def 'should handle dollar in secrets' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def secretFile = folder.resolve('secrets.json');
+        and:
+        def DOLLAR1 = new SecretImpl('dollar', '$foo')
+        def DOLLAR2 = new SecretImpl('dollar2', "\$foo")
+
+        def provider = new LocalSecretsProvider(storeFile: secretFile)
+        and:
+        provider.putSecret(DOLLAR1)
+        provider.putSecret(DOLLAR2)
+
+        when:
+        def file = provider.makeTempSecretsFile()
+        then:
+        file.permissions == 'rw-------'
+        and:
+        file.text == '''\
+                     export dollar="\\\$foo"
+                     export dollar2="\\\$foo"
+                     '''.stripIndent()
+
+        cleanup:
+        folder?.deleteDir()
+    }
 }


### PR DESCRIPTION
Closes https://github.com/nextflow-io/nextflow/issues/4977  , i.e. handles proper escaping of dollar characther in secrets values.

- Uses `nextflow.util.Escape`
- Added unit test