### PR TITLE
Docs/wave singularity builds

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -109,6 +109,8 @@ The following settings are available:
   :::
 : When enabled, OCI (and Docker) container images are pulled and converted to the SIF format by the Apptainer run command, instead of Nextflow (default: `false`).
 
+  Note: leave `ociAutoPull` disabled if willing to build a Singularity/Apptainer native image with Wave (see the {ref}`wave-singularity` page).
+
 `apptainer.pullTimeout`
 : The amount of time the Apptainer pull can last, exceeding which the process is terminated (default: `20 min`).
 
@@ -1561,10 +1563,14 @@ The following settings are available:
   :::
 : When enabled, OCI (and Docker) container images are pull and converted to a SIF image file format implicitly by the Singularity run command, instead of Nextflow. Requires Singularity 3.11 or later (default: `false`).
 
+  Note: leave `ociAutoPull` disabled if willing to build a Singularity native image with Wave (see the {ref}`wave-singularity` page).
+
 `singularity.ociMode`
 : :::{versionadded} 23.12.0-edge
   :::
 : Enable OCI-mode, that allows running native OCI compliant container image with Singularity using `crun` or `runc` as low-level runtime. Note: it requires Singularity 4 or later. See `--oci` flag in the [Singularity documentation](https://docs.sylabs.io/guides/4.0/user-guide/oci_runtime.html#oci-mode) for more details and requirements (default: `false`).
+
+  Note: leave `ociMode` disabled if willing to build a Singularity native image with Wave (see the {ref}`wave-singularity` page).
 
 `singularity.pullTimeout`
 : The amount of time the Singularity pull can last, exceeding which the process is terminated (default: `20 min`).

--- a/docs/wave.md
+++ b/docs/wave.md
@@ -132,6 +132,8 @@ In order to request the build of containers that are optimised for a specific CP
 If using a Spack YAML file to provide the required packages, you should avoid editing the following sections, which are already configured by the Wave plugin: `packages`, `config`, `view` and `concretizer` (your edits may be ignored), and `compilers` (your edits will be considered, and may interfere with the setup by the Wave plugin).
 :::
 
+(wave-singularity)=
+
 ### Build Singularity native images
 
 :::{versionadded} 23.09.0-edge
@@ -164,6 +166,9 @@ When using a private repository, the repository access keys must be provided via
 Moreover the access to the repository must be granted in the compute nodes by using the command `singularity remote login <registry>`.
 Please see Singularity documentation for further details.
 :::
+
+:::{note}
+In order to build Singularity native images, both configuration options `singularity.ociAutoPull` and `singularity.ociMode` need to be disabled (see the {ref}`config-singularity` page).
 
 ### Push to a private repository
 


### PR DESCRIPTION
Update to `Wave` and `Configuration` docs: clarify that OCI related options need to be disabled to trigger Singularity native builds with Wave.