### PR TITLE
Retry Google 500 errors when writing task helper files

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -449,7 +449,7 @@ class BashWrapperBuilder {
                 }
                 return path
             }
-            catch (FileSystemException | SocketException | RuntimeException e) {
+            catch (FileSystemException | IOException | RuntimeException | SocketException e) {
                 final isLocalFS = path.getFileSystem()==FileSystems.default
                 // the retry logic is needed for non-local file system such as S3.
                 // when the file is local fail without retrying

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -449,7 +449,9 @@ class BashWrapperBuilder {
                 }
                 return path
             }
-            catch (FileSystemException | IOException | RuntimeException | SocketException e) {
+            catch (Exception e) {
+                if( !isRetryable0(e) )
+                    throw e
                 final isLocalFS = path.getFileSystem()==FileSystems.default
                 // the retry logic is needed for non-local file system such as S3.
                 // when the file is local fail without retrying
@@ -461,6 +463,18 @@ class BashWrapperBuilder {
                 Thread.sleep(delay)
             }
         }
+    }
+
+    static protected boolean isRetryable0(Exception e) {
+        if( e instanceof FileSystemException )
+            return true
+        if( e instanceof SocketException )
+            return true
+        if( e instanceof RuntimeException )
+            return true
+        if( e.class.getSimpleName() == 'HttpResponseException' )
+            return true
+        return false
     }
 
     protected String getTaskMetadata() {

--- a/plugins/nf-google/src/test/nextflow/executor/BashWrapperBuilderWithGoogleTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/executor/BashWrapperBuilderWithGoogleTest.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.executor
+
+
+import com.google.api.client.http.HttpResponseException
+import spock.lang.Specification
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class BashWrapperBuilderWithGoogleTest extends Specification {
+
+    def 'should check retryable errors' () {
+        expect:
+        BashWrapperBuilder.isRetryable0(ERROR) == EXPECTED
+        where:
+        ERROR                                                                   | EXPECTED
+        new HttpResponseException(GroovyMock(HttpResponseException.Builder))    | true
+        new Exception()                                                         | false
+    }
+
+}


### PR DESCRIPTION
Close #4537 

HTTP response exceptions from the Google SDK are IOExceptions: https://cloud.google.com/java/docs/reference/google-http-client/latest/com.google.api.client.http.HttpResponseException