### PR TITLE
Do not require tentantId when using Azure system-assigned managed identity

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzManagedIdentityOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzManagedIdentityOpts.groovy
@@ -30,13 +30,10 @@ class AzManagedIdentityOpts {
 
     Boolean system
 
-    String tenantId
-
     AzManagedIdentityOpts(Map config) {
         assert config != null
         this.clientId = config.clientId
         this.system = config.system as Boolean
-        this.tenantId = config.tenantId
     }
 
     Map<String, Object> getEnv() {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzManagedIdentityOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzManagedIdentityOpts.groovy
@@ -49,11 +49,11 @@ class AzManagedIdentityOpts {
     boolean isConfigured() {
         if( clientId && !system )
             return true
-        if( !clientId && system && tenantId )
+        if( !clientId && system )
             return true
-        if( !clientId && !system && !tenantId )
+        if( !clientId && !system )
             return false
-        throw new IllegalArgumentException("Invalid Managed Identity configuration - Make sure the `clientId` or `system` is set in the nextflow config, as well as `tenantId`")
+        throw new IllegalArgumentException("Invalid Managed Identity configuration - Make sure the `clientId` or `system` is set in the nextflow config")
     }
 
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -710,7 +710,7 @@ class AzBatchServiceTest extends Specification {
     }
 
     @Unroll
-    def 'should create manage credentials token' () {
+    def 'should create user-assigned managed identity credentials token' () {
         given:
         def config = Mock(AzConfig)
         def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
@@ -728,5 +728,25 @@ class AzBatchServiceTest extends Specification {
         CONFIG                                          | EXPECTED
         [:]                                             | null
         [managedIdentity: [clientId: 'client-123']]     | 'client-123'
+    }
+
+    @Unroll
+    def 'should create system assigned managed identity credentials token' () {
+        given:
+        def config = Mock(AzConfig)
+        def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
+        AzBatchService service = Spy(new AzBatchService(exec))
+
+        when:
+        def token = service.createBatchCredentialsWithManagedIdentity()
+        then:
+        config.managedIdentity() >> { Mock(AzManagedIdentityOpts) }
+        then:
+        token instanceof ManagedIdentityCredential
+
+        where:
+        CONFIG                                | EXPECTED
+        [:]                                   | null
+        [managedIdentity: [system: true]]     | true
     }
 }


### PR DESCRIPTION
Azure system-assigned managed identity no longer needs the tenant ID after we updated the Java SDK, but the checks prevented it being allowed. This PR removes the check for system + tenant ID so system assigned identities can be used.

I've tested this to work on an Azure VM with a managed identity.
