### PR TITLE
Implement ignoreThenFail as pseudo error strategy

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1050,8 +1050,9 @@ class Session implements ISession {
         cache.putTaskAsync(handler, trace)
 
         // set the pipeline to return non-exit code if specified
-        if( handler.task.errorAction == ErrorStrategy.IGNORETHENFAIL )
+        if( handler.task.errorAction == ErrorStrategy.IGNORE && handler.task.config.getFailOnComplete() ) {
             failOnComplete = true
+        }
 
         // notify the event to the observers
         for( int i=0; i<observers.size(); i++ ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/ErrorStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/ErrorStrategy.groovy
@@ -26,8 +26,10 @@ enum ErrorStrategy {
     TERMINATE(false),       // on error, terminate the pipeline execution, killing all pending and running tasks
     FINISH(false),          // on error, terminate the pipeline execution, waiting for pending and running tasks to complete
     IGNORE(true),           // on error, ignore it and continue
-    IGNORETHENFAIL(true),   // on error, ignore it and continue, return non-zero exit code
     RETRY(true);            // on error, retry
+
+
+    static final public String IGNORE_THEN_FAIL = 'ignoreThenFail';
 
     final boolean soft
 
@@ -38,6 +40,8 @@ enum ErrorStrategy {
     static boolean isValid(CharSequence name) {
         if( !name )
             return false
+        if( IGNORE_THEN_FAIL.equalsIgnoreCase(name.toString()))
+            return true
         try {
             valueOf(name.toString().toUpperCase())
             return true

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -46,6 +46,8 @@ class TaskConfig extends LazyMap implements Cloneable {
 
     private transient Map cache = new LinkedHashMap(20)
 
+    private Boolean failOnComplete
+
     TaskConfig() {  }
 
     TaskConfig( Map<String,Object> entries ) {
@@ -224,10 +226,20 @@ class TaskConfig extends LazyMap implements Cloneable {
         return value != null && value.toString().toLowerCase() in Const.BOOL_YES
     }
 
+    boolean getFailOnComplete() {
+        return failOnComplete
+    }
+
     ErrorStrategy getErrorStrategy() {
         final strategy = get('errorStrategy')
-        if( strategy instanceof CharSequence )
+
+        if( strategy instanceof CharSequence ) {
+            if( ErrorStrategy.IGNORE_THEN_FAIL.equalsIgnoreCase(strategy.toString()) ) {
+                failOnComplete = true
+                return ErrorStrategy.IGNORE
+            }
             return strategy.toString().toUpperCase() as ErrorStrategy
+        }
 
         if( strategy instanceof ErrorStrategy )
             return (ErrorStrategy)strategy

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1072,7 +1072,7 @@ class TaskProcessor {
                 errorStrategy = checkErrorStrategy(task, error, taskErrCount, procErrCount, submitRetries)
                 if( errorStrategy.soft ) {
                     def msg = "[$task.hashLog] NOTE: ${submitTimeout ? submitErrMsg : error.message}"
-                    if( errorStrategy == IGNORE || errorStrategy == IGNORETHENFAIL )
+                    if( errorStrategy == IGNORE )
                         msg += " -- Error is ignored"
                     else if( errorStrategy == RETRY )
                         msg += " -- Execution is retried (${submitTimeout ? submitRetries : taskErrCount})"
@@ -1146,10 +1146,6 @@ class TaskProcessor {
         // IGNORE strategy -- just continue
         if( action == IGNORE ) {
             return IGNORE
-        }
-
-        if( action == IGNORETHENFAIL ) {
-            return IGNORETHENFAIL
         }
 
         // RETRY strategy -- check that process do not exceed 'maxError' and the task do not exceed 'maxRetries'

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -49,6 +49,7 @@ import nextflow.script.params.TupleInParam
 import nextflow.script.params.TupleOutParam
 import nextflow.script.params.ValueInParam
 import nextflow.script.params.ValueOutParam
+import static nextflow.processor.ErrorStrategy.IGNORE_THEN_FAIL
 
 /**
  * Holds the process configuration properties
@@ -849,7 +850,8 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
      */
     ProcessConfig errorStrategy( strategy ) {
         if( strategy instanceof CharSequence && !ErrorStrategy.isValid(strategy) ) {
-            throw new IllegalArgumentException("Unknown error strategy '${strategy}' ― Available strategies are: ${ErrorStrategy.values().join(',').toLowerCase()}")
+            final list = (ErrorStrategy.values().collect(it->it.toString().toLowerCase()) + IGNORE_THEN_FAIL).sort().join(',')
+            throw new IllegalArgumentException("Unknown error strategy '${strategy}' ― Available strategies are: ${list}")
         }
 
         configProperties.put('errorStrategy', strategy)

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -25,6 +25,8 @@ import nextflow.script.TaskClosure
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
 import spock.lang.Specification
+import spock.lang.Unroll
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -53,25 +55,27 @@ class TaskConfigTest extends Specification {
         ['hello']            | { "$my_shell" }
     }
 
+    @Unroll
     def testErrorStrategy() {
 
         when:
-        def config = new TaskConfig(map)
+        def config = new TaskConfig(MAP)
 
         then:
-        config.errorStrategy == strategy
-        config.getErrorStrategy() == strategy
+        config.errorStrategy == STRATEGY
+        config.getErrorStrategy() == STRATEGY
+        config.getFailOnComplete() == FAIL
 
         where:
-        strategy                    | map
-        ErrorStrategy.TERMINATE     | [:]
-        ErrorStrategy.TERMINATE     | [errorStrategy: 'terminate']
-        ErrorStrategy.TERMINATE     | [errorStrategy: 'TERMINATE']
-        ErrorStrategy.IGNORE        | [errorStrategy: 'ignore']
-        ErrorStrategy.IGNORE        | [errorStrategy: 'Ignore']
-        ErrorStrategy.RETRY         | [errorStrategy: 'retry']
-        ErrorStrategy.RETRY         | [errorStrategy: 'Retry']
-
+        STRATEGY                    | MAP                               | FAIL
+        ErrorStrategy.TERMINATE     | [:]                               | false
+        ErrorStrategy.TERMINATE     | [errorStrategy: 'terminate']      | false
+        ErrorStrategy.TERMINATE     | [errorStrategy: 'TERMINATE']      | false
+        ErrorStrategy.IGNORE        | [errorStrategy: 'ignore']         | false
+        ErrorStrategy.IGNORE        | [errorStrategy: 'Ignore']         | false
+        ErrorStrategy.RETRY         | [errorStrategy: 'retry']          | false
+        ErrorStrategy.RETRY         | [errorStrategy: 'Retry']          | false
+        ErrorStrategy.IGNORE        | [errorStrategy: 'ignoreThenFail'] | true
     }
 
     def testErrorStrategy2() {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -795,7 +795,7 @@ class ProcessConfigTest extends Specification {
 
         then:
         def e1 = thrown(IllegalArgumentException)
-        e1.message == "Unknown error strategy 'abort' ― Available strategies are: terminate,finish,ignore,ignorethenfail,retry"
+        e1.message == "Unknown error strategy 'abort' ― Available strategies are: finish,ignore,ignoreThenFail,retry,terminate"
 
     }
 
@@ -812,13 +812,20 @@ class ProcessConfigTest extends Specification {
         process2.errorStrategy 'terminate'
 
         then:
-        def e2 = noExceptionThrown()
+        process2.errorStrategy == 'terminate'
 
         when:
         def process3 = new ProcessConfig(Mock(BaseScript))
         process3.errorStrategy { task.exitStatus==14 ? 'retry' : 'terminate' }
 
         then:
-        def e3 = noExceptionThrown()
+        process3.errorStrategy instanceof Closure
+
+        when:
+        def process4 = new ProcessConfig(Mock(BaseScript))
+        process4.errorStrategy 'ignoreThenFail'
+
+        then:
+        process4.errorStrategy == 'ignoreThenFail'
     }
 }


### PR DESCRIPTION
This PR implements the `ignoreThenFail` as a pseudo error strategy that's mapped to `ignore` behind the scenes. 

