### PR TITLE
Fix for issue #4757

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
@@ -162,7 +162,7 @@ class S3BashLib extends BashFunLib<S3BashLib> {
             local source=\$1
             local target=\$2
             local file_name=\$(basename \$1)
-            local is_dir=\$($cli ls \$source | grep -F "DIR \${file_name}/" -c)
+            local is_dir=\$($cli ls \$source | grep -F "DIR  \${file_name}/" -c)
             if [[ \$is_dir == 1 ]]; then
                 $cli cp "\$source/*" "\$target"
             else 


### PR DESCRIPTION
This is a fix for #4757 

When nxf_s3_download attempts to check whether an s3 URI represents a file or directory it fails because the matching string expects a single space where the output of s5cmd has two spaces. This causes it to always treat the URI as a file and not work.

I just added the extra space and verified it fixes the issue.