### PR TITLE
Fix executions hangs on finalisation exception

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -663,11 +663,21 @@ class TaskPollingMonitor implements TaskMonitor {
 
             // finalize the task asynchronously
             if( enableAsyncFinalizer ) {
-                finalizerPool.submit( ()-> finalizeTask(handler) )
+                finalizerPool.submit( ()-> safeFinalizeTask(handler) )
             }
             else {
                 finalizeTask(handler)
             }
+        }
+    }
+
+    protected void safeFinalizeTask(TaskHandler handler) {
+        try {
+            finalizeTask(handler)
+        }
+        catch (Throwable t) {
+            log.error "Unexpected error while finalizing task '${handler.task.name}' - cause: ${t.message}"
+            session.abort(t)
         }
     }
 


### PR DESCRIPTION
This PR prevents the execution from hanging when an exception is thrown in the task finalisation phase. 

Closes #5041