### PR TITLE
4446 ignore then fail strategy v3

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -58,6 +58,11 @@ The following table lists the properties that can be accessed on the `workflow` 
 : *Available only in the `workflow.onComplete` and `workflow.onError` handlers*
 : Exit status of the task that caused the workflow execution to fail.
 
+`workflow.failOnIgnore`
+: :::{versionadded} 24.05.0-edge
+  :::
+: Whether `failOnIgnore` execution option was set.
+
 `workflow.fusion.enabled`
 : Whether Fusion is enabled.
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1660,11 +1660,6 @@ The following error strategies are available:
 `ignore`
 : Ignore all task failures.
 
-`ignoreThenFail`
-: :::{versionadded} 24.05.0-edge
-  :::
-: Ignore all task failures, but return a non-zero exit code when the pipeline is complete.
-
 `retry`
 : When a task fails, retry it.
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1658,7 +1658,9 @@ The following error strategies are available:
 : When a task fails, wait for pending and running tasks to finish and then terminate the pipeline.
 
 `ignore`
-: Ignore all task failures.
+: Ignore all task failures and complete the pipeline execution successfully. As of version `24.05.0-edge` the option
+`workflow.failOnIgnore=true` can be specified in the `nextflow.config` file to force the pipeline execution to fail on
+completion when one or more task failures where marked as ignored.
 
 `retry`
 : When a task fails, retry it.

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -223,7 +223,7 @@ class Session implements ISession {
 
     private Barrier monitorsBarrier = new Barrier()
 
-    private volatile boolean failOnComplete
+    private volatile boolean failOnIgnore
 
     private volatile boolean cancelled
 
@@ -826,7 +826,7 @@ class Session implements ISession {
 
     boolean isCancelled() { cancelled }
 
-    boolean isSuccess() { !aborted && !cancelled && !failOnComplete }
+    boolean isSuccess() { !aborted && !cancelled && !failOnIgnore }
 
     void processRegister(TaskProcessor process) {
         log.trace ">>> barrier register (process: ${process.name})"
@@ -864,6 +864,10 @@ class Session implements ISession {
 
     boolean enableModuleBinaries() {
         config.navigate('nextflow.enable.moduleBinaries', false) as boolean
+    }
+
+    boolean enableFailOnIgnore() {
+        config.navigate('nextflow.enable.failOnIgnore', false) as boolean
     }
 
     @PackageScope VersionNumber getCurrentVersion() {
@@ -1050,8 +1054,8 @@ class Session implements ISession {
         cache.putTaskAsync(handler, trace)
 
         // set the pipeline to return non-exit code if specified
-        if( handler.task.errorAction == ErrorStrategy.IGNORETHENFAIL )
-            failOnComplete = true
+        if( handler.task.errorAction == ErrorStrategy.IGNORE && enableFailOnIgnore() )
+            failOnIgnore = true
 
         // notify the event to the observers
         for( int i=0; i<observers.size(); i++ ) {

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -866,8 +866,8 @@ class Session implements ISession {
         config.navigate('nextflow.enable.moduleBinaries', false) as boolean
     }
 
-    boolean enableFailOnIgnore() {
-        config.navigate('nextflow.enable.failOnIgnore', false) as boolean
+    boolean failOnIgnore() {
+        config.navigate('workflow.failOnIgnore', false) as boolean
     }
 
     @PackageScope VersionNumber getCurrentVersion() {
@@ -1054,8 +1054,10 @@ class Session implements ISession {
         cache.putTaskAsync(handler, trace)
 
         // set the pipeline to return non-exit code if specified
-        if( handler.task.errorAction == ErrorStrategy.IGNORE && enableFailOnIgnore() )
+        if( handler.task.errorAction == ErrorStrategy.IGNORE && failOnIgnore() ) {
+            log.debug "Setting fail-on-ignore flag due to ignored task '${handler.task.lazyName()}'"
             failOnIgnore = true
+        }
 
         // notify the event to the observers
         for( int i=0; i<observers.size(); i++ ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/ErrorStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/ErrorStrategy.groovy
@@ -26,7 +26,6 @@ enum ErrorStrategy {
     TERMINATE(false),       // on error, terminate the pipeline execution, killing all pending and running tasks
     FINISH(false),          // on error, terminate the pipeline execution, waiting for pending and running tasks to complete
     IGNORE(true),           // on error, ignore it and continue
-    IGNORETHENFAIL(true),   // on error, ignore it and continue, return non-zero exit code
     RETRY(true);            // on error, retry
 
     final boolean soft

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1072,7 +1072,7 @@ class TaskProcessor {
                 errorStrategy = checkErrorStrategy(task, error, taskErrCount, procErrCount, submitRetries)
                 if( errorStrategy.soft ) {
                     def msg = "[$task.hashLog] NOTE: ${submitTimeout ? submitErrMsg : error.message}"
-                    if( errorStrategy == IGNORE || errorStrategy == IGNORETHENFAIL )
+                    if( errorStrategy == IGNORE )
                         msg += " -- Error is ignored"
                     else if( errorStrategy == RETRY )
                         msg += " -- Execution is retried (${submitTimeout ? submitRetries : taskErrCount})"
@@ -1146,10 +1146,6 @@ class TaskProcessor {
         // IGNORE strategy -- just continue
         if( action == IGNORE ) {
             return IGNORE
-        }
-
-        if( action == IGNORETHENFAIL ) {
-            return IGNORETHENFAIL
         }
 
         // RETRY strategy -- check that process do not exceed 'maxError' and the task do not exceed 'maxRetries'

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -227,6 +227,11 @@ class WorkflowMetadata {
      */
     Manifest manifest
 
+    /**
+     * whenever it should terminate with a failure when one or more task execution failed in an error strategy
+     */
+    boolean failOnIgnore
+
     private Session session
 
     final private List<Closure> onCompleteActions = []
@@ -268,6 +273,7 @@ class WorkflowMetadata {
         this.manifest = session.getManifest()
         this.wave = new WaveMetadata(session)
         this.fusion = new FusionMetadata(session)
+        this.failOnIgnore = session.failOnIgnore()
 
         // check if there's a onComplete action in the config file
         registerConfigAction(session.config.workflow as Map)

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -795,7 +795,7 @@ class ProcessConfigTest extends Specification {
 
         then:
         def e1 = thrown(IllegalArgumentException)
-        e1.message == "Unknown error strategy 'abort' ― Available strategies are: terminate,finish,ignore,ignorethenfail,retry"
+        e1.message == "Unknown error strategy 'abort' ― Available strategies are: terminate,finish,ignore,retry"
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
@@ -101,6 +101,7 @@ class WorkflowMetadataTest extends Specification {
         metadata.homeDir == Paths.get(System.getProperty('user.home'))
         metadata.manifest.version == '1.0.0'
         metadata.manifest.nextflowVersion == '>=0.31.1'
+        !metadata.failOnIgnore
 
         when:
         metadata.invokeOnComplete()
@@ -116,12 +117,14 @@ class WorkflowMetadataTest extends Specification {
         session.resumeMode >> true
         session.stubRun >> true
         session.preview >> true
+        session.failOnIgnore() >> true
         metadata = new WorkflowMetadata(session, script)
         then:
         metadata.profile == 'foo_profile'
         metadata.resume
         metadata.stubRun
         metadata.preview
+        metadata.failOnIgnore
     }
 
     def foo_test_method() {

--- a/tests/checks/error-ignore-then-fail.nf/.checks
+++ b/tests/checks/error-ignore-then-fail.nf/.checks
@@ -2,7 +2,7 @@ set -e
 
 set +e
 echo ''
-$NXF_RUN > stdout
+$NXF_CMD -q run $NXF_SCRIPT -c .nextflow.config  > stdout
 status=$?
 set -e
 

--- a/tests/checks/error-ignore-then-fail.nf/.checks
+++ b/tests/checks/error-ignore-then-fail.nf/.checks
@@ -2,7 +2,7 @@ set -e
 
 set +e
 echo ''
-$NXF_CMD -q run $NXF_SCRIPT -c .nextflow.config  > stdout
+$NXF_CMD -q run $NXF_SCRIPT -c .config  > stdout
 status=$?
 set -e
 

--- a/tests/checks/error-ignore-then-fail.nf/.config
+++ b/tests/checks/error-ignore-then-fail.nf/.config
@@ -1,1 +1,1 @@
-workflow.failOnIgnore = false
+workflow.failOnIgnore = true

--- a/tests/checks/error-ignore-then-fail.nf/.config
+++ b/tests/checks/error-ignore-then-fail.nf/.config
@@ -1,0 +1,1 @@
+workflow.failOnIgnore = false

--- a/tests/checks/error-ignore-then-fail.nf/.nextflow.config
+++ b/tests/checks/error-ignore-then-fail.nf/.nextflow.config
@@ -1,0 +1,1 @@
+workflow.failOnIgnore = true

--- a/tests/checks/error-ignore-then-fail.nf/.nextflow.config
+++ b/tests/checks/error-ignore-then-fail.nf/.nextflow.config
@@ -1,2 +1,0 @@
-workflow.failOnIgnore = true
-

--- a/tests/checks/error-ignore-then-fail.nf/.nextflow.config
+++ b/tests/checks/error-ignore-then-fail.nf/.nextflow.config
@@ -1,1 +1,2 @@
 workflow.failOnIgnore = true
+

--- a/tests/error-ignore-then-fail.nf
+++ b/tests/error-ignore-then-fail.nf
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+nextflow.enable.failOnIgnore = true
 
 process foo {
-    errorStrategy 'ignoreThenFail'
+    errorStrategy 'ignore'
 
     script:
     '''

--- a/tests/error-ignore-then-fail.nf
+++ b/tests/error-ignore-then-fail.nf
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-nextflow.enable.failOnIgnore = true
 
 process foo {
     errorStrategy 'ignore'


### PR DESCRIPTION
This PR implements the fail on ignore by using by setting the option `nextflow.enable.failOnIgnore` in the nextflow config file. 

 