### PR TITLE
Docs: Pending tasks won't execute

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1656,7 +1656,7 @@ The following error strategies are available:
 : When a task fails, terminate the pipeline immediately. Pending and running jobs are killed.
 
 `finish`
-: When a task fails, wait for pending and running tasks to finish and then terminate the pipeline.
+: When a task fails, wait for submitted and running tasks to finish and then terminate the pipeline.
 
 `ignore`
 : Ignore all task failures and complete the pipeline execution successfully.


### PR DESCRIPTION
Suggestion from Slack by @vagkaratzas

Pending tasks are cancelled immediately. Only submitted and running tasks are left to complete.