### PR TITLE
Fix publish error when remote path contains double slash

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -144,7 +144,7 @@ class PublishDir {
         final resolved = value instanceof Closure ? value.call() : value
         if( resolved instanceof String || resolved instanceof GString )
             nullPathWarn = checkNull(resolved.toString())
-        this.path = FileHelper.toCanonicalPath(resolved)
+        this.path = (resolved as Path).complete()
     }
 
     void setMode( String str ) {


### PR DESCRIPTION
GCP doesn't accept paths that contain a double slash. Apparently this has been the case for a while, but we didn't realize it because publish errors were being ignored by default. Until recently when we made publish errors fatal.

The root cause appears to be that `FileHelper.toCanonicalPath()` does not normalize the path when it is remote. You can verify using this test case:

```groovy
// local
outdir = 'results/'
filename = "${outdir}/bco.json"

println "local complete: ${(filename as Path).complete()}"
println "local canonical: ${nextflow.file.FileHelper.toCanonicalPath(filename)}"

// remote
outdir = 'gs://bucket/results/'
filename = "${outdir}/bco.json"

println "remote complete:  ${(filename as Path).complete().toUriString()}"
println "remote canonical: ${nextflow.file.FileHelper.toCanonicalPath(filename).toUriString()}"
```

Output:
```
local complete: /home/bent/projects/sketches/results/bco.json
local canonical: /home/bent/projects/sketches/results/bco.json
remote complete:  gs://bucket/results/bco.json
remote canonical: gs://bucket/results//bco.json
```

This will fix the specific issue with PublishDir, but long-term we should probably review the various ways in which strings are converted to paths across the codebase (which there are several) and try to use a uniform approach. The approach I used in this PR seems to be the most common one and the most robust.

See also: https://github.com/nextflow-io/nf-prov/issues/34