### PR TITLE
Documentation clarification for `failOnDuplicate` and `failOnMismatch`

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -758,10 +758,10 @@ Available options:
 : The zero-based index of each item to use as the matching key. Can also be a list of indices, e.g. `by: [0, 2]` (default: `[0]`).
 
 `failOnDuplicate`
-: When `true`, an error is reported when the operator receives multiple items from the same channel with the same key (default: `true` if {ref}`strict mode <config-feature-flags>` is enabled, `false` otherwise).
+: When `true`, an error is reported when the operator receives multiple items from the same channel with the same key (default: `false`). Value is set to `true` if {ref}`strict mode <config-feature-flags>` is enabled.
 
 `failOnMismatch`
-: When `true`, an error is reported when the operator receives an item from one channel for which there no matching item from the other channel (default: `true` if {ref}`strict mode <config-feature-flags>` is enabled, `false` otherwise). This option cannot be used with `remainder`.
+: When `true`, an error is reported when the operator receives an item from one channel for which there no matching item from the other channel (default: `false`). Value is set to `true` if {ref}`strict mode <config-feature-flags>` is enabled. This option cannot be used with `remainder`.
 
 `remainder`
 : When `true`, unmatched items are emitted at the end, otherwise they are discarded (default: `false`). 


### PR DESCRIPTION
Before this PR, the docs claimed the "default" value for these configuration values was true when strict mode is enabled. In truth, the value is _set_ to `true` when strict mode is enabled (stronger than just the default).