### PR TITLE
Add ability to override failOnError setting default via env variable

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -2017,6 +2017,11 @@ The following environment variables control the configuration of the Nextflow ru
   :::
 : Defines a custom plugin registry or plugin release URL for testing plugins outside of the main registry. See {ref}`testing-plugins` for more information.
 
+`NXF_PUBLISH_FAIL_ON_ERROR`
+: :::{versionadded} 24.04.3
+  :::
+: Defines the default behavior of `publishDir.failOnError` setting. See {ref}`publishDir<process-publishdir>` directive for more information.
+
 `NXF_SCM_FILE`
 : :::{versionadded} 20.10.0
   :::

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,3 @@ sphinx==5.3.0
 sphinx-rtd-theme==1.1.1
 sphinxcontrib-mermaid==0.9.2
 sphinxext-rediraffe==0.2.7
-urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.processor
 
+import static nextflow.util.CacheHelper.*
+
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
@@ -40,15 +42,12 @@ import groovy.util.logging.Slf4j
 import nextflow.Global
 import nextflow.NF
 import nextflow.Session
+import nextflow.SysEnv
 import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.file.TagAwareFile
-import nextflow.fusion.FusionHelper
 import nextflow.util.HashBuilder
 import nextflow.util.PathTrie
-
-import static nextflow.util.CacheHelper.HashMode
-
 /**
  * Implements the {@code publishDir} directory. It create links or copies the output
  * files of a given task to a user specified directory.
@@ -98,9 +97,9 @@ class PublishDir {
     boolean enabled = true
 
     /**
-     * Trow an exception in case publish fails
+     * Throw an exception in case publish fails
      */
-    boolean failOnError = true
+    boolean failOnError = SysEnv.getBool('NXF_PUBLISH_FAIL_ON_ERROR', true)
 
     /**
      * Tags to be associated to the target file

--- a/modules/nextflow/src/test/groovy/nextflow/processor/PublishDirTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/PublishDirTest.groovy
@@ -22,6 +22,7 @@ import java.nio.file.Paths
 
 import nextflow.Global
 import nextflow.Session
+import nextflow.SysEnv
 import spock.lang.Specification
 import test.TestHelper
 /**
@@ -397,5 +398,23 @@ class PublishDirTest extends Specification {
 
         cleanup:
         folder?.deleteDir()
+    }
+
+    def 'should set failOnError via env variable' () {
+        given:
+        SysEnv.push(ENV)
+
+        when:
+        def publish = new PublishDir()
+        then:
+        publish.failOnError == EXPECTED
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        ENV                                         | EXPECTED
+        [:]                                         | true
+        [NXF_PUBLISH_FAIL_ON_ERROR: 'true']         | true
+        [NXF_PUBLISH_FAIL_ON_ERROR: 'false']        | false
     }
 }


### PR DESCRIPTION
This PR adds the ability to override the default of failOnError publish setting default by using the env variable `NXF_PUBLISH_FAIL_ON_ERROR=true|false`. 

 