### PR TITLE
Adds example of error strategies to documentation

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1684,6 +1684,15 @@ process ignoreAnyError {
 By definition, a command script fails when it ends with a non-zero exit status.
 :::
 
+:::{note}
+To illustrate the differences between error strategies, it can be helpful to imagine an example. Let's say you are analysing 96 patient samples, however the data from one is corrupted and will fail. If you try to analyse these samples with a pipeline written in Nextflow, here is the behaviour when using the following strategies when the process for the corrupted file fails:
+
+- `terminate`: Nextflow will cancel any existing processes and exit the pipeline and report an error
+- `finish`: Nextflow will finish any existing jobs but not submit any more and report an error
+- `ignore`: Nextflow will proceed to continue submitting processes for the remaining 95 samples and proceed to completion. Nextflow will ignore the error and report a successful pipeline completion
+- `ignore` and `workflow.failOnIgnore`: Nextflow will proceed to continue submitting processes for the remaining 95 samples and proceed to completion, then exit with an error status and report the error
+:::
+
 The `retry` error strategy allows you to re-submit for execution a process returning an error condition. For example:
 
 ```groovy

--- a/docs/process.md
+++ b/docs/process.md
@@ -1684,7 +1684,7 @@ process ignoreAnyError {
 By definition, a command script fails when it ends with a non-zero exit status.
 :::
 
-:::{note}
+:::{tip}
 To illustrate the differences between error strategies, it can be helpful to imagine an example. Let's say you are analysing 96 patient samples, however the data from one is corrupted and will fail. If you try to analyse these samples with a pipeline written in Nextflow, here is the behaviour when using the following strategies when the process for the corrupted file fails:
 
 - `terminate`: Nextflow will cancel any existing processes and exit the pipeline and report an error

--- a/docs/process.md
+++ b/docs/process.md
@@ -1688,7 +1688,7 @@ By definition, a command script fails when it ends with a non-zero exit status.
 To illustrate the differences between error strategies, it can be helpful to imagine an example. Let's say you are analysing 96 patient samples, however the data from one is corrupted and will fail. If you try to analyse these samples with a pipeline written in Nextflow, here is the behaviour when using the following strategies when the process for the corrupted file fails:
 
 - `terminate`: Nextflow will cancel any existing processes and exit the pipeline and report an error
-- `finish`: Nextflow will finish any existing jobs but not submit any more and report an error
+- `finish`: Nextflow will allow any existing jobs to conclude but not submit any more and report an error
 - `ignore`: Nextflow will proceed to continue submitting processes for the remaining 95 samples and proceed to completion. Nextflow will ignore the error and report a successful pipeline completion
 - `ignore` and `workflow.failOnIgnore`: Nextflow will proceed to continue submitting processes for the remaining 95 samples and proceed to completion, then exit with an error status and report the error
 :::


### PR DESCRIPTION
Should improve clarity around the role of `workflow.failOnIgnore` with the different errorStrategies