### PR TITLE
Fix aws logs group name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ temp
 plugins-prod
 sandbox
 wave-tests
+x/*

--- a/docs/config.md
+++ b/docs/config.md
@@ -189,7 +189,7 @@ The following settings are available:
 `aws.batch.logsGroup`
 : :::{versionadded} 22.09.0-edge
   :::
-: The name of the logs group used by Batch Jobs (default: `/aws/batch`).
+: The name of the logs group used by Batch Jobs (default: `/aws/batch/job`).
 
 `aws.batch.maxParallelTransfers`
 : Max parallel upload/download transfer operations *per job* (default: `4`).


### PR DESCRIPTION
Fix the default AWS Logs group name in the docs consistently with the implementation 

https://github.com/nextflow-io/nextflow/blob/1ab8d56a628b2d7361d0bf37fa069b410086d69a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchHelper.groovy#L209-L209