### PR TITLE
Make auto retry codes configurable

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -848,8 +848,7 @@ The following settings are available for Google Cloud Batch:
 `google.batch.autoRetryExitCodes`
 : :::{versionadded} 24.06.0-edge
   :::
-: Defines the task exit codes that determine an automatic task execution retry when the setting `maxSpotAttempts` is set
-to a value greater than 0. (default `[50001]`). For more details check out the [Google Batch documentation](https://cloud.google.com/batch/docs/troubleshooting#vm_preemption_50001).
+: Defines the list of exit codes that will be automatically retried by Google Batch when `google.batch.maxSpotAttempts` is greater than 0 (default `[50001]`). Refer to the [Google Batch documentation](https://cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes) for the list of retryable exit codes.
 
 `google.enableRequesterPaysBuckets`
 : When `true` uses the given Google Cloud project ID as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`).
@@ -871,7 +870,7 @@ to a value greater than 0. (default `[50001]`). For more details check out the [
 : :::{versionadded} 23.11.0-edge
   :::
 : Max number of execution attempts of a job interrupted by a Compute Engine spot reclaim event (default: `5`).
-See also `autoRetryExitCodes`.
+: See also: `google.batch.autoRetryExitCodes`
 
 `google.project`
 : The Google Cloud project ID to use for pipeline execution

--- a/docs/config.md
+++ b/docs/config.md
@@ -846,7 +846,7 @@ Read the {ref}`google-page` page for more information.
 The following settings are available for Google Cloud Batch:
 
 `google.batch.autoRetryExitCodes`
-: :::{versionadded} 24.06.0-edge
+: :::{versionadded} 24.07.0-edge
   :::
 : Defines the list of exit codes that will be automatically retried by Google Batch when `google.batch.maxSpotAttempts` is greater than 0 (default `[50001]`). Refer to the [Google Batch documentation](https://cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes) for the list of retryable exit codes.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -845,6 +845,12 @@ Read the {ref}`google-page` page for more information.
 
 The following settings are available for Google Cloud Batch:
 
+`google.batch.autoRetryExitCodes`
+: :::{versionadded} 24.06.0-edge
+  :::
+: Defines the task exit codes that determine an automatic task execution retry when the setting `maxSpotAttempts` is set
+to a value greater than 0. (default `[50001]`). For more details check out the [Google Batch documentation](https://cloud.google.com/batch/docs/troubleshooting#vm_preemption_50001).
+
 `google.enableRequesterPaysBuckets`
 : When `true` uses the given Google Cloud project ID as the billing project for storage access. This is required when accessing data from *requester pays enabled* buckets. See [Requester Pays on Google Cloud Storage documentation](https://cloud.google.com/storage/docs/requester-pays) (default: `false`).
 
@@ -865,6 +871,7 @@ The following settings are available for Google Cloud Batch:
 : :::{versionadded} 23.11.0-edge
   :::
 : Max number of execution attempts of a job interrupted by a Compute Engine spot reclaim event (default: `5`).
+See also `autoRetryExitCodes`.
 
 `google.project`
 : The Google Cloud project ID to use for pipeline execution

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -33,6 +33,8 @@ import nextflow.util.MemoryUnit
 @CompileStatic
 class BatchConfig {
 
+    static private List<Integer> DEFAULT_RETRY_LIST = List.of(50001)
+
     private GoogleOpts googleOpts
     private GoogleCredentials credentials
     private List<String> allowedLocations
@@ -81,43 +83,13 @@ class BatchConfig {
         result.subnetwork = session.config.navigate('google.batch.subnetwork')
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
-        result.autoRetryExitCodes = parseAutoRetryExitCodes0(session.config.navigate('google.batch.autoRetryExitCodes','50001'))
+        result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes',DEFAULT_RETRY_LIST) as List<Integer>
         return result
     }
 
     @Override
     String toString(){
         return "BatchConfig[googleOpts=$googleOpts"
-    }
-
-    static private String _50001 = '50001'
-
-    static private List<Integer> DEFAULT_RETRY_LIST = List.of(_50001.toInteger())
-
-    static protected List<Integer> parseAutoRetryExitCodes0(value) {
-        if(!value)
-            return List.of()
-        if( value instanceof List ) {
-            // it's expected to be a list of integer
-            return value as List<Integer>
-        }
-        if( value instanceof CharSequence ) {
-            final v0 = value.toString()
-            if( v0==_50001 )
-                return DEFAULT_RETRY_LIST
-            else
-                return v0.tokenize(',').toList().collect(it->parseCode(it))
-        }
-        return null
-    }
-
-    static private Integer parseCode(String v) {
-        try {
-            return v.toInteger()
-        }
-        catch (NumberFormatException e) {
-            throw new ProcessUnrecoverableException("Invalid exit code value: $v -- check the setting `google.batch.autoRetryExitCodes`")
-        }
     }
 
 }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
@@ -20,8 +20,6 @@ package nextflow.cloud.google.batch.client
 import nextflow.Session
 import spock.lang.Requires
 import spock.lang.Specification
-import spock.lang.Unroll
-
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -32,10 +30,10 @@ class BatchConfigTest extends Specification {
     def 'should create batch config' () {
         given:
         def CONFIG = [google: [
-                                batch: [
-                                    spot: true
-                                ]
-                        ] ]
+            batch: [
+                spot: true
+            ]
+        ] ]
         def session = Mock(Session) { getConfig()>>CONFIG }
 
         when:
@@ -69,18 +67,6 @@ class BatchConfigTest extends Specification {
         config.retryConfig.maxAttempts == 10
         config.maxSpotAttempts == 8
         config.autoRetryExitCodes == [50001, 50003, 50005]
-    }
-
-    @Unroll
-    def 'should should parse exit codes' () {
-        expect:
-        BatchConfig.parseAutoRetryExitCodes0(CODES) == EXPECTED
-        where:
-        CODES       | EXPECTED
-        null        | []
-        '1'         | [1]
-        '2,4,8'     | [2,4,8]
-        [10,20]     | [10,20]
     }
 
 }


### PR DESCRIPTION
This PR introduces a new config option that allows setting one more exit codes when running a task with Google Batch that should trigger an automatic retry when a task returns an error code and the opinion `google.batch.maxSpotAttempts` is set to a value greater than zero.

By default this option is set to `[50001]`. See the [Google docs](https://cloud.google.com/batch/docs/troubleshooting#vm_preemption_50001) for more details.   