### PR TITLE
Prevent default output/error logs for job arrays

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/CrgExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/CrgExecutor.groovy
@@ -49,10 +49,13 @@ class CrgExecutor extends SgeExecutor {
 
         result << '-N' << getJobNameFor(task)
 
-        if( task !instanceof TaskArrayRun ) {
-            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
-            result << '-j' << 'y'
+        if( task instanceof TaskArrayRun ) {
+            result << '-o' << '/dev/null'
         }
+        else {
+            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
+        }
+        result << '-j' << 'y'
 
         result << '-terse' << ''    // note: directive need to be returned as pairs
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -70,7 +70,10 @@ class LsfExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
      */
     protected List<String> getDirectives(TaskRun task, List<String> result) {
 
-        if( task !instanceof TaskArrayRun ) {
+        if( task instanceof TaskArrayRun ) {
+            result << '-o' << '/dev/null'
+        }
+        else {
             result << '-o' << task.workDir.resolve(TaskRun.CMD_LOG).toString()
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -51,10 +51,13 @@ class PbsExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
 
         result << '-N' << getJobNameFor(task)
 
-        if( task !instanceof TaskArrayRun ) {
-            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
-            result << '-j' << 'oe'
+        if( task instanceof TaskArrayRun ) {
+            result << '-o' << '/dev/null'
         }
+        else {
+            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
+        }
+        result << '-j' << 'oe'
 
         // the requested queue name
         if( task.config.queue ) {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsProExecutor.groovy
@@ -58,10 +58,13 @@ class PbsProExecutor extends PbsExecutor {
 
         result << '-N' << getJobNameFor(task)
 
-        if( task !instanceof TaskArrayRun ) {
-            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
-            result << '-j' << 'oe'
+        if( task instanceof TaskArrayRun ) {
+            result << '-o' << '/dev/null'
         }
+        else {
+            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
+        }
+        result << '-j' << 'oe'
 
         // the requested queue name
         if( task.config.queue ) {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
@@ -45,10 +45,13 @@ class SgeExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
 
         result << '-N' << getJobNameFor(task)
 
-        if( task !instanceof TaskArrayRun ) {
-            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
-            result << '-j' << 'y'
+        if( task instanceof TaskArrayRun ) {
+            result << '-o' << '/dev/null'
         }
+        else {
+            result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
+        }
+        result << '-j' << 'y'
 
         result << '-terse' << ''    // note: directive need to be returned as pairs
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -62,8 +62,11 @@ class SlurmExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
 
         result << '-J' << getJobNameFor(task)
 
-        if( task !instanceof TaskArrayRun ) {
-            // -o OUTFILE and no -e option => stdout and stderr merged to stdout/OUTFILE
+        // -o OUTFILE and no -e option => stdout and stderr merged to stdout/OUTFILE
+        if( task instanceof TaskArrayRun ) {
+            result << '-o' << '/dev/null'
+        }
+        else {
             result << '-o' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/CrgExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/CrgExecutorTest.groovy
@@ -351,6 +351,8 @@ class CrgExecutorTest extends Specification {
         executor.getHeaders(task) == '''
                     #$ -t 1-5
                     #$ -N nf-mapping_tag
+                    #$ -o /dev/null
+                    #$ -j y
                     #$ -terse
                     #$ -notify
                     '''

--- a/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/LsfExecutorTest.groovy
@@ -324,6 +324,7 @@ class LsfExecutorTest extends Specification {
         }
         then:
         executor.getHeaders(taskArray) == '''
+                #BSUB -o /dev/null
                 #BSUB -J "nf-mapping_hola[1-5]"
                 '''
                 .stripIndent().leftTrim()

--- a/modules/nextflow/src/test/groovy/nextflow/executor/PbsExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/PbsExecutorTest.groovy
@@ -174,6 +174,8 @@ class PbsExecutorTest extends Specification {
         executor.getHeaders(taskArray) == '''
                 #PBS -J 0-4
                 #PBS -N nf-task_name
+                #PBS -o /dev/null
+                #PBS -j oe
                 '''
                 .stripIndent().leftTrim()
     }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/PbsProExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/PbsProExecutorTest.groovy
@@ -201,6 +201,8 @@ class PbsProExecutorTest extends Specification {
         executor.getDirectives(task, []) == [
                 '-J', '0-4',
                 '-N', 'nf-foo',
+                '-o', '/dev/null',
+                '-j', 'oe'
         ]
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SgeExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SgeExecutorTest.groovy
@@ -207,6 +207,8 @@ class SgeExecutorTest extends Specification {
         executor.getHeaders(taskArray) == '''
                 #$ -t 1-5
                 #$ -N nf-the_task_name
+                #$ -o /dev/null
+                #$ -j y
                 #$ -terse
                 #$ -notify
                 '''

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SlurmExecutorTest.groovy
@@ -230,6 +230,7 @@ class SlurmExecutorTest extends Specification {
         executor.getHeaders(taskArray) == '''
                 #SBATCH --array 0-4
                 #SBATCH -J nf-the_task_name
+                #SBATCH -o /dev/null
                 #SBATCH --no-requeue
                 #SBATCH --signal B:USR2@30
                 '''


### PR DESCRIPTION
Close #5092 

Most grid executors will still write output/error logs for a job to some default location if you don't give a location. So we must explicitly set to `/dev/null` to disable them.