### PR TITLE
Update script.md for mklink

### DIFF
--- a/docs/script.md
+++ b/docs/script.md
@@ -1186,12 +1186,13 @@ The following methods are available for manipulating files and directories in a 
   file('any/path').mkdirs()
   ```
 
-`mklink( linkName, options = [:] )`
+`mklink( options = [:], linkName )`
 : Creates a *filesystem link* to a given path:
 
   ```groovy
   myFile = file('/some/path/file.txt')
   myFile.mklink('/user/name/link-to-file.txt')
+  myFile.mklink(['overwrite':true], '/user/name/other-link-to-file.txt')
   ```
 
   Available options:


### PR DESCRIPTION
The documentation for mklink indicates options as 2nd parameter ( mklink( linkName, options = [:] ) ), however they need to be provided as 1st parameter, following the function signature ( [mklink(java.util.Map opts, java.nio.file.Path link)](https://javadoc.io/static/io.nextflow/nextflow/20.04.1-edge/nextflow/processor/TaskPath.html#mklink(java.util.Map,%20java.nio.file.Path)) )