### PR TITLE
Add runtime error for missing channel factory

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/plugin/extension/PluginExtensionProvider.groovy
@@ -286,6 +286,9 @@ class PluginExtensionProvider implements ExtensionProvider {
             def factory = (ChannelFactoryInstance)reference.target
             return factory.invokeExtensionMethod(reference.method, args)
         }
+        else {
+            throw new MissingMethodException("Channel.${name}", Object.class, args)
+        }
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptDslTest.groovy
@@ -604,4 +604,26 @@ class ScriptDslTest extends Dsl2Spec {
         result.val == 'Hello'
     }
 
+
+    def 'should throw an exception on missing method' () {
+
+        when:
+        dsl_eval '''
+           Channel.doesNotExist()
+        '''
+        then:
+        def e1 = thrown(MissingMethodException)
+        e1.message == 'No signature of method: java.lang.Object.Channel.doesNotExist() is applicable for argument types: () values: []'
+
+        when:
+        dsl_eval '''
+        workflow {
+           Channel.doesNotExist()
+        }
+        '''
+        then:
+        def e2 = thrown(MissingProcessException)
+        e2.message == 'Missing process or function Channel.doesNotExist()'
+    }
+
 }


### PR DESCRIPTION
Consider the following script:
```groovy
Channel.doesNotExist()
```

Nextflow does not throw an error for an invalid channel factory. This PR adds the following error:
```
Missing process or function Channel.doesNotExist()

 -- Check script 'test.nf' at line: 1 or see '.nextflow.log' file for more details
```

reported by @robsyme 