### PR TITLE
More robust parsing of shm-size containerOptions

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsContainerOptionsMapper.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsContainerOptionsMapper.groovy
@@ -22,6 +22,7 @@ import com.amazonaws.services.batch.model.Tmpfs
 import com.amazonaws.services.batch.model.Ulimit
 import groovy.transform.CompileStatic
 import nextflow.util.CmdLineOptionMap
+import nextflow.util.MemoryUnit
 
 /**
  * Maps task container options to AWS container properties
@@ -106,7 +107,8 @@ class AwsContainerOptionsMapper {
         // shared Memory Size
         def value = findOptionWithSingleValue(options, 'shm-size')
         if ( value ) {
-            params.setSharedMemorySize(value as Integer)
+            MemoryUnit sharedMemorySize = (value as MemoryUnit)
+            params.setSharedMemorySize(sharedMemorySize.mega as Integer)
             atLeastOneSet = true
         }
 

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsContainerOptionsMapper.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsContainerOptionsMapper.groovy
@@ -107,7 +107,7 @@ class AwsContainerOptionsMapper {
         // shared Memory Size
         def value = findOptionWithSingleValue(options, 'shm-size')
         if ( value ) {
-            MemoryUnit sharedMemorySize = (value as MemoryUnit)
+            final sharedMemorySize = MemoryUnit.of(value)
             params.setSharedMemorySize(sharedMemorySize.mega as Integer)
             atLeastOneSet = true
         }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsContainerOptionsMapperTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsContainerOptionsMapperTest.groovy
@@ -94,7 +94,25 @@ class AwsContainerOptionsMapperTest extends Specification {
         def map = CmdLineHelper.parseGnuArgs('--shm-size 12048024')
         def properties = AwsContainerOptionsMapper.createContainerProperties(map)
         then:
-        properties.getLinuxParameters().getSharedMemorySize() == 12048024
+        properties.getLinuxParameters().getSharedMemorySize() == 11
+    }
+
+    def 'should set shared memory size with unit in MiB'() {
+
+        when:
+        def map = CmdLineHelper.parseGnuArgs('--shm-size 256m')
+        def properties = AwsContainerOptionsMapper.createContainerProperties(map)
+        then:
+        properties.getLinuxParameters().getSharedMemorySize() == 256
+    }
+
+    def 'should set shared memory size with unit in GiB'() {
+
+        when:
+        def map = CmdLineHelper.parseGnuArgs('--shm-size 1g')
+        def properties = AwsContainerOptionsMapper.createContainerProperties(map)
+        then:
+        properties.getLinuxParameters().getSharedMemorySize() == 1024
     }
 
     def 'should set memory swappiness'() {


### PR DESCRIPTION
This commit ensures that the `shm-size` option is correctly parsed from the containerOptions. This is necessary to ensure that the correct value in MiB is passed to the AWS Batch API when creating a job definition.

Fixes https://github.com/nextflow-io/nextflow/issues/5176