### PR TITLE
Finalize workflow output definition

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1193,6 +1193,9 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
 `-offline`
 : Do not check for remote project updates.
 
+`-o, -output-dir` (`results`)
+: Directory where workflow outputs are stored.
+
 `-params-file`
 : Load script parameters from a JSON/YAML file.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1274,32 +1274,6 @@ manifest {
 
 Read the {ref}`sharing-page` page to learn how to publish your pipeline to GitHub, BitBucket or GitLab.
 
-(config-nextflow)=
-
-### Scope `nextflow`
-
-The `nextflow` scope provides configuration options for the Nextflow runtime.
-
-`nextflow.publish.retryPolicy.delay`
-: :::{versionadded} 24.03.0-edge
-  :::
-: Delay when retrying a failed publish operation (default: `350ms`).
-
-`nextflow.publish.retryPolicy.jitter`
-: :::{versionadded} 24.03.0-edge
-  :::
-: Jitter value when retrying a failed publish operation (default: `0.25`).
-
-`nextflow.publish.retryPolicy.maxAttempt`
-: :::{versionadded} 24.03.0-edge
-  :::
-: Max attempts when retrying a failed publish operation (default: `5`).
-
-`nextflow.publish.retryPolicy.maxDelay`
-: :::{versionadded} 24.03.0-edge
-  :::
-: Max delay when retrying a failed publish operation (default: `90s`).
-
 (config-notification)=
 
 ### Scope `notification`
@@ -1779,7 +1753,12 @@ The following settings are available:
 `wave.strategy`
 : The strategy to be used when resolving ambiguous Wave container requirements (default: `'container,dockerfile,conda,spack'`).
 
+(config-workflow)=
+
 ### Scope `workflow`
+
+:::{versionadded} 24.10.0
+:::
 
 The `workflow` scope provides workflow execution options.
 
@@ -1787,6 +1766,79 @@ The `workflow` scope provides workflow execution options.
 : :::{versionadded} 24.05.0-edge
   :::
 : When `true`, the pipeline will exit with a non-zero exit code if any failed tasks are ignored using the `ignore` error strategy.
+
+`workflow.output.contentType`
+: *Currently only supported for S3.*
+: Specify the media type a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types) of published files (default: `false`). Can be a string (e.g. `'text/html'`), or `true` to infer the content type from the file extension.
+
+`workflow.output.enabled`
+: Enable or disable publishing (default: `true`).
+
+`workflow.output.ignoreErrors`
+: When `true`, the workflow will not fail if a file can't be published for some reason (default: `false`).
+
+`workflow.output.mode`
+: The file publishing method (default: `'symlink'`). The following options are available:
+
+  `'copy'`
+  : Copy each file into the output directory.
+
+  `'copyNoFollow'`
+  : Copy each file into the output directory without following symlinks, i.e. only the link is copied.
+
+  `'link'`
+  : Create a hard link in the output directory for each file.
+
+  `'move'`
+  : Move each file into the output directory.
+  : Should only be used for files which are not used by downstream processes in the workflow.
+
+  `'rellink'`
+  : Create a relative symbolic link in the output directory for each file.
+
+  `'symlink'`
+  : Create an absolute symbolic link in the output directory for each output file.
+
+`workflow.output.overwrite`
+: When `true` any existing file in the specified folder will be overwritten (default: `'standard'`). The following options are available:
+
+  `false`
+  : Never overwrite existing files.
+
+  `true`
+  : Always overwrite existing files.
+
+  `'deep'`
+  : Overwrite existing files when the file content is different.
+
+  `'lenient'`
+  : Overwrite existing files when the file size is different.
+
+  `'standard'`
+  : Overwrite existing files when the file size or last modified timestamp is different.
+
+`workflow.output.retryPolicy.delay`
+: Delay when retrying a failed publish operation (default: `350ms`).
+
+`workflow.output.retryPolicy.jitter`
+: Jitter value when retrying a failed publish operation (default: `0.25`).
+
+`workflow.output.retryPolicy.maxAttempt`
+: Max attempts when retrying a failed publish operation (default: `5`).
+
+`workflow.output.retryPolicy.maxDelay`
+: Max delay when retrying a failed publish operation (default: `90s`).
+
+`workflow.output.storageClass`
+: *Currently only supported for S3.*
+: Specify the storage class for published files.
+
+`workflow.output.tags`
+: *Currently only supported for S3.*
+: Specify arbitrary tags for published files. For example:
+  ```groovy
+  tags FOO: 'hello', BAR: 'world'
+  ```
 
 (config-miscellaneous)=
 
@@ -1803,6 +1855,9 @@ There are additional variables that can be defined within a configuration file t
 
 `dumpHashes`
 : If `true`, dump task hash keys in the log file, for debugging purposes. Equivalent to the `-dump-hashes` option of the `run` command.
+
+`outputDir`
+: Defines the pipeline output directory. Equivalent to the `-output-dir` option of the `run` command.
 
 `resume`
 : If `true`, enable the use of previously cached task executions. Equivalent to the `-resume` option of the `run` command.
@@ -2150,10 +2205,9 @@ Some features can be enabled using the `nextflow.enable` and `nextflow.preview` 
 
 `nextflow.preview.output`
 
-: :::{versionadded} 24.04.0
+: :::{deprecated} 24.10.0
+  This feature was introduced as a preview in 24.04. It has now been finalized and no longer requires the preview flag.
   :::
-
-: *Experimental: may change in a future release.*
 
 : When `true`, enables the use of the {ref}`workflow output definition <workflow-output-def>`.
 

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -123,6 +123,11 @@ class Session implements ISession {
     boolean resumeMode
 
     /**
+     * The folder where workflow outputs are stored
+     */
+    Path outputDir
+
+    /**
      * The folder where tasks temporary files are stored
      */
     Path workDir
@@ -375,8 +380,11 @@ class Session implements ISession {
         // -- DAG object
         this.dag = new DAG()
 
+        // -- init output dir
+        this.outputDir = FileHelper.toCanonicalPath(config.outputDir ?: 'results')
+
         // -- init work dir
-        this.workDir = ((config.workDir ?: 'work') as Path).complete()
+        this.workDir = FileHelper.toCanonicalPath(config.workDir ?: 'work')
         this.setLibDir( config.libDir as String )
 
         // -- init cloud cache path

--- a/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
@@ -633,11 +633,6 @@ class NextflowDSLImpl implements ASTTransformation {
                             }
                             break
 
-                        case 'publish':
-                            if( stm instanceof ExpressionStatement )
-                                convertPublishMethod( stm )
-                            break
-
                         case 'exec':
                             bodyLabel = currentLabel
                             iterator.remove()
@@ -1297,27 +1292,6 @@ class NextflowDSLImpl implements ASTTransformation {
             }
 
             return false
-        }
-
-        protected void convertPublishMethod(ExpressionStatement stmt) {
-            if( stmt.expression !instanceof BinaryExpression ) {
-                syntaxError(stmt, "Invalid process publish statement")
-                return
-            }
-
-            final binaryX = (BinaryExpression)stmt.expression
-            if( binaryX.operation.type != Types.RIGHT_SHIFT ) {
-                syntaxError(stmt, "Invalid process publish statement")
-                return
-            }
-
-            final left = binaryX.leftExpression
-            if( left !instanceof VariableExpression ) {
-                syntaxError(stmt, "Invalid process publish statement")
-                return
-            }
-
-            stmt.expression = callThisX('_publish_target', args(constX(((VariableExpression)left).name), binaryX.rightExpression))
         }
 
         protected boolean isIllegalName(String name, ASTNode node) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -107,6 +107,9 @@ class CmdRun extends CmdBase implements HubOptions {
     @Parameter(names=['-test'], description = 'Test a script function with the name specified')
     String test
 
+    @Parameter(names=['-o', '-output-dir'], description = 'Directory where workflow outputs are stored')
+    String outputDir
+
     @Parameter(names=['-w', '-work-dir'], description = 'Directory where intermediate result files are stored')
     String workDir
 

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -545,6 +545,10 @@ class ConfigBuilder {
         if( cmdRun.stubRun )
             config.stubRun = cmdRun.stubRun
 
+        // -- set the output directory
+        if( cmdRun.outputDir )
+            config.outputDir = cmdRun.outputDir
+
         if( cmdRun.preview )
             config.preview = cmdRun.preview
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -222,7 +222,7 @@ class PublishDir {
     protected void apply0(Set<Path> files) {
         assert path
 
-        final retryOpts = session.config.navigate('nextflow.publish.retryPolicy') as Map ?: Collections.emptyMap()
+        final retryOpts = session.config.navigate('workflow.output.retryPolicy') as Map ?: Collections.emptyMap()
         this.retryConfig = new PublishRetryConfig(retryOpts)
 
         createPublishDir()

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -124,8 +124,6 @@ abstract class BaseScript extends Script implements ExecutionContext {
     }
 
     protected output(Closure closure) {
-        if( !NF.outputDefinitionEnabled )
-            throw new IllegalStateException("Workflow output definition requires the `nextflow.preview.output` feature flag")
         if( !entryFlow )
             throw new IllegalStateException("Workflow output definition must be defined after the anonymous workflow")
         if( ExecutionStack.withinWorkflow() )

--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -21,6 +21,8 @@ import java.nio.file.Path
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import groovyx.gpars.dataflow.DataflowWriteChannel
+import nextflow.Global
+import nextflow.Session
 import nextflow.exception.ScriptRuntimeException
 import nextflow.extension.CH
 import nextflow.extension.MixOp
@@ -35,65 +37,19 @@ import nextflow.file.FileHelper
 @CompileStatic
 class OutputDsl {
 
+    private Session session = Global.session as Session
+
     private Map<String,Map> publishConfigs = [:]
-
-    private Path directory
-
-    private Map defaults = [:]
 
     private volatile List<PublishOp> ops = []
 
     void directory(String directory) {
-        if( this.directory )
-            throw new ScriptRuntimeException("Publish directory cannot be defined more than once in the workflow publish definition")
-        this.directory = FileHelper.toCanonicalPath(directory)
-    }
-
-    void contentType(String value) {
-        setDefault('contentType', value)
-    }
-
-    void contentType(boolean value) {
-        setDefault('contentType', value)
-    }
-
-    void ignoreErrors(boolean value) {
-        setDefault('ignoreErrors', value)
-    }
-
-    void mode(String value) {
-        setDefault('mode', value)
-    }
-
-    void overwrite(boolean value) {
-        setDefault('overwrite', value)
-    }
-
-    void overwrite(String value) {
-        setDefault('overwrite', value)
-    }
-
-    void storageClass(String value) {
-        setDefault('storageClass', value)
-    }
-
-    void tags(Map value) {
-        setDefault('tags', value)
-    }
-
-    void enabled( boolean value ) {
-        setDefault('enabled', value)
-    }
-
-    private void setDefault(String name, Object value) {
-        if( defaults.containsKey(name) )
-            throw new ScriptRuntimeException("Default `${name}` option cannot be defined more than once in the workflow publish definition")
-        defaults[name] = value
+        throw new ScriptRuntimeException('Output directory should be set using the `outputDir` config option or `-output-dir` command line option')
     }
 
     void target(String name, Closure closure) {
         if( publishConfigs.containsKey(name) )
-            throw new ScriptRuntimeException("Target '${name}' is defined more than once in the workflow publish definition")
+            throw new ScriptRuntimeException("Target '${name}' is defined more than once in the workflow output definition")
 
         final dsl = new TargetDsl()
         final cl = (Closure)closure.clone()
@@ -105,6 +61,8 @@ class OutputDsl {
     }
 
     void build(Map<DataflowWriteChannel,String> targets) {
+        final defaults = session.config.navigate('workflow.output', Collections.emptyMap()) as Map
+
         // construct mapping of target name -> source channels
         final Map<String,List<DataflowWriteChannel>> publishSources = [:]
         for( final source : targets.keySet() ) {
@@ -122,16 +80,14 @@ class OutputDsl {
             final mixed = sources.size() > 1
                 ? new MixOp(sources.collect( ch -> CH.getReadChannel(ch) )).apply()
                 : sources.first()
-            final opts = publishOptions(name, publishConfigs[name] ?: [:])
+            final overrides = publishConfigs[name] ?: Collections.emptyMap()
+            final opts = publishOptions(name, defaults, overrides)
 
             ops << new PublishOp(CH.getReadChannel(mixed), opts).apply()
         }
     }
 
-    private Map publishOptions(String name, Map overrides) {
-        if( !directory )
-            directory = FileHelper.toCanonicalPath('.')
-
+    private Map publishOptions(String name, Map defaults, Map overrides) {
         final opts = defaults + overrides
         if( opts.containsKey('ignoreErrors') )
             opts.failOnError = !opts.remove('ignoreErrors')
@@ -139,9 +95,9 @@ class OutputDsl {
             opts.overwrite = 'standard'
 
         final path = opts.path as String ?: name
-        if( path.startsWith('/') )
-            throw new ScriptRuntimeException("Invalid publish target path '${path}' -- it should be a relative path")
-        opts.path = directory.resolve(path)
+        if( path.startsWith('/') || path.endsWith('/') )
+            throw new ScriptRuntimeException("Invalid publish target path '${path}' -- it should not contain a leading or trailing slash")
+        opts.path = session.outputDir.resolve(path)
 
         if( opts.index && !(opts.index as Map).path )
             throw new ScriptRuntimeException("Index file definition for publish target '${name}' is missing `path` option")
@@ -166,6 +122,10 @@ class OutputDsl {
 
         void contentType(boolean value) {
             setOption('contentType', value)
+        }
+
+        void enabled(boolean value) {
+            setOption('enabled', value)
         }
 
         void ignoreErrors(boolean value) {
@@ -197,16 +157,17 @@ class OutputDsl {
             setOption('path', value)
         }
 
+        void path(Closure value) {
+            setOption('path', '.')
+            setOption('pathAs', value)
+        }
+
         void storageClass(String value) {
             setOption('storageClass', value)
         }
 
         void tags(Map value) {
             setOption('tags', value)
-        }
-
-        void enabled( boolean value ) {
-            setOption('enabled', value)
         }
 
         private void setOption(String name, Object value) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -165,11 +165,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
     private outputs = new OutputsList()
 
     /**
-     * Map of default publish targets
-     */
-    private Map<String,String> publishTargets = [:]
-
-    /**
      * Initialize the taskConfig object with the defaults values
      *
      * @param script The owner {@code BaseScript} configuration object
@@ -520,13 +515,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
     }
 
     /**
-     * Typed shortcut to {@code #publishTargets}
-     */
-    Map<String,String> getPublishTargets() {
-        publishTargets
-    }
-
-    /**
      * Implements the process {@code debug} directive.
      */
     ProcessConfig debug( value ) {
@@ -661,13 +649,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             result.into(obj)
         }
         result
-    }
-
-    void _publish_target(String emit, String name) {
-        final emitNames = outputs.collect { param -> param.channelEmitName }
-        if( emit !in emitNames )
-            throw new IllegalArgumentException("Invalid emit name '${emit}' in publish statement, valid emits are: ${emitNames.join(', ')}")
-        publishTargets[emit] = name
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -18,7 +18,6 @@ package nextflow.script
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import groovyx.gpars.dataflow.DataflowWriteChannel
 import nextflow.Const
 import nextflow.Global
 import nextflow.Session
@@ -208,14 +207,6 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
 
         // make a copy of the output list because execution can change it
         output = new ChannelOut(declaredOutputs.clone())
-
-        // register process publish targets
-        for( final entry : processConfig.getPublishTargets() ) {
-            final emit = entry.key
-            final name = entry.value
-            final source = (DataflowWriteChannel)output.getProperty(emit)
-            session.publishTargets[source] = name
-        }
 
         // create the executor
         final executor = session

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -140,6 +140,11 @@ class WorkflowMetadata {
     Path launchDir
 
     /**
+     * Workflow output directory
+     */
+    Path outputDir
+
+    /**
      * Workflow working directory
      */
     Path workDir
@@ -257,6 +262,7 @@ class WorkflowMetadata {
         this.container = session.fetchContainers()
         this.commandLine = session.commandLine
         this.nextflow = NextflowMeta.instance
+        this.outputDir = session.outputDir
         this.workDir = session.workDir
         this.launchDir = Paths.get('.').complete()
         this.profile = session.profile ?: ConfigBuilder.DEFAULT_PROFILE

--- a/tests/output-dsl.nf
+++ b/tests/output-dsl.nf
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-nextflow.preview.output = true
-
 params.save_foo = true
 
 process align {
@@ -59,13 +57,14 @@ process foo {
 }
 
 workflow {
-  def input = Channel.of('alpha','beta','delta')
+  main:
+  input = Channel.of('alpha','beta','delta')
   align(input)
 
-  def bam = align.out[0].toSortedList { it.name }
-  def bai = align.out[1].toSortedList { it.name }
-  my_combine( bam, bai )
-  my_combine.out.view{ it.text }
+  bams = align.out[0].toSortedList { bam -> bam.name }
+  bais = align.out[1].toSortedList { bai -> bai.name }
+  my_combine( bams, bais )
+  my_combine.out.view { it -> it.text }
 
   foo()
 
@@ -76,10 +75,8 @@ workflow {
 }
 
 output {
-  directory 'results'
-  mode 'copy'
-
   'data' {
+    path { filename, val -> filename }
     index {
       path 'index.csv'
       mapper { val -> [filename: val] }


### PR DESCRIPTION
Close #5103 

TODO:

language improvements:
- [x] support dynamic path
- [x] move publish options to config
- [x] remove publish section from process definition
- [ ] preserve preview version ?

runtime improvements:
- [x] prevent leading/trailing slashes
- [ ] report undefined target names
- [ ] detect file collisions at runtime ?
- [ ] detect outputs that aren't published or used downstream ?

new features (might be handled separately):
- [ ] support JSON index file
- [ ] generate output schema
- [ ] include publish targets in inspect command ?