### PR TITLE
Fix readAllBytes with http files

### DIFF
--- a/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
@@ -255,7 +255,7 @@ abstract class XFileSystemProvider extends FileSystemProvider {
             int read(ByteBuffer buffer) throws IOException {
                 def data=0
                 int len=0
-                while( len<buffer.capacity() && (data=stream.read())!=-1 ) {
+                while( buffer.hasRemaining() && (data=stream.read())!=-1 ) {
                     buffer.put((byte)data)
                     len++
                 }

--- a/modules/nf-httpfs/src/test/nextflow/file/http/HttpFilesTests.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/HttpFilesTests.groovy
@@ -113,7 +113,7 @@ class HttpFilesTests extends Specification {
         then:
         lines.size()>0
         lines[0].startsWith('<!DOCTYPE html><html lang="en">')
-
+        
     }
 
     def 'should check file properties' () {
@@ -190,27 +190,17 @@ class HttpFilesTests extends Specification {
     @IgnoreIf({System.getenv('NXF_SMOKE')})
     def 'should read lines' () {
         given:
-        def path = Paths.get(new URI('ftp://ftp.ncbi.nlm.nih.gov/robots.txt'))
+        def uri = new URI('http://www.nextflow.io/index.html')
+        when:
+        def path = Paths.get(uri)
+        then:
+        path instanceof XPath
 
         when:
-        def lines = Files.readAllLines(path, Charset.forName('UTF-8'))
+        def str = new String(Files.readAllBytes(path), Charset.forName('UTF-8'))
         then:
-        lines[0] == 'User-agent: *'
-        lines[1] == 'Disallow: /'
-    }
-
-    @IgnoreIf({System.getenv('NXF_SMOKE')})
-    def 'should read all bytes' ( ) {
-        given:
-        def path = Paths.get(new URI('ftp://ftp.ncbi.nlm.nih.gov/robots.txt'))
-
-        when:
-        def bytes = Files.readAllBytes(path)
-        def lines = new String(bytes).readLines()
-        then:
-        lines[0] == 'User-agent: *'
-        lines[1] == 'Disallow: /'
-
+        str.size()>0
+        str.startsWith('<!DOCTYPE html><html lang="en">')
     }
 
     def 'should read with a newByteChannel' () {


### PR DESCRIPTION
This commit fixes the use of `Files.readAllBytes` when applied to a Http file `Path`. The implement was only working for files smaller than buffer object.  