### PR TITLE
Disable AWS spot retry

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsBatchConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsBatchConfig.groovy
@@ -36,7 +36,7 @@ import nextflow.util.Duration
 @CompileStatic
 class AwsBatchConfig implements CloudTransferOptions {
 
-    public static final int DEFAULT_MAX_SPOT_ATTEMPTS = 5
+    public static final int DEFAULT_MAX_SPOT_ATTEMPTS = 0
 
     public static final int DEFAULT_AWS_MAX_ATTEMPTS = 5
 


### PR DESCRIPTION
This PR disables the automatic retry made by AWS Batch when a spot instance is reclaimed. 

The main reasons to disable this capability is: 

* The same tasks can be re-tried multiple times incurring in significant spending increase with the user is a aware of that 
* The AWS automatic retry re-execute a task in the same working directory because it's not directly managed by nextflow. This can introduce nasty side effects with partial/corrupted data left in a previous execution 
* There's not log/visual feedback during the pipeline execution, because it's managed directly by AWS Batch. 
* Keep it aligned with same feature with Google Batch that's disabled by default. 


User can still enable this capability by setting the following option: 

```
aws.batch.maxSpotAttempts = n 
``` 

where `n` is a integer > 0  