### PR TITLE
naive conda-lock unified lockfile implementation

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -302,7 +302,7 @@ class CondaCache {
                 } catch (IOException e) {
                     throw new RuntimeException("Error checking conda-lock command: ${e.message}")
                 }
-                cmd = "conda-lock install --prefix ${Escape.path(prefixPath)} conda-lock.yml"
+                cmd = "conda-lock install --conda ${binaryName} --prefix ${Escape.path(prefixPath)} conda-lock.yml"
             }
             else {
                 cmd = "${binaryName} env create --prefix ${Escape.path(prefixPath)} --file ${target}"

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -302,7 +302,7 @@ class CondaCache {
                 } catch (IOException e) {
                     throw new RuntimeException("Error checking conda-lock command: ${e.message}")
                 }
-                cmd = "conda-lock install --prefix ${Escape.path(prefixPath)} --lockfile conda-lock.yml"
+                cmd = "conda-lock install --prefix ${Escape.path(prefixPath)} conda-lock.yml"
             }
             else {
                 cmd = "${binaryName} env create --prefix ${Escape.path(prefixPath)} --file ${target}"

--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -163,7 +163,11 @@ class CondaCache {
     }
 
     boolean isCondalockFilePath(String str) {
-        (str.endsWith('-lock.yml') || str.endsWith('-lock.yaml')) && !str.contains('\n')
+        if ((str.endsWith('-lock.yml') || str.endsWith('-lock.yaml')) && !str.contains('\n')) {
+            def content = new File(str).text
+            return content.contains('version:') && content.contains('metadata:') && content.contains('package:')
+        }
+        return false
     }
 
     boolean isTextFilePath(String str) {


### PR DESCRIPTION
Proposed direction for addressing https://github.com/nextflow-io/nextflow/issues/5220

~~We could also do some parsing of the unified lockfile yaml, rather than relying on the file extension (suggestion from @ewels ).~~ Need to do this anyway, since .lock.yml is already in use for non- conda-lock files in the CI.

**Edit:** Leaving this here for posterity, but discussion on https://github.com/nextflow-io/nextflow/issues/5220 suggests it might not be going anywhere, so I won't debug further.