### PR TITLE
Disable Google Batch spot retries

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -869,7 +869,10 @@ The following settings are available for Google Cloud Batch:
 `google.batch.maxSpotAttempts`
 : :::{versionadded} 23.11.0-edge
   :::
-: Max number of execution attempts of a job interrupted by a Compute Engine spot reclaim event (default: `5`).
+: :::{versionchanged} 24.08.0-edge
+  The default value was changed from `5` to `0`.
+  :::
+: Max number of execution attempts of a job interrupted by a Compute Engine spot reclaim event (default: `0`).
 : See also: `google.batch.autoRetryExitCodes`
 
 `google.project`

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -16,13 +16,11 @@
 
 package nextflow.cloud.google.batch.client
 
-
 import com.google.auth.oauth2.GoogleCredentials
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.cloud.google.GoogleOpts
-import nextflow.exception.ProcessUnrecoverableException
 import nextflow.util.MemoryUnit
 /**
  * Model Google Batch config settings
@@ -33,6 +31,8 @@ import nextflow.util.MemoryUnit
 @CompileStatic
 class BatchConfig {
 
+    static private int DEFAULT_MAX_SPOT_ATTEMPTS = 0
+    
     static private List<Integer> DEFAULT_RETRY_LIST = List.of(50001)
 
     private GoogleOpts googleOpts
@@ -74,7 +74,7 @@ class BatchConfig {
         result.allowedLocations = session.config.navigate('google.batch.allowedLocations', List.of()) as List<String>
         result.bootDiskSize = session.config.navigate('google.batch.bootDiskSize') as MemoryUnit
         result.cpuPlatform = session.config.navigate('google.batch.cpuPlatform')
-        result.maxSpotAttempts = session.config.navigate('google.batch.maxSpotAttempts',5) as int
+        result.maxSpotAttempts = session.config.navigate('google.batch.maxSpotAttempts', DEFAULT_MAX_SPOT_ATTEMPTS) as int
         result.installGpuDrivers = session.config.navigate('google.batch.installGpuDrivers',false)
         result.preemptible = session.config.navigate('google.batch.preemptible',false)
         result.spot = session.config.navigate('google.batch.spot',false)
@@ -83,7 +83,7 @@ class BatchConfig {
         result.subnetwork = session.config.navigate('google.batch.subnetwork')
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
-        result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes',DEFAULT_RETRY_LIST) as List<Integer>
+        result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
         return result
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -31,9 +31,9 @@ import nextflow.util.MemoryUnit
 @CompileStatic
 class BatchConfig {
 
-    static private int DEFAULT_MAX_SPOT_ATTEMPTS = 0
+    static final private int DEFAULT_MAX_SPOT_ATTEMPTS = 0
     
-    static private List<Integer> DEFAULT_RETRY_LIST = List.of(50001)
+    static final private List<Integer> DEFAULT_RETRY_LIST = List.of(50001)
 
     private GoogleOpts googleOpts
     private GoogleCredentials credentials

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
@@ -42,7 +42,7 @@ class BatchConfigTest extends Specification {
         config.getSpot()
         and:
         config.retryConfig.maxAttempts == 5
-        config.maxSpotAttempts == 5
+        config.maxSpotAttempts == 0
         config.autoRetryExitCodes == [50001]
     }
 


### PR DESCRIPTION
This PR disables the automatic retry made by Googke Batch when a spot instance is reclaimed. 

The main reasons to disable this capability is: 

* The same tasks can be re-tried multiple times incurring in significant spending increase with the user is a aware of that 
* The Google automatic retry re-execute a task in the same working directory because it's not directly managed by nextflow. This can introduce nasty side effects with partial/corrupted data left in a previous execution 
* There's not log/visual feedback during the pipeline execution, because it's managed directly by Google Batch. 
* Keep it aligned with same feature with Google Batch that's disabled by default. 


User can still enable this capability by setting the following option: 

```
google.batch.maxSpotAttempts = n 
``` 

where `n` is a integer > 0  



See also https://github.com/nextflow-io/nextflow/pull/5215