### PR TITLE
Docs sidebar: Fix logo for nested pages.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -21,7 +21,7 @@
     <div class="nav-footer-logo">
         <a href="https://seqera.io/" target="_blank" title="Developed by Seqera Labs">
             Nextflow is developed by:<br>
-            <img src="_static/seqera-logo.svg" alt="Seqera Labs">
+            <img src="{{ pathto('_static/seqera-logo.svg', 1) }}" alt="Seqera Labs">
         </a>
     </div>
 {% endblock %}


### PR DESCRIPTION
Docs pages under the developer/ directory (workflow diagram, packages, core plugins etc) had a broken Seqera logo in the sidebar.

Fixes this by using a Sphinx function to always use a path for that file that's relative to the build root.

To test, see https://nextflow.io/docs/latest/developer/index.html:
![CleanShot 2024-08-15 at 09 24 29@2x](https://github.com/user-attachments/assets/03691948-9184-4dff-bc32-923080d77ecb)

@netlify /developer/index.html