### PR TITLE
Draft proposal for supporting Flux (different to flux mini)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
@@ -61,9 +61,10 @@ class FluxExecutor extends AbstractGridExecutor {
     @Override
     List<String> getSubmitCommandLine(TaskRun task, Path scriptFile ) {
 
-        List<String> result = ['flux', 'mini', 'submit']
+        List<String> result = ['flux', 'submit']
         result << '--setattr=cwd=' + quote(task.workDir)
         result << '--job-name="' + getJobNameFor(task) + '"'
+        result << '--flags=waitable'
 
         // Only write output to file if user doesn't want written entirely to terminal
         Boolean terminalOutput = session.config.navigate('flux.terminalOutput') as Boolean
@@ -77,7 +78,8 @@ class FluxExecutor extends AbstractGridExecutor {
 
         // Time limit in minutes when no units provided
         if( task.config.getTime() ) {
-            result << '--time-limit=' + task.config.getTime().format('mm')
+            log.debug "Custom task wallclock time request is not currently supported here."
+//            result << '--time-limit=' + task.config.getTime().format('mm')
         }
 
         // Flux does not support asking for specific memory
@@ -87,7 +89,8 @@ class FluxExecutor extends AbstractGridExecutor {
 
         // the requested partition (a.k.a queue) name
         if( task.config.queue ) {
-            result << '--queue=' + (task.config.queue.toString())
+            log.debug "Queue parameter not supported by standalone flux."
+//            result << '--queue=' + (task.config.queue.toString())
         }
 
         // Any extra cluster options the user wants!


### PR DESCRIPTION
Porting a set of changes from an email thread for discussion.

Context is that a user was trying to use Nextflow with Flux. The executor is written for _flux mini_ and didn't work for him.

After some back and forth and investigation, he found the following set of changes got the executor to work on their system. This led to the creation of the following docs page for the system users: https://doku.lrz.de/nextflow-on-hpc-systems-test-operation-788693597.html

This was all only in an email thread, so moving here so that it doesn't get lost. I'm curious whether the flux executor support could be tweaked to work with both flux core and flux mini? (maybe with some configuration?). The changes seem pretty minor.

'cc @pditommaso and I think the original implementation was by @vsoch 