### PR TITLE
Avoid double vv in `<title>` for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ version = release.replace("-edge", "")
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = f"Nextflow v{release} documentation"
+html_title = f"Nextflow {release} documentation"
 
 # Get the current sha if not checked out at a specific version
 if len(release) == 0:


### PR DESCRIPTION
Should avoid duplicate `v` in google results:
![image](https://github.com/user-attachments/assets/7476b461-f226-4265-9f76-e6e9434d1e8d)

Reported by @FriederikeHanssen