### PR TITLE
Fix _JAVA_OPTIONS breaking launch exactly like issue #1716

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -229,6 +229,7 @@ fi
 # clean up env
 # see https://github.com/nextflow-io/nextflow/issues/1716
 unset JAVA_TOOL_OPTIONS
+unset _JAVA_OPTIONS
 
 # parse the command line
 bg=''


### PR DESCRIPTION
Just like in #1716, the _JAVA_OPTIONS variable results in messages like:

```
Picked up _JAVA_OPTIONS: -Djava.io.tmpdir=/tmp -Xmx221184m -Xms256m
CAPSULE EXCEPTION: Could not parse version line: Picked up _JAVA_OPTIONS: -Djava.io.tmpdir=/scratch/03166/xcgalaxy/main/staging/59941234/tmp -Xmx221184m -Xms256m (for stack trace, run with -Dcapsule.log=verbose)
```
 These messages interfere with the Capsule loader Java version detection.
 
 From the OpenJDK source: https://github.com/openjdk/jdk/blob/ab8071d28027ecbf5e8984c30b35fa1c2d934de7/src/java.base/share/classes/jdk/internal/misc/VM.java#L459