### PR TITLE
Change GitHub clone URL implementation

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/GithubRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GithubRepositoryProvider.groovy
@@ -76,13 +76,7 @@ class GithubRepositoryProvider extends RepositoryProvider {
     /** {@inheritDoc} */
     @Override
     String getCloneUrl() {
-        Map response = invokeAndParseResponse( getEndpointUrl() )
-
-        def result = response.get('clone_url')
-        if( !result )
-            throw new IllegalStateException("Missing clone URL for: $project")
-
-        return result
+        return "${config.server}/${project}.git"
     }
 
     @Override


### PR DESCRIPTION
We've come across an issue where the 60 requests per hour rate limit causes the workflow to error out. It stems from having to lookup the Clone URL via the API. 

I propose that the Clone URL be hardcoded so that we don't need to call the GitHub API. 

Alternatively, I could put it under try / catch for the RateLimitExceeded exception