### PR TITLE
GCP support for spot/onDemand per process

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -210,6 +210,11 @@ class TaskConfig extends LazyMap implements Cloneable {
         return get('stageOutMode')
     }
 
+    boolean spot() {
+        def value = get('spot')
+        return toBool(value)
+    }
+
     boolean getDebug() {
         // check both `debug` and `echo` for backward
         // compatibility until `echo` is not removed

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -103,6 +103,7 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             'storeDir',
             'tag',
             'time',
+            'spot',
             // input-output qualifiers
             'file',
             'val',

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -565,7 +565,8 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         final location = client.location
         final cpus = config.getCpus()
         final memory = config.getMemory() ? config.getMemory().toMega().toInteger() : 1024
-        final spot = executor.config.spot ?: executor.config.preemptible
+        final executorPriceModel = executor.config.spot ?: executor.config.preemptible
+        final spot = config.spot() ?: executorPriceModel
         final machineType = config.getMachineType()
         final families = machineType ? machineType.tokenize(',') : List.<String>of()
         final priceModel = spot ? PriceModel.spot : PriceModel.standard

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -382,7 +382,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             if( executor.config.preemptible )
                 instancePolicy.setProvisioningModel( AllocationPolicy.ProvisioningModel.PREEMPTIBLE )
 
-            if( executor.config.spot )
+            if (machineType.priceModel == PriceModel.spot)
                 instancePolicy.setProvisioningModel( AllocationPolicy.ProvisioningModel.SPOT )
 
             instancePolicyOrTemplate.setPolicy( instancePolicy )
@@ -566,7 +566,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         final cpus = config.getCpus()
         final memory = config.getMemory() ? config.getMemory().toMega().toInteger() : 1024
         final executorPriceModel = executor.config.spot ?: executor.config.preemptible
-        final spot = config.spot() ?: executorPriceModel
+        final spot = config.spot() != null ? config.spot() : executorPriceModel
         final machineType = config.getMachineType()
         final families = machineType ? machineType.tokenize(',') : List.<String>of()
         final priceModel = spot ? PriceModel.spot : PriceModel.standard


### PR DESCRIPTION
Currently GCP Batch supports spot/onDemand globally. However, in most real time scenarios it's desirable to have some processes run on spot instances and others using on demand pricing. This PR introduces `spot` directive allowing to specify pricing model per processes.