### PR TITLE
Support Azure Managed Identities in Fusion configuration logic

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzActiveDirectoryOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzActiveDirectoryOpts.groovy
@@ -16,6 +16,7 @@
 package nextflow.cloud.azure.config
 
 import groovy.transform.CompileStatic
+import nextflow.SysEnv
 import nextflow.cloud.azure.nio.AzFileSystemProvider
 
 /**
@@ -26,18 +27,15 @@ import nextflow.cloud.azure.nio.AzFileSystemProvider
 @CompileStatic
 class AzActiveDirectoryOpts {
 
-    private Map<String, String> sysEnv
-
     String servicePrincipalId
     String servicePrincipalSecret
     String tenantId
 
     AzActiveDirectoryOpts(Map config, Map<String, String> env = null) {
         assert config != null
-        this.sysEnv = env == null ? new HashMap<String, String>(System.getenv()) : env
-        this.servicePrincipalId = config.servicePrincipalId ?: sysEnv.get('AZURE_CLIENT_ID')
-        this.servicePrincipalSecret = config.servicePrincipalSecret ?: sysEnv.get('AZURE_CLIENT_SECRET')
-        this.tenantId = config.tenantId ?: sysEnv.get('AZURE_TENANT_ID')
+        this.servicePrincipalId = config.servicePrincipalId ?: SysEnv.get('AZURE_CLIENT_ID')
+        this.servicePrincipalSecret = config.servicePrincipalSecret ?: SysEnv.get('AZURE_CLIENT_SECRET')
+        this.tenantId = config.tenantId ?: SysEnv.get('AZURE_TENANT_ID')
     }
 
     Map<String, Object> getEnv() {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzRegistryOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzRegistryOpts.groovy
@@ -16,8 +16,8 @@
 
 package nextflow.cloud.azure.config
 
-
 import groovy.transform.CompileStatic
+import nextflow.SysEnv
 
 /**
  * Model Azure Batch registry config settings from nextflow config file
@@ -27,8 +27,6 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class AzRegistryOpts {
 
-    private Map<String,String> sysEnv
-
     String server
     String userName
     String password
@@ -37,12 +35,11 @@ class AzRegistryOpts {
         this(Collections.emptyMap())
     }
 
-    AzRegistryOpts(Map config, Map<String,String> env=null) {
+    AzRegistryOpts(Map config, Map<String,String> env=SysEnv.get()) {
         assert config!=null
-        this.sysEnv = env==null ? new HashMap<String,String>(System.getenv()) : env
         this.server = config.server ?: 'docker.io'
-        this.userName = config.userName ?: sysEnv.get('AZURE_REGISTRY_USER_NAME')
-        this.password = config.password ?: sysEnv.get('AZURE_REGISTRY_PASSWORD')
+        this.userName = config.userName ?: env.get('AZURE_REGISTRY_USER_NAME')
+        this.password = config.password ?: env.get('AZURE_REGISTRY_PASSWORD')
     }
 
     boolean isConfigured() {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzStorageOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzStorageOpts.groovy
@@ -17,6 +17,7 @@
 package nextflow.cloud.azure.config
 
 import groovy.transform.CompileStatic
+import nextflow.SysEnv
 import nextflow.cloud.azure.batch.AzHelper
 import nextflow.cloud.azure.nio.AzFileSystemProvider
 import nextflow.util.Duration
@@ -28,7 +29,6 @@ import nextflow.util.Duration
 @CompileStatic
 class AzStorageOpts {
 
-    private Map<String,String> sysEnv
     String accountKey
     String accountName
     String sasToken
@@ -36,12 +36,11 @@ class AzStorageOpts {
     Map<String,AzFileShareOpts> fileShares
 
 
-    AzStorageOpts(Map config, Map<String,String> env=null) {
+    AzStorageOpts(Map config, Map<String,String> env=SysEnv.get()) {
         assert config!=null
-        this.sysEnv = env==null ? new HashMap<String,String>(System.getenv()) : env
-        this.accountKey = config.accountKey ?: sysEnv.get('AZURE_STORAGE_ACCOUNT_KEY')
-        this.accountName = config.accountName ?: sysEnv.get('AZURE_STORAGE_ACCOUNT_NAME')
-        this.sasToken = config.sasToken ?: sysEnv.get('AZURE_STORAGE_SAS_TOKEN')
+        this.accountKey = config.accountKey ?: env.get('AZURE_STORAGE_ACCOUNT_KEY')
+        this.accountName = config.accountName ?: env.get('AZURE_STORAGE_ACCOUNT_NAME')
+        this.sasToken = config.sasToken ?: env.get('AZURE_STORAGE_SAS_TOKEN')
         this.tokenDuration = (config.tokenDuration as Duration) ?: Duration.of('48h')
         this.fileShares = parseFileShares(config.fileShares instanceof Map ? config.fileShares as Map<String, Map>
                 : Collections.<String,Map> emptyMap())

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -10,6 +10,7 @@ import com.azure.identity.ManagedIdentityCredential
 import com.google.common.hash.HashCode
 import nextflow.Global
 import nextflow.Session
+import nextflow.SysEnv
 import nextflow.cloud.azure.config.AzConfig
 import nextflow.cloud.azure.config.AzManagedIdentityOpts
 import nextflow.cloud.azure.config.AzPoolOpts
@@ -30,6 +31,14 @@ import spock.lang.Unroll
 class AzBatchServiceTest extends Specification {
 
     static long _1GB = 1024 * 1024 * 1024
+
+    def setup() {
+        SysEnv.push([:])  // <-- clear the system host env
+    }
+
+    def cleanup() {
+        SysEnv.pop()      // <-- restore the system host env
+    }
 
     def 'should make job id'() {
         given:

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/fusion/AzFusionEnvTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/fusion/AzFusionEnvTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.azure.fusion
+
+import nextflow.Global
+import nextflow.Session
+import nextflow.fusion.FusionConfig
+import spock.lang.Specification
+
+/**
+ *
+ * @author Alberto Miranda <alberto.miranda@seqera.io>
+ */
+class AzFusionEnvTest extends Specification {
+
+    def 'should return empty env'() {
+        given:
+        def provider = new AzFusionEnv()
+        when:
+        def env = provider.getEnvironment('aws', Mock(FusionConfig))
+        then:
+        env == Collections.emptyMap()
+    }
+
+    def 'should return env environment'() {
+        given:
+        Global.session = Mock(Session) {
+            getConfig() >> [azure: [storage: [accountName: 'x1']]]
+        }
+        and:
+
+        when:
+        def config = Mock(FusionConfig)
+        def env = new AzFusionEnv().getEnvironment('az', config)
+        then:
+        env == [AZURE_STORAGE_ACCOUNT: 'x1']
+
+        cleanup:
+        Global.session = null
+    }
+
+    def 'should return env environment with SAS token config'() {
+        given:
+        Global.session = Mock(Session) {
+            getConfig() >> [azure: [storage: [accountName: 'x1', sasToken: 'y1']]]
+        }
+        and:
+
+        when:
+        def config = Mock(FusionConfig)
+        def env = new AzFusionEnv().getEnvironment('az', config)
+        then:
+        env == [AZURE_STORAGE_ACCOUNT: 'x1', AZURE_STORAGE_SAS_TOKEN: 'y1']
+
+        cleanup:
+        Global.session = null
+    }
+
+    def 'should throw an exception when missing Azure Storage account name'() {
+        given:
+        Global.session = Mock(Session) {
+            getConfig() >> [azure: [storage: [sasToken: 'y1']]]
+        }
+        when:
+        def config = Mock(FusionConfig)
+        def env = new AzFusionEnv().getEnvironment('az', Mock(FusionConfig))
+        then:
+        thrown(IllegalArgumentException)
+        cleanup:
+        Global.session = null
+    }
+
+    def 'should throw an exception when both account key and SAS token are present'() {
+        given:
+        Global.session = Mock(Session) {
+            getConfig() >> [azure: [storage: [accountName: 'x1', accountKey: 'y1', sasToken: 'z1']]]
+        }
+        when:
+        def config = Mock(FusionConfig)
+        def env = new AzFusionEnv().getEnvironment('az', Mock(FusionConfig))
+        then:
+        thrown(IllegalArgumentException)
+        cleanup:
+        Global.session = null
+    }
+}

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/fusion/AzFusionEnvTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/fusion/AzFusionEnvTest.groovy
@@ -19,6 +19,7 @@ package nextflow.cloud.azure.fusion
 
 import nextflow.Global
 import nextflow.Session
+import nextflow.SysEnv
 import nextflow.fusion.FusionConfig
 import spock.lang.Specification
 
@@ -27,6 +28,14 @@ import spock.lang.Specification
  * @author Alberto Miranda <alberto.miranda@seqera.io>
  */
 class AzFusionEnvTest extends Specification {
+
+    def setup() {
+        SysEnv.push([:])  // <-- clear the system host env
+    }
+
+    def cleanup() {
+        SysEnv.pop()      // <-- restore the system host env
+    }
 
     def 'should return empty env'() {
         given:
@@ -50,8 +59,6 @@ class AzFusionEnvTest extends Specification {
         then:
         env == [AZURE_STORAGE_ACCOUNT: 'x1']
 
-        cleanup:
-        Global.session = null
     }
 
     def 'should return env environment with SAS token config'() {
@@ -67,8 +74,6 @@ class AzFusionEnvTest extends Specification {
         then:
         env == [AZURE_STORAGE_ACCOUNT: 'x1', AZURE_STORAGE_SAS_TOKEN: 'y1']
 
-        cleanup:
-        Global.session = null
     }
 
     def 'should throw an exception when missing Azure Storage account name'() {
@@ -81,8 +86,6 @@ class AzFusionEnvTest extends Specification {
         def env = new AzFusionEnv().getEnvironment('az', Mock(FusionConfig))
         then:
         thrown(IllegalArgumentException)
-        cleanup:
-        Global.session = null
     }
 
     def 'should throw an exception when both account key and SAS token are present'() {
@@ -95,7 +98,5 @@ class AzFusionEnvTest extends Specification {
         def env = new AzFusionEnv().getEnvironment('az', Mock(FusionConfig))
         then:
         thrown(IllegalArgumentException)
-        cleanup:
-        Global.session = null
     }
 }


### PR DESCRIPTION
## Description
This PR extends the `nextflow.cloud.azure.fusion.AzFusionEnv` class so that it now takes into account a potential Azure Managed Identity in Nextflow's [configuration file](https://www.nextflow.io/docs/latest/azure.html#managed-identities). This also fixes a configuration error (#5081) by which Nextflow complained of a missing SAS token despite having a Managed Identity properly configured.