### PR TITLE
Add container tip in the task error report

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1285,6 +1285,9 @@ class TaskProcessor {
         if( task?.workDir )
             message << "\nWork dir:\n  ${task.workDirStr}"
 
+        if( task?.isContainerEnabled() )
+            message << "\nContainer:\n  ${task.container}".toString()
+
         message << suggestTip(message)
 
         return message


### PR DESCRIPTION
This PR adds the container image name in the error dump reported when a task fail. For example 


```

Work dir:
  /Users/pditommaso/Projects/rnaseq-nf/work/3c/84cf5887bae50581acb8df41fa01a4

Container:
  community.wave.seqera.io/library/fastqc:0.12.1--959cb910d069d258

Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line

```