### PR TITLE
Update container handling with charliecloud

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -491,6 +491,9 @@ The `charliecloud` scope controls how [Charliecloud](https://hpc.github.io/charl
 
 The following settings are available:
 
+`charliecloud.writeFake`
+: Enable `writeFake` with charliecloud (default) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires `overlayfs` (Linux kernel >= 5.11). For full suppornt tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required , see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
+
 `charliecloud.cacheDir`
 : The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
 
@@ -511,12 +514,6 @@ The following settings are available:
 
 `charliecloud.registry`
 : The registry from where images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
-
-`charliecloud.writeFake`
-: Enable `writeFake` with charliecloud (default) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires `overlayfs` (Linux kernel >= 5.11). For full suppornt tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required , see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
-
-`charliecloud.useSquash`
-: Create a temporary squashFS container image in the process work directory instead of a folder.
 
 Read the {ref}`container-charliecloud` page to learn more about how to use Charliecloud containers with Nextflow.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -495,7 +495,7 @@ The following settings are available:
 : Enable Charliecloud execution (default: `false`).
 
 `charliecloud.writeFake`
-: Enable `writeFake` with charliecloud (default: `true`) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires `overlayfs` (Linux kernel >= 5.11). For full suppornt tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required , see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
+: Enable `writeFake` with charliecloud (default: `true`) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires unprivileged `overlayfs` (Linux kernel >= 5.11). For full support, tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required, see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
 
 `charliecloud.cacheDir`
 : The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.

--- a/docs/config.md
+++ b/docs/config.md
@@ -488,7 +488,6 @@ The following settings are available:
 ### Scope `charliecloud`
 
 The `charliecloud` scope controls how [Charliecloud](https://hpc.github.io/charliecloud/) containers are executed by Nextflow.
-If `charliecloud.writeFake` is unset / `false`, charliecloud will create a copy of the container in the process working directory.
 
 The following settings are available:
 
@@ -514,7 +513,7 @@ The following settings are available:
 : The registry from where images are pulled. It should be only used to specify a private registry server. It should NOT include the protocol prefix i.e. `http://`.
 
 `charliecloud.writeFake`
-: Enable `writeFake` with charliecloud. This allows to run containers from storage in writeable mode, using overlayfs, see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details 
+: Enable `writeFake` with charliecloud (default) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires `overlayfs` (Linux kernel >= 5.11). For full suppornt tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required , see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
 
 `charliecloud.useSquash`
 : Create a temporary squashFS container image in the process work directory instead of a folder.

--- a/docs/config.md
+++ b/docs/config.md
@@ -491,14 +491,14 @@ The `charliecloud` scope controls how [Charliecloud](https://hpc.github.io/charl
 
 The following settings are available:
 
+`charliecloud.enabled`
+: Enable Charliecloud execution (default: `false`).
+
 `charliecloud.writeFake`
-: Enable `writeFake` with charliecloud (default) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires `overlayfs` (Linux kernel >= 5.11). For full suppornt tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required , see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
+: Enable `writeFake` with charliecloud (default: `true`) This allows to run containers from storage in writeable mode, using overlayfs. `writeFake` requires `overlayfs` (Linux kernel >= 5.11). For full suppornt tempfs with xattrs in the user namespace (Linux kernel >= 6.6) is required , see [charliecloud documentation](https://hpc.github.io/charliecloud/ch-run.html#ch-run-overlay) for details.
 
 `charliecloud.cacheDir`
 : The directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible to all compute nodes.
-
-`charliecloud.enabled`
-: Enable Charliecloud execution (default: `false`).
 
 `charliecloud.envWhitelist`
 : Comma separated list of environment variable names to be included in the container environment.

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -131,7 +131,7 @@ class CharliecloudCache {
         if( config.pullTimeout )
             pullTimeout = config.pullTimeout as Duration
 
-        def writeFake = true as Boolean
+        def writeFake = true
 
         if( config.writeFake ) 
             writeFake = config.writeFake?.toString() == 'true'

--- a/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/CharliecloudCache.groovy
@@ -117,9 +117,10 @@ class CharliecloudCache {
     /**
      * Retrieve the directory where to store the charliecloud images once downloaded.
      * It tries these settings in the following order:
-     * 1) {@code charliecloud.cacheDir} setting in the nextflow config file
-     * 2) the {@code NXF_CHARLIECLOUD_CACHEDIR} environment variable
-     * 3) the {@code $workDir/charliecloud} path
+     * 1) If writeFake is enabled, the {@code CH_IMAGE_STORAGE} environment variable.
+     * 2) {@code charliecloud.cacheDir} setting in the nextflow config file
+     * 3) the {@code NXF_CHARLIECLOUD_CACHEDIR} environment variable
+     * 4) the {@code $workDir/charliecloud} path
      *
      * @return
      *      the {@code Path} where store the charliecloud images as flattened directories
@@ -130,19 +131,38 @@ class CharliecloudCache {
         if( config.pullTimeout )
             pullTimeout = config.pullTimeout as Duration
 
+        def writeFake = true as Boolean
+
+        if( config.writeFake ) 
+            writeFake = config.writeFake?.toString() == 'true'
+
         def str = config.cacheDir as String
-        if( str )
+
+        def charliecloudImageStorage = env.get('CH_IMAGE_STORAGE')
+
+        if( charliecloudImageStorage && writeFake) {
+            return checkDir(charliecloudImageStorage)
+        }
+            
+        if( str ) {
+            // If charliecloudImageStorage exists and writeFake is true, we never get here
+            if( str.equals( charliecloudImageStorage ) ) {
+                throw new Exception("`charliecloud.cacheDir` configuration parameter must be different from env variable `CH_IMAGE_STORAGE`")
+            }
             return checkDir(str)
+        }
 
         str = env.get('NXF_CHARLIECLOUD_CACHEDIR')
-        if( str )
-            return checkDir(str)
 
-        str = env.get('CH_IMAGE_STORAGE')
-        if( str )
+        if( str ) {
+            if( str.equals( charliecloudImageStorage ) ) {
+                throw new Exception("`NXF_CHARLIECLOUD_CACHEDIR` env variable must be different from env variable `CH_IMAGE_STORAGE`")
+            }
             return checkDir(str)
+        }
 
         def workDir = Global.session.workDir
+
         if( workDir.fileSystem != FileSystems.default ) {
             throw new IOException("Charliecloud cannot store image in a remote work directory -- Use a POSIX compatible work directory or specify an alternative path with the `NXF_CHARLIECLOUD_CACHEDIR` env variable")
         }

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudBuilderTest.groovy
@@ -36,102 +36,124 @@ class CharliecloudBuilderTest extends Specification {
         def path2 = Paths.get('/bar/data/file2')
 
         expect:
-        new CharliecloudBuilder('/cacheDir/img/busybox')
+        new CharliecloudBuilder('/cacheDir/busybox')
                 .build()
-                .runCommand == 'ch-convert -i ch-image --storage /cacheDir busybox "$NXF_TASK_WORKDIR"/container_busybox && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" /cacheDir/busybox --'
 
-        new CharliecloudBuilder('/cacheDir/img/busybox')
+        new CharliecloudBuilder('/cacheDir/busybox')
+                .params(writeFake: false)
+                .build()
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" /cacheDir/busybox --'
+
+        new CharliecloudBuilder('/cacheDir/busybox')
+                .params(writeFake: false)
+                .params(readOnlyInputs: true)
+                .build()
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -b "$NXF_TASK_WORKDIR" /cacheDir/busybox --'
+
+        new CharliecloudBuilder('/cacheDir/busybox')
                 .params(runOptions: '-j --no-home')
                 .build()
-                .runCommand == 'ch-convert -i ch-image --storage /cacheDir busybox "$NXF_TASK_WORKDIR"/container_busybox && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" -j --no-home "$NXF_TASK_WORKDIR"/container_busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" -j --no-home /cacheDir/busybox --'
         
-        new CharliecloudBuilder('/cacheDir/img/busybox')
+        new CharliecloudBuilder('/cacheDir/busybox')
                 .params(temp: '/foo')
                 .build()
-                .runCommand == 'ch-convert -i ch-image --storage /cacheDir busybox "$NXF_TASK_WORKDIR"/container_busybox && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b /foo:/tmp -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b /foo:/tmp -b "$NXF_TASK_WORKDIR" /cacheDir/busybox --'
 
-        new CharliecloudBuilder('/cacheDir/img/busybox')
+        new CharliecloudBuilder('/cacheDir/busybox')
                 .addEnv('X=1')
                 .addEnv(ALPHA:'aaa', BETA: 'bbb')
                 .build()
-                .runCommand == 'ch-convert -i ch-image --storage /cacheDir busybox "$NXF_TASK_WORKDIR"/container_busybox && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w --set-env=X=1 --set-env=ALPHA=aaa --set-env=BETA=bbb -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_busybox --'
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake --set-env=X=1 --set-env=ALPHA=aaa --set-env=BETA=bbb -b "$NXF_TASK_WORKDIR" /cacheDir/busybox --'
 
-        new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        new CharliecloudBuilder('/cacheDir/ubuntu')
                 .addMount(path1)
                 .build()
-                .runCommand == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b /foo/data/file1 -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu --'
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b /foo/data/file1 -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu --'
 
-        new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        new CharliecloudBuilder('/cacheDir/ubuntu')
                 .addMount(path1)
                 .addMount(path2)
                 .build()
-                .runCommand == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b /foo/data/file1 -b /bar/data/file2 -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu --'
+                .runCommand == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b /foo/data/file1 -b /bar/data/file2 -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu --'
     }
 
     def db_file = Paths.get('/home/db')
     def 'should get run command' () {
 
         when:
-        def cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        def cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .build()
             .getRunCommand()
         then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu --'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu --'
 
         when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
-            .params(useSquash: 'true')
-            .build()
-            .getRunCommand()
-        then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu.squashfs && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu.squashfs --'
-
-        when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .params(writeFake: 'true')
             .build()
             .getRunCommand()
         then:
-        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -w -b "$NXF_TASK_WORKDIR" ubuntu --'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu --'
 
         when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
+            .params(writeFake: 'false')
+            .build()
+            .getRunCommand()
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu --'
+
+        when:
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .params(entry:'/bin/sh')
             .build()
             .getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
 
         when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .params(entry:'/bin/sh')
             .params(readOnlyInputs: 'true')
             .build()
             .getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
 
         when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .params(entry:'/bin/sh')
             .params(readOnlyInputs: 'false')
             .build()
             .getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
 
         when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .params(entry:'/bin/sh')
-            .addMount(db_file)
-            .addMount(db_file)
+            .params(readOnlyInputs: 'false')
+            .params(writeFake: 'false')
+            .build()
+            .getRunCommand('bwa --this --that file.fastq')
+        then:
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+
+        when:
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
+            .params(entry:'/bin/sh')
             .params(readOnlyInputs: 'true')
+            .params(writeFake: 'false')
+            .addMount(db_file)
+            .addMount(db_file)
             .build().getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -b /home -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -b /home -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
 
         when:
-        cmd = new CharliecloudBuilder('/cacheDir/img/ubuntu')
+        cmd = new CharliecloudBuilder('/cacheDir/ubuntu')
             .params(entry:'/bin/sh')
             .addMount(db_file)
             .addMount(db_file)
@@ -139,7 +161,7 @@ class CharliecloudBuilderTest extends Specification {
             .build()
             .getRunCommand('bwa --this --that file.fastq')
         then:
-        cmd == 'ch-convert -i ch-image --storage /cacheDir ubuntu "$NXF_TASK_WORKDIR"/container_ubuntu && ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env -w -b /home/db -b "$NXF_TASK_WORKDIR" "$NXF_TASK_WORKDIR"/container_ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
+        cmd == 'ch-run --unset-env="*" -c "$NXF_TASK_WORKDIR" --set-env --write-fake -b /home/db -b "$NXF_TASK_WORKDIR" /cacheDir/ubuntu -- /bin/sh -c "bwa --this --that file.fastq"'
     }
 
     @Unroll

--- a/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/CharliecloudCacheTest.groovy
@@ -62,7 +62,7 @@ class CharliecloudCacheTest extends Specification {
         'foo:2.0'                | 'my.reg/'  | 'my.reg%foo+2.0'
     }
 
-    def 'should return the cache dir from the config file' () {
+    def 'should return the cache dir from the config file'() {
 
         given:
         def dir = Files.createTempDirectory('test')
@@ -78,7 +78,7 @@ class CharliecloudCacheTest extends Specification {
         dir.deleteDir()
     }
 
-    def 'should return the cache dir from the environment' () {
+    def 'should return the cache dir from the environment'() {
 
         given:
         def dir = Files.createTempDirectory('test')
@@ -89,6 +89,84 @@ class CharliecloudCacheTest extends Specification {
         def cache = new CharliecloudCache(GroovyMock(ContainerConfig), [NXF_CHARLIECLOUD_CACHEDIR: "$cacheDir"])
         then:
         cache.getCacheDir() == cacheDir
+
+        cleanup:
+        dir.deleteDir()
+    }
+
+    def 'should use CH_IMAGE_STORAGE over cacheDir'() {
+
+        given:
+        def dir = Files.createTempDirectory('test')
+        and:
+        def cacheDir = dir.resolve('nxf.ch')
+        and:
+        def charliecloudCacheDir = dir.resolve('charliecloud')
+
+        when:
+        def cache = new CharliecloudCache([cacheDir: "$cacheDir"] as ContainerConfig, [CH_IMAGE_STORAGE: "$charliecloudCacheDir"])
+     
+        then:
+        cache.getCacheDir() == charliecloudCacheDir
+
+        cleanup:
+        dir.deleteDir()
+    }
+
+    def 'should use CH_IMAGE_STORAGE over NXF_CHARLIECLOUD_CACHEDIR'() {
+
+        given:
+        def dir = Files.createTempDirectory('test')
+        and:
+        def cacheDir = dir.resolve('nxf.ch')
+        and:
+        def charliecloudCacheDir = dir.resolve('charliecloud')
+
+        when:
+        def cache = new CharliecloudCache(GroovyMock(ContainerConfig), [NXF_CHARLIECLOUD_CACHEDIR: "$cacheDir", CH_IMAGE_STORAGE: "$charliecloudCacheDir"])
+     
+        then:
+        cache.getCacheDir() == charliecloudCacheDir
+
+        cleanup:
+        dir.deleteDir()
+    }
+
+    def 'should throw exception: cacheDir and CH_IMAGE_STORAGE are the same'() {
+
+        given:
+        def dir = Files.createTempDirectory('test')
+        and:
+        def cacheDir = dir.resolve('nxf.ch')
+
+        when:
+        def cache = new CharliecloudCache([cacheDir: "$cacheDir", writeFake: 'false'] as ContainerConfig, [CH_IMAGE_STORAGE: "$cacheDir"])
+        and:
+        cache.getCacheDir()
+
+        then:
+        def e = thrown(Exception)
+        e.message == "`charliecloud.cacheDir` configuration parameter must be different from env variable `CH_IMAGE_STORAGE`"
+
+        cleanup:
+        dir.deleteDir()
+    }
+
+    def 'should throw exception: NXF_CHARLIECLOUD_CACHEDIR and CH_IMAGE_STORAGE are the same'() {
+
+        given:
+        def dir = Files.createTempDirectory('test')
+        and:
+        def cacheDir = dir.resolve('nxf.ch')
+
+        when:
+        def cache = new CharliecloudCache([writeFake: 'false'] as ContainerConfig, [ NXF_CHARLIECLOUD_CACHEDIR: "$cacheDir", CH_IMAGE_STORAGE: "$cacheDir" ])
+        and:
+        cache.getCacheDir()
+        
+        then:
+        def e = thrown(Exception)
+        e.message == "`NXF_CHARLIECLOUD_CACHEDIR` env variable must be different from env variable `CH_IMAGE_STORAGE`"
 
         cleanup:
         dir.deleteDir()
@@ -146,7 +224,7 @@ class CharliecloudCacheTest extends Specification {
 
     @Ignore
     @Timeout(1)
-    def 'should pull a charliecloud image' () {
+    def 'should pull a charliecloud image'() {
 
         given:
         def IMAGE = 'busybox:latest'


### PR DESCRIPTION
Here are changes to the charliecloud driver.

- `charliecloud.writeFake` is true by default (!)

- if `charliecloud.writeFake` is true and `$CH_IMAGE_STORAGE` is set, images will go into `$CH_IMAGE_STORAGE` and be run from there with --write-fake (will be run by name in that case).

- if charliecloud.writeFake is true, but `$CH_IMAGE_STORAGE` is unset, images will go into `charliecloud.cacheDir`, `$NXF_CHARLIECLOUD_CACHE` or `work/charliecloud` (order of priority) and will be run by path (since run by name only works if `$CH_IMAGE_STORAGE `is set)

- if `charliecloud.writeFake` is set to `false`, images will need to be run with `-w` to enable mounting of the workDir. In this case `$CH_IMAGE_STORAGE` will not be used to store images, since `$CH_IMAGE_STORAGE` is incompatible with `-w`. Images will instead go into `charliecloud.cacheDir`, `$NXF_CHARLIECLOUD_CACHE` or `work/charliecloud` (order of priority). If the folder used to store images is the same as `$CH_IMAGE_STORAGE`, throw an exception. Images will be run by path.

In summary:

- Give preference to `$CH_IMAGE_STORAGE` in the default case of `writeFake`

- Make some effort to avoid using `$CH_IMAGE_STORAGE` when `writeFake` is `false`.

- No longer create temporary containers for each task. 

This is the same as #5212, but without the many merge conflicts created by a failed sign-off.

@phue I have updated the documentation. I have not added a unit test for switching between `image` and `imageName` in the builder, since I do not know of a way to set an env var for the tests. I have tested this locally (i.e. running tests with the var set or not) and it produced the expected results. Is it really worth adding a way to inject fake environments into the BuilderTest to test this specific behaviour?