### PR TITLE
Bump groovy 4.0.23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,8 @@ allprojects {
 
         // Documentation required libraries
         groovyDoc 'org.fusesource.jansi:jansi:2.4.0'
-        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.22"
-        groovyDoc "org.apache.groovy:groovy-ant:4.0.22"
+        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.23"
+        groovyDoc "org.apache.groovy:groovy-ant:4.0.23"
     }
 
     test {

--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -20,12 +20,12 @@ compileGroovy {
 dependencies {
     api(project(':nf-commons'))
     api(project(':nf-httpfs'))
-    api "org.apache.groovy:groovy:4.0.22"
-    api "org.apache.groovy:groovy-nio:4.0.22"
-    api "org.apache.groovy:groovy-xml:4.0.22"
-    api "org.apache.groovy:groovy-json:4.0.22"
-    api "org.apache.groovy:groovy-templates:4.0.22"
-    api "org.apache.groovy:groovy-yaml:4.0.22"
+    api "org.apache.groovy:groovy:4.0.23"
+    api "org.apache.groovy:groovy-nio:4.0.23"
+    api "org.apache.groovy:groovy-xml:4.0.23"
+    api "org.apache.groovy:groovy-json:4.0.23"
+    api "org.apache.groovy:groovy-templates:4.0.23"
+    api "org.apache.groovy:groovy-yaml:4.0.23"
     api "org.slf4j:jcl-over-slf4j:2.0.7"
     api "org.slf4j:jul-to-slf4j:2.0.7"
     api "org.slf4j:log4j-over-slf4j:2.0.7"
@@ -53,7 +53,7 @@ dependencies {
     testImplementation 'org.subethamail:subethasmtp:3.1.7'
 
     // test configuration
-    testFixturesApi ("org.apache.groovy:groovy-test:4.0.22") { exclude group: 'org.apache.groovy' }
+    testFixturesApi ("org.apache.groovy:groovy-test:4.0.23") { exclude group: 'org.apache.groovy' }
     testFixturesApi ("cglib:cglib-nodep:3.3.0")
     testFixturesApi ("org.objenesis:objenesis:3.2")
     testFixturesApi ("org.spockframework:spock-core:2.3-groovy-4.0") { exclude group: 'org.apache.groovy'; exclude group: 'net.bytebuddy' }

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -26,8 +26,8 @@ sourceSets {
 
 dependencies {
     api "ch.qos.logback:logback-classic:1.4.14"
-    api "org.apache.groovy:groovy:4.0.22"
-    api "org.apache.groovy:groovy-nio:4.0.22"
+    api "org.apache.groovy:groovy:4.0.23"
+    api "org.apache.groovy:groovy-nio:4.0.23"
     api "commons-lang:commons-lang:2.6"
     api 'com.google.guava:guava:33.0.0-jre'
     api 'org.pf4j:pf4j:3.12.0'

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -30,12 +30,12 @@ sourceSets {
 dependencies {
     api project(':nf-commons')
     api "ch.qos.logback:logback-classic:1.4.14"
-    api "org.apache.groovy:groovy:4.0.22"
-    api "org.apache.groovy:groovy-nio:4.0.22"
+    api "org.apache.groovy:groovy:4.0.23"
+    api "org.apache.groovy:groovy-nio:4.0.23"
     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
 
     /* testImplementation inherited from top gradle build file */
-    testImplementation "org.apache.groovy:groovy-json:4.0.22" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.23" // needed by wiremock
     testImplementation ('com.github.tomakehurst:wiremock:1.57') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -56,6 +56,6 @@ dependencies {
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }

--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -49,6 +49,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }

--- a/plugins/nf-cloudcache/build.gradle
+++ b/plugins/nf-cloudcache/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }
 

--- a/plugins/nf-codecommit/build.gradle
+++ b/plugins/nf-codecommit/build.gradle
@@ -42,6 +42,6 @@ dependencies {
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }

--- a/plugins/nf-console/build.gradle
+++ b/plugins/nf-console/build.gradle
@@ -38,13 +38,13 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
     api("org.apache.groovy:groovy-console:4.0.21-patch.2") { transitive=false }
-    api("org.apache.groovy:groovy-swing:4.0.22")  { transitive=false }
+    api("org.apache.groovy:groovy-swing:4.0.23")  { transitive=false }
     // this is required by 'groovy-console'  
     api("com.github.javaparser:javaparser-core:3.25.8")
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }
 

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     api 'com.google.code.gson:gson:2.10.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }
 
 test {

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.12.7.1"
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -40,6 +40,6 @@ dependencies {
     api 'io.seqera:wave-utils:0.12.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.22"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.22"
+    testImplementation "org.apache.groovy:groovy:4.0.23"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.23"
 }


### PR DESCRIPTION
This PR bumps groovy runtime to version 4.0.23 