### PR TITLE
Fix Azure Fusion env misses credentials when no key or SAS provided

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzStorageOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzStorageOpts.groovy
@@ -62,10 +62,4 @@ class AzStorageOpts {
         }
         return result
     }
-
-    synchronized String getOrCreateSasToken() {
-        if( !sasToken )
-            sasToken = AzHelper.generateAccountSas(accountName, accountKey, tokenDuration)
-        return sasToken
-    }
 }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/fusion/AzFusionEnv.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/fusion/AzFusionEnv.groovy
@@ -17,47 +17,72 @@
 
 package nextflow.cloud.azure.fusion
 
+import groovy.util.logging.Slf4j
+import nextflow.Global
+import nextflow.cloud.azure.batch.AzHelper
 import groovy.transform.CompileStatic
 import nextflow.cloud.azure.config.AzConfig
 import nextflow.fusion.FusionConfig
 import nextflow.fusion.FusionEnv
 import org.pf4j.Extension
+
 /**
  * Implement environment provider for Azure specific variables
- * 
+ *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Extension
 @CompileStatic
+@Slf4j
 class AzFusionEnv implements FusionEnv {
 
     @Override
     Map<String, String> getEnvironment(String scheme, FusionConfig config) {
-        if (scheme != 'az')
+        if (scheme != 'az') {
             return Collections.<String, String> emptyMap()
+        }
 
         final cfg = AzConfig.config
         final result = new LinkedHashMap(10)
 
-        if (!cfg.storage().accountName)
+        if (!cfg.storage().accountName) {
             throw new IllegalArgumentException("Missing Azure Storage account name")
+        }
 
-        if (cfg.storage().accountKey && cfg.storage().sasToken)
+        if (cfg.storage().accountKey && cfg.storage().sasToken) {
             throw new IllegalArgumentException("Azure Storage Access key and SAS token detected. Only one is allowed")
+        }
 
-        // the account name is always required
         result.AZURE_STORAGE_ACCOUNT = cfg.storage().accountName
-
-        // If a Managed Identity or Service Principal is configured, Fusion only needs to know the account name
-        if (cfg.managedIdentity().isConfigured() || cfg.activeDirectory().isConfigured()) {
-            return result
-        }
-
-        // If a SAS token is configured, instead, Fusion also requires the token value
-        if (cfg.storage().sasToken) {
-            result.AZURE_STORAGE_SAS_TOKEN = cfg.storage().getOrCreateSasToken()
-        }
+        // TODO: In theory, generating an impromptu SAS token for authentication methods other than
+        // `azure.storage.sasToken` should not be necessary, because those methods should already allow sufficient
+        // access for normal operation. Nevertheless, #5287 heavily implies that failing to do so causes the Azure
+        // Storage plugin or Fusion to fail. In any case, it may be possible to remove this in the future.
+        result.AZURE_STORAGE_SAS_TOKEN = getOrCreateSasToken()
 
         return result
+    }
+
+    /**
+     * Return the SAS token if it is defined in the configuration, otherwise generate one based on the requested
+     * authentication method.
+     */
+    synchronized String getOrCreateSasToken() {
+
+        final cfg = AzConfig.config
+
+        // If a SAS token is already defined in the configuration, just return it
+        if (cfg.storage().sasToken) {
+            return cfg.storage().sasToken
+        }
+
+        // For Active Directory and Managed Identity, we cannot generate an *account* SAS token, but we can generate
+        // a *container* SAS token for the work directory.
+        if (cfg.activeDirectory().isConfigured() || cfg.managedIdentity().isConfigured()) {
+            return AzHelper.generateContainerSasWithActiveDirectory(Global.session.workDir, cfg.storage().tokenDuration)
+        }
+
+        // Shared Key authentication can use an account SAS token
+        return AzHelper.generateAccountSasWithAccountKey(Global.session.workDir, cfg.storage().tokenDuration)
     }
 }


### PR DESCRIPTION
This PR fixes two issues: 
* Azure Fusion missing authentication if accountKey is provided
* Catch when service principal exists but no keys or SAS

