### PR TITLE
Add missing `workflow` config scope

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1584,3 +1584,20 @@ The following settings are available:
 
 `wave.strategy`
 : The strategy to be used when resolving ambiguous Wave container requirements (default: `'container,dockerfile,conda,spack'`).
+
+(config-workflow)=
+
+## `workflow`
+
+The `workflow` scope provides workflow execution options.
+
+`workflow.failOnIgnore`
+: :::{versionadded} 24.05.0-edge
+  :::
+: When `true`, the pipeline will exit with a non-zero exit code if any failed tasks are ignored using the `ignore` {ref}`error strategy <process-error-strategy>`.
+
+`workflow.onComplete`
+: Specify a closure that will be invoked at the end of a workflow run (including failed runs). See {ref}`workflow-handlers` for more information.
+
+`workflow.onError`
+: Specify a closure that will be invoked if a workflow run is terminated. See {ref}`workflow-handlers` for more information.

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -584,12 +584,9 @@ Use `debug` instead
 
 ### errorStrategy
 
-The `errorStrategy` directive allows you to define how an error condition is managed by the process. By default when an error status is returned by the executed script, the process stops immediately. This in turn forces the entire pipeline to terminate.
+The `errorStrategy` directive allows you to define how an error condition is managed by the process. By default when an error status is returned by the executed script (i.e. when it ends with a non-zero exit status), the process stops immediately. This in turn forces the entire pipeline to terminate.
 
 The following error strategies are available:
-
-- **errorStrategy `ignore`**: Nextflow will continue submitting tasks for the remaining 95 samples, complete the workflow, and report a successful pipeline completion.
-- **errorStrategy `ignore` and `workflow.failOnIgnore` set to `true` in configuration**: The same behavior as setting the errorStrategy alone, except the pipeline will return an exit status of -1 and report an error.
 
 `terminate` (default)
 : When a task fails, terminate the pipeline immediately and report an error. Pending and running jobs are killed.
@@ -617,9 +614,7 @@ process ignoreAnyError {
 }
 ```
 
-:::{note}
-By definition, a command script fails when it ends with a non-zero exit status.
-:::
+In this case, the workflow will complete successfully and return an exit status of 0. However, if you set `workflow.failOnIgnore = true` in your Nextflow configuration, the workflow will return non-zero exit status and report the failed tasks as an error.
 
 The `retry` error strategy allows you to re-submit for execution a process returning an error condition. For example:
 


### PR DESCRIPTION
The `workflow.failOnIgnore` config option got lost in the mix somehow with #4766 , adding it back in and cleaning up some merge artifacts