### PR TITLE
Docs version dropdown: latest

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -10,7 +10,7 @@
         <select onchange="window.location = this.value;">
             <option value="/docs/stable/index.html" {% if version_selected == 'stable' %}selected{% endif %}>Stable</option>
             <option value="/docs/edge/index.html" {% if version_selected == 'edge' %}selected{% endif %}>Edge</option>
-            <option value="/docs/latest/index.html" {% if version_selected == 'dev' %}selected{% endif %}>Development</option>
+            <option value="/docs/latest/index.html" {% if version_selected == 'dev' %}selected{% endif %}>Latest</option>
         </select>
         </select>
     </div>


### PR DESCRIPTION
Call the default version of the docs `latest` instead of `development`, as it's less scary. And still accurate. Also then matches the URL.