### PR TITLE
Hash improvements

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
+++ b/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
@@ -144,10 +144,13 @@ public class HashBuilder {
             for( Object item : ((Object[])value) )
                 with(item);
 
-        // note: should map be order invariant as Set ?
-        else if( value instanceof Map )
-            for( Object item : ((Map)value).values() )
+        else if( value instanceof List ) {
+            for( Object item : ((List)value) )
                 with(item);
+        }
+
+        else if( value instanceof Map )
+            hashUnorderedCollection(hasher, ((Map) value).entrySet(), mode);
 
         else if( value instanceof Map.Entry ) {
             Map.Entry entry = (Map.Entry)value;
@@ -155,12 +158,8 @@ public class HashBuilder {
             with(entry.getValue());
         }
 
-        else if( value instanceof Bag || value instanceof Set )
+        else if( value instanceof Collection )
             hashUnorderedCollection(hasher, (Collection) value, mode);
-
-        else if( value instanceof Collection)
-            for( Object item : ((Collection)value) )
-                with(item);
 
         else if( value instanceof FileHolder )
             with(((FileHolder) value).getSourceObj());
@@ -185,8 +184,10 @@ public class HashBuilder {
         else if( value instanceof CacheFunnel )
             ((CacheFunnel)value).funnel(hasher, mode);
 
-        else if( value instanceof Enum )
-            hasher.putUnencodedChars( value.getClass().getName() + "." + value );
+        else if( value instanceof Enum ) {
+            hasher.putUnencodedChars(value.getClass().getName());
+            hasher.putUnencodedChars(value);
+        }
 
         else {
             Bolts.debug1(log, FIRST_ONLY, "[WARN] Unknown hashing type: " + value.getClass());


### PR DESCRIPTION
Close #4916 

- Map should be hashed as an unordered collection of map entries
- all collections other than List should be hashed as unordered collection (in practice what we're already doing but make it more clear)
- while we're changing the hash, might as well make the enum hash more efficient

Tests need to be updated. This PR will break everyone's cache.