### PR TITLE
Use `Channel` instead of `channel`

### DIFF
--- a/docs/channel.md
+++ b/docs/channel.md
@@ -71,10 +71,6 @@ For example, the `Channel.of()` factory can be used to create a channel from an 
 Channel.of(1, 2, 3).view()
 ```
 
-:::{versionadded} 20.07.0
-`channel` was introduced as an alias of `Channel`, allowing factory methods to be specified as `channel.of()` or `Channel.of()`, and so on.
-:::
-
 See {ref}`channel-factory` for the full list of channel factories.
 
 ## Operators

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -178,7 +178,7 @@ You can then use this function in your pipeline:
 ```groovy
 include { reverseString } from 'plugin/my-plugin'
 
-channel.of( reverseString('hi') )
+Channel.of( reverseString('hi') )
 ```
 
 You can also use an alias:

--- a/docs/module.md
+++ b/docs/module.md
@@ -18,7 +18,7 @@ For example:
 include { foo } from './some/module'
 
 workflow {
-    data = channel.fromPath('/some/data/*.txt')
+    data = Channel.fromPath('/some/data/*.txt')
     foo(data)
 }
 ```
@@ -63,7 +63,7 @@ A Nextflow script can include any number of modules, and an `include` statement 
 include { foo; bar } from './some/module'
 
 workflow {
-    data = channel.fromPath('/some/data/*.txt')
+    data = Channel.fromPath('/some/data/*.txt')
     foo(data)
     bar(data)
 }

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -6,7 +6,7 @@
 
 ## empty
 
-The `channel.empty` factory method, by definition, creates a channel that doesn't emit any value.
+The `Channel.empty` factory method, by definition, creates a channel that doesn't emit any value.
 
 See also: {ref}`operator-ifempty`.
 
@@ -15,13 +15,13 @@ See also: {ref}`operator-ifempty`.
 ## from
 
 :::{deprecated} 19.09.0-edge
-Use [channel.of](#of) or [channel.fromList](#fromlist) instead.
+Use [Channel.of](#of) or [Channel.fromList](#fromlist) instead.
 :::
 
-The `channel.from` method allows you to create a channel emitting any sequence of values that are specified as the method argument, for example:
+The `Channel.from` method allows you to create a channel emitting any sequence of values that are specified as the method argument, for example:
 
 ```groovy
-ch = channel.from( 1, 3, 5, 7 )
+ch = Channel.from( 1, 3, 5, 7 )
 ch.subscribe { println "value: $it" }
 ```
 
@@ -37,25 +37,25 @@ value: 7
 The following example shows how to create a channel from a *range* of numbers or strings:
 
 ```groovy
-zeroToNine = channel.from( 0..9 )
-strings = channel.from( 'A'..'Z' )
+zeroToNine = Channel.from( 0..9 )
+strings = Channel.from( 'A'..'Z' )
 ```
 
 :::{note}
-When the `channel.from` argument is an object implementing the (Java) [Collection](http://docs.oracle.com/javase/7/docs/api/java/util/Collection.html) interface, the resulting channel emits the collection entries as individual items.
+When the `Channel.from` argument is an object implementing the (Java) [Collection](http://docs.oracle.com/javase/7/docs/api/java/util/Collection.html) interface, the resulting channel emits the collection entries as individual items.
 :::
 
 Thus the following two declarations produce an identical result even though in the first case the items are specified as multiple arguments while in the second case as a single list object argument:
 
 ```groovy
-channel.from( 1, 3, 5, 7, 9 )
-channel.from( [1, 3, 5, 7, 9] )
+Channel.from( 1, 3, 5, 7, 9 )
+Channel.from( [1, 3, 5, 7, 9] )
 ```
 
 But when more than one argument is provided, they are always managed as *single* emissions. Thus, the following example creates a channel emitting three entries each of which is a list containing two elements:
 
 ```groovy
-channel.from( [1, 2], [5,6], [7,9] )
+Channel.from( [1, 2], [5,6], [7,9] )
 ```
 
 (channel-fromlist)=
@@ -65,10 +65,10 @@ channel.from( [1, 2], [5,6], [7,9] )
 :::{versionadded} 19.10.0
 :::
 
-The `channel.fromList` method allows you to create a channel emitting the values provided as a list of elements, for example:
+The `Channel.fromList` method allows you to create a channel emitting the values provided as a list of elements, for example:
 
 ```groovy
-channel
+Channel
     .fromList( ['a', 'b', 'c', 'd'] )
     .view { "value: $it" }
 ```
@@ -82,31 +82,31 @@ value: c
 value: d
 ```
 
-See also: [channel.of](#of) factory method.
+See also: [Channel.of](#of) factory method.
 
 (channel-path)=
 
 ## fromPath
 
-You can create a channel emitting one or more file paths by using the `channel.fromPath` method and specifying a path
+You can create a channel emitting one or more file paths by using the `Channel.fromPath` method and specifying a path
 string as an argument. For example:
 
 ```groovy
-myFileChannel = channel.fromPath( '/data/some/bigfile.txt' )
+myFileChannel = Channel.fromPath( '/data/some/bigfile.txt' )
 ```
 
 The above line creates a channel and binds it to a [Path](http://docs.oracle.com/javase/7/docs/api/java/nio/file/Path.html)
 object for the specified file.
 
 :::{note}
-`channel.fromPath` does not check whether the file exists.
+`Channel.fromPath` does not check whether the file exists.
 :::
 
-Whenever the `channel.fromPath` argument contains a `*` or `?` wildcard character it is interpreted as a [glob][glob] path matcher.
+Whenever the `Channel.fromPath` argument contains a `*` or `?` wildcard character it is interpreted as a [glob][glob] path matcher.
 For example:
 
 ```groovy
-myFileChannel = channel.fromPath( '/data/big/*.txt' )
+myFileChannel = Channel.fromPath( '/data/big/*.txt' )
 ```
 
 This example creates a channel and emits as many `Path` items as there are files with `txt` extension in the `/data/big` folder.
@@ -118,9 +118,9 @@ Two asterisks, i.e. `**`, works like `*` but crosses directory boundaries. This 
 For example:
 
 ```groovy
-files = channel.fromPath( 'data/**.fa' )
-moreFiles = channel.fromPath( 'data/**/*.fa' )
-pairFiles = channel.fromPath( 'data/file_{1,2}.fq' )
+files = Channel.fromPath( 'data/**.fa' )
+moreFiles = Channel.fromPath( 'data/**/*.fa' )
+pairFiles = Channel.fromPath( 'data/file_{1,2}.fq' )
 ```
 
 The first line returns a channel emitting the files ending with the suffix `.fa` in the `data` folder *and* recursively in all its sub-folders. While the second one only emits the files which have the same suffix in *any* sub-folder in the `data` path. Finally the last example emits two files: `data/file_1.fq` and `data/file_2.fq`.
@@ -132,15 +132,15 @@ As in Linux Bash, the `*` wildcard does not catch hidden files (i.e. files whose
 Multiple paths or glob patterns can be specified using a list:
 
 ```groovy
-channel.fromPath( ['/some/path/*.fq', '/other/path/*.fastq'] )
+Channel.fromPath( ['/some/path/*.fq', '/other/path/*.fastq'] )
 ```
 
 In order to include hidden files, you need to start your pattern with a period character or specify the `hidden: true` option. For example:
 
 ```groovy
-expl1 = channel.fromPath( '/path/.*' )
-expl2 = channel.fromPath( '/path/.*.fa' )
-expl3 = channel.fromPath( '/path/*', hidden: true )
+expl1 = Channel.fromPath( '/path/.*' )
+expl2 = Channel.fromPath( '/path/.*.fa' )
+expl3 = Channel.fromPath( '/path/*', hidden: true )
 ```
 
 The first example returns all hidden files in the specified path. The second one returns all hidden files ending with the `.fa` suffix. Finally the last example returns all files (hidden and non-hidden) in that path.
@@ -150,8 +150,8 @@ By default a [glob][glob] pattern only looks for regular file paths that match t
 You can use the `type` option specifying the value `file`, `dir` or `any` in order to define what kind of paths you want. For example:
 
 ```groovy
-myFileChannel = channel.fromPath( '/path/*b', type: 'dir' )
-myFileChannel = channel.fromPath( '/path/a*', type: 'any' )
+myFileChannel = Channel.fromPath( '/path/*b', type: 'dir' )
+myFileChannel = Channel.fromPath( '/path/a*', type: 'any' )
 ```
 
 The first example will return all *directory* paths ending with the `b` suffix, while the second will return any file or directory starting with a `a` prefix.
@@ -183,11 +183,11 @@ Available options:
 
 ## fromFilePairs
 
-The `channel.fromFilePairs` method creates a channel emitting the file pairs matching a [glob][glob] pattern provided
+The `Channel.fromFilePairs` method creates a channel emitting the file pairs matching a [glob][glob] pattern provided
 by the user. The matching files are emitted as tuples in which the first element is the grouping key of the matching pair and the second element is the list of files (sorted in lexicographical order). For example:
 
 ```groovy
-channel
+Channel
     .fromFilePairs('/my/data/SRR*_{1,2}.fastq')
     .view()
 ```
@@ -210,13 +210,13 @@ The glob pattern must contain at least one `*` wildcard character.
 Multiple glob patterns can be specified using a list:
 
 ```groovy
-channel.fromFilePairs( ['/some/data/SRR*_{1,2}.fastq', '/other/data/QFF*_{1,2}.fastq'] )
+Channel.fromFilePairs( ['/some/data/SRR*_{1,2}.fastq', '/other/data/QFF*_{1,2}.fastq'] )
 ```
 
 Alternatively, it is possible to implement a custom file pair grouping strategy providing a closure which, given the current file as parameter, returns the grouping key. For example:
 
 ```groovy
-channel
+Channel
     .fromFilePairs('/some/data/*', size: -1) { file -> file.extension }
     .view { ext, files -> "Files with the extension $ext are $files" }
 ```
@@ -251,10 +251,10 @@ Available options:
 :::{versionadded} 19.04.0
 :::
 
-The `channel.fromSRA` method queries the [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) database and returns a channel emitting the FASTQ files matching the specified criteria i.e project or accession number(s). For example:
+The `Channel.fromSRA` method queries the [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) database and returns a channel emitting the FASTQ files matching the specified criteria i.e project or accession number(s). For example:
 
 ```groovy
-channel
+Channel
     .fromSRA('SRP043510')
     .view()
 ```
@@ -275,7 +275,7 @@ Multiple accession IDs can be specified using a list object:
 
 ```groovy
 ids = ['ERR908507', 'ERR908506', 'ERR908505']
-channel
+Channel
     .fromSRA(ids)
     .view()
 ```
@@ -296,7 +296,7 @@ To access the ESearch API, you must provide your [NCBI API keys](https://ncbiins
 
 - The `apiKey` option:
   ```groovy
-  channel.fromSRA(ids, apiKey:'0123456789abcdef')
+  Channel.fromSRA(ids, apiKey:'0123456789abcdef')
   ```
 
 - The `NCBI_API_KEY` variable in your environment:
@@ -346,10 +346,10 @@ ch.view()
 :::{versionadded} 19.10.0
 :::
 
-The `channel.of` method allows you to create a channel that emits the arguments provided to it, for example:
+The `Channel.of` method allows you to create a channel that emits the arguments provided to it, for example:
 
 ```groovy
-ch = channel.of( 1, 3, 5, 7 )
+ch = Channel.of( 1, 3, 5, 7 )
 ch.view { "value: $it" }
 ```
 
@@ -366,7 +366,7 @@ value: 7
 Ranges of values are expanded accordingly:
 
 ```groovy
-channel
+Channel
     .of(1..23, 'X', 'Y')
     .view()
 ```
@@ -384,7 +384,7 @@ X
 Y
 ```
 
-See also: [channel.fromList](#fromlist) factory method.
+See also: [Channel.fromList](#fromlist) factory method.
 
 (channel-topic)=
 
@@ -417,11 +417,11 @@ process bar {
 }
 ```
 
-The `channel.topic` method allows referencing the topic channel with the specified name, which can be used as a process
+The `Channel.topic` method allows referencing the topic channel with the specified name, which can be used as a process
 input or operator composition as any other Nextflow channel:
 
 ```groovy
-channel.topic('my-topic').view()
+Channel.topic('my-topic').view()
 ```
 
 This approach is a convenient way to collect related items from many different sources without explicitly connecting them (e.g. using the `mix` operator).
@@ -436,13 +436,13 @@ See also: {ref}`process-additional-options` for process outputs.
 
 ## value
 
-The `channel.value` method is used to create a value channel. An optional (not `null`) argument can be specified to bind
+The `Channel.value` method is used to create a value Channel. An optional (not `null`) argument can be specified to bind
 the channel to a specific value. For example:
 
 ```groovy
-expl1 = channel.value()
-expl2 = channel.value( 'Hello there' )
-expl3 = channel.value( [1,2,3,4,5] )
+expl1 = Channel.value()
+expl2 = Channel.value( 'Hello there' )
+expl3 = Channel.value( [1,2,3,4,5] )
 ```
 
 The first line in the example creates an 'empty' variable. The second line creates a channel and binds a string to it.
@@ -452,14 +452,14 @@ The third line creates a channel and binds a list object to it that will be emit
 
 ## watchPath
 
-The `channel.watchPath` method watches a folder for one or more files matching a specified pattern. As soon as there
+The `Channel.watchPath` method watches a folder for one or more files matching a specified pattern. As soon as there
 is a file that meets the specified condition, it is emitted over the channel that is returned by the `watchPath` method.
 The condition on files to watch can be specified by using `*` or `?` wildcard characters i.e. by specifying a [glob][glob] path matching criteria.
 
 For example:
 
 ```groovy
-channel
+Channel
     .watchPath( '/path/*.fa' )
     .subscribe { println "Fasta file: $it" }
 ```
@@ -474,17 +474,17 @@ argument that specifies what event(s) to watch. The supported events are:
 You can specify more than one of these events by using a comma separated string as shown below:
 
 ```groovy
-channel
+Channel
     .watchPath( '/path/*.fa', 'create,modify' )
     .subscribe { println "File created or modified: $it" }
 ```
 
 :::{warning}
-The `channel.watchPath` factory waits endlessly for files that match the specified pattern and event(s), which means
+The `Channel.watchPath` factory waits endlessly for files that match the specified pattern and event(s), which means
 that it will cause your pipeline to run forever. Consider using the `take` or `until` operator to close the channel when
 a certain condition is met (e.g. after receiving 10 files, receiving a file named `DONE`).
 :::
 
-See also: [channel.fromPath](#frompath) factory method.
+See also: [Channel.fromPath](#frompath) factory method.
 
 [glob]: http://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -740,7 +740,7 @@ process foo {
 }
 
 workflow {
-    channel.of('A','B','C','D') | foo | view
+    Channel.of('A','B','C','D') | foo | view
 }
 ```
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -109,7 +109,7 @@ Inputs can be specified like arguments when invoking the workflow:
 
 ```groovy
 workflow {
-    my_pipeline( channel.from('/some/data') )
+    my_pipeline( Channel.from('/some/data') )
 }
 ```
 
@@ -178,7 +178,7 @@ process bar {
 }
 
 workflow {
-    data = channel.fromPath('/some/path/*.txt')
+    data = Channel.fromPath('/some/path/*.txt')
     foo()
     bar(data)
 }
@@ -272,7 +272,7 @@ process sayHello {
 }
 
 workflow {
-    things = channel.of('Hello world!', 'Yo, dude!', 'Duck!')
+    things = Channel.of('Hello world!', 'Yo, dude!', 'Duck!')
     sayHello(things)
     sayHello.out.verbiage.view()
 }
@@ -336,7 +336,7 @@ process foo {
 }
 
 workflow {
-   channel.from('Hello','Hola','Ciao') | foo | map { it.toUpperCase() } | view
+   Channel.from('Hello','Hola','Ciao') | foo | map { it.toUpperCase() } | view
 }
 ```
 
@@ -347,7 +347,7 @@ Statements can also be split across multiple lines for better readability:
 
 ```groovy
 workflow {
-    channel.from('Hello','Hola','Ciao')
+    Channel.from('Hello','Hola','Ciao')
       | foo
       | map { it.toUpperCase() }
       | view
@@ -383,7 +383,7 @@ process bar {
 }
 
 workflow {
-    channel.from('Hello')
+    Channel.from('Hello')
       | map { it.reverse() }
       | (foo & bar)
       | mix


### PR DESCRIPTION
DSL2 introduced `channel` as an alias for `Channel` to create channel factories. I assume this was for consistency with other lower-case words like "process" and "workflow". However, Channel is a type like List or Map or Path, and the channel factories are static methods that create values of type Channel.

Technically, channels in Nextflow are of type `DataflowReadChannel`, but this is really an implementation detail. When we implement static types, we can provide an explicit `Channel` type to the user that does not expose such internal details To prepare for that, we should deprecate the use of `channel` before it gets any more widespread and causes confusion