### PR TITLE
Add retry policy to google batch describe task

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -110,7 +110,7 @@ class BatchClient {
 
     Task describeTask(String jobId, String taskId) {
         final name = TaskName.of(projectId, location, jobId, 'group0', taskId)
-        return batchServiceClient.getTask(name)
+        return apply(()-> batchServiceClient.getTask(name))
     }
 
     void deleteJob(String jobId) {


### PR DESCRIPTION
Raised by Adam during some testing. The Google Batch describeTask didn't have a retry policy like the other methods and sure enough a 5xx error struck