### PR TITLE
Fix incorrect total count at the end of the execution

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/ProgressRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ProgressRecord.groovy
@@ -63,7 +63,7 @@ class ProgressRecord implements Cloneable {
 
     int getTotalCount() {
         pending+ submitted+ running+
-           succeeded+ failed+ cached+ stored
+           succeeded+ failed+ cached+ stored + aborted
     }
 
     int getCompletedCount() {

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ProgressRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ProgressRecordTest.groovy
@@ -60,6 +60,7 @@ class ProgressRecordTest extends Specification {
         def FAILED =5
         def CACHED =6
         def STORED =7
+        def ABORTED = 8
         and:
         def rec = new ProgressRecord(10, 'foo')
 
@@ -71,10 +72,11 @@ class ProgressRecordTest extends Specification {
         rec.failed =FAILED
         rec.cached =CACHED
         rec.stored =STORED
+        rec.aborted = ABORTED
 
         then:
         rec.getCompletedCount() == SUCCEEDED+ FAILED+ CACHED+ STORED
-        rec.getTotalCount() == PENDING+ SUBMITTED+ RUNNING + SUCCEEDED+ FAILED+ CACHED+ STORED
+        rec.getTotalCount() == PENDING+ SUBMITTED+ RUNNING + SUCCEEDED+ FAILED+ CACHED+ STORED+ ABORTED
     }
 
 


### PR DESCRIPTION
The number of total tasks during the execution did not match with the total tasks at the end of the execution. This was due to  aborted taks where not included in the ProgressRecord total count. This PR fixes it, including aborted tasks to the total count. 