### PR TITLE
Fix workflow onComplete and onError in the entry workflow

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -303,12 +303,7 @@ class WorkflowMetadata {
      * @param action The action handler
      */
     void onComplete( Closure action ) {
-
-        final clone = (Closure)action.clone()
-        clone.delegate = NF.binding.variables
-        clone.resolveStrategy = Closure.DELEGATE_FIRST
-
-        onCompleteActions.add(clone)
+        onCompleteActions.add(action)
     }
 
     /**
@@ -335,12 +330,7 @@ class WorkflowMetadata {
      * @param action
      */
     void onError( Closure action ) {
-
-        final clone = (Closure)action.clone()
-        clone.delegate = NF.binding.variables
-        clone.resolveStrategy = Closure.DELEGATE_FIRST
-
-        onErrorActions.add(clone)
+        onErrorActions.add(action)
     }
 
     /**


### PR DESCRIPTION
Close #5261 

Tested with this script:
```groovy
workflow {
    params.outdir = 'results'

    def local = 'local'

    workflow.onComplete {
        if( workflow.success )
            log.info "Success! View results: $params.outdir"
        else
            log.info "Failure!"

        log.info "local variable: ${local}"
    }
}
```

The problem is that this change breaks the WorkflowMetadata unit tests. But these unit tests do not accurately represent how the onComplete/onError is defined

I could rewrite the unit tests to print to stdout and try to capture the stdout. But these tests probably just need to be e2e tests in order to test the actual script context