### PR TITLE
Include rateLimit to the Channel.fromSRA factory

### DIFF
--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -318,6 +318,9 @@ Available options:
 `protocol`
 : Allow choosing the protocol for the resulting remote URLs. Available choices: `ftp`, `http`, `https` (default: `ftp`).
 
+`rateLimit`
+: Determines the maximum rate of NCBI SRA request per time unit, for example `'10sec'` (10 request per second) or `'50/2min'` (50 requests every 2 minutes) (default: unlimited).
+
 (channel-interval)=
 
 ## interval

--- a/modules/nextflow/src/main/groovy/nextflow/util/RateLimiterHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/RateLimiterHelper.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.util
+
+import com.google.common.util.concurrent.RateLimiter
+import groovy.transform.CompileStatic
+
+
+@CompileStatic
+class RateLimiterHelper {
+
+    private static String RATE_FORMAT = ~/^(\d+\.?\d*)\s*([a-zA-Z]*)/
+
+    static RateLimiter createRateLimit(String limit) {
+
+        def tokens = limit.tokenize('/')
+        if( tokens.size() == 2 ) {
+            /*
+             * the rate limit is provide num of task over a duration
+             * - eg. 100 / 5 min
+             * - ie. max 100 task per 5 minutes
+             */
+
+            final X = tokens[0].trim()
+            final Y = tokens[1].trim()
+
+            return newRateLimiter(X, Y, limit)
+        }
+
+        /*
+         * the rate limit is provide as a duration
+         * - eg. 200 min
+         * - ie. max 200 task per minutes
+         */
+
+        final matcher = (limit =~ RATE_FORMAT)
+        if( !matcher.matches() )
+            throw new IllegalArgumentException("Invalid submit-rate-limit value: $limit -- It must be provide using the following format `num request sec|min|hour` eg. 10 sec ie. max 10 tasks per second")
+
+        final num = matcher.group(1) ?: '_'
+        final unit = matcher.group(2) ?: 'sec'
+
+        return newRateLimiter(num, "1 $unit", limit)
+    }
+
+    private static RateLimiter newRateLimiter( String X, String Y, String limit ) {
+        if( !X.isInteger() )
+            throw new IllegalArgumentException("Invalid submit-rate-limit value: $limit -- It must be provided using the following format `num request / duration` eg. 10/1s")
+
+        final num = Integer.parseInt(X)
+        final duration = Y.isInteger() ? Duration.of( Y+'sec' ) : ( Y[0].isInteger() ? Duration.of(Y) : Duration.of('1'+Y) )
+        long seconds = duration.toSeconds()
+        if( !seconds )
+            throw new IllegalArgumentException("Invalid submit-rate-limit value: $limit -- The interval must be at least 1 second")
+
+        return RateLimiter.create( num / seconds as double )
+    }
+}

--- a/modules/nextflow/src/test/groovy/nextflow/util/RateLimiterHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/RateLimiterHelperTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.util
+
+import spock.lang.Specification
+
+/**
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+class RateLimiterHelperTest extends Specification {
+
+    def 'should create a rate limiter for the given rate format'() {
+
+        when:
+        def limit = RateLimiterHelper.createRateLimit(RATE)
+        then:
+        limit ? Math.round(limit.getRate()) : null == EXPECTED
+
+        where:
+        RATE            | EXPECTED
+        '1'             | 1                         // 1 per second
+        '5'             | 5                         // 5 per second
+        '100 min'       | 100 / 60                  // 100 per minute
+        '100 / 1 s'     | 100                       // 100 per second
+        '100 / 2 s'     | 50                        // 100 per 2 seconds
+        '200 / sec'     | 200                       // 200 per second
+        '600 / 5'       | 600i / 5l as double       // 600 per 5 seconds
+        '600 / 5min'    | 600 / (5 * 60)            // 600 per 5 minutes
+
+    }
+}


### PR DESCRIPTION
- Include a rateLimit option for Channel.fromSRA with the same semantics that submitRateLimit in the executor
- Move code for managing rateLimits from TaskPollMonitoring to RateLimiterHelper to avoid repeating code.
- Add RateLimiter to SRA Explorer.
- Include new Channel.fromSRA rateLimit option in documentation
- Include test for RateLimiterHelper and SRAExplorer
