### PR TITLE
Exposing trace record meta info in the task context

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1290,7 +1290,7 @@ Similarly to the previous scenario, task resources can be also updated according
 
 ```groovy
 process foo {
-    memory { (trace != null) ? trace.memory * 2 : (1.GB) }
+    memory { task.attempt > 1 ? trace.memory * 2 : (1.GB) }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1284,13 +1284,13 @@ If the task execution fail reporting an exit status in the range between 137 and
 The directive {ref}`process-maxretries` set the maximum number of time the same task can be re-executed.
 
 ### Dynamic task resources with previous execution trace
-:::{versionadded} 24.09.1-edge
+:::{versionadded} 24.09.2-edge
 :::
-Similarly to the previous scenario, task resources can be also updated according to the metrics included in the {ref}`trace record <trace-report>` of the previous task attempt. The metrics can be accessed through the `trace` variable. For example:
+Similarly to the previous scenario, task resources can be also updated according to the metrics included in the {ref}`trace record <trace-report>` of the previous task attempt. The metrics can be accessed through the `task.previousTrace` variable. For example:
 
 ```groovy
 process foo {
-    memory { task.attempt > 1 ? trace.memory * 2 : (1.GB) }
+    memory { task.attempt > 1 ? task.previousTrace.memory * 2 : (1.GB) }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1286,6 +1286,7 @@ The directive {ref}`process-maxretries` set the maximum number of time the same 
 ### Dynamic task resources with previous execution trace
 :::{versionadded} 24.09.2-edge
 :::
+
 Similarly to the previous scenario, task resources can be also updated according to the metrics included in the {ref}`trace record <trace-report>` of the previous task attempt. The metrics can be accessed through the `task.previousTrace` variable. For example:
 
 ```groovy

--- a/docs/process.md
+++ b/docs/process.md
@@ -1290,7 +1290,7 @@ Similarly to the previous scenario, task resources can be also updated according
 
 ```groovy
 process foo {
-    memory { task.attempt > 1 ? task.previousTrace.memory * 2 : (1.GB) }
+    memory { (task.attempt > 1) ? task.previousTrace.memory * 2 : (1.GB) }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1291,7 +1291,7 @@ Similarly to the previous scenario, task resources can be also updated according
 
 ```groovy
 process foo {
-    memory { (task.attempt > 1) ? task.previousTrace.memory * 2 : (1.GB) }
+    memory { task.attempt > 1 ? task.previousTrace.memory * 2 : (1.GB) }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -1299,7 +1299,7 @@ process foo {
     <your job here>
 }
 ```
-In the above example the {ref}`process-memory` is set according to previous trace record metrics. In the first attempt, when no trace metrics are available, it is set to one GB, while in the other attempts it is doubling the previously allocated memory. The available metrics in the trace record can be found in the {ref}`Trace Report section <trace-report>`.
+In the above example, the {ref}`process-memory` is set according to previous trace record metrics. In the first attempt, when no trace metrics are available, it is set to one GB. In the subsequent attempts, it doubles the previously allocated memory. See {ref}`trace-report` for more information about trace records.
 
 
 ### Dynamic retry with backoff

--- a/docs/process.md
+++ b/docs/process.md
@@ -1283,6 +1283,24 @@ If the task execution fail reporting an exit status in the range between 137 and
 
 The directive {ref}`process-maxretries` set the maximum number of time the same task can be re-executed.
 
+### Dynamic task resources with previous execution trace
+:::{versionadded} 24.09.1-edge
+:::
+Similarly to the previous scenario, task resources can be also updated according to the metrics included in the {ref}`trace record <trace-report>` of the previous task attempt. The metrics can be accessed through the `trace` variable. For example:
+
+```groovy
+process foo {
+    memory { (trace != null) ? trace.memory * 2 : (1.GB) }
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    script:
+    <your job here>
+}
+```
+In the above example the {ref}`process-memory` is set according to previous trace record metrics. In the first attempt, when no trace metrics are available, it is set to one GB, while in the other attempts it is doubling the previously allocated memory. The available metrics in the trace record can be found in the {ref}`Trace Report section <trace-report>`.
+
+
 ### Dynamic retry with backoff
 
 There are cases in which the required execution resources may be temporary unavailable e.g. network congestion. In these cases immediately re-executing the task will likely result in the identical error. A retry with an exponential backoff delay can better recover these error conditions:

--- a/docs/process.md
+++ b/docs/process.md
@@ -1287,7 +1287,7 @@ The directive {ref}`process-maxretries` set the maximum number of time the same 
 :::{versionadded} 24.10.0
 :::
 
-Similarly to the previous scenario, task resources can be also updated according to the metrics included in the {ref}`trace record <trace-report>` of the previous task attempt. The metrics can be accessed through the `task.previousTrace` variable. For example:
+Task resource requests can be updated relative to the {ref}`trace record <trace-report>` metrics of the previous task attempt. The metrics can be accessed through the `task.previousTrace` variable. For example:
 
 ```groovy
 process foo {

--- a/docs/process.md
+++ b/docs/process.md
@@ -1284,7 +1284,7 @@ If the task execution fail reporting an exit status in the range between 137 and
 The directive {ref}`process-maxretries` set the maximum number of time the same task can be re-executed.
 
 ### Dynamic task resources with previous execution trace
-:::{versionadded} 24.09.2-edge
+:::{versionadded} 24.10.0
 :::
 
 Similarly to the previous scenario, task resources can be also updated according to the metrics included in the {ref}`trace record <trace-report>` of the previous task attempt. The metrics can be accessed through the `task.previousTrace` variable. For example:

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -27,13 +27,13 @@ The following task properties are defined in the process body:
 : The current task name.
 
 `task.previousError`
-:::{versionadded} 24.09.2-edge
+: :::{versionadded} 24.09.2-edge
 :::
 : The error message of the task execution.
 : Since the error message is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
 
 `task.previousTrace`
-:::{versionadded} 24.09.2-edge
+: :::{versionadded} 24.09.2-edge
 :::
 : The trace record of the task execution.
 : Since the trace record is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1. 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -26,6 +26,12 @@ The following task properties are defined in the process body:
 : *Available only in `exec:` blocks*
 : The current task name.
 
+`task.previousTrace`
+:::{versionadded} 24.09.2-edge
+:::
+: The trace record of the task execution. 
+: Since the trace record is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1. 
+
 `task.process`
 : The current process name.
 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -26,10 +26,16 @@ The following task properties are defined in the process body:
 : *Available only in `exec:` blocks*
 : The current task name.
 
+`task.previousError`
+:::{versionadded} 24.09.2-edge
+:::
+: The error message of the task execution.
+: Since the error message is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
+
 `task.previousTrace`
 :::{versionadded} 24.09.2-edge
 :::
-: The trace record of the task execution. 
+: The trace record of the task execution.
 : Since the trace record is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1. 
 
 `task.process`

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -28,13 +28,13 @@ The following task properties are defined in the process body:
 
 `task.previousError`
 : :::{versionadded} 24.09.2-edge
-:::
+  :::
 : The error message of the task execution.
 : Since the error message is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
 
 `task.previousTrace`
 : :::{versionadded} 24.09.2-edge
-:::
+  :::
 : The trace record of the task execution.
 : Since the trace record is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1. 
 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -33,7 +33,7 @@ The following task properties are defined in the process body:
 : Since the error message is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
 
 `task.previousTrace`
-: :::{versionadded} 24.09.2-edge
+: :::{versionadded} 24.10.0
   :::
 : The trace record of the task execution.
 : Since the trace record is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1. 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -27,7 +27,7 @@ The following task properties are defined in the process body:
 : The current task name.
 
 `task.previousError`
-: :::{versionadded} 24.09.2-edge
+: :::{versionadded} 24.10.0
   :::
 : The error message of the task execution.
 : Since the error message is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -29,14 +29,16 @@ The following task properties are defined in the process body:
 `task.previousException`
 : :::{versionadded} 24.10.0
   :::
-: The task execution of previous execution.
-: Since the exception is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
+: The exception reported by the previous task attempt.
+: Since the exception is only available after a failed task execution, it can only be used when `task.attempt` is greater than 1.
 
 `task.previousTrace`
 : :::{versionadded} 24.10.0
   :::
-: The trace record of the task execution.
-: Since the trace record is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1. 
+: The trace record associated with the previous task attempt. Since the trace record is only available after the task
+  has been executed, it can only be accessed when retrying a failed task execution, and therefore when `task.attempt`
+  is greater than 1.
+: This is useful when retrying a task execution to access the previous task attempt runtime metrics e.g. used memory and CPUs.
 
 `task.process`
 : The current process name.

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -30,14 +30,15 @@ The following task properties are defined in the process body:
 : :::{versionadded} 24.10.0
   :::
 : The exception reported by the previous task attempt.
-: Since the exception is only available after a failed task execution, it can only be used when `task.attempt` is greater than 1.
+: Since the exception is available after a failed task attempt,
+  it can only be accessed when retrying a failed task execution, and therefore when `task.attempt` is greater than 1.
 
 `task.previousTrace`
 : :::{versionadded} 24.10.0
   :::
-: The trace record associated with the previous task attempt. Since the trace record is only available after the task
-  has been executed, it can only be accessed when retrying a failed task execution, and therefore when `task.attempt`
-  is greater than 1.
+: The trace record associated with the previous task attempt.
+: Since the trace record is available after a failed task attempt,
+  it can only be accessed when retrying a failed task execution, and therefore when `task.attempt` is greater than 1.
 : This is useful when retrying a task execution to access the previous task attempt runtime metrics e.g. used memory and CPUs.
 
 `task.process`

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -26,11 +26,11 @@ The following task properties are defined in the process body:
 : *Available only in `exec:` blocks*
 : The current task name.
 
-`task.previousError`
+`task.previousException`
 : :::{versionadded} 24.10.0
   :::
-: The error message of the task execution.
-: Since the error message is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
+: The task execution of previous execution.
+: Since the exception is only available after the task has been executed, it can only be used when `task.attempt` is bigger than 1.
 
 `task.previousTrace`
 : :::{versionadded} 24.10.0

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.processor
 
+import static nextflow.processor.TaskProcessor.TRACE_PROPERTY_NAME
+
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -617,6 +619,8 @@ class TaskPollingMonitor implements TaskMonitor {
             if (evict(handler)) { 
                 handler.decProcessForks()
             }
+            //Add trace of the previous execution in the task context for next execution
+            handler.task.config.put(TRACE_PROPERTY_NAME, handler.getTraceRecord())
             fault = handler.task.processor.resumeOrDie(handler?.task, error)
             log.trace "Task fault (1): $fault"
         }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -16,7 +16,7 @@
 
 package nextflow.processor
 
-import static nextflow.processor.TaskProcessor.TRACE_PROPERTY_NAME
+import static nextflow.processor.TaskProcessor.*
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
@@ -621,6 +621,7 @@ class TaskPollingMonitor implements TaskMonitor {
             }
             //Add trace of the previous execution in the task context for next execution
             handler.task.config.put(TRACE_PROPERTY_NAME, handler.getTraceRecord())
+            handler.task.config.put(ERROR_PROPERTY_NAME, error.getMessage())
             fault = handler.task.processor.resumeOrDie(handler?.task, error)
             log.trace "Task fault (1): $fault"
         }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -683,7 +683,7 @@ class TaskPollingMonitor implements TaskMonitor {
 
     protected void finalizeTask( TaskHandler handler ) {
         // finalize the task execution
-        final fault = handler.task.processor.finalizeTask(handler.task)
+        final fault = handler.task.processor.finalizeTask(handler)
 
         // notify task completion
         session.notifyTaskComplete(handler)

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -619,10 +619,7 @@ class TaskPollingMonitor implements TaskMonitor {
             if (evict(handler)) { 
                 handler.decProcessForks()
             }
-            //Add trace of the previous execution in the task context for next execution
-            handler.task.config.put(TRACE_PROPERTY_NAME, handler.getTraceRecord())
-            handler.task.config.put(ERROR_PROPERTY_NAME, error.getMessage())
-            fault = handler.task.processor.resumeOrDie(handler?.task, error)
+            fault = handler.task.processor.resumeOrDie(handler?.task, error, handler.getTraceRecord())
             log.trace "Task fault (1): $fault"
         }
         finally {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -137,6 +137,8 @@ class TaskProcessor {
 
     static final public String TRACE_PROPERTY_NAME = 'previousTrace'
 
+    static final public String ERROR_PROPERTY_NAME = 'previousError'
+
     final private static Pattern ENV_VAR_NAME = ~/[a-zA-Z_]+[a-zA-Z0-9_]*/
 
     final private static Pattern QUESTION_MARK = ~/(\?+)/
@@ -2390,8 +2392,9 @@ class TaskProcessor {
             collectOutputs(task)
         }
         catch ( Throwable error ) {
-            //Add trace of the previous execution in the task context for next execution
+            //Add trace and error message of the previous execution in the task context for next execution
             task.config.put(TRACE_PROPERTY_NAME, handler.getTraceRecord())
+            task.config.put(ERROR_PROPERTY_NAME, error.getMessage())
             fault = resumeOrDie(task, error)
             log.trace "Task fault (3): $fault"
         }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -135,6 +135,8 @@ class TaskProcessor {
 
     static final public String TASK_CONTEXT_PROPERTY_NAME = 'task'
 
+    static final public String TRACE_PROPERTY_NAME = 'previousTrace'
+
     final private static Pattern ENV_VAR_NAME = ~/[a-zA-Z_]+[a-zA-Z0-9_]*/
 
     final private static Pattern QUESTION_MARK = ~/(\?+)/
@@ -2388,8 +2390,8 @@ class TaskProcessor {
             collectOutputs(task)
         }
         catch ( Throwable error ) {
-            def trace = handler.getTraceRecord()
-            task.context.put('trace', trace)
+            //Add trace of the previous execution in the task context for next execution
+            task.config.put(TRACE_PROPERTY_NAME, handler.getTraceRecord())
             fault = resumeOrDie(task, error)
             log.trace "Task fault (3): $fault"
         }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1066,7 +1066,7 @@ class TaskProcessor {
                 //Add trace of the previous execution in the task context for next execution
                 if ( traceRecord )
                     task.config.previousTrace = traceRecord
-                task.config.previousError = error.getMessage()
+                task.config.previousException = error
 
                 errorStrategy = checkErrorStrategy(task, error, taskErrCount, procErrCount, submitRetries)
                 if( errorStrategy.soft ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1042,7 +1042,6 @@ class TaskProcessor {
                 session.getExecService().submit {
                     try {
                         taskCopy.runType = RunType.RETRY
-
                         checkCachedOrLaunchTask( taskCopy, taskCopy.hash, false )
                     }
                     catch( Throwable e ) {

--- a/modules/nextflow/src/testFixtures/groovy/test/MockHelpers.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/MockHelpers.groovy
@@ -175,7 +175,7 @@ class MockTaskHandler extends TaskHandler {
             task.code.call()
         }
         status = TaskStatus.COMPLETED
-        task.processor.finalizeTask(task)
+        task.processor.finalizeTask(this)
     }
 
     @Override

--- a/tests/checks/trace-access.nf/.checks
+++ b/tests/checks/trace-access.nf/.checks
@@ -6,6 +6,6 @@ $NXF_RUN | tee stdout
 [[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > foo'` == 1 ]] || false
 [[ `grep 'INFO' .nextflow.log | grep -c 'Re-submitted process > foo'` == 3 ]] || false
 
-[[ `grep -c 'mem: 8 GB (previous: 4294967296)' stdout` == 1 ]] || false
+[[ `grep -c 'mem: 8 GB (previous: 4294967296) (error: Process .* terminated with an error exit status (137))' stdout` == 1 ]] || false
 
 

--- a/tests/checks/trace-access.nf/.checks
+++ b/tests/checks/trace-access.nf/.checks
@@ -6,6 +6,6 @@ $NXF_RUN | tee stdout
 [[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > foo'` == 1 ]] || false
 [[ `grep 'INFO' .nextflow.log | grep -c 'Re-submitted process > foo'` == 3 ]] || false
 
-[[ `grep -c 'mem: 8 GB' stdout` == 1 ]] || false
+[[ `grep -c 'mem: 8 GB (previous: 4294967296)' stdout` == 1 ]] || false
 
 

--- a/tests/checks/trace-access.nf/.checks
+++ b/tests/checks/trace-access.nf/.checks
@@ -6,6 +6,6 @@ $NXF_RUN | tee stdout
 [[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > foo'` == 1 ]] || false
 [[ `grep 'INFO' .nextflow.log | grep -c 'Re-submitted process > foo'` == 3 ]] || false
 
-[[ `grep -c 'mem: 8 GB (previous: 4294967296) (error: Process .* terminated with an error exit status (137))' stdout` == 1 ]] || false
+[[ `grep -c 'mem: 8 GB (previous: 4294967296) (error: nextflow.exception.ProcessFailedException: Process .* terminated with an error exit status (137))' stdout` == 1 ]] || false
 
 

--- a/tests/checks/trace-access.nf/.checks
+++ b/tests/checks/trace-access.nf/.checks
@@ -1,0 +1,11 @@
+set -e
+
+echo ''
+$NXF_RUN | tee stdout
+
+[[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > foo'` == 1 ]] || false
+[[ `grep 'INFO' .nextflow.log | grep -c 'Re-submitted process > foo'` == 3 ]] || false
+
+[[ `grep -c 'mem: 8 GB' stdout` == 1 ]] || false
+
+

--- a/tests/trace-access.nf
+++ b/tests/trace-access.nf
@@ -1,5 +1,5 @@
 process foo {
-  memory { (trace != null) ? trace.memory * 2 : (1.GB) }
+  memory { (task.attempt > 1) ? task.previousTrace.memory * 2 : (1.GB) }
   errorStrategy 'retry'
   maxRetries 3
   input:
@@ -9,12 +9,11 @@ process foo {
   script:
   if( task.attempt <= 3 ){
   """
-  echo mem: $task.memory
   exit 137
   """
   } else {
   """
-  echo mem: $task.memory
+  echo mem: $task.memory (previous: $task.previousTrace.memory)
   exit 0
   """
   }

--- a/tests/trace-access.nf
+++ b/tests/trace-access.nf
@@ -1,5 +1,5 @@
 process foo {
-  memory { (task.attempt > 1) ? task.previousTrace.memory * 2 : (1.GB) }
+  memory { task.attempt > 1 ? task.previousTrace.memory * 2 : (1.GB) }
   errorStrategy 'retry'
   maxRetries 3
   input:
@@ -13,7 +13,7 @@ process foo {
   """
   } else {
   """
-  echo mem: $task.memory (previous: $task.previousTrace.memory)
+  echo 'mem: $task.memory (previous: $task.previousTrace.memory) (error: $task.previousError)'
   exit 0
   """
   }

--- a/tests/trace-access.nf
+++ b/tests/trace-access.nf
@@ -13,7 +13,7 @@ process foo {
   """
   } else {
   """
-  echo 'mem: $task.memory (previous: $task.previousTrace.memory) (error: $task.previousError)'
+  echo 'mem: $task.memory (previous: $task.previousTrace.memory) (error: $task.previousException)'
   exit 0
   """
   }

--- a/tests/trace-access.nf
+++ b/tests/trace-access.nf
@@ -1,0 +1,25 @@
+process foo {
+  memory { (trace != null) ? trace.memory * 2 : (1.GB) }
+  errorStrategy 'retry'
+  maxRetries 3
+  input:
+     val i
+  output:
+     stdout
+  script:
+  if( task.attempt <= 3 ){
+  """
+  echo mem: $task.memory
+  exit 137
+  """
+  } else {
+  """
+  echo mem: $task.memory
+  exit 0
+  """
+  }
+}
+
+workflow {
+  foo(channel.of(1)).view() 
+}


### PR DESCRIPTION
When retry trace record is generated and included in the task context with variable `trace`

In the first attempt, trace is null. I tried to set a partial trace record for the first attempt generating the trace record just after the creation of the TaskHandler. But the evaluation of the directives is executed before the generation of the first TaskHandler at executor.submit. So, the value was null. One alternative, could be to move the generation of the trace record to the TaskRun but it implies to move some data such as the status, start and stop time in the TaskRun.

Included a suggestion for documentation