### PR TITLE
Allow http file to be closed early

### DIFF
--- a/modules/nf-commons/src/main/nextflow/file/CopyMoveHelper.java
+++ b/modules/nf-commons/src/main/nextflow/file/CopyMoveHelper.java
@@ -41,6 +41,10 @@ import org.slf4j.LoggerFactory;
  * Helper class to handle copy/move files and directories
  */
 public class CopyMoveHelper {
+    /**
+     * True if currently performing a copy of a foreign file.
+     */
+    public static final ThreadLocal<Boolean> IN_FOREIGN_COPY = new ThreadLocal<>();
 
     private static Logger log = LoggerFactory.getLogger(CopyMoveHelper.class);
 
@@ -81,14 +85,16 @@ public class CopyMoveHelper {
     private static void copyFile(Path source, Path target, boolean foreign, CopyOption... options)
             throws IOException
     {
-
         if( !foreign ) {
             source.getFileSystem().provider().copy(source, target, options);
             return;
         }
 
+        IN_FOREIGN_COPY.set(true);
         try (InputStream in = Files.newInputStream(source)) {
             Files.copy(in, target);
+        } finally {
+            IN_FOREIGN_COPY.set(false);
         }
     }
 

--- a/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.file.http
 
+import nextflow.file.CopyMoveHelper
+
 import static nextflow.file.http.XFileSystemConfig.*
 
 import java.nio.ByteBuffer
@@ -352,7 +354,8 @@ abstract class XFileSystemProvider extends FileSystemProvider {
 
         final conn = toConnection(path)
         final length = conn.getContentLengthLong()
-        return length>0
+        // only apply the FixedInputStream check if staging files
+        return length>0 && CopyMoveHelper.IN_FOREIGN_COPY.get()
             ? new FixedInputStream(conn.getInputStream(), length)
             : conn.getInputStream()
     }


### PR DESCRIPTION
Proof of concept for #5360 

This uses Java's [OpenOption](https://docs.oracle.com/javase/8/docs/api/java/nio/file/OpenOption.html) mechanism to pass a configuration param to the `XFileSystemProvider`, allowing a script to declare that it doesn't care if the input stream is closed before being fully read:

```groovy
import nextflow.file.http.HttpOpenOption

def firstLine(path) {
    path.withInputStream(HttpOpenOption.ALLOW_EARLY_CLOSE) {
        def r = new BufferedReader(new InputStreamReader(it))
        return r.readLine()
    }
}
```

This approach is quite flexible and generic, since it would also allow other `OpenOptions` to be passed to other `FileSystemProviders`, and as a result might be a little in conflict with the formalisation of a nextflow script syntax. An alternative could be to add a single-purpose method to `XPath`, eg:

```groovy
InputStream newLenientInputStream() {
   ...
}
```