### PR TITLE
Remove invalid equals char

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/AbstractGridExecutor.groovy
@@ -41,7 +41,7 @@ abstract class AbstractGridExecutor extends Executor {
 
     protected Duration queueInterval
 
-    private final static List<String> INVALID_NAME_CHARS = [ " ", "/", ":", "@", "*", "?", "\\n", "\\t", "\\r" ]
+    private final static List<String> INVALID_NAME_CHARS = [ " ", "/", ":", "@", "*", "?", "\\n", "\\t", "\\r", "=" ]
 
     private Map lastQueueStatus
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/AbstractGridExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/AbstractGridExecutorTest.groovy
@@ -32,11 +32,11 @@ class AbstractGridExecutorTest extends Specification {
     def 'should remove invalid chars from name' () {
 
         given:
-        def task = new TaskRun(name: 'task 90 (foo:bar/baz)')
+        def task = new TaskRun(name: 'task 90 = (foo:bar/baz)')
         def exec = [:] as AbstractGridExecutor
 
         expect:
-        exec.getJobNameFor(task) == 'nf-task_90_(foo_bar_baz)'
+        exec.getJobNameFor(task) == 'nf-task_90___(foo_bar_baz)'
 
     }
 


### PR DESCRIPTION
The equals character from nf-core modules/local/hicpro/dnase_mapping_stats.nf causes pipeline to crash on SGE executor.

Add "=" to list of invalid chars