### PR TITLE
Document `subscribe` as a teminal operator

### DIFF
--- a/docs/reference/operator.md
+++ b/docs/reference/operator.md
@@ -1426,7 +1426,7 @@ The `subscribe` operator supports multiple types of event handlers:
 ```
 
 :::{note}
-Unlike most operators, `subscribe` does not emit any values -- it is a *terminal operator*. Instead, `subscribe` should be used only for *side effects* such as printing to the console, writing to a file, or making HTTP requests.
+Unlike most operators, `subscribe` is a *terminal operator* and does not emit any values. It should only be used for *side effects*, such as printing to the console, writing to a file, or making HTTP requests.
 :::
 
 Available options:

--- a/docs/reference/operator.md
+++ b/docs/reference/operator.md
@@ -1393,7 +1393,7 @@ See also: [countLines](#countlines)
 
 ## subscribe
 
-*Returns: the source channel*
+*Returns: nothing*
 
 The `subscribe` operator invokes a custom function for each item from a source channel:
 
@@ -1424,6 +1424,10 @@ The `subscribe` operator supports multiple types of event handlers:
 ```{literalinclude} ../snippets/subscribe-with-on-complete.out
 :language: console
 ```
+
+:::{note}
+Unlike most operators, `subscribe` does not emit any values -- it is a *terminal operator*. Instead, `subscribe` should be used only for *side effects* such as printing to the console, writing to a file, or making HTTP requests.
+:::
 
 Available options:
 


### PR DESCRIPTION
Close #5354 

Clarify that `subscribe` should be used only as a terminal operator.

We could also update the `subscribe()` API to return `void`, but that could break some existing pipeline. On the other hand, from the issue it sounds like it already causes the pipeline to hang, so perhaps it would be better to change the API so that there is a runtime error.

Doesn't matter much to me because I have plans for a "v2" operator library anyway