### PR TITLE
Use `conda-forge` and `bioconda` channels by default

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaConfig.groovy
@@ -49,7 +49,7 @@ class CondaConfig extends LinkedHashMap {
     List<String> getChannels() {
         final value = get('channels')
         if( !value ) {
-            return Collections.<String>emptyList()
+            return ['conda-forge','bioconda']
         }
         if( value instanceof List ) {
             return value


### PR DESCRIPTION
If `conda.channels` is not specified, set it to `conda-forge`,`bioconda` by default.

Quick edit, haven't adjusted tests or anything here, just wanted to raise for discussion.