### PR TITLE
Make Nextflow compatible with NixOS (or other systems without `/bin/bash`)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -63,7 +63,11 @@ class BashWrapperBuilder {
 
     static final private ENDL = '\n'
 
+    static final private String LOCAL_BASH_BINARY = "which bash".execute().text.strip()
+
     static final public List<String> BASH
+
+    static final public List<String> HOST_BASH
 
     static private int level
 
@@ -85,6 +89,7 @@ class BashWrapperBuilder {
             log.warn "Invalid value for `NXF_DEBUG` variable: $str -- See http://www.nextflow.io/docs/latest/config.html#environment-variables"
         }
         BASH = Collections.unmodifiableList( level > 0 ? ['/bin/bash','-uex'] : ['/bin/bash','-ue'] )
+        HOST_BASH = Collections.unmodifiableList([LOCAL_BASH_BINARY, BASH[1]])
 
     }
 
@@ -292,7 +297,8 @@ class BashWrapperBuilder {
         /*
          * fetch the script interpreter i.e. BASH, Perl, Python, etc
          */
-        final interpreter = TaskProcessor.fetchInterpreter(script)
+        String interpreter = TaskProcessor.fetchInterpreter(script)
+        interpreter = containerBuilder ? interpreter : interpreter.replace('/bin/bash', LOCAL_BASH_BINARY)
 
         /*
          * append to the command script a prolog to capture the declared
@@ -571,7 +577,7 @@ class BashWrapperBuilder {
         final traceWrapper = isTraceRequired()
         if( traceWrapper ) {
             // executes the stub which in turn executes the target command
-            launcher = "/bin/bash ${fileStr(wrapperFile)} nxf_trace"
+            launcher = "${interpreter} ${fileStr(wrapperFile)} nxf_trace"
         }
         else {
             launcher = "${interpreter} ${fileStr(scriptFile)}"

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -575,7 +575,8 @@ class BashWrapperBuilder {
         final traceWrapper = isTraceRequired()
         if( traceWrapper ) {
             // executes the stub which in turn executes the target command
-            launcher = "/usr/bin/env -S bash ${fileStr(wrapperFile)} nxf_trace"
+            String traceInterpreter = runWithContainer ? "/bin/bash" : "/usr/bin/env bash"
+            launcher = "${traceInterpreter} ${fileStr(wrapperFile)} nxf_trace"
         }
         else {
             launcher = "${interpreter} ${fileStr(scriptFile)}"

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -295,8 +295,7 @@ class BashWrapperBuilder {
         /*
          * fetch the script interpreter i.e. BASH, Perl, Python, etc
          */
-        String fetchedInterpreter = TaskProcessor.fetchInterpreter(script)
-        final interpreter = runWithContainer ? fetchedInterpreter : fetchedInterpreter.replace('/bin/bash', '/usr/bin/env -S bash')
+        final interpreter = TaskProcessor.fetchInterpreter(script)
 
         /*
          * append to the command script a prolog to capture the declared

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -63,11 +63,9 @@ class BashWrapperBuilder {
 
     static final private ENDL = '\n'
 
-    static final private String LOCAL_BASH_BINARY = "which bash".execute().text.strip()
-
     static final public List<String> BASH
 
-    static final public List<String> HOST_BASH
+    static final public List<String> ENV_BASH
 
     static private int level
 
@@ -89,7 +87,7 @@ class BashWrapperBuilder {
             log.warn "Invalid value for `NXF_DEBUG` variable: $str -- See http://www.nextflow.io/docs/latest/config.html#environment-variables"
         }
         BASH = Collections.unmodifiableList( level > 0 ? ['/bin/bash','-uex'] : ['/bin/bash','-ue'] )
-        HOST_BASH = Collections.unmodifiableList([LOCAL_BASH_BINARY, BASH[1]])
+        ENV_BASH = Collections.unmodifiableList(['/usr/bin/env', '-S', 'bash', BASH[1]])
 
     }
 
@@ -297,8 +295,8 @@ class BashWrapperBuilder {
         /*
          * fetch the script interpreter i.e. BASH, Perl, Python, etc
          */
-        String interpreter = TaskProcessor.fetchInterpreter(script)
-        interpreter = containerBuilder ? interpreter : interpreter.replace('/bin/bash', LOCAL_BASH_BINARY)
+        String fetchedInterpreter = TaskProcessor.fetchInterpreter(script)
+        final interpreter = containerBuilder ? fetchedInterpreter : fetchedInterpreter.replace('/bin/bash', '/usr/bin/env -S bash')
 
         /*
          * append to the command script a prolog to capture the declared
@@ -577,7 +575,7 @@ class BashWrapperBuilder {
         final traceWrapper = isTraceRequired()
         if( traceWrapper ) {
             // executes the stub which in turn executes the target command
-            launcher = "${interpreter} ${fileStr(wrapperFile)} nxf_trace"
+            launcher = "/usr/bin/env -S bash ${fileStr(wrapperFile)} nxf_trace"
         }
         else {
             launcher = "${interpreter} ${fileStr(scriptFile)}"

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -296,7 +296,7 @@ class BashWrapperBuilder {
          * fetch the script interpreter i.e. BASH, Perl, Python, etc
          */
         String fetchedInterpreter = TaskProcessor.fetchInterpreter(script)
-        final interpreter = containerBuilder ? fetchedInterpreter : fetchedInterpreter.replace('/bin/bash', '/usr/bin/env -S bash')
+        final interpreter = runWithContainer ? fetchedInterpreter : fetchedInterpreter.replace('/bin/bash', '/usr/bin/env -S bash')
 
         /*
          * append to the command script a prolog to capture the declared

--- a/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
@@ -131,7 +131,7 @@ class LocalTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     protected ProcessBuilder localProcessBuilder() {
-        final cmd = new ArrayList<String>(BashWrapperBuilder.HOST_BASH) << wrapperFile.getName()
+        final cmd = new ArrayList<String>(BashWrapperBuilder.ENV_BASH) << wrapperFile.getName()
         log.debug "Launch cmd line: ${cmd.join(' ')}"
         // make sure it's a posix file system
         if( task.workDir.fileSystem != FileSystems.default )

--- a/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
@@ -131,7 +131,7 @@ class LocalTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     protected ProcessBuilder localProcessBuilder() {
-        final cmd = new ArrayList<String>(BashWrapperBuilder.BASH) << wrapperFile.getName()
+        final cmd = new ArrayList<String>(BashWrapperBuilder.HOST_BASH) << wrapperFile.getName()
         log.debug "Launch cmd line: ${cmd.join(' ')}"
         // make sure it's a posix file system
         if( task.workDir.fileSystem != FileSystems.default )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -133,7 +133,7 @@ class TaskBean implements Serializable, Cloneable {
         this.condaEnv = task.getCondaEnv()
         this.spackEnv = task.getSpackEnv()
         this.moduleNames = task.config.getModule()
-        this.shell = task.config.getShell() ?: BashWrapperBuilder.BASH
+        this.shell = task.config.getShell(task.isContainerEnabled()) ?: BashWrapperBuilder.BASH
         this.script = task.getScript()
         this.beforeScript = task.config.getBeforeScript()
         this.afterScript = task.config.getAfterScript()

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -375,10 +375,10 @@ class TaskConfig extends LazyMap implements Cloneable {
         return (List<String>) get('secret')
     }
 
-    List<String> getShell() {
+    List<String> getShell(boolean isContainerEnabled = true) {
         final value = get('shell')
         if( !value )
-            return BashWrapperBuilder.BASH
+            return isContainerEnabled ? BashWrapperBuilder.BASH : BashWrapperBuilder.ENV_BASH
 
         if( value instanceof List )
             return (List)value

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -125,7 +125,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
     static final Map<String,Object> DEFAULT_CONFIG = [
             debug: false,
             cacheable: true,
-            shell: BashWrapperBuilder.BASH,
             maxRetries: 0,
             maxErrors: -1,
             errorStrategy: ErrorStrategy.TERMINATE
@@ -174,14 +173,15 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
      *
      * @param script The owner {@code BaseScript} configuration object
      */
-    protected ProcessConfig( BaseScript script ) {
+    protected ProcessConfig( BaseScript script, boolean isContainerEnabled = true) {
         ownerScript = script
         configProperties = new LinkedHashMap()
         configProperties.putAll( DEFAULT_CONFIG )
+        configProperties.put('shell', isContainerEnabled ? BashWrapperBuilder.BASH : BashWrapperBuilder.ENV_BASH)
     }
 
-    ProcessConfig( BaseScript script, String name ) {
-        this(script)
+    ProcessConfig( BaseScript script, String name, boolean isContainerEnabled = true) {
+        this(script, isContainerEnabled)
         this.processName = name
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -100,7 +100,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         assert processConfig==null
 
         // the config object
-        processConfig = new ProcessConfig(owner,processName)
+        processConfig = new ProcessConfig(owner,processName,session.getContainerConfig().isEnabled())
 
         // Invoke the code block which will return the script closure to the executed.
         // As side effect will set all the property declarations in the 'taskConfig' object.


### PR DESCRIPTION
UPDATE: After having created this PR I realized that I could do better (see comments below) and have also invested more time to understand the code base. Now, I (hopefully) have a version that fits well and is satisfying for everybody. Please refer to all the comments below before looking into the diff.

---
ORIGINAL PR description:
(This comment was made when 29df9b71a587c34e5e6248de4f972692193d6227 was HEAD.)

This PR allows to use `nextfow` on NixOS where `/bin/bash` does not exist. This is achieved by invoking `/usr/bin/env -S bash` where necessary. This approach (or similar) has been discussed previously:

* https://github.com/nextflow-io/nextflow/pull/2341
* https://github.com/nextflow-io/nextflow/issues/1598
* https://github.com/nextflow-io/nextflow/pull/1614
* https://github.com/nextflow-io/nextflow/issues/5420

However, compared the previous discussions/implementations, I specifically do *not* propose to change `/bin/bash` unless really necessary. By "necessary" I mean that `bash` is invoked on a local host system where it may not be available. Namely, when `<task>/.command.run` shall be invoked (always on the host) and when `<task>/.command.sh` is invoked in a non-container context (i.e. also on the host). I have *not* touched any other occurrences of `/bin/bash`, esp. not within the container.

My initial implementation used `which bash` instead if `/usr/bin/env -S bash` but I esteemed the latter to be more correct. Please refer to the git commit history/messages for some further insights.

I understand that it is possible for downstream consumers to work around `/bin/bash` (symlink was proposed in one of the linked issues above). However, I believe that my proposal/approach (=assume `/bin/bash` to be available everywhere except on the local host where `nextflow` is invoked) here is not too intrusive.

I'm happy  to change the the code as requested. I have not added any comments since I expect (at least) change requests. Please review this with an unbiased mind set. Multiple people have expressed their intention to use `nextflow` on systems without `/bin/bash`.

I have tested solely on NixOS.

--- 
Further context:

[Here](https://github.com/NixOS/nixpkgs/issues/350183) is the corresponding nixpkgs issue that motivates this PR.

[Here](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/interpreters/nextflow/default.nix#L36) is the current package definition for Nextflow in NixOS which causes trouble (see nixpkgs issue above).

[Here](https://github.com/rollf/nixpkgs/commit/ef7881768e7b8cebc63cbfb81ae389a0b37fe6df) is a new package definition assuming Nextflow would be compatible with NixOS out of the box.