### PR TITLE
Add GHA to submit dependencies to dependabot

### DIFF
--- a/.github/workflows/generate-send-dependencies.yml
+++ b/.github/workflows/generate-send-dependencies.yml
@@ -1,7 +1,7 @@
 name: Generate and submit dependency graph for nextflow
 on:
-    # for testing purposes, to be removed later
-    pull_request:
+    push:
+      branches: ['master']
 
 permissions:
   contents: write

--- a/.github/workflows/generate-send-dependencies.yml
+++ b/.github/workflows/generate-send-dependencies.yml
@@ -1,0 +1,27 @@
+name: Generate and submit dependency graph for nextflow
+on:
+    # for testing purposes, to be removed later
+    pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        components: ["nextflow", "plugins:nf-google", "plugins:nf-amazon", "plugins:nf-azure", "plugins:nf-cloudcache", "plugins:nf-codecommit", "plugins:nf-console", "plugins:nf-tower", "plugins:nf-wave"]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+
+    - name: Generate and submit dependency graph for nextflow
+      uses: gradle/actions/dependency-submission@v4
+      with:
+        dependency-resolution-task: ":${{ matrix.components }}:dependencies"
+        additional-arguments: "--configuration runtimeClasspath"
+        dependency-graph: generate-and-submit


### PR DESCRIPTION
Added a Github action to generate and submit the dependencies used by the project. Then, dependabot will be able to display the vulnerabilities found on the libraries used by Nextflow. 

Task has been tested on PR:
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/eaed2e2d-1368-42d8-a9da-70483545a08f">

although result cannot be published because it is not being run from `master` branch:

>Notice: Submitted dependency-graph-reports/generate_and_submit_dependency_graph_for_nextflow-dependency-submission-nextflow.json: The snapshot was accepted, but it is not for the default branch. It will not update dependency results for the repository.