### PR TITLE
Include input and output file sizes in the trace

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -367,6 +367,17 @@ class BashWrapperBuilder {
         binding.stdout_file = TaskRun.CMD_OUTFILE
         binding.stderr_file = TaskRun.CMD_ERRFILE
         binding.trace_file = TaskRun.CMD_TRACE
+        binding.sizes_file = TaskRun.CMD_SIZES
+        if( bean.inputFiles.size() > 0){
+            binding.inputs_list = bean.inputFiles.keySet().join(" ")
+        } else {
+            binding.inputs_list = ""
+        }
+        if( bean.outputFiles.size() > 0 ){
+            binding.outputs_list = bean.outputFiles.join(" ")
+        } else {
+            binding.outputs_list = ""
+        }
 
         binding.trace_cmd = getTraceCommand(interpreter)
         binding.launch_cmd = getLaunchCommand(interpreter,env)
@@ -754,6 +765,7 @@ class BashWrapperBuilder {
     protected String getStageCommand() { 'nxf_stage' }
 
     protected String getUnstageCommand() { 'nxf_unstage' }
+
 
     protected String getUnstageControls() {
         def result = copyFileToWorkDir(TaskRun.CMD_OUTFILE) + ' || true' + ENDL

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -219,6 +219,14 @@ abstract class TaskHandler {
             catch( NoSuchFileException e ) {
                 // ignore it
             }
+            def sizesFile = task.workDir?.resolve(TaskRun.CMD_SIZES)
+            try {
+                if(sizesFile) record.parseSizesFile(sizesFile)
+            }
+            catch( NoSuchFileException e ) {
+                // ignore it
+            }
+
             catch( IOException e ) {
                 log.debug "[WARN] Cannot read trace file: $file -- Cause: ${e.message}"
             }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -570,6 +570,7 @@ class TaskRun implements Cloneable {
     static final public String CMD_RUN = '.command.run'
     static final public String CMD_STAGE = '.command.stage'
     static final public String CMD_TRACE = '.command.trace'
+    static final public String CMD_SIZES = '.command.filesize.yaml'
     static final public String CMD_ENV = '.command.env'
 
 

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
@@ -57,7 +57,9 @@ class TraceFileObserver implements TraceObserver {
             'peak_rss',
             'peak_vmem',
             'rchar',
-            'wchar'
+            'wchar',
+            'inputs',
+            'outputs'
     ]
 
     List<String> formats

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.trace
 
+import groovy.yaml.YamlSlurper
+
 import java.nio.file.Path
 import java.util.regex.Pattern
 
@@ -101,7 +103,9 @@ class TraceRecord implements Serializable {
             vol_ctxt: 'num',        // -- /proc/$pid/status field 'voluntary_ctxt_switches'
             inv_ctxt: 'num',        // -- /proc/$pid/status field 'nonvoluntary_ctxt_switches'
             hostname: 'str',
-            cpu_model:  'str'
+            cpu_model:  'str',
+            inputs: 'str',
+            outputs: 'str'
     ]
 
     static public Map<String,Closure<String>> FORMATTER = [
@@ -463,6 +467,16 @@ class TraceRecord implements Serializable {
         }
 
         return this
+    }
+
+    TraceRecord parseSizesFile(Path file){
+        def yaml = new YamlSlurper().parse(file)
+        if( yaml.getAt('inputs') != null ) {
+            this.put('inputs', yaml.getAt('inputs'))
+        }
+        if( yaml.getAt('outputs') != null ) {
+            this.put('outputs', yaml.getAt('outputs'))
+        }
     }
 
     private TraceRecord parseLegacy( Path file, List<String> lines) {

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -136,6 +136,27 @@ nxf_write_trace() {
     echo "write_bytes=${io_stat1[5]}"  >> $trace_file
 }
 
+nxf_files_size() {
+    local sizes_file={{sizes_file}}
+    local inputs="{{inputs_list}}"
+    local outputs="{{outputs_list}}"
+    if [ ! -z "$outputs" ]; then
+        echo "outputs: " >> $sizes_file
+        for f in $outputs ; do
+            echo -e "- name: $f " >> $sizes_file
+            echo -e "  size: $( du -s -b $f | awk '{print $1}')" >> $sizes_file
+        done
+    fi
+    if [ ! -z "$inputs" ]; then
+        echo "inputs: " >> $sizes_file
+        for f in $inputs ; do
+            echo -e "- name: $f " >> $sizes_file
+            echo -e "  size: $( du -s -L -b $f | awk '{print $1}')" >> $sizes_file
+        done
+    fi
+}
+
+
 nxf_trace_mac() {
     local start_millis=$(nxf_date)
 
@@ -227,4 +248,5 @@ nxf_trace() {
     else
         nxf_trace_linux
     fi
+    nxf_files_size
 }

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
@@ -186,11 +186,14 @@ class TraceFileObserverTest extends Specification {
         record.peak_vmem = 30_000 * 1024
         record.rchar = 30_000 * 1024
         record.wchar = 10_000 * 1024
+        record.inputs = [ [name: "in_file_1", size: 123456], [name: "in_file_2", size: 654321] ]
+        record.outputs = [ [name: "out_file_1", size: 123456] ]
 
         when:
         def trace = [:] as TraceFileObserver
         def result = trace.render(record).split('\t')
         then:
+        result.size() == 16
         result[0] == '30'                       // task id
         result[1] == '43d7ef'                   // hash
         result[2] == '2000'                     // native id
@@ -205,6 +208,8 @@ class TraceFileObserverTest extends Specification {
         result[11] == '29.3 MB'                 // peak_vmem
         result[12] == '29.3 MB'                 // rchar
         result[13] == '9.8 MB'                  // wchar
+        result[14] == '[[name:in_file_1, size:123456], [name:in_file_2, size:654321]]' // inputs
+        result[15] == '[[name:out_file_1, size:123456]]' // outputs
 
     }
 

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -120,6 +120,27 @@ nxf_write_trace() {
     echo "write_bytes=${io_stat1[5]}"  >> $trace_file
 }
 
+nxf_files_size() {
+    local sizes_file=.command.filesize.yaml
+    local inputs=""
+    local outputs=""
+    if [ ! -z "$outputs" ]; then
+        echo "outputs: " >> $sizes_file
+        for f in $outputs ; do
+            echo -e "- name: $f " >> $sizes_file
+            echo -e "  size: $( du -s -b $f | awk '{print $1}')" >> $sizes_file
+        done
+    fi
+    if [ ! -z "$inputs" ]; then
+        echo "inputs: " >> $sizes_file
+        for f in $inputs ; do
+            echo -e "- name: $f " >> $sizes_file
+            echo -e "  size: $( du -s -L -b $f | awk '{print $1}')" >> $sizes_file
+        done
+    fi
+}
+
+
 nxf_trace_mac() {
     local start_millis=$(nxf_date)
 
@@ -197,6 +218,7 @@ nxf_trace() {
     else
         nxf_trace_linux
     fi
+    nxf_files_size
 }
 
 nxf_sleep() {


### PR DESCRIPTION
After the execution input and output sizes are stored in the task working directory using the du UNIX utility and storing in .command.filesizes.yaml file. For every input and output file/directory it stores the name and the size in bytes.

For instance:
```
outputs:
- name: multiqc_report.html
  size: 5285017
inputs:
- name: ggal_gut
  size: 34221
- name: fastqc_ggal_gut_logs
  size: 2102143
- name: config
  size: 26568
```
This information is also included in the TraceRecord and the trace file at the end of the execution

```
task_id hash    native_id       name    status  exit    submit  duration        realtime        %cpu    peak_rss        peak_vmem       rchar   wchar   inputs  outputs
2       f4/a70e1f       66582   RNASEQ:FASTQC (FASTQC on ggal_gut)      COMPLETED       0       2024-10-29 14:58:49.807 2.3s    2.2s    188.8%  179.2 MB        3.5 GB  12.4 MB 3.8 MB  [[name:ggal_gut_2.fq, size:691995], [name:ggal_gut_1.fq, size:691873]]  [[name:fastqc_ggal_gut_logs, size:2102143]]
1       6b/deab39       66576   RNASEQ:INDEX (ggal_1_48850000_49020000) COMPLETED       0       2024-10-29 14:58:49.796 5.6s    5.5s    3.1%    27.4 MB 88.2 MB 2.4 MB  1.3 MB  [[name:ggal_1_48850000_49020000.Ggal71.500bpflank.fa, size:173911]]     [[name:index, size:613419]]
3       3a/323ae9       67340   RNASEQ:QUANT (ggal_gut) COMPLETED       0       2024-10-29 14:58:55.431 906ms   808ms   18.4%   12.9 MB 51.2 MB 2 MB    21.8 KB [[name:ggal_gut_2.fq, size:691995], [name:index, size:613419], [name:ggal_gut_1.fq, size:691873]]       [[name:ggal_gut, size:34221]]
4       94/9fe1ca       67479   MULTIQC COMPLETED       0       2024-10-29 14:58:56.369 3s      2.9s    76.0%   99.4 MB 1.7 GB  38.7 MB 17.7 MB [[name:ggal_gut, size:34221], [name:fastqc_ggal_gut_logs, size:2102143], [name:config, size:26568]]     [[name:multiqc_report.html, size:5285017]]
```