### PR TITLE
Update gradle 'shadow' plugin version to 8.3.5

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.gradleup.shadow" version "8.3.5"
 }
 apply plugin: 'groovy'
 apply plugin: 'application'


### PR DESCRIPTION
`com.github.johnrengelman.shadow` plugin has moved to `com.gradleup.shadow`

This change updates to the new name and latest version, and in so doing updates a transitive build-time dependency on the vulnerable apache commons-io 2.11.0 to the latest 2.17.0