### PR TITLE
Add `nextflow lsp` command

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -261,6 +261,10 @@ while [[ $# != 0 ]]; do
       exit 0
       fi
       ;;
+    lsp)
+      java -jar "$NXF_DIST/$NXF_VER/language-server-all.jar"
+      exit 0
+      ;;
     -self-update|self-update)
       if [[ ! "$cmd" ]]; then
       [[ -z $NXF_EDGE && $NXF_VER = *-edge ]] && NXF_EDGE=1


### PR DESCRIPTION
Add `lsp` command to the nextflow launcher script, which should download or reuse an appropriate version of the language server JAR from GitHub.

TODO:
- download language server JAR if not present
- try NXF_VER or fallback to default version e.g. 1.0.x