### PR TITLE
Update 'bouncycastle' dependency to 1.78.1

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     api 'jline:jline:2.9'
     api 'org.pf4j:pf4j:3.12.0'
     api 'dev.failsafe:failsafe:3.1.0'
-    api 'org.bouncycastle:bcprov-ext-jdk15on:1.70'
-    api 'org.bouncycastle:bcpkix-jdk15on:1.70'
+    api 'org.bouncycastle:bcprov-ext-jdk18on:1.78.1'
+    api 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
 
     testImplementation 'org.subethamail:subethasmtp:3.1.7'
 

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -39,16 +39,11 @@ dependencies {
 
     api 'com.google.apis:google-api-services-lifesciences:v2beta-rev20210527-1.31.5'
     api 'com.google.auth:google-auth-library-oauth2-http:0.18.0'
-    api 'com.google.cloud:google-cloud-batch:0.29.0'
-    api ('com.google.cloud:google-cloud-logging:3.8.0') {
-        // use version of bouncycastle provided by nextflow
-        exclude group: 'org.bouncycastle'
-    }
+    api 'com.google.cloud:google-cloud-batch:0.53.0'
+    api 'com.google.cloud:google-cloud-logging:3.20.6'
     api 'com.google.cloud:google-cloud-nio:0.124.8'
     api 'com.google.cloud:google-cloud-storage:2.9.3'
     api 'com.google.code.gson:gson:2.10.1'
-    // include protobuf to address vulnerability issues
-    runtimeOnly 'com.google.protobuf:protobuf-java:3.25.5'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.apache.groovy:groovy:4.0.23"

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -40,7 +40,10 @@ dependencies {
     api 'com.google.apis:google-api-services-lifesciences:v2beta-rev20210527-1.31.5'
     api 'com.google.auth:google-auth-library-oauth2-http:0.18.0'
     api 'com.google.cloud:google-cloud-batch:0.29.0'
-    api 'com.google.cloud:google-cloud-logging:3.8.0'
+    api ('com.google.cloud:google-cloud-logging:3.8.0') {
+        // use version of bouncycastle provided by nextflow
+        exclude group: 'org.bouncycastle'
+    }
     api 'com.google.cloud:google-cloud-nio:0.124.8'
     api 'com.google.cloud:google-cloud-storage:2.9.3'
     api 'com.google.code.gson:gson:2.10.1'


### PR DESCRIPTION
This change updates bouncy castle to the 1.78.1 to get the latest security fixes.

It also switches from the Java 1.5+ compatible version (_jdk15on_) to the Java 1.8+ compatible version (_jdk18on_) since I don't think Nextflow supports Java versions that old.