### PR TITLE
Fixing bug when execution with stub and no stub defined

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -790,7 +790,7 @@ class TaskRun implements Cloneable {
      * @param body A {@code BodyDef} object instance
      */
     void resolve(BodyDef body)  {
-        processor.session.stubRun
+        (processor.session.stubRun && config.getStubBlock())
             ? resolveStub(config.getStubBlock())
             : resolveBody(body)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -790,7 +790,7 @@ class TaskRun implements Cloneable {
      * @param body A {@code BodyDef} object instance
      */
     void resolve(BodyDef body)  {
-        (processor.session.stubRun && config.getStubBlock())
+        processor.session.stubRun && config.getStubBlock()
             ? resolveStub(config.getStubBlock())
             : resolveBody(body)
     }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
@@ -907,6 +907,23 @@ class TaskRunTest extends Specification {
         0 * task.resolveStub(_) >> null
     }
 
+    def 'should resolve task body when no stub' () {
+        given:
+        def task = Spy(TaskRun)
+        task.processor = Mock(TaskProcessor) {
+            getSession()>>Mock(Session) { getStubRun() >> true}
+        }
+        task.config = Mock(TaskConfig) { getStubBlock()>> null }
+        and:
+        def body = Mock(BodyDef)
+
+        when:
+        task.resolve(body)
+        then:
+        1 * task.resolveBody(body) >> null
+        0 * task.resolveStub(_) >> null
+    }
+
     def 'should resolve task stub' () {
         given:
         def body = Mock(BodyDef)


### PR DESCRIPTION
When migrating resolve evaluation from TaskProcessor to TaskRun it was not checking if stub block was not defined.

Adding stub check and including the corresponding unit test.
 