### PR TITLE
Remove errorStrategy check in getMaxRetries to avoid possible deadloc…

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -345,7 +345,7 @@ class TaskConfig extends LazyMap implements Cloneable {
 
     int getMaxRetries() {
         def result = get('maxRetries')
-        result != null ? result as int : 1
+        result ? result as int : 1
     }
 
     int getMaxErrors() {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -345,8 +345,7 @@ class TaskConfig extends LazyMap implements Cloneable {
 
     int getMaxRetries() {
         def result = get('maxRetries')
-        def defResult = getErrorStrategy() == ErrorStrategy.RETRY ? 1 : 0
-        result ? result as int : defResult
+        result != null ? result as int : 1
     }
 
     int getMaxErrors() {

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -126,7 +126,7 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
             debug: false,
             cacheable: true,
             shell: BashWrapperBuilder.BASH,
-            maxRetries: 0,
+            maxRetries: 1,
             maxErrors: -1,
             errorStrategy: ErrorStrategy.TERMINATE
     ]
@@ -319,6 +319,7 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
     BaseScript getOwnerScript() { ownerScript }
 
     TaskConfig createTaskConfig() {
+
         return new TaskConfig(configProperties)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -319,7 +319,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
     BaseScript getOwnerScript() { ownerScript }
 
     TaskConfig createTaskConfig() {
-
         return new TaskConfig(configProperties)
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -157,7 +157,7 @@ class TaskConfigTest extends Specification {
 
         where:
         value   | expected
-        null    | 0
+        null    | 1
         0       | 0
         1       | 1
         '3'     | 3
@@ -171,8 +171,8 @@ class TaskConfigTest extends Specification {
         when:
         config = new TaskConfig()
         then:
-        config.maxRetries == 0
-        config.getMaxRetries() == 0
+        config.maxRetries == 1
+        config.getMaxRetries() == 1
         config.getErrorStrategy() == ErrorStrategy.TERMINATE
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -158,7 +158,7 @@ class TaskConfigTest extends Specification {
         where:
         value   | expected
         null    | 1
-        0       | 0
+        0       | 1
         1       | 1
         '3'     | 3
         10      | 10

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessConfigTest.groovy
@@ -47,7 +47,7 @@ class ProcessConfigTest extends Specification {
         expect:
         config.shell ==  ['/bin/bash','-ue']
         config.cacheable
-        config.maxRetries == 0
+        config.maxRetries == 1
         config.maxErrors == -1
         config.errorStrategy == ErrorStrategy.TERMINATE
     }


### PR DESCRIPTION
close #5464
 
Remove errorStrategy check in getMaxRetries method. It avoids possible deadlock when using task.maxRetries in dynamic errorStrategy directives.

Default maxRetries is set to 1