### PR TITLE
Stop fargate complaing when memory is exactly the minimum required.

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -931,7 +931,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         final slot = FARGATE_MEM.get(cpus)
         if( slot==null )
             throw new ProcessUnrecoverableException("Requirement of $cpus CPUs is not allowed by Fargate -- Check process with name '${task.lazyName()}'")
-        if( mega <=slot.min ) {
+        if( mega <slot.min ) {
             log.warn "Process '${task.lazyName()}' memory requirement of ${mem} is below the minimum allowed by Fargate of ${MemoryUnit.of(mega+'MB')}"
             return slot.min
         }


### PR DESCRIPTION
Fixes #5471.

Although it would also be good to make the error message on the line above more explicit, as if for instance cpus = 6 it will just give an error. Can we make it list what the possible values are?
