### PR TITLE
feat: nextflow.scm.RepositoryProvider.revision now public

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -65,7 +65,7 @@ abstract class RepositoryProvider {
     /**
      * The name of the commit/branch/tag
      */
-    protected String revision
+    public String revision
 
     RepositoryProvider setCredentials(String userName, String password) {
         config.user = userName


### PR DESCRIPTION
One line change to make the RepositoryProvider.revision public. The driver for this is to allow clients to better manage repository validation by allowing the RepositoryProvider to be the source of truth for the current revision that is set.

An alternate approach would be to add revision validation within the RepositoryProvider itself, e.g. `setRevision(String revision, boolean validateRevision = false)`. Validation could then proceed by verifying the revision is present in getBranches or getTags.


Refs: PLAT-252