### PR TITLE
feat: RepositoryProvider.revision now public property

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -65,12 +65,16 @@ abstract class RepositoryProvider {
     /**
      * The name of the commit/branch/tag
      */
-    String revision
+    protected String revision
 
     RepositoryProvider setCredentials(String userName, String password) {
         config.user = userName
         config.password = password
         return this
+    }
+
+    String getRevision() {
+        return this.revision
     }
 
     RepositoryProvider setRevision(String revision) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -78,6 +78,14 @@ abstract class RepositoryProvider {
         return this
     }
 
+    String getProject() {
+        return this.project
+    }
+
+    ProviderConfig getConfig() {
+        return this.config
+    }
+
     boolean hasCredentials() {
         getUser() && getPassword()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -65,7 +65,7 @@ abstract class RepositoryProvider {
     /**
      * The name of the commit/branch/tag
      */
-    protected String revision
+    String revision
 
     RepositoryProvider setCredentials(String userName, String password) {
         config.user = userName

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -108,4 +108,15 @@ class RepositoryProviderTest extends Specification {
         and:
         1 * conn.setRequestProperty('Authorization', "Basic ${'foo:bar'.bytes.encodeBase64()}")
     }
+
+    def 'should have public revision property' () {
+        given:
+        def provider = Spy(RepositoryProvider)
+        when:
+        provider.revision = 'branch_or_tag'
+        then:
+        provider.revision == 'branch_or_tag'
+        provider.hasProperty('revision') ? true : false
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -24,35 +24,35 @@ import spock.lang.Specification
  */
 class RepositoryProviderTest extends Specification {
 
-    def 'should create repository provider object'() {
+    def 'should create repository provider object' () {
 
         def provider
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('github'), 'project/x')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('github'),'project/x')
         then:
         provider instanceof GithubRepositoryProvider
         provider.endpointUrl == 'https://api.github.com/repos/project/x'
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('gitlab'), 'project/y')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('gitlab'),'project/y')
         then:
         provider instanceof GitlabRepositoryProvider
         provider.endpointUrl == 'https://gitlab.com/api/v4/projects/project%2Fy'
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('bitbucket'), 'project/z')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('bitbucket'),'project/z')
         then:
         provider instanceof BitbucketRepositoryProvider
         provider.endpointUrl == 'https://bitbucket.org/api/2.0/repositories/project/z'
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('local', [path: '/user/data']), 'local/w')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('local', [path:'/user/data']),'local/w')
         then:
         provider.endpointUrl == 'file:/user/data/w'
     }
 
-    def 'should set credentials'() {
+    def 'should set credentials' () {
 
         given:
         def config = Mock(ProviderConfig)
@@ -67,7 +67,7 @@ class RepositoryProviderTest extends Specification {
 
     }
 
-    def 'should hide creds'() {
+    def 'should hide creds' () {
         given:
         def provider = Spy(RepositoryProvider)
 
@@ -86,7 +86,7 @@ class RepositoryProviderTest extends Specification {
 
     }
 
-    def 'should auth using credentials'() {
+    def 'should auth using credentials' () {
         given:
         def provider = Spy(RepositoryProvider)
         and:

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -24,35 +24,35 @@ import spock.lang.Specification
  */
 class RepositoryProviderTest extends Specification {
 
-    def 'should create repository provider object' () {
+    def 'should create repository provider object'() {
 
         def provider
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('github'),'project/x')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('github'), 'project/x')
         then:
         provider instanceof GithubRepositoryProvider
         provider.endpointUrl == 'https://api.github.com/repos/project/x'
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('gitlab'),'project/y')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('gitlab'), 'project/y')
         then:
         provider instanceof GitlabRepositoryProvider
         provider.endpointUrl == 'https://gitlab.com/api/v4/projects/project%2Fy'
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('bitbucket'),'project/z')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('bitbucket'), 'project/z')
         then:
         provider instanceof BitbucketRepositoryProvider
         provider.endpointUrl == 'https://bitbucket.org/api/2.0/repositories/project/z'
 
         when:
-        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('local', [path:'/user/data']),'local/w')
+        provider = RepositoryFactory.newRepositoryProvider(new ProviderConfig('local', [path: '/user/data']), 'local/w')
         then:
         provider.endpointUrl == 'file:/user/data/w'
     }
 
-    def 'should set credentials' () {
+    def 'should set credentials'() {
 
         given:
         def config = Mock(ProviderConfig)
@@ -67,7 +67,7 @@ class RepositoryProviderTest extends Specification {
 
     }
 
-    def 'should hide creds' () {
+    def 'should hide creds'() {
         given:
         def provider = Spy(RepositoryProvider)
 
@@ -86,7 +86,7 @@ class RepositoryProviderTest extends Specification {
 
     }
 
-    def 'should auth using credentials' () {
+    def 'should auth using credentials'() {
         given:
         def provider = Spy(RepositoryProvider)
         and:
@@ -108,15 +108,4 @@ class RepositoryProviderTest extends Specification {
         and:
         1 * conn.setRequestProperty('Authorization', "Basic ${'foo:bar'.bytes.encodeBase64()}")
     }
-
-    def 'should have public revision property' () {
-        given:
-        def provider = Spy(RepositoryProvider)
-        when:
-        provider.revision = 'branch_or_tag'
-        then:
-        provider.revision == 'branch_or_tag'
-        provider.hasProperty('revision') ? true : false
-    }
-
 }


### PR DESCRIPTION
One line change to make the RepositoryProvider.revision a public property. The driver for this is to allow clients to better manage repository validation by allowing the RepositoryProvider to be the source of truth for the current revision that is set. 

An alternate approach would be to add revision validation within the RepositoryProvider itself, e.g. 
    `setRevision(String revision, boolean validateRevision = false)` 
Validation could then proceed by verifying the revision is present in getBranches or getTags.