### PR TITLE
Fix problem that Nextflow Executions stuck on Kubernetes

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -420,10 +420,13 @@ class TraceRecord implements Serializable {
     TraceRecord parseTraceFile( Path file ) {
         try (BufferedReader reader = new BufferedReader(new FileReader(file.toFile()))) {
 
-            if( reader.readLine() != 'nextflow.trace/v2' )
-                return parseLegacy(file, file.readLines())
-
             String line
+            if( ( line = reader.readLine() ) == null ) {
+                return this
+            } else if ( line != 'nextflow.trace/v2' ) {
+                return parseLegacy(file, file.readLines())
+            }
+
             while(( line = reader.readLine() ) != null ) {
                 final pair = line.tokenize('=')
                 final name = pair[0]

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskHandlerTest.groovy
@@ -16,6 +16,9 @@
 
 package nextflow.processor
 
+import spock.lang.TempDir
+
+import java.nio.file.Path
 import java.util.concurrent.atomic.LongAdder
 
 import nextflow.Session
@@ -33,6 +36,9 @@ class TaskHandlerTest extends Specification {
 
     def static final long KB = 1024
 
+    @TempDir
+    Path folder
+
     def 'test get trace record'() {
 
         given:
@@ -42,7 +48,6 @@ class TaskHandlerTest extends Specification {
         '''
                 .leftTrim()
 
-        def folder = TestHelper.createInMemTempDir()
         folder.resolve( TaskRun.CMD_TRACE ).text = traceText
 
         def config = [

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
@@ -15,6 +15,9 @@
  */
 
 package nextflow.trace
+
+import spock.lang.TempDir
+
 import java.nio.file.Files
 
 import nextflow.Session
@@ -28,7 +31,9 @@ import nextflow.processor.TaskStatus
 import nextflow.util.CacheHelper
 import nextflow.util.Duration
 import spock.lang.Specification
-import test.TestHelper
+
+import java.nio.file.Path
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -36,6 +41,9 @@ import test.TestHelper
 class TraceFileObserverTest extends Specification {
 
     final static long MB = 1024 * 1024
+
+    @TempDir
+    Path tempDir
 
     def setupSpec() {
         TraceRecord.TIMEZONE = TimeZone.getTimeZone('UTC') // note: set the timezone to be sure the time string does not change on CI test servers
@@ -235,7 +243,7 @@ class TraceFileObserverTest extends Specification {
 
         given:
         final KB = 1024L
-        final file = TestHelper.createInMemTempFile('trace')
+        final file = Files.createTempFile(tempDir,'trace', '.txt')
         file.text =  '''
                 pid state %cpu %mem vmem rss peak_vmem peak_rss rchar wchar syscr syscw read_bytes write_bytes
                 18 0 7999 46 7868980 6694900 7876620 6702144 2147483647 2147483647 44001533 148401890 2147483647 2147483647

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
@@ -18,8 +18,12 @@ package nextflow.trace
 
 import groovy.json.JsonSlurper
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 import test.TestHelper
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  *
@@ -32,6 +36,9 @@ class TraceRecordTest extends Specification {
     def setupSpec() {
         TraceRecord.TIMEZONE = TimeZone.getTimeZone('UTC') // note: set the timezone to be sure the time string does not change on CI test servers
     }
+
+    @TempDir
+    Path tempDir
 
     def 'test get field'() {
 
@@ -153,7 +160,7 @@ class TraceRecordTest extends Specification {
     def 'should parse a trace file and return a TraceRecord object'() {
 
         given:
-        def file = TestHelper.createInMemTempFile('trace')
+        def file = Files.createTempFile(tempDir,'trace', '.txt')
         file.text = '''\
             nextflow.trace/v2
             realtime=12021
@@ -200,7 +207,7 @@ class TraceRecordTest extends Specification {
     def 'should parse a legacy trace file and return a TraceRecord object'() {
 
         given:
-        def file = TestHelper.createInMemTempFile('trace')
+        def file = Files.createTempFile(tempDir,'trace', '.txt')
         file.text =  '''
         pid state %cpu %mem vmem rss peak_vmem peak_rss rchar wchar syscr syscw read_bytes write_bytes
         1 0 10 20 11084 1220 21084 2220 4790 12 11 1 20 30


### PR DESCRIPTION
When running Nextflow workflows on Kubernetes, workflows would often get stuck with Pods remaining in the Succeeded state without being removed, and the workflow itself would not progress.

After running a jstack on the Nextflow Java process, I identified a thread hanging at this line in TraceRecord.groovy:
[TraceRecord.groovy#L422](https://github.com/nextflow-io/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy#L422).

To resolve this, I replaced the Groovy methods with native Java functions. After using this change in production for over six months, the problem has not recurred, so I am contributing it with confidence that it will benefit other Nextflow and Kubernetes users.

We experienced this issue on three different clusters, all running Ceph with Kubernetes.
