### PR TITLE
Add `env()` function

### DIFF
--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -197,6 +197,11 @@ The following functions are available in Nextflow scripts:
 `branchCriteria( closure )`
 : Create a branch criteria to use with the {ref}`operator-branch` operator.
 
+`env( name )`
+: :::{versionadded} 24.11.0-edge
+  :::
+: Get the value of an environment variable in the launch environment.
+
 `error( message = null )`
 : Throw a script runtime error with an optional error message.
 

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -275,6 +275,14 @@ The Nextflow language specification does not support implicit environment variab
 println "PWD = ${System.getenv('PWD')}"
 ```
 
+:::{versionadded} 24.11.0-edge
+The `env()` function can be used instead of `System.getenv()`:
+
+```nextflow
+println "PWD = ${env('PWD')}"
+```
+:::
+
 ### Restricted syntax
 
 The following patterns are still supported but have been restricted, i.e. some syntax variants have been removed.

--- a/modules/nextflow/src/main/groovy/nextflow/Nextflow.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Nextflow.groovy
@@ -57,6 +57,9 @@ class Nextflow {
 
     private static final Random random = new Random()
 
+    static String env(String name) {
+        return SysEnv.get(name)
+    }
 
     static private fileNamePattern( FilePatternSplitter splitter, Map opts ) {
 

--- a/modules/nextflow/src/test/groovy/nextflow/NextflowTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/NextflowTest.groovy
@@ -35,6 +35,17 @@ class NextflowTest extends Specification {
         System.getenv('CI_GROOVY_VERSION') == GroovySystem.getVersion()
     }
 
+    def 'should get an environment variable' () {
+        given:
+        SysEnv.push(FOO: 'FOO_VALUE')
+
+        expect:
+        Nextflow.env('FOO') == 'FOO_VALUE'
+
+        cleanup:
+        SysEnv.pop()
+    }
+
     def testFile() {
         expect:
         Nextflow.file('file.log').toFile() == new File('file.log').canonicalFile


### PR DESCRIPTION
From our conversation here: https://github.com/nextflow-io/language-server/issues/47

Provide a nicer way to access environment variables in the script