### PR TITLE
Deprecate process `shell` block

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -212,6 +212,10 @@ Template scripts are generally discouraged due to the caveats described above. T
 
 ### Shell
 
+:::{deprecated} 24.11.0-edge
+Use the `script` block instead. Consider using the {ref}`VS Code extension <vscode-page>`, which provides syntax highlighting and error checking to distinguish Nextflow variables from Bash variables in the process script.
+:::
+
 The `shell` block is a string expression that defines the script that is executed by the process. It is an alternative to the {ref}`process-script` definition with one important difference: it uses the exclamation mark `!` character, instead of the usual dollar `$` character, to denote Nextflow variables.
 
 This way, it is possible to use both Nextflow and Bash variables in the same script without having to escape the latter, which makes process scripts easier to read and maintain. For example:

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -1,3 +1,4 @@
+(vscode-page)=
 
 # VS Code integration
 


### PR DESCRIPTION
Based on some recent internal discussions. The original purpose of the `shell` block was to help distinguish between Nextflow and Bash variables in the process script. Since the VS Code extension now provides both syntax highlighting and error checking for variable names, the `shell` block isn't needed as much and can be phased out to promote consistent code.

I didn't bother to add a warning in the code because I will add one in the language server, but we can add one here if you want.