### PR TITLE
Fix isContainerReady when wave is disabled

### DIFF
--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/resolver/WaveContainerResolver.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/resolver/WaveContainerResolver.groovy
@@ -129,6 +129,9 @@ class WaveContainerResolver implements ContainerResolver {
 
     @Override
     boolean isContainerReady(String key) {
-        return client().isContainerReady(key)
+        final c=client()
+        return c.enabled()
+            ? c.isContainerReady(key)
+            : defaultResolver.isContainerReady(key)
     }
 }


### PR DESCRIPTION
This PR fixes the access to the method [isContainerReady](https://github.com/nextflow-io/nextflow/blob/803f4ee386c63e945dfd3daf5cbef895428a456b/plugins/nf-wave/src/main/io/seqera/wave/plugin/resolver/WaveContainerResolver.groovy#L131-L131) when Wave is disabled. 

Solve #5503 

