### PR TITLE
Removing secondary exceptions from console

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Nextflow.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Nextflow.groovy
@@ -223,7 +223,9 @@ class Nextflow {
      * @param message An optional error message
      */
     static void error( String message = null ) {
-        throw message ? new WorkflowScriptErrorException(message) : new WorkflowScriptErrorException()
+        def err = message ? new WorkflowScriptErrorException(message) : new WorkflowScriptErrorException()
+        log.error("@Unknown", err)
+        throw err
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -798,8 +798,15 @@ class Session implements ISession {
                 log.debug(status)
             // dump threads status
             log.debug(SysHelper.dumpThreads())
+
+            // Do not duplicate error notifications if session has been previously cancelled
+            if (cancelled) {
+                log.debug("Session aborted, but was previously cancelled")
+            } else {
+                notifyError(null)
+            }
+
             // force termination
-            notifyError(null)
             ansiLogObserver?.forceTermination()
             executorFactory?.signalExecutors()
             processesBarrier.forceTermination()

--- a/modules/nextflow/src/main/groovy/nextflow/extension/BufferOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/BufferOp.groovy
@@ -178,7 +178,7 @@ class BufferOp {
 
             @Override
             boolean onException(DataflowProcessor processor, Throwable e) {
-                OperatorImpl.log.error("@unknown", e)
+                OperatorImpl.log.debug("@unknown", e)
                 session.abort(e)
                 return true
             }

--- a/modules/nextflow/src/main/groovy/nextflow/extension/DataflowHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/DataflowHelper.groovy
@@ -95,7 +95,7 @@ class DataflowHelper {
         @Override
         boolean onException(final DataflowProcessor processor, final Throwable t) {
             final e = t instanceof InvocationTargetException ? t.cause : t
-            OperatorImpl.log.error("@unknown", e)
+            OperatorImpl.log.debug("@unknown", e)
             session?.abort(e)
             return true;
         }
@@ -116,7 +116,7 @@ class DataflowHelper {
 
             @Override
             boolean onException(final DataflowProcessor processor, final Throwable e) {
-                DataflowHelper.log.error("@unknown", e)
+                DataflowHelper.log.debug("@unknown", e)
                 session.abort(e)
                 return true
             }
@@ -257,7 +257,7 @@ class DataflowHelper {
                     events.onComplete.call(processor)
                 }
                 catch( Exception e ) {
-                    OperatorImpl.log.error("@unknown", e)
+                    OperatorImpl.log.debug("@unknown", e)
                     session.abort(e)
                 }
             }
@@ -266,7 +266,7 @@ class DataflowHelper {
             boolean onException(final DataflowProcessor processor, final Throwable e) {
                 error = true
                 if( !events.onError ) {
-                    log.error("@unknown", e)
+                    log.debug("@unknown", e)
                     session.abort(e)
                 }
                 else {
@@ -343,7 +343,7 @@ class DataflowHelper {
             }
 
             boolean onException(final DataflowProcessor processor, final Throwable e) {
-                log.error("@unknown", e)
+                log.debug("@unknown", e)
                 session.abort(e)
                 return true;
             }

--- a/modules/nextflow/src/main/groovy/nextflow/extension/IntoOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/IntoOp.groovy
@@ -124,7 +124,7 @@ class IntoOp {
 
             @Override
             public boolean onException(final DataflowProcessor processor, final Throwable e) {
-                log.error("@unknown", e)
+                log.debug("@unknown", e)
                 session.abort(e)
                 return true;
             }

--- a/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/OperatorImpl.groovy
@@ -748,7 +748,7 @@ class OperatorImpl {
             }
 
             boolean onException(final DataflowProcessor processor, final Throwable e) {
-                OperatorImpl.log.error("@unknown", e)
+                OperatorImpl.log.debug("@unknown", e)
                 session.abort(e)
                 return true;
             }
@@ -859,7 +859,7 @@ class OperatorImpl {
 
             @Override
             boolean onException(DataflowProcessor processor, Throwable e) {
-                OperatorImpl.log.error("@unknown", e)
+                OperatorImpl.log.debug("@unknown", e)
                 session.abort(e)
                 return true
             }

--- a/modules/nextflow/src/main/groovy/nextflow/extension/TakeOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/TakeOp.groovy
@@ -67,7 +67,7 @@ class TakeOp {
             }
 
             boolean onException(final DataflowProcessor processor, final Throwable e) {
-                TakeOp.log.error("@unknown", e)
+                TakeOp.log.debug("@unknown", e)
                 (Global.session as Session).abort(e)
                 return true;
             }


### PR DESCRIPTION
- Unknown errors before session abort have been moved from log.error to log.debug to do not print them in the console.
- When session is cancelled and later aborted, do not call notifyError in abort (duplicate error notifications)