### PR TITLE
Include job status report when failure and no exit code found

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BridgeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BridgeExecutor.groovy
@@ -124,6 +124,11 @@ class BridgeExecutor extends AbstractGridExecutor {
     protected List<String> getKillCommand() { ['ccc_mdel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        return ['ccc_mstat','-H', jobId.toString()]
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
 
         final result = ['ccc_bsstat','-o','batchid,state']

--- a/modules/nextflow/src/main/groovy/nextflow/executor/CondorExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/CondorExecutor.groovy
@@ -105,6 +105,11 @@ class CondorExecutor extends AbstractGridExecutor {
     }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        return null
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
         ["condor_q", "-nobatch"]
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/FluxExecutor.groovy
@@ -141,6 +141,11 @@ class FluxExecutor extends AbstractGridExecutor {
     protected List<String> getKillCommand() { ['flux', 'job', 'cancel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        ['flux', 'job', 'info', jobId.toString()]
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
 
         // Look at jobs from last 15 minutes

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -83,6 +83,8 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
 
     BatchCleanup batch
 
+    private boolean failureDetected
+
     /** only for testing purpose */
     protected GridTaskHandler() {}
 
@@ -372,8 +374,8 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
             def errMessage = []
             errMessage << "Failed to get exit status for process ${this} -- exitStatusReadTimeoutMillis: $exitStatusReadTimeoutMillis; delta: $delta"
             // -- dump current queue stats
-            errMessage << "Current queue status:"
-            errMessage << executor.dumpQueueStatus()?.indent('> ')
+            errMessage << "Current $jobId status:"
+            errMessage << executor.dumpJobStatusReport(jobId, queue)?.indent('> ')
             // -- dump directory listing
             errMessage << "Content of workDir: ${task.workDir}"
             errMessage << workDirList?.indent('> ')

--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -99,6 +99,11 @@ class HyperQueueExecutor extends AbstractGridExecutor {
     }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        return ['hq', 'job', 'info', jobId.toString() ]
+    }
+
+    @Override
     protected List<String> killTaskCommand(def jobId) {
         final result = getKillCommand()
         if( jobId instanceof Collection ) {

--- a/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/LsfExecutor.groovy
@@ -192,6 +192,16 @@ class LsfExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     protected List<String> getKillCommand() { ['bkill'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        final result = ['bjobs', '-w']
+
+        if( queue )
+            result << '-q' << queue.toString()
+        result << jobId.toString()
+        return result
+    }
+
+    @Override
     protected List<String> queueStatusCommand( queue ) {
         // note: use the `-w` option to avoid that the printed jobid may be truncated when exceed 7 digits
         // see https://www.ibm.com/support/knowledgecenter/en/SSETD4_9.1.3/lsf_config_ref/lsf.conf.lsb_jobid_disp_length.5.html

--- a/modules/nextflow/src/main/groovy/nextflow/executor/MoabExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/MoabExecutor.groovy
@@ -126,6 +126,11 @@ class MoabExecutor extends AbstractGridExecutor {
     protected List<String> getKillCommand() { ['mjobctl', '-c'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        return ['checkjob', '-v', jobId.toString()]
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
         return ['showq', '--xml', '-w', "user="+System.getProperty('user.name')]
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/NqsiiExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/NqsiiExecutor.groovy
@@ -114,6 +114,15 @@ class NqsiiExecutor extends AbstractGridExecutor {
     protected List<String> getKillCommand() { ['qdel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        def result = ['qstat', '-J', jobId.toString()]
+        if( queue )
+            result << '-q' << queue.toString()
+
+        return result
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
         def result = ['qstat']
         if( queue )

--- a/modules/nextflow/src/main/groovy/nextflow/executor/OarExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/OarExecutor.groovy
@@ -141,6 +141,11 @@ class OarExecutor extends AbstractGridExecutor {
     protected List<String> getKillCommand() { ['oardel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        return ['oarstat', '-j', jobId.toString(), '-f']
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
         // To have a parsable list of jobs in queue by user
         // see page 21 http://oar.imag.fr/docs/2.5/OAR-Documentation.pdf

--- a/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/PbsExecutor.groovy
@@ -137,6 +137,11 @@ class PbsExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     protected List<String> getKillCommand() { ['qdel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        return ['tracejob', jobId.toString()]
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
         String cmd = 'qstat -f -1'
         if( queue ) cmd += ' ' + queue

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SgeExecutor.groovy
@@ -137,6 +137,15 @@ class SgeExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     protected List<String> getKillCommand() { ['qdel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(Object jobId, Object queue) {
+        def result = ['qstat', '-j', jobId.toString()]
+        if( queue )
+            result << '-q' << queue.toString()
+
+        return result
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
         def result = ['qstat']
         if( queue )

--- a/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SlurmExecutor.groovy
@@ -155,6 +155,23 @@ class SlurmExecutor extends AbstractGridExecutor implements TaskArrayExecutor {
     protected List<String> getKillCommand() { ['scancel'] }
 
     @Override
+    List<String> queueJobStatusReportCommand(jobId, queue) {
+
+        // Report id status nodelist and reason
+        final result = ['squeue', '-o', '%i %T %N %R', '-j', jobId.toString()]
+        if (queue)
+            result << '-p' << queue.toString()
+
+        final user = System.getProperty('user.name')
+        if (user)
+            result << '-u' << user
+        else
+            log.debug "Cannot retrieve current user"
+
+        return result
+    }
+
+    @Override
     protected List<String> queueStatusCommand(Object queue) {
 
         final result = ['squeue','--noheader','-o','%i %t', '-t', 'all']


### PR DESCRIPTION
When a job fail and no exit code is found. It prints a dump of the queue however no details of the failed jobs are shown specially in Slurm, where the job is not shown in the queue dump. This dump is replaced by a job status report provided by a call to te queue system 