### PR TITLE
Fix hash when CmdEvalParam as output

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -2211,6 +2211,13 @@ class TaskProcessor {
             keys.add( it.value )
         }
 
+        // add all eval commands (they are part of the script)
+        for( Map.Entry<OutParam,Object> it : task.outputs ) {
+            if( it.key instanceof CmdEvalParam ) {
+                keys.add(((CmdEvalParam) it.key).getTarget(task.context))
+            }
+        }
+
         // add all variable references in the task script but not declared as input/output
         def vars = getTaskGlobalVars(task)
         if( vars ) {
@@ -2245,6 +2252,7 @@ class TaskProcessor {
             }
         }
 
+        // add stub-run flag
         if( session.stubRun && task.config.getStubBlock() ) {
             keys.add('stub-run')
         }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -41,6 +41,7 @@ import nextflow.script.BodyDef
 import nextflow.script.ProcessConfig
 import nextflow.script.ScriptType
 import nextflow.script.bundle.ResourcesBundle
+import nextflow.script.params.CmdEvalParam
 import nextflow.script.params.FileInParam
 import nextflow.script.params.FileOutParam
 import nextflow.util.ArrayBag
@@ -1218,4 +1219,52 @@ class TaskProcessorTest extends Specification {
         0 * collector.collect(task)
         1 * exec.submit(task)
     }
+
+    def 'should use eval outputs in hash' () {
+        given:
+        def session = Mock(Session) {
+            getDumpHashes() >> 'json'
+            getUniqueId() >> UUID.fromString('b69b6eeb-b332-4d2c-9957-c291b15f498c')
+            getBinEntries() >> ['foo.sh': Paths.get('/some/path/foo.sh'), 'bar.sh': Paths.get('/some/path/bar.sh')]
+        }
+        def outParam = Mock(CmdEvalParam) {
+            getTarget( _ as Map) >> 'foo --version'
+        }
+        def task1 = Spy(TaskRun) {
+            getSource() >> 'hello world'
+            lazyName() >> 'hello'
+            isContainerEnabled() >> false
+            getContainer() >> null
+            getSpackEnv() >> null
+            getCondaEnv() >> null
+            getConfig() >> Mock(TaskConfig)
+            getContext() >> [:]
+        }
+        def task2 = Spy(TaskRun) {
+            getSource() >> 'hello world'
+            lazyName() >> 'hello'
+            isContainerEnabled() >> false
+            getContainer() >> null
+            getSpackEnv() >> null
+            getCondaEnv() >> null
+            getConfig() >> Mock(TaskConfig)
+            getContext() >> [:]
+        }
+        task2.setOutput(outParam)
+
+        def processor = Spy(TaskProcessor){
+            getTaskGlobalVars( _ as TaskRun) >> [foo:'a', bar:'b']
+        }
+        processor.@session = session
+        processor.@config = Mock(ProcessConfig)
+
+        when:
+        def uuid1 = processor.createTaskHashKey(task1)
+        def uuid2 = processor.createTaskHashKey(task2)
+
+        then:
+        uuid1 != uuid2
+
+    }
+
 }


### PR DESCRIPTION
close  #5470

Adds the CmdEvalParams in the task outputs as a key to compute the hash