### PR TITLE
Fix secondary exceptions from console

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -792,7 +792,7 @@ class Session implements ISession {
             log.debug "Session aborted -- Cause: ${cause?.message ?: cause ?: '-'}"
         aborted = true
         error = cause
-        LoggerHelper.skipConsole = true
+        LoggerHelper.aborted = true
         try {
             // log the dataflow network status
             def status = dumpNetworkStatus()

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -71,6 +71,7 @@ import nextflow.util.Barrier
 import nextflow.util.ConfigHelper
 import nextflow.util.Duration
 import nextflow.util.HistoryFile
+import nextflow.util.LoggerHelper
 import nextflow.util.NameGenerator
 import nextflow.util.SysHelper
 import nextflow.util.ThreadPoolManager
@@ -787,10 +788,11 @@ class Session implements ISession {
      */
     void abort(Throwable cause = null) {
         if( aborted ) return
-        if( !(cause instanceof ScriptCompilationException) )
+        if( cause !instanceof ScriptCompilationException )
             log.debug "Session aborted -- Cause: ${cause?.message ?: cause ?: '-'}"
         aborted = true
         error = cause
+        LoggerHelper.skipConsole = true
         try {
             // log the dataflow network status
             def status = dumpNetworkStatus()

--- a/modules/nextflow/src/main/groovy/nextflow/util/LoggerHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/LoggerHelper.groovy
@@ -16,10 +16,6 @@
 
 package nextflow.util
 
-import ch.qos.logback.core.encoder.Encoder
-import ch.qos.logback.core.spi.FilterAttachable
-import ch.qos.logback.core.spi.LifeCycle
-
 import static nextflow.Const.*
 
 import java.lang.reflect.Field
@@ -28,6 +24,7 @@ import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 
 import ch.qos.logback.classic.Level
@@ -42,13 +39,16 @@ import ch.qos.logback.core.ConsoleAppender
 import ch.qos.logback.core.CoreConstants
 import ch.qos.logback.core.FileAppender
 import ch.qos.logback.core.LayoutBase
+import ch.qos.logback.core.encoder.Encoder
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.joran.spi.NoAutoStart
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy
 import ch.qos.logback.core.rolling.RollingFileAppender
 import ch.qos.logback.core.rolling.TriggeringPolicyBase
+import ch.qos.logback.core.spi.FilterAttachable
 import ch.qos.logback.core.spi.FilterReply
+import ch.qos.logback.core.spi.LifeCycle
 import ch.qos.logback.core.util.FileSize
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
@@ -85,7 +85,9 @@ import org.slf4j.MarkerFactory
 @CompileStatic
 class LoggerHelper {
 
-    static volatile boolean skipConsole
+    static volatile boolean aborted
+
+    static final AtomicInteger errCount = new AtomicInteger()
 
     static private Logger log = LoggerFactory.getLogger(LoggerHelper)
 
@@ -421,7 +423,8 @@ class LoggerHelper {
                 return FilterReply.NEUTRAL;
             }
 
-            if( skipConsole )
+            // print to console only the very first error log and ignore the others
+            if( aborted && event.level==Level.ERROR && errCount.getAndIncrement()>0 )
                 return FilterReply.DENY;
 
             def logger = event.getLoggerName()

--- a/modules/nextflow/src/main/groovy/nextflow/util/LoggerHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/LoggerHelper.groovy
@@ -85,6 +85,8 @@ import org.slf4j.MarkerFactory
 @CompileStatic
 class LoggerHelper {
 
+    static volatile boolean skipConsole
+
     static private Logger log = LoggerFactory.getLogger(LoggerHelper)
 
     static public Marker STICKY = MarkerFactory.getMarker('sticky')
@@ -418,6 +420,9 @@ class LoggerHelper {
             if (!isStarted()) {
                 return FilterReply.NEUTRAL;
             }
+
+            if( skipConsole )
+                return FilterReply.DENY;
 
             def logger = event.getLoggerName()
             def level = event.getLevel()


### PR DESCRIPTION
This PR is a an attempt to fix issues https://github.com/nextflow-io/nextflow/issues/5437 turning off the printing of logs once `abort` has been invoked