### PR TITLE
[FSN-35] Propagate Azure credentials to Fusion

### DIFF
--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/fusion/AzFusionEnvTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/fusion/AzFusionEnvTest.groovy
@@ -47,7 +47,7 @@ class AzFusionEnvTest extends Specification {
         env == Collections.emptyMap()
     }
 
-    def 'should return env environment with SAS token config when accountKey is provided'() {
+    def 'should return env environment with sasToken and accountName config when accountKey is provided'() {
         given:
         def NAME = 'myaccount'
         def KEY = 'myaccountkey'
@@ -67,7 +67,7 @@ class AzFusionEnvTest extends Specification {
         env.size() == 2
     }
 
-    def 'should return env environment with SAS token config when a Service Principal is provided'() {
+    def 'should return env environment with tenantID, servicePrincipalId, servicePrincipalSecret, and accountName config when a Service Principal is provided'() {
         given:
         def NAME = 'myaccount'
         def CLIENT_ID = 'myclientid'
@@ -90,17 +90,18 @@ class AzFusionEnvTest extends Specification {
 
         when:
         def config = Mock(FusionConfig)
-        def fusionEnv = Spy(AzFusionEnv)
-        1 * fusionEnv.getOrCreateSasToken() >> 'generatedSasToken'
-        def env = fusionEnv.getEnvironment('az', config)
+        def env = new AzFusionEnv().getEnvironment('az', config)
 
         then:
         env.AZURE_STORAGE_ACCOUNT == NAME
-        env.AZURE_STORAGE_SAS_TOKEN == 'generatedSasToken'
-        env.size() == 2
+        env.AZURE_TENANT_ID == TENANT_ID
+        env.AZURE_CLIENT_ID == CLIENT_ID
+        env.AZURE_CLIENT_SECRET == CLIENT_SECRET
+        env.AZURE_STORAGE_SAS_TOKEN == null
+        env.size() == 4
     }
 
-    def 'should return env environment with SAS token config when a user-assigned Managed Identity is provided'() {
+    def 'should return env environment with the clientId and accountName config when a user-assigned Managed Identity is provided'() {
         given:
         def NAME = 'myaccount'
         def CLIENT_ID = 'myclientid'
@@ -119,17 +120,16 @@ class AzFusionEnvTest extends Specification {
 
         when:
         def config = Mock(FusionConfig)
-        def fusionEnv = Spy(AzFusionEnv)
-        1 * fusionEnv.getOrCreateSasToken() >> 'generatedSasToken'
-        def env = fusionEnv.getEnvironment('az', config)
+        def env = new AzFusionEnv().getEnvironment('az', config)
 
         then:
         env.AZURE_STORAGE_ACCOUNT == NAME
-        env.AZURE_STORAGE_SAS_TOKEN == 'generatedSasToken'
+        env.AZURE_CLIENT_ID == CLIENT_ID
+        env.AZURE_STORAGE_SAS_TOKEN == null
         env.size() == 2
     }
 
-    def 'should return env environment with SAS token config when a system-assigned Managed Identity is provided'() {
+    def 'should return env environment with only the accountName config when a system-assigned Managed Identity is provided'() {
         given:
         def NAME = 'myaccount'
         Global.session = Mock(Session) {
@@ -147,17 +147,15 @@ class AzFusionEnvTest extends Specification {
 
         when:
         def config = Mock(FusionConfig)
-        def fusionEnv = Spy(AzFusionEnv)
-        1 * fusionEnv.getOrCreateSasToken() >> 'generatedSasToken'
-        def env = fusionEnv.getEnvironment('az', config)
+        def env = new AzFusionEnv().getEnvironment('az', config)
 
         then:
         env.AZURE_STORAGE_ACCOUNT == NAME
-        env.AZURE_STORAGE_SAS_TOKEN == 'generatedSasToken'
-        env.size() == 2
+        env.AZURE_STORAGE_SAS_TOKEN == null
+        env.size() == 1
     }
 
-    def 'should return env environment with SAS token config when a sasToken is provided'() {
+    def 'should return env environment sasToken and accountName config when a sasToken is provided'() {
         given:
         Global.session = Mock(Session) {
             getConfig() >> [azure: [storage: [accountName: 'x1', sasToken: 'y1']]]
@@ -176,18 +174,6 @@ class AzFusionEnvTest extends Specification {
         given:
         Global.session = Mock(Session) {
             getConfig() >> [azure: [storage: [sasToken: 'y1']]]
-        }
-        when:
-        def config = Mock(FusionConfig)
-        def env = new AzFusionEnv().getEnvironment('az', Mock(FusionConfig))
-        then:
-        thrown(IllegalArgumentException)
-    }
-
-    def 'should throw an exception when both account key and SAS token are present'() {
-        given:
-        Global.session = Mock(Session) {
-            getConfig() >> [azure: [storage: [accountName: 'x1', accountKey: 'y1', sasToken: 'z1']]]
         }
         when:
         def config = Mock(FusionConfig)


### PR DESCRIPTION
## Description
This PR ensures that sufficient authentication information is propagated between Nextflow and Fusion so that Fusion can authenticate on behalf of the user. This fixes some authentication problems with the current SAS token-based approach, which was limiting.

> [!WARNING]
> This depends on https://github.com/seqeralabs/fusion/pull/622 to work as expected.

* Related GH issues: #5444 