### PR TITLE
Update process snippets to comply with strict syntax

### DIFF
--- a/docs/cache-and-resume.md
+++ b/docs/cache-and-resume.md
@@ -148,6 +148,8 @@ process gather {
     input:
     tuple val(id), file(foo)
     tuple val(id), file(bar)
+
+    script:
     """
     merge_command $foo $bar
     """
@@ -168,6 +170,8 @@ workflow {
 process gather {
     input:
     tuple val(id), file(foo), file(bar)
+
+    script:
     """
     merge_command $foo $bar
     """

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -45,6 +45,7 @@ process foo {
   output:
   path 'x.txt'
 
+  script:
   """
   echo $x > x.txt
   """

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -50,9 +50,9 @@ process foo {
   conda 'bwa samtools multiqc'
 
   script:
-  '''
+  """
   your_command --here
-  '''
+  """
 }
 ```
 
@@ -100,9 +100,9 @@ process foo {
   conda '/some/path/my-env.yaml'
 
   script:
-  '''
+  """
   your_command --here
-  '''
+  """
 }
 ```
 
@@ -131,9 +131,9 @@ process foo {
   conda '/path/to/an/existing/env/directory'
 
   script:
-  '''
+  """
   your_command --here
-  '''
+  """
 }
 ```
 

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -49,6 +49,7 @@ Conda package names can specified using the `conda` directive. Multiple package 
 process foo {
   conda 'bwa samtools multiqc'
 
+  script:
   '''
   your_command --here
   '''
@@ -98,6 +99,7 @@ The path of an environment file can be specified using the `conda` directive:
 process foo {
   conda '/some/path/my-env.yaml'
 
+  script:
   '''
   your_command --here
   '''
@@ -128,6 +130,7 @@ If you already have a local Conda environment, you can use it in your workflow s
 process foo {
   conda '/path/to/an/existing/env/directory'
 
+  script:
   '''
   your_command --here
   '''

--- a/docs/container.md
+++ b/docs/container.md
@@ -294,18 +294,18 @@ process foo {
   container 'image_name_1'
 
   script:
-  '''
+  """
   do this
-  '''
+  """
 }
 
 process bar {
   container 'image_name_2'
 
   script:
-  '''
+  """
   do that
-  '''
+  """
 }
 ```
 
@@ -383,18 +383,18 @@ process foo {
   container 'image_name_1'
 
   script:
-  '''
+  """
   do this
-  '''
+  """
 }
 
 process bar {
   container 'image_name_2'
 
   script:
-  '''
+  """
   do that
-  '''
+  """
 }
 ```
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -293,6 +293,7 @@ It is possible to specify a different Docker image for each process definition i
 process foo {
   container 'image_name_1'
 
+  script:
   '''
   do this
   '''
@@ -301,6 +302,7 @@ process foo {
 process bar {
   container 'image_name_2'
 
+  script:
   '''
   do that
   '''
@@ -380,6 +382,7 @@ It is possible to specify a different container image for each process definitio
 process foo {
   container 'image_name_1'
 
+  script:
   '''
   do this
   '''
@@ -388,6 +391,7 @@ process foo {
 process bar {
   container 'image_name_2'
 
+  script:
   '''
   do that
   '''

--- a/docs/developer/nextflow.ast.md
+++ b/docs/developer/nextflow.ast.md
@@ -32,6 +32,7 @@ process splitLetters {
   output:
     path 'chunk_*'
 
+  script:
   """
   printf '${params.str}' | split -b 6 - chunk_
   """
@@ -43,6 +44,7 @@ process convertToUpper {
   output:
     stdout
 
+  script:
   """
   cat $x | tr '[a-z]' '[A-Z]'
   """
@@ -62,6 +64,7 @@ process( splitLetters( {
   output:
     path('chunk_*')
 
+  script:
   """
   printf '${params.str}' | split -b 6 - chunk_
   """
@@ -73,6 +76,7 @@ process( convertToUpper( {
   output:
     stdout
 
+  script:
   """
   cat $x | tr '[a-z]' '[A-Z]'
   """

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -141,6 +141,8 @@ You can then use this executor in your pipeline:
 ```nextflow
 process foo {
     executor 'my-executor'
+
+    // ...
 }
 ```
 

--- a/docs/dsl1.md
+++ b/docs/dsl1.md
@@ -29,6 +29,7 @@ process splitLetters {
     output:
     file 'chunk_*' into letters
 
+    script:
     """
     printf '${params.str}' | split -b 6 - chunk_
     """
@@ -41,6 +42,7 @@ process convertToUpper {
     output:
     stdout result
 
+    script:
     """
     cat $x | tr '[a-z]' '[A-Z]'
     """

--- a/docs/google.md
+++ b/docs/google.md
@@ -104,6 +104,7 @@ process myTask {
     cpus 8
     memory '40 GB'
 
+    script:
     """
     your_command --here
     """
@@ -112,6 +113,7 @@ process myTask {
 process anotherTask {
     machineType 'n1-highmem-8'
 
+    script:
     """
     your_command --here
     """
@@ -130,6 +132,7 @@ process myTask {
     memory '20 GB'
     machineType 'n2-*,c2-*,m3-*'
 
+    script:
     """
     your_command --here
     """
@@ -148,6 +151,7 @@ process myTask {
     memory '20 GB'
     machineType 'template://my-template'
 
+    script:
     """
     your_command --here
     """
@@ -341,6 +345,7 @@ process custom_resources_task {
     memory '40 GB'
     disk '200 GB'
 
+    script:
     """
     <Your script here>
     """
@@ -349,6 +354,7 @@ process custom_resources_task {
 process predefined_resources_task {
     machineType 'n1-highmem-8'
 
+    script:
     """
     <Your script here>
     """

--- a/docs/google.md
+++ b/docs/google.md
@@ -347,7 +347,7 @@ process custom_resources_task {
 
     script:
     """
-    <Your script here>
+    your_command --here
     """
 }
 
@@ -356,7 +356,7 @@ process predefined_resources_task {
 
     script:
     """
-    <Your script here>
+    your_command --here
     """
 }
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,6 +21,7 @@ In the first example, let's consider the simple use case in which a process perf
 process CpuUsageEx1 {
   cpus 2
 
+  script:
   """
   stress -c 1 -t 10 # compute square-root of random numbers during 10s using 1 CPU
   """
@@ -35,6 +36,7 @@ In the second example, some time will be spent performing pure computation and s
 process CpuUsageEx2 {
   cpus 1
 
+  script:
   """
   stress -c 1 -t 10 # compute square-root of random numbers during 10s using 1 CPU
   stress -c 1 -t 5 # compute square-root of random numbers during 5s using 1 CPU
@@ -57,6 +59,7 @@ The third example is similar to the second one except that the pure computation 
 process CpuUsageEx3 {
   cpus 2
 
+  script:
   """
   stress -c 2 -t 10 # compute square-root of random numbers during 10s using 2 CPUs
   sleep 10 # use no CPU during 10s
@@ -232,6 +235,7 @@ The first and second programs are executed in `foo` and `bar` processes respecti
 process foo {
     memory '1.5 GB'
 
+    script:
     """
     memory_vmem_1GiB_ram_0Gib
     """
@@ -240,6 +244,7 @@ process foo {
 process bar {
     memory '1.5 GB'
 
+    script:
     """
     memory_vmem_1GiB_ram_1Gib
     """

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -33,6 +33,7 @@ process blastSearch {
   output:
   path "top_hits.txt"
 
+  script:
   """
   blastp -db $db -query $query -outfmt 6 > blast_result
   cat blast_result | head -n 10 | cut -f 2 > top_hits.txt
@@ -47,6 +48,7 @@ process extractTopHits {
   output:
   path "sequences.txt"
 
+  script:
   """
   blastdbcmd -db $db -entry_batch $top_hits > sequences.txt
   """

--- a/docs/process.md
+++ b/docs/process.md
@@ -345,6 +345,7 @@ process basicExample {
   input:
   val x
 
+  script:
   "echo process job $x"
 }
 
@@ -374,6 +375,7 @@ process basicExample {
   input:
   val x
 
+  script:
   "echo process job $x"
 }
 
@@ -394,6 +396,7 @@ process blastThemAll {
   input:
   path query_file
 
+  script:
   "blastp -query ${query_file} -db nr"
 }
 
@@ -428,6 +431,7 @@ process blastThemAll {
   input:
   path 'query.fa'
 
+  script:
   "blastp -query query.fa -db nr"
 }
 
@@ -450,6 +454,7 @@ process foo {
   input:
   path x
 
+  script:
   """
   your_command --in $x
   """
@@ -497,6 +502,7 @@ process blastThemAll {
     input:
     path 'seq'
 
+    script:
     "echo seq*"
 }
 
@@ -536,6 +542,7 @@ process blastThemAll {
     input:
     path 'seq?.fa'
 
+    script:
     "cat seq1.fa seq2.fa seq3.fa"
 }
 
@@ -559,6 +566,7 @@ process simpleCount {
   val x
   path "${x}.fa"
 
+  script:
   """
   cat ${x}.fa | grep '>'
   """
@@ -582,6 +590,7 @@ process printEnv {
     input:
     env 'HELLO'
 
+    script:
     '''
     echo $HELLO world!
     '''
@@ -608,6 +617,7 @@ process printAll {
   input:
   stdin
 
+  script:
   """
   cat -
   """
@@ -640,6 +650,7 @@ process tupleExample {
     input:
     tuple val(x), path('input.txt')
 
+    script:
     """
     echo "Processing $x"
     cat input.txt > copy
@@ -665,6 +676,7 @@ process alignSequences {
   path seq
   each mode
 
+  script:
   """
   t_coffee -in $seq -mode $mode > result
   """
@@ -689,6 +701,7 @@ process alignSequences {
   each mode
   each path(lib)
 
+  script:
   """
   t_coffee -in $seq -mode $mode -lib $lib > result
   """
@@ -828,6 +841,7 @@ process foo {
   output:
   val x
 
+  script:
   """
   echo $x > file
   """
@@ -879,6 +893,7 @@ process randomNum {
   output:
   path 'result.txt'
 
+  script:
   '''
   echo $RANDOM > result.txt
   '''
@@ -919,6 +934,7 @@ process splitLetters {
     output:
     path 'chunk_*'
 
+    script:
     '''
     printf 'Hola' | split -b 1 - chunk_
     '''
@@ -966,6 +982,7 @@ process align {
   output:
   path "${species}.aln"
 
+  script:
   """
   t_coffee -in $seq > ${species}.aln
   """
@@ -1066,6 +1083,7 @@ process foo {
     output:
     path 'result.txt', hidden: true
 
+    script:
     '''
     echo 'another new line' >> result.txt
     '''
@@ -1079,6 +1097,7 @@ process foo {
     output:
     tuple path('last_result.txt'), path('result.txt', hidden: true)
 
+    script:
     '''
     echo 'another new line' >> result.txt
     echo 'another new line' > last_result.txt
@@ -1099,6 +1118,7 @@ process FOO {
     path 'hello.txt', emit: hello
     path 'bye.txt', emit: bye
 
+    script:
     """
     echo "hello" > hello.txt
     echo "bye" > bye.txt

--- a/docs/process.md
+++ b/docs/process.md
@@ -346,7 +346,9 @@ process basicExample {
   val x
 
   script:
-  "echo process job $x"
+  """
+  echo process job $x
+  """
 }
 
 workflow {
@@ -376,7 +378,9 @@ process basicExample {
   val x
 
   script:
-  "echo process job $x"
+  """
+  echo process job $x
+  """
 }
 
 workflow {
@@ -397,7 +401,9 @@ process blastThemAll {
   path query_file
 
   script:
-  "blastp -query ${query_file} -db nr"
+  """
+  blastp -query ${query_file} -db nr
+  """
 }
 
 workflow {
@@ -432,7 +438,9 @@ process blastThemAll {
   path 'query.fa'
 
   script:
-  "blastp -query query.fa -db nr"
+  """
+  blastp -query query.fa -db nr
+  """
 }
 
 workflow {
@@ -503,7 +511,9 @@ process blastThemAll {
     path 'seq'
 
     script:
-    "echo seq*"
+    """
+    echo seq*
+    """
 }
 
 workflow {
@@ -543,7 +553,9 @@ process blastThemAll {
     path 'seq?.fa'
 
     script:
-    "cat seq1.fa seq2.fa seq3.fa"
+    """
+    cat seq1.fa seq2.fa seq3.fa
+    """
 }
 
 workflow {
@@ -935,9 +947,9 @@ process splitLetters {
     path 'chunk_*'
 
     script:
-    '''
+    """
     printf 'Hola' | split -b 1 - chunk_
-    '''
+    """
 }
 
 workflow {
@@ -1084,9 +1096,9 @@ process foo {
     path 'result.txt', hidden: true
 
     script:
-    '''
+    """
     echo 'another new line' >> result.txt
-    '''
+    """
 }
 ```
 
@@ -1098,10 +1110,10 @@ process foo {
     tuple path('last_result.txt'), path('result.txt', hidden: true)
 
     script:
-    '''
+    """
     echo 'another new line' >> result.txt
     echo 'another new line' > last_result.txt
-    '''
+    """
 }
 ```
 :::
@@ -1235,7 +1247,7 @@ process foo {
 
   script:
   """
-  < your job here >
+  your_command --here
   """
 }
 ```
@@ -1275,7 +1287,9 @@ process foo {
     maxRetries 3
 
     script:
-    <your job here>
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -1298,7 +1312,9 @@ process foo {
     maxRetries 3
 
     script:
-    <your job here>
+    """
+    your_command --here
+    """
 }
 ```
 In the above example, the {ref}`process-memory` is set according to previous trace record metrics. In the first attempt, when no trace metrics are available, it is set to one GB. In the subsequent attempts, it doubles the previously allocated memory. See {ref}`trace-report` for more information about trace records.
@@ -1314,9 +1330,9 @@ process foo {
   maxRetries 5
 
   script:
-  '''
+  """
   your_command --here
-  '''
+  """
 }
 ```
 

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -428,11 +428,15 @@ A process output can be assigned to a topic using the `topic` option on an outpu
 process foo {
   output:
   val('foo'), topic: my_topic
+
+  // ...
 }
 
 process bar {
   output:
   val('bar'), topic: my_topic
+
+  // ...
 }
 ```
 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -313,9 +313,9 @@ process cpu_task {
     array 100
 
     script:
-    '''
+    """
     your_command --here
-    '''
+    """
 }
 ```
 
@@ -453,9 +453,9 @@ process foo {
   conda 'bwa=0.7.15'
 
   script:
-  '''
+  """
   your_command --here
-  '''
+  """
 }
 ```
 
@@ -479,7 +479,7 @@ process runThisInDocker {
 
   script:
   """
-  <your holy script here>
+  your_command --here
   """
 }
 ```
@@ -509,9 +509,9 @@ process runThisWithDocker {
     path 'output.txt'
 
     script:
-    '''
+    """
     your_command --data /db > output.txt
-    '''
+    """
 }
 ```
 
@@ -554,7 +554,9 @@ process sayHello {
   debug true
 
   script:
-  "echo Hello"
+  """
+  echo Hello
+  """
 }
 ```
 
@@ -577,7 +579,7 @@ process big_job {
 
     script:
     """
-    your task script here
+    your_command --here
     """
 }
 ```
@@ -792,9 +794,9 @@ process bigTask {
   label 'big_mem'
 
   script:
-  '''
-  <task script>
-  '''
+  """
+  your_command --here
+  """
 }
 ```
 
@@ -825,7 +827,7 @@ process foo {
 
   script:
   """
-  <your script here>
+  your_command --here
   """
 }
 ```
@@ -850,9 +852,9 @@ process foo {
   queue "${task.submitAttempt==1 : 'spot-compute' : 'on-demand-compute'}"
 
   script:
-  '''
-  your_job --here
-  '''
+  """
+  your_command --here
+  """
 }
 ```
 
@@ -897,9 +899,9 @@ process doNotParallelizeIt {
   maxForks 1
 
   script:
-  '''
-  <your script here>
-  '''
+  """
+  your_command --here
+  """
 }
 ```
 
@@ -940,7 +942,7 @@ process big_job {
 
     script:
     """
-    your task script here
+    your_command --here
     """
 }
 ```
@@ -1029,9 +1031,9 @@ process your_task {
   pod env: 'FOO', value: 'bar'
 
   script:
-  '''
+  """
   echo $FOO
-  '''
+  """
 }
 ```
 
@@ -1227,9 +1229,9 @@ process foo {
     path 'chunk_*'
 
     script:
-    '''
+    """
     printf 'Hola' | split -b 1 - chunk_
-    '''
+    """
 }
 ```
 
@@ -1253,9 +1255,9 @@ process foo {
     path 'chunk_*'
 
     script:
-    '''
+    """
     printf 'Hola' | split -b 1 - chunk_
-    '''
+    """
 }
 ```
 
@@ -1327,7 +1329,7 @@ process grid_job {
 
     script:
     """
-    your task script here
+    your_command --here
     """
 }
 ```
@@ -1360,9 +1362,9 @@ process my_task {
     resourceLabels region: 'some-region', user: 'some-username'
 
     script:
-    '''
-    <task script>
-    '''
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -1398,9 +1400,9 @@ process my_task {
   resourceLimits cpus: 24, memory: 768.GB, time: 72.h
 
   script:
-  '''
+  """
   your_command --here
-  '''
+  """
 }
 ```
 
@@ -1439,9 +1441,9 @@ process simpleTask {
   path 'data_out'
 
   script:
-  '''
-  <task script>
-  '''
+  """
+  your_command --here
+  """
 }
 ```
 
@@ -1479,9 +1481,9 @@ process doMoreThings {
     shell '/bin/bash', '-euo', 'pipefail'
 
     script:
-    '''
-    your_command_here
-    '''
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -1504,9 +1506,9 @@ process foo {
     spack 'bwa@0.7.15'
 
     script:
-    '''
+    """
     your_command --here
-    '''
+    """
 }
 ```
 
@@ -1644,7 +1646,7 @@ process big_job {
 
     script:
     """
-    your task script here
+    your_command --here
     """
 }
 ```

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -269,6 +269,7 @@ process cpu_task {
     spack 'blast-plus@2.13.0'
     arch 'linux/x86_64', target: 'cascadelake'
 
+    script:
     """
     blastp -query input_sequence -num_threads ${task.cpus}
     """
@@ -311,6 +312,7 @@ process cpu_task {
     executor 'slurm'
     array 100
 
+    script:
     '''
     your_command --here
     '''
@@ -361,6 +363,7 @@ For example:
 process foo {
   beforeScript 'source /cluster/bin/setup'
 
+  script:
   """
   echo bar
   """
@@ -380,9 +383,7 @@ The cache is enabled by default, but you can disable it for a specific process b
 ```nextflow
 process noCacheThis {
   cache false
-
-  script:
-  <your command string here>
+  // ...
 }
 ```
 
@@ -451,6 +452,7 @@ Nextflow automatically sets up an environment for the given package names listed
 process foo {
   conda 'bwa=0.7.15'
 
+  script:
   '''
   your_command --here
   '''
@@ -475,6 +477,7 @@ For example:
 process runThisInDocker {
   container 'dockerbox:tag'
 
+  script:
   """
   <your holy script here>
   """
@@ -505,6 +508,7 @@ process runThisWithDocker {
     output:
     path 'output.txt'
 
+    script:
     '''
     your_command --data /db > output.txt
     '''
@@ -526,6 +530,7 @@ process big_job {
   cpus 8
   executor 'sge'
 
+  script:
   """
   blastp -query input_sequence -num_threads ${task.cpus}
   """
@@ -570,6 +575,7 @@ process big_job {
     disk '2 GB'
     executor 'cirrus'
 
+    script:
     """
     your task script here
     """
@@ -631,8 +637,7 @@ For example:
 process ignoreAnyError {
   errorStrategy 'ignore'
 
-  script:
-  <your command string here>
+  // ...
 }
 ```
 
@@ -644,8 +649,7 @@ The `retry` error strategy allows you to re-submit for execution a process retur
 process retryIfFail {
   errorStrategy 'retry'
 
-  script:
-  <your command string here>
+  // ...
 }
 ```
 
@@ -691,8 +695,7 @@ The following example shows how to set the process's executor:
 process doSomething {
   executor 'sge'
 
-  script:
-  <your script here>
+  // ...
 }
 ```
 
@@ -714,6 +717,7 @@ process mapping {
   path genome
   tuple val(sampleId), path(reads)
 
+  script:
   """
   STAR --genomeDir $genome --readFilesIn $reads ${task.ext.args ?: ''}
   """
@@ -727,6 +731,8 @@ The `ext` directive can be set in the process definition:
 ```nextflow
 process mapping {
   ext version: '2.5.3', args: '--foo --bar'
+
+  // ...
 }
 ```
 
@@ -785,6 +791,7 @@ The `label` directive allows the annotation of processes with mnemonic identifie
 process bigTask {
   label 'big_mem'
 
+  script:
   '''
   <task script>
   '''
@@ -816,6 +823,7 @@ This directive is optional and if specified overrides the cpus and memory direct
 process foo {
   machineType 'n1-highmem-8'
 
+  script:
   """
   <your script here>
   """
@@ -840,6 +848,7 @@ process foo {
   maxSubmitAwait '10 mins'
   maxRetries 3
   queue "${task.submitAttempt==1 : 'spot-compute' : 'on-demand-compute'}"
+
   script:
   '''
   your_job --here
@@ -862,6 +871,7 @@ process retryIfFail {
   errorStrategy 'retry'
   maxErrors 5
 
+  script:
   """
   echo 'do this as that .. '
   """
@@ -886,6 +896,7 @@ If you want to execute a process in a sequential manner, set this directive to o
 process doNotParallelizeIt {
   maxForks 1
 
+  script:
   '''
   <your script here>
   '''
@@ -903,6 +914,7 @@ process retryIfFail {
     errorStrategy 'retry'
     maxRetries 3
 
+    script:
     """
     echo 'do this as that .. '
     """
@@ -926,6 +938,7 @@ process big_job {
     memory '2 GB'
     executor 'sge'
 
+    script:
     """
     your task script here
     """
@@ -960,6 +973,7 @@ In a process definition you can use the `module` directive to load a specific mo
 process basicExample {
   module 'ncbi-blast/2.2.27'
 
+  script:
   """
   blastp -query <etc..>
   """
@@ -972,6 +986,7 @@ You can repeat the `module` directive for each module you need to load. Alternat
 process manyModules {
   module 'ncbi-blast/2.2.27:t_coffee/10.0:clustalw/2.1'
 
+  script:
   """
   blastp -query <etc..>
   """
@@ -990,6 +1005,7 @@ process big_job {
   penv 'smp'
   executor 'sge'
 
+  script:
   """
   blastp -query input_sequence -num_threads ${task.cpus}
   """
@@ -1012,6 +1028,7 @@ For example:
 process your_task {
   pod env: 'FOO', value: 'bar'
 
+  script:
   '''
   echo $FOO
   '''
@@ -1209,6 +1226,7 @@ process foo {
     output:
     path 'chunk_*'
 
+    script:
     '''
     printf 'Hola' | split -b 1 - chunk_
     '''
@@ -1234,6 +1252,7 @@ process foo {
     output:
     path 'chunk_*'
 
+    script:
     '''
     printf 'Hola' | split -b 1 - chunk_
     '''
@@ -1306,6 +1325,7 @@ process grid_job {
     queue 'long'
     executor 'sge'
 
+    script:
     """
     your task script here
     """
@@ -1339,6 +1359,7 @@ The `resourceLabels` directive allows you to specify custom name-value pairs tha
 process my_task {
     resourceLabels region: 'some-region', user: 'some-username'
 
+    script:
     '''
     <task script>
     '''
@@ -1417,6 +1438,7 @@ process simpleTask {
   output:
   path 'data_out'
 
+  script:
   '''
   <task script>
   '''
@@ -1456,6 +1478,7 @@ The `shell` directive allows you to define a custom shell command for process sc
 process doMoreThings {
     shell '/bin/bash', '-euo', 'pipefail'
 
+    script:
     '''
     your_command_here
     '''
@@ -1480,6 +1503,7 @@ Nextflow automatically sets up an environment for the given package names listed
 process foo {
     spack 'bwa@0.7.15'
 
+    script:
     '''
     your_command --here
     '''
@@ -1587,6 +1611,7 @@ process foo {
   input:
   val code
 
+  script:
   """
   echo $code
   """
@@ -1617,6 +1642,7 @@ The `time` directive allows you to define how long a process is allowed to run. 
 process big_job {
     time '1h'
 
+    script:
     """
     your task script here
     """

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -56,6 +56,7 @@ process someJob {
     secret 'MY_ACCESS_KEY'
     secret 'MY_SECRET_KEY'
 
+    script:
     """
     your_command --access \$MY_ACCESS_KEY --secret \$MY_SECRET_KEY
     """

--- a/docs/spack.md
+++ b/docs/spack.md
@@ -49,6 +49,7 @@ Spack package names can specified using the `spack` directive. Multiple package 
 process foo {
   spack 'bwa samtools py-multiqc'
 
+  script:
   '''
   your_command --here
   '''
@@ -93,6 +94,7 @@ The path of an environment file can be specified using the `spack` directive:
 process foo {
   spack '/some/path/my-env.yaml'
 
+  script:
   '''
   your_command --here
   '''
@@ -111,6 +113,7 @@ If you already have a local Spack environment, you can use it in your workflow s
 process foo {
   spack '/path/to/an/existing/env/directory'
 
+  script:
   '''
   your_command --here
   '''

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -342,6 +342,8 @@ process PROC {
     input:
     env FOO
     env 'BAR'
+
+    // ...
 }
 ```
 
@@ -352,6 +354,8 @@ process PROC {
     input:
     env 'FOO'
     env 'BAR'
+
+    // ...
 }
 ```
 

--- a/docs/your-first-script.md
+++ b/docs/your-first-script.md
@@ -55,6 +55,7 @@ process convertToUpper {
   output:
     stdout
 
+  script:
   """
   rev $x
   """


### PR DESCRIPTION
The strict syntax is a bit more picky about the process `script:` section label ([source](https://nextflow.io/docs/latest/vscode.html#restricted-syntax)):

> The Nextflow language specification allows the `script:` label to be omitted only if there are no other sections

This PR updates process snippets throughout the docs to comply with this rule.