### PR TITLE
Docs: Improve Conda docs - PyPI + lock files

### DIFF
--- a/docs/conda.md
+++ b/docs/conda.md
@@ -100,7 +100,7 @@ The environment file name **must** have a `.yml` or `.yaml` extension or else it
 (conda-pypi)=
 ### Python Packages from PyPI
 
-Conda environment files can also be used to install Python packages from the [PyPI repository](https://pypi.org/)), through the `pip` package manager (which must also be explicitly listed as a required package):
+Conda environment files can also be used to install Python packages from the [PyPI repository](https://pypi.org/), through the `pip` package manager (which must also be explicitly listed as a required package):
 
 ```yaml
 name: my-env-2
@@ -144,7 +144,7 @@ or if using Mamba / Micromamba:
 micromamba env export --explicit > spec-file.txt
 ```
 
-Conda lock files can also be downloaded from Wave build pages.
+Conda lock files can also be downloaded from [Wave](https://seqera.io/wave/) build pages.
 
 These files include every package and their dependencies. As such, no Conda environment resolution step is needed. This is faster and more reproducible.
 

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -6,7 +6,7 @@
 
 Nextflow has built-in support for Conda that allows the configuration of workflow dependencies using Conda recipes and environment files.
 
-This allows Nextflow applications to use popular tool collections such as [Bioconda](https://bioconda.github.io) whilst taking advantage of the configuration flexibility provided by Nextflow.
+This allows Nextflow applications to use popular tool collections such as [Bioconda](https://bioconda.github.io) and the [Python Package index](https://pypi.org/), whilst taking advantage of the configuration flexibility provided by Nextflow.
 
 ## Prerequisites
 

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -62,6 +62,7 @@ The usual Conda package syntax and naming conventions can be used. The version o
 
 The name of the channel where a package is located can be specified prefixing the package with the channel name as shown here `bioconda::bwa=0.7.15`.
 
+(conda-env-files)=
 ### Use Conda environment files
 
 Conda environments can also be defined using one or more Conda environment files. This is a file that lists the required packages and channels structured using the YAML format. For example:
@@ -96,6 +97,7 @@ process foo {
 The environment file name **must** have a `.yml` or `.yaml` extension or else it won't be properly recognised.
 :::
 
+(conda-pypi)=
 ### Python Packages from PyPI
 
 Conda environment files can also be used to install Python packages from the [PyPI repository](https://pypi.org/)), through the `pip` package manager (which must also be explicitly listed as a required package):

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -116,7 +116,7 @@ dependencies:
 
 ### Conda text files
 
-It is possible to provide the dependencies using a plain text file, just listing each package name as a separate line. For example:
+It is possible to provide dependencies by listing each package name as a separate line in a plain text file. For example:
 
 ```
 bioconda::star=2.5.4a
@@ -132,7 +132,7 @@ Like before, the extension matters. Make sure the dependencies file has a `.txt`
 
 The final way to provide packages to Conda is with [Conda lock files](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#identical-conda-envs).
 
-These are generated from existing conda environements using the following command:
+These are generated from existing Conda environments using the following command:
 
 ```bash
 conda list --explicit > spec-file.txt
@@ -144,11 +144,11 @@ or if using Mamba / Micromamba:
 micromamba env export --explicit > spec-file.txt
 ```
 
-They can also be downloaded from Wave build pages.
+Conda lock files can also be downloaded from Wave build pages.
 
-These files include the every package, including dependencies. As such, no conda environment resolution step is needed. This is faster and also better for reproducibility between runs.
+These files include every package and their dependencies. As such, no Conda environment resolution step is needed. This is faster and more reproducible.
 
-The files contain package URLs and optionally also a md5hash for each download to confirm identity:
+The files contain package URLs and an optional md5hash for each download to confirm identity:
 
 ```
 # micromamba env export --explicit

--- a/docs/wave.md
+++ b/docs/wave.md
@@ -90,7 +90,7 @@ conda.channels = 'conda-forge,bioconda'
 ```
 :::
 
-Packages from the [Python Package Index](https://pypi.org/) can also be used by using a Conda `environment.yml` file - see the documentation about {ref}`Conda and PyPI <conda-pypi>` for details.
+Packages from the [Python Package Index](https://pypi.org/) can also be added to a Conda `environment.yml` file. See {ref}`Conda and PyPI <conda-pypi>` for more information.
 
 (wave-singularity)=
 

--- a/docs/wave.md
+++ b/docs/wave.md
@@ -90,6 +90,8 @@ conda.channels = 'conda-forge,bioconda'
 ```
 :::
 
+Packages from the [Python Package Index](https://pypi.org/) can also be used by using a Conda `environment.yml` file - see the documentation about {ref}`Conda and PyPI <conda-pypi>` for details.
+
 (wave-singularity)=
 
 ### Build Singularity native images


### PR DESCRIPTION
* Add docs about Conda lock files
* Create new headings specifically for PyPI, text files and lock files
* Add mention of ability to use PyPI packages to the Wave docs, with link

@netlify /conda#use-conda-environment-files