### PR TITLE
Docs: Move `-params-file` config from CLI to config

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,6 +243,36 @@ $ nextflow run <pipeline> --files "*.fasta"
 ```
 :::
 
+Parameters specified on the command line can be also specified in a params file using the `-params-file` option.
+
+```bash
+nextflow run main.nf -params-file pipeline_params.yml
+```
+
+The `-params-file` option loads parameters for your Nextflow pipeline from a JSON or YAML file. Parameters defined in the file are equivalent to specifying them directly on the command line. For example, instead of specifying parameters on the command line:
+
+```bash
+nextflow run main.nf --alpha 1 --beta foo
+```
+
+Parameters can be represented in YAML format:
+
+```yaml
+alpha: 1
+beta: 'foo'
+```
+
+Or in JSON format:
+
+```json
+{
+  "alpha": 1,
+  "beta": "foo"
+}
+```
+
+The parameters specified in a params file are merged with the resolved configuration. The values provided via a params file overwrite those of the same name in the Nextflow configuration file, but not those specified on the command line.
+
 ## Managing projects
 
 Nextflow seamlessly integrates with popular Git providers, including [BitBucket](http://bitbucket.org/), [GitHub](http://github.com), and [GitLab](http://gitlab.com) for managing Nextflow pipelines as version-controlled Git repositories.

--- a/docs/config.md
+++ b/docs/config.md
@@ -138,6 +138,8 @@ params {
 }
 ```
 
+See {ref}`cli-params` for information about how to modify these on the command line.
+
 (config-process)=
 
 ## Process configuration
@@ -331,37 +333,3 @@ workflow.onError = {
 ```
 
 See {ref}`workflow-handlers` for more information.
-
-(config-params-file)=
-
-## Params file
-
-Parameters specified on the command line can be specified in a params file using the `-params-file` option.
-
-```bash
-nextflow run main.nf -params-file pipeline_params.yml
-```
-
-The `-params-file` option loads parameters for your Nextflow pipeline from a JSON or YAML file. Parameters defined in the file are equivalent to specifying them directly on the command line. For example, instead of specifying parameters on the command line:
-
-```bash
-nextflow run main.nf --alpha 1 --beta foo
-```
-
-Parameters can be represented in YAML format:
-
-```yaml
-alpha: 1
-beta: 'foo'
-```
-
-Or in JSON format:
-
-```json
-{
-  "alpha": 1,
-  "beta": "foo"
-}
-```
-
-The parameters specified in a params file are merged with the resolved configuration. The values provided via a params file overwrite those of the same name in the Nextflow configuration file, but not those specified on the command line.

--- a/docs/config.md
+++ b/docs/config.md
@@ -331,3 +331,35 @@ workflow.onError = {
 ```
 
 See {ref}`workflow-handlers` for more information.
+
+## Params file
+
+Parameters specified on the command line can be specified in a params file using the `-params-file` option.
+
+```bash
+nextflow run main.nf -params-file pipeline_params.yml
+```
+
+The `-params-file` option loads parameters for your Nextflow pipeline from a JSON or YAML file. Parameters defined in the file are equivalent to specifying them directly on the command line. For example:
+
+```bash
+nextflow run main.nf --alpha 1 --beta foo
+```
+
+The above parameters can be represented in YAML format:
+
+```yaml
+alpha: 1
+beta: 'foo'
+```
+
+The same parameters can be represented in JSON format:
+
+```json
+{
+  "alpha": 1,
+  "beta": "foo"
+}
+```
+
+The parameters specified in a params file are merged with the resolved configuration. The values provided via a params file overwrite those of the same name in the Nextflow configuration file, but not those specified on the command line.

--- a/docs/config.md
+++ b/docs/config.md
@@ -342,20 +342,20 @@ Parameters specified on the command line can be specified in a params file using
 nextflow run main.nf -params-file pipeline_params.yml
 ```
 
-The `-params-file` option loads parameters for your Nextflow pipeline from a JSON or YAML file. Parameters defined in the file are equivalent to specifying them directly on the command line. For example:
+The `-params-file` option loads parameters for your Nextflow pipeline from a JSON or YAML file. Parameters defined in the file are equivalent to specifying them directly on the command line. For example, instead of specifying parameters on the command line:
 
 ```bash
 nextflow run main.nf --alpha 1 --beta foo
 ```
 
-The above parameters can be represented in YAML format:
+Parameters can be represented in YAML format:
 
 ```yaml
 alpha: 1
 beta: 'foo'
 ```
 
-The same parameters can be represented in JSON format:
+Or in JSON format:
 
 ```json
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -332,6 +332,8 @@ workflow.onError = {
 
 See {ref}`workflow-handlers` for more information.
 
+(config-params-file)=
+
 ## Params file
 
 Parameters specified on the command line can be specified in a params file using the `-params-file` option.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1172,29 +1172,7 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
   $ nextflow run main.nf -params-file pipeline_params.yml
   ```
 
-  For example, the following params file in YAML format:
-
-  ```yaml
-  alpha: 1
-  beta: 'foo'
-  ```
-
-  Or in JSON format:
-
-  ```json
-  {
-    "alpha": 1,
-    "beta": "foo"
-  }
-  ```
-
-  Is equivalent to the following command line:
-
-  ```console
-  $ nextflow run main.nf --alpha 1 --beta foo
-  ```
-
-  The parameters specified with this mechanism are merged with the resolved configuration (base configuration and profiles). The values provided via a params file overwrite those of the same name in the Nextflow configuration file.
+  See {ref}`config-params-file` for more information about writing custom parameters files.
 
 ### `self-update`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1172,7 +1172,7 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
   $ nextflow run main.nf -params-file pipeline_params.yml
   ```
 
-  See {ref}`config-params-file` for more information about writing custom parameters files.
+  See {ref}`cli-params` for more information about writing custom parameters files.
 
 ### `self-update`
 


### PR DESCRIPTION
- Added params file section to the config page
- Reduced CLI documentation (not the place to describe JSON and YAML)
    - Added link to config page in the example

cc @FriederikeHanssen

@netlify /config#params-file