### PR TITLE
Support not using a container in Azure Batch

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -437,15 +437,18 @@ class AzBatchService implements Closeable {
 
         log.trace "[AZURE BATCH] Submitting task: $taskId, cpus=${task.config.getCpus()}, mem=${task.config.getMemory()?:'-'}, slots: $slots"
 
-        return new BatchTaskCreateContent(taskId, cmd)
+        final batchTask = new BatchTaskCreateContent(taskId, cmd)
                 .setUserIdentity(userIdentity(pool.opts.privileged, pool.opts.runAs, AutoUserScope.TASK))
-                .setContainerSettings(containerOpts)
                 .setResourceFiles(resourceFileUrls(task, sas))
                 .setOutputFiles(outputFileUrls(task, sas))
                 .setRequiredSlots(slots)
                 .setConstraints(constraints)
-                
 
+        if (containerOpts) {
+            batchTask.setContainerSettings(containerOpts)
+        }
+
+        return batchTask
     }
 
     AzTaskKey runTask(String poolId, String jobId, TaskRun task) {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -393,7 +393,7 @@ class AzBatchService implements Closeable {
 
         final container = task.getContainer()
         if( !container )
-            throw new IllegalArgumentException("Missing container image for process: $task.name")
+            log.warn "Missing container image for process: $task.name"
         final taskId = "nf-${task.hash.toString()}"
         // get the pool config
         final pool = getPoolSpec(poolId)
@@ -419,8 +419,11 @@ class AzBatchService implements Closeable {
             }
         }
         // config overall container settings
-        final containerOpts = new BatchTaskContainerSettings(container)
+        BatchTaskContainerSettings containerOpts = null
+        if (container) {
+            containerOpts = new BatchTaskContainerSettings(container)
                 .setContainerRunOptions(opts)
+        }
         // submit command line
         final String cmd = fusionEnabled
                 ? launcher.fusionSubmitCli(task).join(' ')

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -60,7 +60,6 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         this.outputFile = task.workDir.resolve(TaskRun.CMD_OUTFILE)
         this.errorFile = task.workDir.resolve(TaskRun.CMD_ERRFILE)
         this.exitFile = task.workDir.resolve(TaskRun.CMD_EXIT)
-        validateConfiguration()
     }
 
     /** only for testing purpose - DO NOT USE */
@@ -68,12 +67,6 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     AzBatchService getBatchService() {
         return executor.batchService
-    }
-
-    void validateConfiguration() {
-        if (!task.container) {
-            throw new ProcessUnrecoverableException("No container image specified for process $task.name -- Either specify the container to use in the process definition or with 'process.container' value in your config")
-        }
     }
 
     protected BashWrapperBuilder createBashWrapper() {

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
@@ -18,16 +18,14 @@ import spock.lang.Specification
  */
 class AzBatchTaskHandlerTest extends Specification {
 
-    def 'should validate config' () {
+    def 'should validate config with and without container' () {
         when:
-        def task = Mock(TaskRun) { getName() >> 'foo'; }
+        def task = Mock(TaskRun) { getName() >> 'foo' }
         and:
         new AzBatchTaskHandler(task: task)
                 .validateConfiguration()
         then:
-        def e = thrown(ProcessUnrecoverableException)
-        e.message.startsWith('No container image specified for process foo')
-
+        noExceptionThrown()
 
         when:
         task = Mock(TaskRun) { getName() >> 'foo'; getContainer() >> 'ubuntu' }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
@@ -18,24 +18,6 @@ import spock.lang.Specification
  */
 class AzBatchTaskHandlerTest extends Specification {
 
-    def 'should validate config with and without container' () {
-        when:
-        def task = Mock(TaskRun) { getName() >> 'foo' }
-        and:
-        new AzBatchTaskHandler(task: task)
-                .validateConfiguration()
-        then:
-        noExceptionThrown()
-
-        when:
-        task = Mock(TaskRun) { getName() >> 'foo'; getContainer() >> 'ubuntu' }
-        and:
-        new AzBatchTaskHandler(task: task)
-                .validateConfiguration()
-        then:
-        noExceptionThrown()
-    }
-
     def 'should submit task' () {
         given:
         def builder = Mock(BashWrapperBuilder)


### PR DESCRIPTION
There are rare cases where a user needs to run a process on a bare VM on Azure Batch. Most notably, when using the Dragen which requires you to use a specific machine image that does not support a Docker container. 

Previously, Nextflow prevented this, but this PR removes that safeguard and replaces it with a warning. It's not a good idea, but it can unblock users if they need to use a bare VM.

If nothing else, this PR functions as proof it can be done if anyone else needs to use it.