### PR TITLE
Fix overlapping in conda environment creation when equivalent but diff…

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -359,8 +359,8 @@ class CondaCache {
      *      The {@link DataflowVariable} which hold (and pull) the local image file
      */
     @PackageScope
-    DataflowVariable<Path> getLazyImagePath(String condaEnv) {
-
+    DataflowVariable<Path> getLazyImagePath(String rawCondaEnv) {
+        def condaEnv = normalizeCondaEnv(rawCondaEnv)
         if( condaEnv in condaPrefixPaths ) {
             log.trace "${binaryName} found local environment `$condaEnv`"
             return condaPrefixPaths[condaEnv]
@@ -399,4 +399,12 @@ class CondaCache {
         return result
     }
 
+    String normalizeCondaEnv(String rawCondaEnv) {
+        // Check if it's a path (as in getPrefixPath)
+        if( !isYamlUriPath(rawCondaEnv) && ( isYamlFilePath(rawCondaEnv) || isTextFilePath(rawCondaEnv) || rawCondaEnv.contains('/') ) ) {
+            final path = rawCondaEnv as Path
+            return path.toAbsolutePath().normalize().toString()
+        }
+        return rawCondaEnv
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -569,4 +569,21 @@ class CondaCacheTest extends Specification {
         cleanup:
         folder?.deleteDir()
     }
+
+    def 'should normalize paths' () {
+
+        given:
+        def cache = new CondaCache()
+
+        expect:
+            cache.normalizeCondaEnv(RAW_CONDA_ENV) == EXPECTED
+
+        where:
+        RAW_CONDA_ENV                   | EXPECTED
+        'bwa=1.1.1'                     | 'bwa=1.1.1'
+        'http://url.com/path/env.yml'   | 'http://url.com/path/env.yml'
+        '/path/to/../directory'         | '/path/directory'
+        '/path/./to/file.txt'           | '/path/to/file.txt'
+        '/path/./to/file.yml'           | '/path/to/file.yml'
+    }
 }


### PR DESCRIPTION
When two process uses the same environment file but they are specified in the 'conda' directive using different relative paths, it generates different entries in the 'condaPrefixPaths' hasmap with different keys but the same value. An it tries to concurrently build the same environment twice producing the the lock file overlapping error

To fix it, when the provided conda env is considered a file/directory path (as evaluated in 'createLocalCondaEnv'), it is normalized before inserting to the hasmap or checking if conda environment is already in the hashmap.