### PR TITLE
Fix overlapping conda lock file

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -251,8 +251,8 @@ class CondaCache {
      * @return the conda environment prefix {@link Path}
      */
     @PackageScope
-    Path createLocalCondaEnv(String condaEnv) {
-        final prefixPath = condaPrefixPath(condaEnv)
+    Path createLocalCondaEnv(String condaEnv, Path prefixPath) {
+
         if( prefixPath.isDirectory() ) {
             log.debug "${binaryName} found local env for environment=$condaEnv; path=$prefixPath"
             return prefixPath
@@ -360,17 +360,18 @@ class CondaCache {
      */
     @PackageScope
     DataflowVariable<Path> getLazyImagePath(String condaEnv) {
-
-        if( condaEnv in condaPrefixPaths ) {
+        final prefixPath = condaPrefixPath(condaEnv)
+        final condaEnvPath = prefixPath.toString()
+        if( condaEnvPath in condaPrefixPaths ) {
             log.trace "${binaryName} found local environment `$condaEnv`"
-            return condaPrefixPaths[condaEnv]
+            return condaPrefixPaths[condaEnvPath]
         }
 
         synchronized (condaPrefixPaths) {
-            def result = condaPrefixPaths[condaEnv]
+            def result = condaPrefixPaths[condaEnvPath]
             if( result == null ) {
-                result = new LazyDataflowVariable<Path>({ createLocalCondaEnv(condaEnv) })
-                condaPrefixPaths[condaEnv] = result
+                result = new LazyDataflowVariable<Path>({ createLocalCondaEnv(condaEnv, prefixPath) })
+                condaPrefixPaths[condaEnvPath] = result
             }
             else {
                 log.trace "${binaryName} found local cache for environment `$condaEnv` (2)"

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -197,9 +197,8 @@ class CondaCacheTest extends Specification {
 
         when:
         // the prefix directory exists ==> no conda command is executed
-        def result = cache.createLocalCondaEnv(ENV)
+        def result = cache.createLocalCondaEnv(ENV, PREFIX)
         then:
-        1 * cache.condaPrefixPath(ENV) >> PREFIX
         0 * cache.isYamlFilePath(ENV)
         0 * cache.runCommand(_)
         result == PREFIX
@@ -224,9 +223,8 @@ class CondaCacheTest extends Specification {
 
         when:
         // the prefix directory exists ==> no mamba command is executed
-        def result = cache.createLocalCondaEnv(ENV)
+        def result = cache.createLocalCondaEnv(ENV, PREFIX)
         then:
-        1 * cache.condaPrefixPath(ENV) >> PREFIX
         0 * cache.isYamlFilePath(ENV)
         0 * cache.runCommand(_)
         result == PREFIX
@@ -251,9 +249,8 @@ class CondaCacheTest extends Specification {
 
         when:
         // the prefix directory exists ==> no mamba command is executed
-        def result = cache.createLocalCondaEnv(ENV)
+        def result = cache.createLocalCondaEnv(ENV, PREFIX)
         then:
-        1 * cache.condaPrefixPath(ENV) >> PREFIX
         0 * cache.isYamlFilePath(ENV)
         0 * cache.runCommand(_)
         result == PREFIX
@@ -278,9 +275,8 @@ class CondaCacheTest extends Specification {
 
         when:
         // the prefix directory exists ==> no mamba command is executed
-        def result = cache.createLocalCondaEnv(ENV)
+        def result = cache.createLocalCondaEnv(ENV, PREFIX)
         then:
-        1 * cache.condaPrefixPath(ENV) >> PREFIX
         0 * cache.isYamlFilePath(ENV)
         0 * cache.runCommand(_)
         result == PREFIX
@@ -304,9 +300,8 @@ class CondaCacheTest extends Specification {
 
         when:
         // the prefix directory exists ==> no mamba command is executed
-        def result = cache.createLocalCondaEnv(ENV)
+        def result = cache.createLocalCondaEnv(ENV, PREFIX)
         then:
-        1 * cache.condaPrefixPath(ENV) >> PREFIX
         0 * cache.isYamlFilePath(ENV)
         0 * cache.runCommand(_)
         result == PREFIX


### PR DESCRIPTION
Close #5530 
Alternative for fixing the overlapping conda lock file reusing the condaPrefixPath function.