### PR TITLE
Fix missing wave response

### DIFF
--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -27,7 +27,6 @@ import java.nio.file.attribute.FileTime
 import java.time.Duration
 import java.time.Instant
 
-import com.google.common.cache.Cache
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpHandler
 import com.sun.net.httpserver.HttpServer
@@ -1303,18 +1302,18 @@ class WaveClientTest extends Specification {
     def 'should validate isContainerReady' () {
         given:
         def sess = Mock(Session) {getConfig() >> [wave: [build:[maxDuration: '500ms']]] }
-        def cache = Mock(Cache)
+        def cache = Mock(Map)
         and:
         def resp = Mock(SubmitContainerTokenResponse)
         def handle = new WaveClient.Handle(resp,Instant.now())
-        def wave = Spy(new WaveClient(session:sess, cache: cache))
+        def wave = Spy(new WaveClient(session:sess, responses: cache))
         boolean ready
 
         // container succeeded
         when:
         ready = wave.isContainerReady('xyz')
         then:
-        cache.getIfPresent('xyz') >> handle
+        cache.get('xyz') >> handle
         and:
         resp.requestId >> '12345'
         resp.succeeded >> true
@@ -1328,7 +1327,7 @@ class WaveClientTest extends Specification {
         when:
         ready = wave.isContainerReady('xyz')
         then:
-        cache.getIfPresent('xyz') >> handle
+        cache.get('xyz') >> handle
         and:
         resp.requestId >> '12345'
         resp.succeeded >> null
@@ -1342,7 +1341,7 @@ class WaveClientTest extends Specification {
         when:
         ready = wave.isContainerReady('xyz')
         then:
-        cache.getIfPresent('xyz') >> handle
+        cache.get('xyz') >> handle
         and:
         resp.requestId >> '12345'
         resp.succeeded >> false
@@ -1357,7 +1356,7 @@ class WaveClientTest extends Specification {
         when:
         ready = wave.isContainerReady('xyz')
         then:
-        cache.getIfPresent('xyz') >> handle
+        cache.get('xyz') >> handle
         and:
         resp.buildId >> 'bd-5678'
         resp.cached >> false
@@ -1371,7 +1370,7 @@ class WaveClientTest extends Specification {
         when:
         ready = wave.isContainerReady('xyz')
         then:
-        cache.getIfPresent('xyz') >> handle
+        cache.get('xyz') >> handle
         and:
         resp.requestId >> null
         resp.buildId >> 'bd-5678'
@@ -1386,7 +1385,7 @@ class WaveClientTest extends Specification {
         when:
         ready = wave.isContainerReady('xyz')
         then:
-        cache.getIfPresent('xyz') >> handle
+        cache.get('xyz') >> handle
         and:
         resp.requestId >> null
         resp.buildId >> 'bd-5678'


### PR DESCRIPTION
This PR fixes the error `Unable to find any container with key: XXXXXXX`.

The issues caused when checking the container readiness using the cached handler metadata hold in the cache https://github.com/nextflow-io/nextflow/blob/c591e4eaa5b38d759f67a1d93fe533bb487f55a3/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy#L141-L144


The error arise when the status is checked after the entries is evicted by the cached due the expiration timeout 