### PR TITLE
Improve handling unstage  outputs and controls

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -372,7 +372,6 @@ class BashWrapperBuilder {
         binding.launch_cmd = getLaunchCommand(interpreter,env)
         binding.stage_cmd = getStageCommand()
         binding.unstage_cmd = getUnstageCommand()
-        binding.unstage_controls_cmd = getUnstageControlsCommand()
         binding.unstage_controls = changeDir || shouldUnstageOutputs() ? getUnstageControls() : null
 
         if( changeDir || shouldUnstageOutputs() ) {
@@ -755,9 +754,6 @@ class BashWrapperBuilder {
     protected String getStageCommand() { 'nxf_stage' }
 
     protected String getUnstageCommand() { 'nxf_unstage' }
-
-    protected String getUnstageControlsCommand() { 'nxf_unstage_std_files' }
-
 
     protected String getUnstageControls() {
         def result = copyFileToWorkDir(TaskRun.CMD_OUTFILE) + ' || true' + ENDL

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -127,7 +127,7 @@ nxf_stage() {
     {{stage_inputs}}
 }
 
-nxf_unstage() {
+nxf_unstage_outputs() {
     true
     {{unstage_outputs}}
 }
@@ -135,6 +135,16 @@ nxf_unstage() {
 nxf_unstage_std_files() {
     true
     {{unstage_controls}}
+}
+
+nxf_unstage() {
+    ## Deactivate fast failure to allow uploading stdout and stderr files later
+    if [[ ${nxf_main_ret:=0} == 0 ]]; then
+        ## Data unstaging redirecting stdout and stderr with append mode
+        (set -e -o pipefail; (nxf_unstage_outputs | tee -a {{stdout_file}}) 3>&1 1>&2 2>&3 | tee -a {{stderr_file}})
+        nxf_unstage_ret=$?
+    fi
+    nxf_unstage_std_files
 }
 
 nxf_main() {
@@ -159,17 +169,11 @@ nxf_main() {
     export NXF_TASK_WORKDIR="$PWD"
     {{stage_cmd}}
 
-    ## Deactivate fast failure to allow uploading stdout and stderr files later
     set +e
     (set -o pipefail; (nxf_launch | tee {{stdout_file}}) 3>&1 1>&2 2>&3 | tee {{stderr_file}}) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    if [[ ${nxf_main_ret:=0} == 0 ]]; then
-        ## Data unstaging redirecting stdout and stderr with append mode
-        (set -e -o pipefail; ({{unstage_cmd}} | tee -a {{stdout_file}}) 3>&1 1>&2 2>&3 | tee -a {{stderr_file}})
-        nxf_unstage_ret=$?
-    fi
-    {{unstage_controls_cmd}}
+    {{unstage_cmd}}
     {{after_script}}
 }
 

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -103,8 +103,8 @@ on_exit() {
     ## Can be caused either by the task script, unstage script or after script if defined
     local last_err=$?
     ## capture the task error first or fallback to unstage error
-    exit_status=${nxf_main_ret:=0}
-    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:0} -ne 0 ]] && exit_status=${nxf_unstage_ret}
+    local exit_status=${nxf_main_ret:=0}
+    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
     [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}
     printf -- $exit_status {{exit_file}}
     set +u

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -1328,14 +1328,12 @@ class BashWrapperBuilderTest extends Specification {
         then:
         builder.getStageCommand() == 'nxf_stage'
         builder.getUnstageCommand() == 'nxf_unstage'
-        builder.getUnstageControlsCommand() == 'nxf_unstage_std_files'
 
         when:
         def binding = builder.makeBinding()
         then:
         binding.stage_cmd == 'nxf_stage'
         binding.unstage_cmd == 'nxf_unstage'
-        binding.unstage_controls_cmd == 'nxf_unstage_std_files'
         
     }
 

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -292,12 +292,20 @@ nxf_stage() {
     true
 }
 
-nxf_unstage() {
+nxf_unstage_outputs() {
     true
 }
 
 nxf_unstage_std_files() {
     true
+}
+
+nxf_unstage() {
+    if [[ ${nxf_main_ret:=0} == 0 ]]; then
+        (set -e -o pipefail; (nxf_unstage_outputs | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
+        nxf_unstage_ret=$?
+    fi
+    nxf_unstage_std_files
 }
 
 nxf_main() {
@@ -319,11 +327,7 @@ nxf_main() {
     (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    if [[ ${nxf_main_ret:=0} == 0 ]]; then
-        (set -e -o pipefail; (nxf_unstage | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
-        nxf_unstage_ret=$?
-    fi
-    nxf_unstage_std_files
+    nxf_unstage
 }
 
 $NXF_ENTRY

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -271,8 +271,8 @@ nxf_fs_fcp() {
 
 on_exit() {
     local last_err=$?
-    exit_status=${nxf_main_ret:=0}
-    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:0} -ne 0 ]] && exit_status=${nxf_unstage_ret}
+    local exit_status=${nxf_main_ret:=0}
+    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
     [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}
     printf -- $exit_status > {{folder}}/.exitcode
     set +u

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
@@ -82,8 +82,8 @@ nxf_fs_fcp() {
 
 on_exit() {
     local last_err=$?
-    exit_status=${nxf_main_ret:=0}
-    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:0} -ne 0 ]] && exit_status=${nxf_unstage_ret}
+    local exit_status=${nxf_main_ret:=0}
+    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
     [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}
     printf -- $exit_status > {{folder}}/.exitcode
     set +u

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
@@ -103,12 +103,20 @@ nxf_stage() {
     true
 }
 
-nxf_unstage() {
+nxf_unstage_outputs() {
     true
 }
 
 nxf_unstage_std_files() {
     true
+}
+
+nxf_unstage() {
+    if [[ ${nxf_main_ret:=0} == 0 ]]; then
+        (set -e -o pipefail; (nxf_unstage_outputs | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
+        nxf_unstage_ret=$?
+    fi
+    nxf_unstage_std_files
 }
 
 nxf_main() {
@@ -136,11 +144,7 @@ nxf_main() {
     (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    if [[ ${nxf_main_ret:=0} == 0 ]]; then
-        (set -e -o pipefail; (nxf_unstage | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
-        nxf_unstage_ret=$?
-    fi
-    nxf_unstage_std_files
+    nxf_unstage
 }
 
 $NXF_ENTRY

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelper.groovy
@@ -365,7 +365,7 @@ class GoogleLifeSciencesHelper {
         final remoteTaskDir = getRemoteTaskDir(workDir)
         def result = 'set -x; '
         result += "trap 'err=\$?; exec 1>&2; gsutil -m -q cp -R $localTaskDir/${TaskRun.CMD_LOG} ${remoteTaskDir}/${TaskRun.CMD_LOG} || true; [[ \$err -gt 0 || \$GOOGLE_LAST_EXIT_STATUS -gt 0 || \$NXF_DEBUG -gt 0 ]] && { ls -lah $localTaskDir || true; gsutil -m -q cp -R /google/ ${remoteTaskDir}; } || rm -rf $localTaskDir; exit \$err' EXIT; "
-        result += "{ cd $localTaskDir; bash ${TaskRun.CMD_RUN} nxf_unstage; bash ${TaskRun.CMD_RUN} nxf_unstage_std_files;} >> $localTaskDir/${TaskRun.CMD_LOG} 2>&1"
+        result += "{ cd $localTaskDir; bash ${TaskRun.CMD_RUN} nxf_unstage;} >> $localTaskDir/${TaskRun.CMD_LOG} 2>&1"
         return result
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesScriptLauncher.groovy
@@ -64,10 +64,7 @@ class GoogleLifeSciencesScriptLauncher extends BashWrapperBuilder {
     protected String getStageCommand() { null }
 
     @Override
-    protected String getUnstageCommand() { 'true' }
-
-    @Override
-    protected String getUnstageControlsCommand() { null }
+    protected String getUnstageCommand() { null }
 
     @Override
     String touchFile(Path file) {

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesHelperTest.groovy
@@ -548,7 +548,7 @@ class GoogleLifeSciencesHelperTest extends GoogleSpecification {
         def unstage = helper.getUnstagingScript(dir)
         then:
         unstage ==
-                'set -x; trap \'err=$?; exec 1>&2; gsutil -m -q cp -R /work/dir/.command.log gs://my-bucket/work/dir/.command.log || true; [[ $err -gt 0 || $GOOGLE_LAST_EXIT_STATUS -gt 0 || $NXF_DEBUG -gt 0 ]] && { ls -lah /work/dir || true; gsutil -m -q cp -R /google/ gs://my-bucket/work/dir; } || rm -rf /work/dir; exit $err\' EXIT; { cd /work/dir; bash .command.run nxf_unstage; bash .command.run nxf_unstage_std_files;} >> /work/dir/.command.log 2>&1'
+                'set -x; trap \'err=$?; exec 1>&2; gsutil -m -q cp -R /work/dir/.command.log gs://my-bucket/work/dir/.command.log || true; [[ $err -gt 0 || $GOOGLE_LAST_EXIT_STATUS -gt 0 || $NXF_DEBUG -gt 0 ]] && { ls -lah /work/dir || true; gsutil -m -q cp -R /google/ gs://my-bucket/work/dir; } || rm -rf /work/dir; exit $err\' EXIT; { cd /work/dir; bash .command.run nxf_unstage;} >> /work/dir/.command.log 2>&1'
     }
 
     @Unroll

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesScriptLauncherTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/GoogleLifeSciencesScriptLauncherTest.groovy
@@ -53,8 +53,7 @@ class GoogleLifeSciencesScriptLauncherTest extends GoogleSpecification {
         then:
         binding.touch_file == null
         binding.stage_cmd == null
-        binding.unstage_cmd == 'true'
-        binding.unstage_controls_cmd == null
+        binding.unstage_cmd == null
         binding.task_env == '''\
                 chmod +x /work/xx/yy/nextflow-bin/* || true
                 export PATH=/work/xx/yy/nextflow-bin:$PATH

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -195,7 +195,7 @@ nxf_stage() {
     nxf_parallel "${downloads[@]}"
 }
 
-nxf_unstage() {
+nxf_unstage_outputs() {
     true
 }
 
@@ -204,6 +204,14 @@ nxf_unstage_std_files() {
     gsutil -m -q cp -R .command.out gs://bucket/work/dir/.command.out || true
     gsutil -m -q cp -R .command.err gs://bucket/work/dir/.command.err || true
     gsutil -m -q cp -R .exitcode gs://bucket/work/dir/.exitcode || true
+}
+
+nxf_unstage() {
+    if [[ ${nxf_main_ret:=0} == 0 ]]; then
+        (set -e -o pipefail; (nxf_unstage_outputs | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
+        nxf_unstage_ret=$?
+    fi
+    nxf_unstage_std_files
 }
 
 nxf_main() {
@@ -223,10 +231,6 @@ nxf_main() {
     (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
     pid=$!
     wait $pid || nxf_main_ret=$?
-    if [[ ${nxf_main_ret:=0} == 0 ]]; then
-        (set -e -o pipefail; (true | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
-        nxf_unstage_ret=$?
-    fi
 }
 
 $NXF_ENTRY

--- a/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/lifesciences/bash-wrapper-gcp.txt
@@ -169,8 +169,8 @@ nxf_fs_fcp() {
 
 on_exit() {
     local last_err=$?
-    exit_status=${nxf_main_ret:=0}
-    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:0} -ne 0 ]] && exit_status=${nxf_unstage_ret}
+    local exit_status=${nxf_main_ret:=0}
+    [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
     [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}
     printf -- $exit_status > {{folder}}/.exitcode
     set +u


### PR DESCRIPTION
This is PR is an improvement of PR #5345 trying to keep the changes at level of of launcher script. 

In particular uses re-organise the `nxf_unstage` function splitting into `nxf_unstage_outputs` and `nxf_unstage_std_files` helper functions. 


@jorgee please check if it makes sense to you  