### PR TITLE
Customise mermaid diagram theme in DAG template

### DIFF
--- a/docs/_static/dag.mmd
+++ b/docs/_static/dag.mmd
@@ -1,3 +1,17 @@
+%%{
+    init: {
+        'theme': 'base',
+        'themeVariables': {
+            'primaryColor': '#B6ECE2',
+            'primaryTextColor': '#160F26',
+            'primaryBorderColor': '#065647',
+            'lineColor': '#545555',
+            'clusterBkg': '#BABCBD22',
+            'clusterBorder': '#DDDEDE',
+            'fontFamily': 'arial'
+        }
+    }
+}%%
 flowchart TB
     subgraph " "
     v0["Channel.fromFilePairs"]

--- a/modules/nextflow/src/main/resources/nextflow/dag/mermaid.dag.template.html
+++ b/modules/nextflow/src/main/resources/nextflow/dag/mermaid.dag.template.html
@@ -19,6 +19,20 @@
 </head>
 <body>
 <pre class="mermaid" style="text-align: center;">
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#B6ECE2',
+      'primaryTextColor': '#160F26',
+      'primaryBorderColor': '#065647',
+      'lineColor': '#545555',
+      'clusterBkg': '#BABCBD22',
+      'clusterBorder': '#DDDEDE',
+      'fontFamily': 'arial'
+    }
+  }
+}%%
 REPLACE_WITH_NETWORK_DATA
 </pre>
 <script type="module">


### PR DESCRIPTION
Figured that VSCode shouldn't get all the fun: https://github.com/nextflow-io/vscode-language-nextflow/pull/59

Ported the Nextflow greens theme over to the main Nextflow run-time DAG.

| Before | After |
| -- | -- |
| ![CleanShot 2024-12-01 at 23 56 35@2x](https://github.com/user-attachments/assets/83251094-a2e8-426b-b728-48a1998b3ed7) | ![CleanShot 2024-12-01 at 23 56 41@2x](https://github.com/user-attachments/assets/059afe6a-0fd6-4f2b-b975-c2b16f357695) |

Updated example from the [docs](https://www.nextflow.io/docs/latest/reports.html#workflow-diagram):

![CleanShot 2024-12-02 at 00 00 09@2x](https://github.com/user-attachments/assets/bf748b6b-f444-434d-8e2c-5ee61009ea10)

[new-rnaseq.html.zip](https://github.com/user-attachments/files/17970635/new-rnaseq.html.zip)

@netlify /reports.html#workflow-diagram