### PR TITLE
Fixing PLAT-974

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -35,6 +35,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
 
     private String user
     private String repo
+    private boolean includesRepo; //Flag to indicate if project already include the repo
     private String continuationToken
 
     AzureRepositoryProvider(String project, ProviderConfig config=null) {
@@ -44,10 +45,13 @@ final class AzureRepositoryProvider extends RepositoryProvider {
          */
         def tokens = project.tokenize('/')
         this.repo = tokens.removeLast()
+
         if( tokens.size() == 1){
             this.project = [tokens.first(), this.repo].join('/')
+            this.includesRepo = true
         }else{
             this.project = tokens.join('/')
+            this.includesRepo = false
         }
         this.config = config ?: new ProviderConfig('azurerepos')
         this.continuationToken = null
@@ -164,7 +168,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     /** {@inheritDoc} */
     @Override
     String getRepositoryUrl() {
-        "${config.server}/$project"
+        includesRepo ? "${config.server}/$project" : "${config.server}/$project/$repo"
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -80,7 +80,7 @@ class AzureRepositoryProviderTest extends Specification {
         def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
 
         expect:
-        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT'
+        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT/hello'
 
     }
 


### PR DESCRIPTION
The getRepositoryURL in SCM Azure provider is returning an incomplete URL when organization-name/project-name/repo-name is provided. It is mainly caused because the project-name seems optional and the repo-name is only included RepositoryProvider.project variable when project-name is not provided. 
Just a adding a flag to indicate when project-name and use it in the getRepositoryURL to include the repo name seems enough to fix the issue. 
I think in Nextflow the getRepositoryURL is mainly used for logging purposes and unit tests, because there was no error pulling the repositories using both options (with and without project-name)