### PR TITLE
Fix Google Batch hang when internal error during scheduling

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -62,7 +62,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     private static Pattern EXIT_CODE_REGEX = ~/exit code 500(\d\d)/
 
-    private static Pattern BATCH_ERROR_REGEX = ~/Batch Error: code/
+    private static final Pattern BATCH_ERROR_REGEX = ~/Batch Error: code/
 
     private GoogleBatchExecutor executor
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -62,6 +62,8 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     private static Pattern EXIT_CODE_REGEX = ~/exit code 500(\d\d)/
 
+    private static Pattern BATCH_ERROR_REGEX = ~/Batch Error: code/
+
     private GoogleBatchExecutor executor
 
     private Path exitFile
@@ -535,7 +537,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - last event: ${lastEvent}; exit code: ${lastEvent?.taskExecution?.exitCode}"
 
             final error = lastEvent?.description
-            if( error && EXIT_CODE_REGEX.matcher(error).find() ) {
+            if( error && (EXIT_CODE_REGEX.matcher(error).find() || BATCH_ERROR_REGEX.matcher(error).find())) {
                 return new ProcessException(error)
             }
         }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -475,8 +475,8 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         return taskState
     }
 
-    String checkJobStatus() {
-        final jobStatus = client.getJobStatus(jobId);
+    protected String checkJobStatus() {
+        final jobStatus = client.getJobStatus(jobId)
         final newState = jobStatus?.state as String
         if (newState) {
             taskState = newState
@@ -533,11 +533,11 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     protected Throwable getJobError() {
         try {
             final events = noTaskJobfailure ? client.getJobStatus(jobId).getStatusEventsList() : client.getTaskStatus(jobId, taskId).getStatusEventsList()
-            final lastEvent = events?.get( events.size() -1 )
+            final lastEvent = events?.get(events.size() - 1)
             log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - last event: ${lastEvent}; exit code: ${lastEvent?.taskExecution?.exitCode}"
 
             final error = lastEvent?.description
-            if( error && (EXIT_CODE_REGEX.matcher(error).find() || BATCH_ERROR_REGEX.matcher(error).find())) {
+            if( error && (EXIT_CODE_REGEX.matcher(error).find() || BATCH_ERROR_REGEX.matcher(error).find()) ) {
                 return new ProcessException(error)
             }
         }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -60,7 +60,7 @@ import nextflow.trace.TraceRecord
 @CompileStatic
 class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
-    private static Pattern EXIT_CODE_REGEX = ~/exit code 500(\d\d)/
+    private static final Pattern EXIT_CODE_REGEX = ~/exit code 500(\d\d)/
 
     private static final Pattern BATCH_ERROR_REGEX = ~/Batch Error: code/
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -99,6 +99,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     private volatile CloudMachineInfo machineInfo
 
     private volatile long timestamp
+
     /**
      * A flag to indicate that the job has failed without launching any tasks
      */
@@ -532,7 +533,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     protected Throwable getJobError() {
         try {
-            final events = noTaskJobfailure ? client.getJobStatus(jobId).getStatusEventsList() : client.getTaskStatus(jobId, taskId).getStatusEventsList()
+            final events = noTaskJobfailure
+                ? client.getJobStatus(jobId).getStatusEventsList()
+                : client.getTaskStatus(jobId, taskId).getStatusEventsList()
             final lastEvent = events?.get(events.size() - 1)
             log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - last event: ${lastEvent}; exit code: ${lastEvent?.taskExecution?.exitCode}"
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -100,7 +100,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     private volatile long timestamp
     /**
-     * Flag to indicate job has failed without tasks
+     * A flag to indicate that the job has failed without launching any tasks
      */
     private volatile boolean noTaskJobfailure
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -29,6 +29,7 @@ import com.google.cloud.batch.v1.BatchServiceClient
 import com.google.cloud.batch.v1.BatchServiceSettings
 import com.google.cloud.batch.v1.Job
 import com.google.cloud.batch.v1.JobName
+import com.google.cloud.batch.v1.JobStatus
 import com.google.cloud.batch.v1.LocationName
 import com.google.cloud.batch.v1.Task
 import com.google.cloud.batch.v1.TaskGroupName
@@ -121,6 +122,10 @@ class BatchClient {
 
     TaskStatus getTaskStatus(String jobId, String taskId) {
         return describeTask(jobId, taskId).getStatus()
+    }
+
+    JobStatus getJobStatus(String jobId){
+        return describeJob(jobId).getStatus();
     }
 
     String getTaskState(String jobId, String taskId) {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -125,7 +125,7 @@ class BatchClient {
     }
 
     JobStatus getJobStatus(String jobId){
-        return describeJob(jobId).getStatus();
+        return describeJob(jobId).getStatus()
     }
 
     String getTaskState(String jobId, String taskId) {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -124,7 +124,7 @@ class BatchClient {
         return describeTask(jobId, taskId).getStatus()
     }
 
-    JobStatus getJobStatus(String jobId){
+    JobStatus getJobStatus(String jobId) {
         return describeJob(jobId).getStatus()
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -586,8 +586,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
     }
 
     JobStatus makeJobStatus(JobStatus.State state, String desc = null) {
-        def builder = JobStatus.newBuilder()
-        builder = builder.setState(state)
+        final builder = JobStatus.newBuilder().setState(state)
         if (desc)
             builder = builder.addStatusEvents(
                 StatusEvent.newBuilder()

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -587,11 +587,12 @@ class GoogleBatchTaskHandlerTest extends Specification {
 
     JobStatus makeJobStatus(JobStatus.State state, String desc = null) {
         final builder = JobStatus.newBuilder().setState(state)
-        if (desc)
+        if( desc ) {
             builder.addStatusEvents(
                 StatusEvent.newBuilder()
                     .setDescription(desc)
             )
+        }
         builder.build()
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -595,7 +595,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         builder.build()
     }
 
-    def 'should check job status when '() {
+    def 'should check job status when no tasks in job '() {
 
         given:
         def jobId = 'job-id'
@@ -605,15 +605,17 @@ class GoogleBatchTaskHandlerTest extends Specification {
             lazyName() >> 'foo (1)'
         }
         def handler = Spy(new GoogleBatchTaskHandler(jobId: jobId, taskId: taskId, client: client, task: task))
-
+        final message = 'Job failed when Batch tries to schedule it: Batch Error: code - CODE_MACHINE_TYPE_NOT_FOUND'
         when:
         client.listTasks(jobId) >>> [new LinkedList<Task>(), new LinkedList<Task>()]
         client.getJobStatus(jobId) >>> [
             null,
             makeJobStatus(JobStatus.State.FAILED, 'Scheduling Failed'),
+            makeJobStatus(JobStatus.State.FAILED, message)
         ]
         then:
         handler.getTaskState() == "PENDING"
         handler.getTaskState() == "FAILED"
+        handler.getJobError().message == message
     }
 }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -615,8 +615,5 @@ class GoogleBatchTaskHandlerTest extends Specification {
         then:
         handler.getTaskState() == "PENDING"
         handler.getTaskState() == "FAILED"
-
-
-
     }
 }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -17,6 +17,9 @@
 
 package nextflow.cloud.google.batch
 
+import com.google.cloud.batch.v1.JobStatus
+import com.google.cloud.batch.v1.Task
+
 import java.nio.file.Path
 
 import com.google.cloud.batch.v1.GCS
@@ -580,5 +583,41 @@ class GoogleBatchTaskHandlerTest extends Specification {
         1 * executor.shouldDeleteJob('job1') >> false
         and:
         0 * client.deleteJob('job1') >> null
+    }
+
+    JobStatus makeJobStatus(JobStatus.State state, String desc = null) {
+        def builder = JobStatus.newBuilder()
+        builder = builder.setState(state)
+        if (desc)
+            builder = builder.addStatusEvents(
+                StatusEvent.newBuilder()
+                    .setDescription(desc)
+            )
+        builder.build()
+    }
+
+    def 'should check job status when '() {
+
+        given:
+        def jobId = 'job-id'
+        def taskId = 'task-id'
+        def client = Mock(BatchClient)
+        def task = Mock(TaskRun) {
+            lazyName() >> 'foo (1)'
+        }
+        def handler = Spy(new GoogleBatchTaskHandler(jobId: jobId, taskId: taskId, client: client, task: task))
+
+        when:
+        client.listTasks(jobId) >>> [new LinkedList<Task>(), new LinkedList<Task>()]
+        client.getJobStatus(jobId) >>> [
+            null,
+            makeJobStatus(JobStatus.State.FAILED, 'Scheduling Failed'),
+        ]
+        then:
+        handler.getTaskState() == "PENDING"
+        handler.getTaskState() == "FAILED"
+
+
+
     }
 }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -588,7 +588,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
     JobStatus makeJobStatus(JobStatus.State state, String desc = null) {
         final builder = JobStatus.newBuilder().setState(state)
         if (desc)
-            builder = builder.addStatusEvents(
+            builder.addStatusEvents(
                 StatusEvent.newBuilder()
                     .setDescription(desc)
             )


### PR DESCRIPTION
When there is an internal error in Google Batch the job during scheduling. Jobs go from queued to failed. This situation is happening when request a VM type which is not available in the selected region. In this situation, there are no tasks in the batch job and NF is blocked in an infinite loop caused by the following part of code.

[nextflow/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy](https://github.com/nextflow-io/nextflow/blob/62fc0017ffae1ea151581f738c17ab840649aa0c/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy#L448-L449)

In this PR, this part is modified including a job status check to avoid to continue checking when job is failed.

I still have pending to decide what to do if job do not have tasks and job status is null. I think we should abort but @bentsherman do you remember why you returned PENDING when there are no tasks in the job? Is the some initial state where GCP is creating the tasks and we should consider PENDING?