### PR TITLE
Update jgit to 7.1.0

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api "com.beust:jcommander:1.35"
     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
     api('org.iq80.leveldb:leveldb:0.12')
-    api('org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r')
+    api('org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r')
     api ('javax.activation:activation:1.1.1')
     api ('javax.mail:mail:1.4.7')
     api ('org.yaml:snakeyaml:2.2')

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -833,7 +833,7 @@ class AssetManager {
 
     protected Map refToMap(Ref ref, Map<String,Ref> remote) {
         final entry = new HashMap(2)
-        final peel = git.getRepository().peel(ref)
+        final peel = git.getRepository().getRefDatabase().peel(ref)
         final objId = peel.getPeeledObjectId() ?: peel.getObjectId()
         // the branch or tag name
         entry.name = shortenRefName(ref.name)
@@ -867,7 +867,7 @@ class AssetManager {
         result << (name == current ? '*' : ' ')
 
         if( level ) {
-            def peel = git.getRepository().peel(ref)
+            def peel = git.getRepository().getRefDatabase().peel(ref)
             def obj = peel.getPeeledObjectId() ?: peel.getObjectId()
             result << ' '
             result << formatObjectId(obj, level == 1)


### PR DESCRIPTION
Otherwise the tests fail if you have git config setting `gpg.format=ssh`, with the following error:

```
java.lang.IllegalArgumentException: Invalid value: gpg.format=ssh
	at org.eclipse.jgit.lib.DefaultTypedConfigGetter.getEnum(DefaultTypedConfigGetter.java:103)
	at org.eclipse.jgit.lib.Config.getEnum(Config.java:454)
	at org.eclipse.jgit.lib.GpgConfig.<init>(GpgConfig.java:86)
	at org.eclipse.jgit.api.CommitCommand.processOptions(CommitCommand.java:661)
	at org.eclipse.jgit.api.CommitCommand.call(CommitCommand.java:188)
	at org.eclipse.jgit.api.CommitCommand.call(CommitCommand.java:1)
	at nextflow.scm.LocalRepositoryProviderTest.setup(LocalRepositoryProviderTest.groovy:48)
```