### PR TITLE
Improve kill task logic

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/CachedTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/CachedTaskHandler.groovy
@@ -51,7 +51,7 @@ class CachedTaskHandler extends TaskHandler {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         throw new UnsupportedOperationException()
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -503,7 +503,7 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         if( batch ) {
             batch.collect(executor, jobId)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/NopeExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/NopeExecutor.groovy
@@ -86,7 +86,7 @@ class NopeTaskHandler extends TaskHandler {
     }
 
     @Override
-    void kill() { }
+    protected void killTask() { }
 
 }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/StoredTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/StoredTaskHandler.groovy
@@ -29,7 +29,7 @@ class StoredTaskHandler extends TaskHandler {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         throw new UnsupportedOperationException()
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
@@ -236,7 +236,7 @@ class LocalTaskHandler extends TaskHandler implements FusionAwareTask {
      * Force the submitted job to quit
      */
     @Override
-    void kill() {
+    protected void killTask() {
         if( !process ) return
         final pid = ProcessHelper.pid(process)
         log.trace("Killing process with pid: ${pid}")

--- a/modules/nextflow/src/main/groovy/nextflow/executor/local/NativeTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/local/NativeTaskHandler.groovy
@@ -108,7 +108,7 @@ class NativeTaskHandler extends TaskHandler {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         if( result ) result.cancel(true)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/k8s/K8sTaskHandler.groovy
@@ -472,7 +472,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
      * Terminates the current task execution
      */
     @Override
-    void kill() {
+    protected void killTask() {
         if( cleanupDisabled() )
             return
         

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -19,6 +19,7 @@ package nextflow.processor
 import static nextflow.processor.TaskStatus.*
 
 import java.nio.file.NoSuchFileException
+import java.util.concurrent.atomic.AtomicBoolean
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -36,6 +37,8 @@ import nextflow.trace.TraceRecord
 @Slf4j
 @CompileStatic
 abstract class TaskHandler {
+
+    private AtomicBoolean killed = new AtomicBoolean()
 
     protected TaskHandler(TaskRun task) {
         this.task = task
@@ -77,10 +80,22 @@ abstract class TaskHandler {
     abstract boolean checkIfCompleted()
 
     /**
-     * Force the submitted job to quit
+     * Template method implementing the termination of a task execution.
+     * This is not mean to be invoked directly. See also {@link #kill()}
      */
-    abstract void kill()
+    abstract protected void killTask()
 
+    /**
+     * Kill a job execution.
+     *
+     * @see #killTask()
+     */
+    void kill() {
+        if (!killed.getAndSet(true)) {
+            killTask()
+        }
+    }
+    
     /**
      * Submit the task for execution.
      *
@@ -301,12 +316,4 @@ abstract class TaskHandler {
         return workflowId ? "tw-${workflowId}-${name}" : name
     }
 
-    private volatile boolean terminated
-
-    final void terminate() {
-        if (!terminated) {
-            terminated = true
-            kill()
-        }
-    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskPollingMonitor.groovy
@@ -40,10 +40,9 @@ import nextflow.exception.ProcessSubmitTimeoutException
 import nextflow.executor.BatchCleanup
 import nextflow.executor.GridTaskHandler
 import nextflow.util.Duration
+import nextflow.util.SysHelper
 import nextflow.util.Threads
 import nextflow.util.Throttle
-import static nextflow.util.SysHelper.dumpThreads
-
 /**
  * Monitors the queued tasks waiting for their termination
  *
@@ -471,7 +470,7 @@ class TaskPollingMonitor implements TaskMonitor {
     }
 
     protected dumpCurrentThreads() {
-        log.trace "Current running threads:\n${dumpThreads()}"
+        log.trace "Current running threads:\n${SysHelper.dumpThreads()}"
     }
 
     protected void dumpRunningQueue() {
@@ -581,7 +580,7 @@ class TaskPollingMonitor implements TaskMonitor {
             catch (Throwable error) {
                 // At this point NF assumes job is not running, but there could be errors at monitoring that could leave a job running (#5516).
                 // In this case, NF needs to ensure the job is killed.
-                handler.terminate()
+                handler.kill()
                 handleException(handler, error)
             }
         }

--- a/modules/nextflow/src/test/groovy/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -515,13 +515,13 @@ class K8sTaskHandlerTest extends Specification {
         def handler = Spy(new K8sTaskHandler(client:client, podName: POD_NAME))
 
         when:
-        handler.kill()
+        handler.killTask()
         then:
         1 * handler.cleanupDisabled() >> false
         1 * client.podDelete(POD_NAME) >> null
 
         when:
-        handler.kill()
+        handler.killTask()
         then:
         1 * handler.cleanupDisabled() >> true
         0 * client.podDelete(POD_NAME) >> null

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy
@@ -120,7 +120,7 @@ class TaskPollingMonitorTest extends Specification {
         then:
         1 * session.disableJobsCancellation >> true
         and:
-        0 * handler.kill() >> null
+        0 * handler.killTask() >> null
         0 * session.notifyTaskComplete(handler) >> null
     }
 

--- a/modules/nextflow/src/testFixtures/groovy/test/MockHelpers.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/MockHelpers.groovy
@@ -189,6 +189,6 @@ class MockTaskHandler extends TaskHandler {
     }
 
     @Override
-    void kill() { }
+    protected void killTask() { }
 
 }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -298,7 +298,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
      * {@inheritDoc}
      */
     @Override
-    void kill() {
+    protected void killTask() {
         assert jobId
         log.trace "[AWS BATCH] Process `${task.lazyName()}` - killing job=$jobId"
         final targetId = normaliseJobId(jobId)

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -881,7 +881,7 @@ class AwsBatchTaskHandlerTest extends Specification {
 
         when:
         handler.@jobId = 'job1'
-        handler.kill()
+        handler.killTask()
         then:
         1 * executor.shouldDeleteJob('job1') >> true
         and:
@@ -889,7 +889,7 @@ class AwsBatchTaskHandlerTest extends Specification {
 
         when:
         handler.@jobId = 'job1:task2'
-        handler.kill()
+        handler.killTask()
         then:
         1 * executor.shouldDeleteJob('job1') >> true
         and:
@@ -897,7 +897,7 @@ class AwsBatchTaskHandlerTest extends Specification {
 
         when:
         handler.@jobId = 'job1:task2'
-        handler.kill()
+        handler.killTask()
         then:
         1 * executor.shouldDeleteJob('job1') >> false
         and:

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -177,7 +177,7 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         if( !taskKey )
             return
         batchService.terminate(taskKey)

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -563,7 +563,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         if( isActive() ) {
             log.trace "[GOOGLE BATCH] Process `${task.lazyName()}` - deleting job name=$jobId"
             if( executor.shouldDeleteJob(jobId) )

--- a/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/lifesciences/GoogleLifeSciencesTaskHandler.groovy
@@ -286,7 +286,7 @@ class GoogleLifeSciencesTaskHandler extends TaskHandler {
     }
 
     @Override
-    void kill() {
+    protected void killTask() {
         if( !operation ) return
         log.debug "[GLS] Killing task > $task.name - Pipeline Id: $pipelineId"
         helper.cancelOperation(operation)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -559,7 +559,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
 
         when:
         handler.@jobId = 'job1'
-        handler.kill()
+        handler.killTask()
         then:
         handler.isActive() >> false
         0 * executor.shouldDeleteJob('job1') >> true
@@ -568,7 +568,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
 
         when:
         handler.@jobId = 'job1'
-        handler.kill()
+        handler.killTask()
         then:
         handler.isActive() >> true
         1 * executor.shouldDeleteJob('job1') >> true
@@ -577,7 +577,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
 
         when:
         handler.@jobId = 'job1'
-        handler.kill()
+        handler.killTask()
         then:
         handler.isActive() >> true
         1 * executor.shouldDeleteJob('job1') >> false


### PR DESCRIPTION
This PR improves the task kill logic as below: 

1. implement the flag check in the `kill` method (instead of a new one) for a) API backward compatibility, and b) make sure it's invoked by the already existing component
2. use an `AtomicBool` to make the handling of a possible race condition more robust 
3. rename existing `kill` methods to `killTask` and declare `protected` to highlight it should not be invoked directly 
4. do not mark `kill` as `final` (even if it would be better) to prevent breaking asking plugins    