### PR TITLE
Fix `env` output with quotes

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/params/EnvOutParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/EnvOutParam.groovy
@@ -41,6 +41,12 @@ class EnvOutParam extends BaseOutParam implements OptionalParam {
         if( obj instanceof TokenVar ) {
             this.nameObj = obj.name
         }
+        else if( obj instanceof CharSequence ) {
+            this.nameObj = obj.toString()
+        }
+        else {
+            throw new IllegalArgumentException("Unexpected environment output definition - it should be either a string or a variable identifier - offending value: ${obj?.getClass()?.getName()}")
+        }
 
         return this
     }

--- a/modules/nextflow/src/test/groovy/nextflow/script/params/EnvOutParamTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/EnvOutParamTest.groovy
@@ -54,6 +54,31 @@ class EnvOutParamTest extends Dsl2Spec {
 
     }
 
+    def 'should define env outputs with quotes' () {
+        setup:
+        def text = '''
+            process hola {
+              output:
+              env 'FOO'
+              env 'BAR'
+              
+              /echo command/ 
+            }
+            
+            workflow { hola() }
+            '''
+        def binding = [:]
+        def process = parseAndReturnProcess(text, binding)
+        when:
+        def outs = process.config.getOutputs() as List<EnvOutParam>
+        then:
+        outs.size() == 2
+        and:
+        outs[0].name == 'FOO'
+        and:
+        outs[1].name == 'BAR'
+    }
+
     def 'should define optional env outputs' () {
         setup:
         def text = '''


### PR DESCRIPTION
The strict syntax requires process env inputs/outputs to be quoted. This works for env inputs, but apparently env outputs did not work this way prior to 24.04. Support for this syntax was added as a side effect of [eval outputs](https://github.com/nextflow-io/nextflow/commit/df978113cf05f8767dbd453baff976e899194bcc).

Since some users have reported issues when trying to use this syntax with 23.10, this PR backports just the quoted env syntax.