### PR TITLE
Fix race condition when resuming an aborted run

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -829,7 +829,7 @@ class TaskProcessor {
 
             final lock = lockManager.acquire(hash)
             try {
-                if( !exists && !workDir.mkdirs() )
+                if( !workDir.mkdirs() )
                     throw new IOException("Unable to create directory=$workDir -- check file system permissions")
             }
             finally {


### PR DESCRIPTION
Close #5595 

When a Nextflow run is aborted for any reason, Nextflow will try to kill all jobs and save them to the cache as failed tasks, so that on a resumed run, the new jobs will use new task directories.

However, if Nextflow is unable to complete this cleanup for any reason, such as an abrupt crash, the task cache might not be updated. On a resumed run, the new task will be re-executed in the same directory as before:

https://github.com/nextflow-io/nextflow/blob/b23e42cd6dea0e4ce6bba19c13968546807be5f1/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy#L806-L826

What I think happens here is:
1. the cache entry is missing
2. Nextflow doesn't check whether the task dir exists
3. Nextflow proceeds to re-use the task dir with a new task

This can cause a race condition because if the begin and exit files are still present, Nextflow could submit a job, detect the begin/exit codes from the previous job, mark the job as completed (as long as the required outputs are still present), and launch downstream tasks on truncated data.

I think this can only happen on grid executors because the GridTaskHandler checks the begin/exit files before polling the scheduler. The cloud executors poll their API first, and the local executor doesn't check these files at all.

It should be possible to replicate this issue on a grid executor by cancelling a run with `-disable-jobs-cancellation` and allowing the jobs to complete before resuming the run. Which by the way is an unsafe property of that CLI option.

I'm trying to modify the local executor to simulate the issue but haven't been able to replicate yet