### PR TITLE
Improve inspect mode

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdInspect.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdInspect.groovy
@@ -70,7 +70,7 @@ class CmdInspect extends CmdBase {
 
     @Override
     void run() {
-        ContainerInspectMode.activate(!concretize)
+        ContainerInspectMode.activate(true, !concretize)
         // configure quiet mode
         LoggerHelper.setQuiet(true)
         // setup the target run command

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdInspect.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdInspect.groovy
@@ -70,7 +70,7 @@ class CmdInspect extends CmdBase {
 
     @Override
     void run() {
-        ContainerInspectMode.activate(true, !concretize)
+        ContainerInspectMode.activate(!concretize)
         // configure quiet mode
         LoggerHelper.setQuiet(true)
         // setup the target run command

--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerHandler.groovy
@@ -70,7 +70,7 @@ class ContainerHandler {
             if( normalizedImageName.startsWith('docker://') && config.canRunOciImage() )
                 return normalizedImageName
             final requiresCaching = normalizedImageName =~ IMAGE_URL_PREFIX
-            if( ContainerInspectMode.active() && requiresCaching )
+            if( ContainerInspectMode.dryRun() && requiresCaching )
                 return imageName
             final result = requiresCaching ? createSingularityCache(this.config, normalizedImageName) : normalizedImageName
             return Escape.path(result)
@@ -82,7 +82,7 @@ class ContainerHandler {
             if( normalizedImageName.startsWith('docker://') && config.canRunOciImage() )
                 return normalizedImageName
             final requiresCaching = normalizedImageName =~ IMAGE_URL_PREFIX
-            if( ContainerInspectMode.active() && requiresCaching )
+            if( ContainerInspectMode.dryRun() && requiresCaching )
                 return imageName
             final result = requiresCaching ? createApptainerCache(this.config, normalizedImageName) : normalizedImageName
             return Escape.path(result)
@@ -94,7 +94,7 @@ class ContainerHandler {
             // if the imagename starts with '/' it's an absolute path
             // otherwise we assume it's in a remote registry and pull it from there
             final requiresCaching = !imageName.startsWith('/')
-            if( ContainerInspectMode.active() && requiresCaching )
+            if( ContainerInspectMode.dryRun() && requiresCaching )
                 return imageName
             final result = requiresCaching ? createCharliecloudCache(this.config, normalizedImageName) : normalizedImageName
             return Escape.path(result)

--- a/modules/nextflow/src/main/groovy/nextflow/container/inspect/ContainerInspectMode.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/inspect/ContainerInspectMode.groovy
@@ -26,10 +26,23 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class ContainerInspectMode {
 
-    private static Boolean active
+    private static boolean active
 
-    static boolean active() { return active==true }
+    private static boolean dryRun
 
-    static void activate(boolean value) { active = value }
+    static boolean active() { return active }
 
+    static boolean dryRun() { return dryRun }
+
+    static void activate(boolean active, boolean dryRun) {
+        if( !active && dryRun )
+            throw new IllegalArgumentException("Argument 'dryRun' cannot be true when 'activate' is false")
+        this.active = active
+        this.dryRun = dryRun
+    }
+
+    static void reset() {
+        this.active = false
+        this.dryRun = false
+    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/container/inspect/ContainerInspectMode.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/inspect/ContainerInspectMode.groovy
@@ -26,23 +26,17 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class ContainerInspectMode {
 
-    private static boolean active
+    private static Boolean dryRun
 
-    private static boolean dryRun
+    static boolean active() { return dryRun!=null }
 
-    static boolean active() { return active }
+    static boolean dryRun() { return dryRun==true }
 
-    static boolean dryRun() { return dryRun }
-
-    static void activate(boolean active, boolean dryRun) {
-        if( !active && dryRun )
-            throw new IllegalArgumentException("Argument 'dryRun' cannot be true when 'activate' is false")
-        this.active = active
+    static void activate(boolean dryRun) {
         this.dryRun = dryRun
     }
 
     static void reset() {
-        this.active = false
-        this.dryRun = false
+        dryRun = null
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/container/inspect/ContainerInspectModeTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/inspect/ContainerInspectModeTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.container.inspect
+
+import spock.lang.Specification
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class ContainerInspectModeTest extends Specification {
+
+    def 'should validate activate and dry-run' () {
+        expect:
+        !ContainerInspectMode.active()
+        !ContainerInspectMode.dryRun()
+
+        when:
+        ContainerInspectMode.activate(true,false)
+        then:
+        ContainerInspectMode.active()
+        !ContainerInspectMode.dryRun()
+
+        when:
+        ContainerInspectMode.activate(true, true)
+        then:
+        ContainerInspectMode.active()
+        ContainerInspectMode.dryRun()
+
+        when:
+        ContainerInspectMode.activate(false,true)
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        ContainerInspectMode.reset()
+        then:
+        !ContainerInspectMode.active()
+        !ContainerInspectMode.dryRun()
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/container/inspect/ContainerInspectModeTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/inspect/ContainerInspectModeTest.groovy
@@ -31,21 +31,16 @@ class ContainerInspectModeTest extends Specification {
         !ContainerInspectMode.dryRun()
 
         when:
-        ContainerInspectMode.activate(true,false)
+        ContainerInspectMode.activate(false)
         then:
         ContainerInspectMode.active()
         !ContainerInspectMode.dryRun()
 
         when:
-        ContainerInspectMode.activate(true, true)
+        ContainerInspectMode.activate(true)
         then:
         ContainerInspectMode.active()
         ContainerInspectMode.dryRun()
-
-        when:
-        ContainerInspectMode.activate(false,true)
-        then:
-        thrown(IllegalArgumentException)
 
         when:
         ContainerInspectMode.reset()

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -222,7 +222,7 @@ class WaveClient {
                 fingerprint: assets.fingerprint(),
                 freeze: config.freezeMode(),
                 format: assets.singularity ? 'sif' : null,
-                dryRun: ContainerInspectMode.active(),
+                dryRun: ContainerInspectMode.dryRun(),
                 mirror: config.mirrorMode(),
                 scanMode: config.scanMode(),
                 scanLevels: config.scanAllowedLevels()
@@ -249,7 +249,7 @@ class WaveClient {
                 towerEndpoint: tower.endpoint,
                 workflowId: tower.workflowId,
                 freeze: config.freezeMode(),
-                dryRun: ContainerInspectMode.active(),
+                dryRun: ContainerInspectMode.dryRun(),
                 mirror: config.mirrorMode(),
                 scanMode: config.scanMode(),
                 scanLevels: config.scanAllowedLevels()

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -285,7 +285,7 @@ class WaveClientTest extends Specification {
 
     def 'should create request object with dry-run mode' () {
         given:
-        ContainerInspectMode.activate(true, true)
+        ContainerInspectMode.activate(true)
         def session = Mock(Session) { getConfig() >> [:]}
         def IMAGE =  'foo:latest'
         def wave = new WaveClient(session)

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -285,7 +285,7 @@ class WaveClientTest extends Specification {
 
     def 'should create request object with dry-run mode' () {
         given:
-        ContainerInspectMode.activate(true)
+        ContainerInspectMode.activate(true, true)
         def session = Mock(Session) { getConfig() >> [:]}
         def IMAGE =  'foo:latest'
         def wave = new WaveClient(session)
@@ -306,7 +306,7 @@ class WaveClientTest extends Specification {
         req.timestamp instanceof String
 
         cleanup:
-        ContainerInspectMode.activate(false)
+        ContainerInspectMode.reset()
     }
 
     def 'should create request object and platform' () {


### PR DESCRIPTION
This PR improve the granularity of `ContainerInspectMode semantics so that it's possible independently if the inspect mode has been enabled and if it's running in dry-run (or concretize) mode.

Previously the `active` method was implemented with the semantics of "dry-run". In this PR it the method is has been renamed to `dryRun` to better reflect its semantics. 

Along with this a method `activate` it has been added to detect when the inspect mode is running. 

