### PR TITLE
Add whitespace rules to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ charset = utf-8
 indent_size = 4
 indent_style = space
 tab_width = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Mandate that there should not be trailing whitespace at the end of lines, and that files should include a newline at their end.