### PR TITLE
Add "script:" before bash script in 'your-first-script' snippet

### DIFF
--- a/docs/snippets/your-first-script.nf
+++ b/docs/snippets/your-first-script.nf
@@ -4,6 +4,7 @@ process splitLetters {
     output:
     path 'chunk_*'
 
+    script:
     """
     printf '${params.str}' | split -b 6 - chunk_
     """
@@ -16,6 +17,7 @@ process convertToUpper {
     output:
     stdout
 
+    script:
     """
     cat $x | tr '[a-z]' '[A-Z]'
     """


### PR DESCRIPTION
While it appears to work fine, the vs code extension for nextflow indicates that the script element should be used.
I thought it should be corrected as this is the first snippet that a user will try executing.

https://www.nextflow.io/docs/latest/your-first-script.html

Here is the VS Code view of the snippet prior to fixing.
![image](https://github.com/user-attachments/assets/76f241a6-7dd2-4c5b-87f3-ee28fe8cbd05)
