### PR TITLE
Added another example for dynamic-task-resources

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1303,6 +1303,24 @@ If the task execution fail reporting an exit status in the range between 137 and
 
 The directive {ref}`process-maxretries` set the maximum number of time the same task can be re-executed.
 
+A more elaborate example:
+
+```nextflow
+process foo {
+  memory { 
+    def baseMem = 16.GB
+    def additionalMem = input_file.size() / 1e9
+    baseMem + (additionalMem * task.attempt).GB
+  }
+
+  input:
+  path input_file
+}
+```
+
+In this example, the minimum memory is 16 GB. The memory will increase depending on the size of `input_file`, and the number of attempts (`task.attempt`). Note: `input_file.size()` must be converted to bytes in order to perform calculations (e.g., to prevent `Unknown method invocation div on Long type` errors).
+
+
 ### Dynamic task resources with previous execution trace
 :::{versionadded} 24.10.0
 :::


### PR DESCRIPTION
This pull request includes an update to the `docs/process.md` file to add a more detailed example for dynamic task resource allocation in Nextflow processes.

Documentation enhancements:

* [`docs/process.md`](diffhunk://#diff-aed6df2932484b499862e14d7e11cd39fd0bd2cb28a80b94c79446c984b9e9abR1306-R1323): Added a detailed example for dynamically allocating memory based on input file size and the number of task attempts. This example demonstrates how to set a minimum memory of 16 GB and increase it proportionally to the size of the `input_file` and the number of attempts (`task.attempt`). It also includes a note on converting `input_file.size()` to bytes to avoid errors.


Addressing issue https://github.com/nextflow-io/nextflow/issues/5626