### PR TITLE
Fix flaky docs snippet

### DIFF
--- a/docs/snippets/process-out-eval.nf
+++ b/docs/snippets/process-out-eval.nf
@@ -1,9 +1,10 @@
 process sayHello {
     output:
-    eval('bash --version')
+    eval('echo Hello world!')
 
+    script:
     """
-    echo Hello world!
+    true
     """
 }
 

--- a/docs/snippets/process-out-eval.out
+++ b/docs/snippets/process-out-eval.out
@@ -1,6 +1,1 @@
-GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
-Copyright (C) 2020 Free Software Foundation, Inc.
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
-
-This is free software; you are free to change and redistribute it.
-There is NO WARRANTY, to the extent permitted by law.
+Hello world!

--- a/docs/snippets/process-stdout.nf
+++ b/docs/snippets/process-stdout.nf
@@ -2,6 +2,7 @@ process sayHello {
     output:
     stdout
 
+    script:
     """
     echo Hello world!
     """


### PR DESCRIPTION
The docs snippet for eval output uses `bash --version` since that is the intended use of eval output. However, it has proven hard to test since the exact bash version text can change between e.g. my local environment and CI. This PR makes the eval output example consistent with the stdout example.

See also: https://github.com/nextflow-io/nextflow/pull/5631#issuecomment-2573484502