### PR TITLE
Warning messages when Cloudinfo fails in Google Batch machine type selection

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -606,8 +606,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             }
         }
         catch (Exception e) {
-            log.warn "Cannot select machine type using Seqera Cloudinfo for task: `${task.lazyName()}`. This feature can be disabled with setting the environment variable NXF_CLOUDINFO_ENABLED to false."
-            log.debug "[GOOGLE BATCH] Cannot select machine type using Seqera Cloudinfo for task: `${task.lazyName()}` - ${e.message}"
+            log.warn "Cannot determine the machine type to be used for task: `${task.lazyName()}` - If this problem persists disable disable the Cloudinfo service by setting the variable NXF_CLOUDINFO_ENABLED=false in your environment", e
         }
 
         // Check if a specific machine type was provided by the user

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -618,7 +618,6 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             )
 
         // Fallback to Google Batch automatically deduce from requested resources
-        log.warn "Using Google Batch default machine type."
         return null
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -606,6 +606,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             }
         }
         catch (Exception e) {
+            log.warn "Cannot select machine type using Seqera Cloudinfo for task: `${task.lazyName()}`. This feature can be disabled with setting the environment variable NXF_CLOUDINFO_ENABLED to false."
             log.debug "[GOOGLE BATCH] Cannot select machine type using Seqera Cloudinfo for task: `${task.lazyName()}` - ${e.message}"
         }
 
@@ -618,6 +619,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             )
 
         // Fallback to Google Batch automatically deduce from requested resources
+        log.warn "Using Google Batch default machine type."
         return null
     }
 


### PR DESCRIPTION
These PR add warning messages when using Cloudinfo fails to retrieve the machine type for a Google Batch