### PR TITLE
Handle attribute caching with Lustre filesystem

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -319,7 +319,7 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
     protected Integer readExitStatus() {
 
         String workDirList = null
-        if( exitTimestampMillis1 && FileHelper.workDirIsNFS ) {
+        if( exitTimestampMillis1 && FileHelper.workDirIsSharedFS ) {
             /*
              * When the file is in a NFS folder in order to avoid false negative
              * list the content of the parent path to force refresh of NFS metadata

--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -468,14 +468,14 @@ class FileHelper {
      * @return The {@code true} when the path is a NFS mount {@code false} otherwise
      */
     @Memoized
-    static boolean isPathNFS(Path path) {
+    static boolean isPathSharedFS(Path path) {
         assert path
         if( path.getFileSystem() != FileSystems.getDefault() )
             return false
 
         final type = getPathFsType(path)
-        def result = type == 'nfs' || type == 'lustre'
-        log.debug "NFS path ($result): $path"
+        final result = type == 'nfs' || type == 'lustre'
+        log.debug "FS path type ($result): $path"
         return result
     }
 
@@ -491,7 +491,7 @@ class FileHelper {
         process.destroy()
 
         if( status ) {
-            log.debug "Can't check if specified path is NFS ($status): ${FilesEx.toUriString(path)}\n${Bolts.indent(text,'  ')}"
+            log.debug "Unable to determine FS type ($status): ${FilesEx.toUriString(path)}\n${Bolts.indent(text,'  ')}"
             return null
         }
 
@@ -503,8 +503,8 @@ class FileHelper {
      *      {@code true} when the current session working directory is a NFS mounted path
      *      {@code false otherwise}
      */
-    static boolean getWorkDirIsNFS() {
-        isPathNFS(Global.session.workDir)
+    static boolean getWorkDirIsSharedFS() {
+        isPathSharedFS(Global.session.workDir)
     }
 
     /**
@@ -546,7 +546,7 @@ class FileHelper {
         if( Files.exists(self) )
             return true
 
-        if( !workDirIsNFS )
+        if( !workDirIsSharedFS )
             return false
 
 

--- a/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHelper.groovy
@@ -474,7 +474,7 @@ class FileHelper {
             return false
 
         final type = getPathFsType(path)
-        def result = type == 'nfs'
+        def result = type == 'nfs' || type == 'lustre'
         log.debug "NFS path ($result): $path"
         return result
     }


### PR DESCRIPTION
Close #5630 

Lustre performs attribute caching similar to NFS, but the `stat` command on a Lustre filesystem returns `lustre` instead of `nfs`. This PR adds a check for Lustre so that the grid executors can handle attribute caching for both NFS and Lustre.