### PR TITLE
Fix azure repos when clone URL is used

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -46,13 +46,14 @@ final class AzureRepositoryProvider extends RepositoryProvider {
         this.config = config ?: new ProviderConfig('azurerepos')
         this.continuationToken = null
     }
-    /**
-     An Azure repo is identified with the Organization/Project/Repository parameters.
-     This function gets these parameters for the different URL path formats supported in Nextflow for Azure repositories.
 
-     @param urlPath Path of the Azure repo URL
-     @return List with the azure repo parameters with the following order [ Organization, Project, Repository ]
-     **/
+    /**
+     * An Azure repo is identified with the Organization/Project/Repository parameters.
+     * This function gets these parameters for the different URL path formats supported in Nextflow for Azure repositories.
+     *
+     * @param urlPath Path of the Azure repo URL
+     * @return List with the azure repo parameters with the following order [ Organization, Project, Repository ]
+     */
     static List<String> getUniformPath(String urlPath){
         def tokens = urlPath.tokenize('/')
         if( tokens.size() == 2 ){

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -58,15 +58,16 @@ final class AzureRepositoryProvider extends RepositoryProvider {
         if( tokens.size() == 2 ){
             // URL is just organization/project. project and repo are the same.
             return [tokens[0], tokens[1], tokens[1]]
-        } else if( tokens.size() == 3 ){
+        } 
+        if( tokens.size() == 3 ){
             // URL is as expected organization/project/repository.
             return tokens
-        } else if( tokens.size() == 4 && tokens[2] == '_git' ){
+        }
+        if( tokens.size() == 4 && tokens[2] == '_git' ){
             // Clone URL organization/project/_git/repository
             return [tokens[0], tokens[1], tokens[3]]
-        } else {
-            throw new IllegalArgumentException("Incorrect Azure repository urlPath ($urlPath)")
-        }
+        } 
+        throw new IllegalArgumentException("Incorrect Azure repository urlPath ($urlPath)")
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -53,7 +53,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
      @param urlPath Path of the Azure repo URL
      @return List with the azure repo parameters with the following order [ Organization, Project, Repository ]
      **/
-    public static List<String> getUniformPath(String urlPath){
+    static List<String> getUniformPath(String urlPath){
         def tokens = urlPath.tokenize('/')
         if( tokens.size() == 2 ){
             // URL is just organization/project. project and repo are the same.
@@ -67,7 +67,7 @@ final class AzureRepositoryProvider extends RepositoryProvider {
             // Clone URL organization/project/_git/repository
             return [tokens[0], tokens[1], tokens[3]]
         } 
-        throw new IllegalArgumentException("Incorrect Azure repository urlPath ($urlPath)")
+        throw new IllegalArgumentException("Unexpected Azure repository path format - offending value: '$urlPath'")
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -39,20 +39,34 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     private String continuationToken
 
     AzureRepositoryProvider(String project, ProviderConfig config=null) {
-        /*
-        Azure repo format follows Organization/Project/Repository where Project can be optional
-        If Project is not present then Repository is used as Project (and also as Repository)
-         */
         this.urlPath = project
-        def tokens = project.tokenize('/')
+        def tokens = getUniformPath(project)
         this.repo = tokens.removeLast()
-        if( tokens.size() == 1){
-            this.project = [tokens.first(), this.repo].join('/')
-        }else{
-            this.project = tokens.join('/')
-        }
+        this.project = tokens.join('/')
         this.config = config ?: new ProviderConfig('azurerepos')
         this.continuationToken = null
+    }
+    /**
+     An Azure repo is identified with the Organization/Project/Repository parameters.
+     This function gets these parameters for the different URL path formats supported in Nextflow for Azure repositories.
+
+     @param urlPath Path of the Azure repo URL
+     @return List with the azure repo parameters with the following order [ Organization, Project, Repository ]
+     **/
+    public static List<String> getUniformPath(String urlPath){
+        def tokens = urlPath.tokenize('/')
+        if( tokens.size() == 2 ){
+            // URL is just organization/project. project and repo are the same.
+            return [tokens[0], tokens[1], tokens[1]]
+        } else if( tokens.size() == 3 ){
+            // URL is as expected organization/project/repository.
+            return tokens
+        } else if( tokens.size() == 4 && tokens[2] == '_git' ){
+            // Clone URL organization/project/_git/repository
+            return [tokens[0], tokens[1], tokens[3]]
+        } else {
+            throw new IllegalArgumentException("Incorrect Azure repository urlPath ($urlPath)")
+        }
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
@@ -362,9 +362,7 @@ class ProviderConfig {
         }
 
         if( server == 'https://dev.azure.com' ) {
-            final parts = project.tokenize('/')
-            if( parts[2]=='_git' )
-                project = "${parts[0]}/${parts[1]}"
+            project = AzureRepositoryProvider.getUniformPath(project).join('/')
         }
 
         return project.stripStart('/')

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -42,6 +42,32 @@ class AzureRepositoryProviderTest extends Specification {
         }
         '''
 
+    def 'should parse repo fields from path' () {
+        expect:
+        AzureRepositoryProvider.getUniformPath(PATH) == EXPECTED
+
+        where:
+        PATH                                | EXPECTED
+        't-neumann/hello'                   | ['t-neumann', 'hello', 'hello']
+        'ORGANIZATION/PROJECT/hello'        | ['ORGANIZATION','PROJECT','hello']
+        'ORGANIZATION/PROJECT/_git/hello'   | ['ORGANIZATION','PROJECT','hello']
+
+    }
+
+    def 'should throw exception if wrong path' () {
+        when:
+        def path = AzureRepositoryProvider.getUniformPath(PATH)
+
+        then :
+        def exception = thrown(IllegalArgumentException)
+        exception?.message == EXCEPTION
+
+        where:
+        PATH                                | EXCEPTION
+        'incorrect_path_1'                  | "Unexpected Azure repository path format - offending value: 'incorrect_path_1'"
+        'ORG/PROJ/hello/incorrect'          | "Unexpected Azure repository path format - offending value: 'ORG/PROJ/hello/incorrect'"
+    }
+
     def 'should return repo url' () {
 
         given:

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -49,17 +49,13 @@ class AzureRepositoryProviderTest extends Specification {
         def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
 
         expect:
-        new AzureRepositoryProvider('t-neumann/hello', obj).getEndpointUrl() == 'https://dev.azure.com/t-neumann/hello/_apis/git/repositories/hello'
-    }
+        new AzureRepositoryProvider(PATH, obj).getEndpointUrl() == EXPECTED
 
-    def 'should return repo with organization url' () {
-
-        given:
-        def config = new ConfigSlurper().parse(CONFIG)
-        def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
-
-        expect:
-        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getEndpointUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT/_apis/git/repositories/hello'
+        where:
+        PATH                                | EXPECTED
+        't-neumann/hello'                   | 'https://dev.azure.com/t-neumann/hello/_apis/git/repositories/hello'
+        'ORGANIZATION/PROJECT/hello'        | 'https://dev.azure.com/ORGANIZATION/PROJECT/_apis/git/repositories/hello'
+        'ORGANIZATION/PROJECT/_git/hello'   | 'https://dev.azure.com/ORGANIZATION/PROJECT/_apis/git/repositories/hello'
     }
 
     def 'should return project URL' () {
@@ -69,18 +65,12 @@ class AzureRepositoryProviderTest extends Specification {
         def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
 
         expect:
-        new AzureRepositoryProvider('t-neumann/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/t-neumann/hello'
-
-    }
-
-    def 'should return project with organization URL' () {
-
-        given:
-        def config = new ConfigSlurper().parse(CONFIG)
-        def obj = new ProviderConfig('azurerepos', config.providers.azurerepos as ConfigObject)
-
-        expect:
-        new AzureRepositoryProvider('ORGANIZATION/PROJECT/hello', obj).getRepositoryUrl() == 'https://dev.azure.com/ORGANIZATION/PROJECT/hello'
+        new AzureRepositoryProvider(PATH, obj).getRepositoryUrl() == EXPECTED
+        where:
+        PATH                                | EXPECTED
+        't-neumann/hello'                   | 'https://dev.azure.com/t-neumann/hello'
+        'ORGANIZATION/PROJECT/hello'        | 'https://dev.azure.com/ORGANIZATION/PROJECT/hello'
+        'ORGANIZATION/PROJECT/_git/hello'   | 'https://dev.azure.com/ORGANIZATION/PROJECT/_git/hello'
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/ProviderConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/ProviderConfigTest.groovy
@@ -238,8 +238,9 @@ class ProviderConfigTest extends Specification {
         'a/b/c'       | 'http://dot.com/a'      | 'b/c'
         'a/b/c'       | 'http://dot.com/a/'     | 'b/c'
         and:
-        'paolo0758/nf-azure-repo'                    | 'https://dev.azure.com' | 'paolo0758/nf-azure-repo'
-        'paolo0758/nf-azure-repo/_git/nf-azure-repo' | 'https://dev.azure.com' | 'paolo0758/nf-azure-repo'
+        'paolo0758/nf-azure-repo'                    | 'https://dev.azure.com' | 'paolo0758/nf-azure-repo/nf-azure-repo'
+        'paolo0758/nf-azure-repo/_git/nf-azure-repo' | 'https://dev.azure.com' | 'paolo0758/nf-azure-repo/nf-azure-repo'
+        'paolo0758/nf-azure-repo/_git/another-azure-repo' | 'https://dev.azure.com' | 'paolo0758/nf-azure-repo/another-azure-repo'
     }
 
 }


### PR DESCRIPTION
- Add support for Clone URL.
- Unifies the parse of URL path to extract organization, project and repository in all the supported cases. (AzureRepositoryProvider.getUniformPath). It is used in the AzureRepositoryProvider constructor to get the project and repo and in the ProviderConfig.resolveProjectName used when pulling the pipeline from a repo.