### PR TITLE
feat: Azure Batch worker pool supports managed identity

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchTaskHandler.groovy
@@ -202,4 +202,5 @@ class AzBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         }
         return machineInfo
     }
+
 }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -68,6 +68,8 @@ class AzPoolOpts implements CacheFunnel {
     boolean lowPriority
     AzStartTaskOpts startTask
     
+    String managedIdentityId
+
     AzPoolOpts() {
         this(Collections.emptyMap())
     }
@@ -92,6 +94,7 @@ class AzPoolOpts implements CacheFunnel {
         this.password = opts.password
         this.virtualNetwork = opts.virtualNetwork
         this.lowPriority = opts.lowPriority as boolean
+        this.managedIdentityId = opts.managedIdentityId
     }
 
     @Override
@@ -114,6 +117,7 @@ class AzPoolOpts implements CacheFunnel {
         hasher.putBoolean(lowPriority)
         hasher.putUnencodedChars(startTask.script ?: '')
         hasher.putBoolean(startTask.privileged)
+        hasher.putUnencodedChars(managedIdentityId ?: '')
         return hasher
     }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
@@ -1,10 +1,13 @@
 package nextflow.cloud.azure.batch
 
+import nextflow.cloud.azure.config.AzPoolOpts
 import nextflow.cloud.types.CloudMachineInfo
 import nextflow.cloud.types.PriceModel
+import nextflow.cloud.azure.batch.AzVmPoolSpec
 import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.BashWrapperBuilder
 import nextflow.executor.Executor
+import nextflow.processor.TaskBean
 import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
@@ -84,5 +87,4 @@ class AzBatchTaskHandlerTest extends Specification {
         trace.machineInfo.zone == 'west-eu'
         trace.machineInfo.priceModel == PriceModel.standard
     }
-
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
@@ -16,7 +16,7 @@
  */
 
 package nextflow.cloud.azure.config
-
+import nextflow.cloud.azure.config.AzPoolOpts
 import nextflow.util.Duration
 import spock.lang.Specification
 /**


### PR DESCRIPTION
This feature adds an option to tell Azure Batch the worker pool has a managed identity attached.

Currently, the only feature is it passes the managed identity client id to the task as an environment variable but this could be extended to support file staging in or out.

Signed-off-by: adamrtalbot <12817534+adamrtalbot@users.noreply.github.com>

Hi! Thanks for contributing to Nextflow project.

When submitting a Pull Request please make sure to not include
in the changeset any modification in these files:

* `nextflow`
* `modules/nf-commons/src/main/nextflow/Const.groovy`

Also, please sign-off the DCO [1] to certify you are the author of the contribution
and you adhere to Nextflow open source license [2] adding a `Signed-off-by` line to
the contribution commit message. For more details check [3].

1. https://developercertificate.org/
2. https://github.com/nextflow-io/nextflow/blob/master/COPYING
3. https://github.com/apps/dco

