### PR TITLE
Configure target java version alongside gradle toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,18 +67,16 @@ allprojects {
     apply plugin: 'jacoco'
 
     java {
+        // these settings apply to all jvm tooling, including groovy
         toolchain {
             languageVersion = JavaLanguageVersion.of(21)
         }
+        sourceCompatibility = 17
+        targetCompatibility = 17
     }
 
     compileJava {
         options.release.set(17)
-    }
-
-    tasks.withType(GroovyCompile) {
-        sourceCompatibility = 17
-        targetCompatibility = 17
     }
 
     idea {


### PR DESCRIPTION
Configure the target Java version inside the gradle `java` block next to the toolchain info, rather than on a per-task basis. This propogates the information to all the variants, in particular the test fixtures.

Without this, a project depending on the test fixtures (such as a nextflow plugin) can, in some situations, fail to build with the following error:
```
- Variant 'testFixturesApiElements' declares a library for use during compile-time, packaged as a jar, and its dependencies declared externally:
    - Incompatible because this component declares a component, compatible with Java 21 and the consumer needed a component, compatible with Java 17
```

# Before this change

Using command `gradle :nextflow:outgoingVariants` to show the variants, the 'main' variants correctly declare that they require Java 17:
![image](https://github.com/user-attachments/assets/3dde7e2c-64fa-41bc-bfcd-57ecc3d03b52)

but the 'testFixtures' variants requires Java 21:
![image](https://github.com/user-attachments/assets/1ba7d551-f420-4749-b7ed-ea2976a7debe)


# After this change

All the Java variants require Java 17:
![image](https://github.com/user-attachments/assets/dabe2b57-9251-4a39-8822-4f27c5210477)
![image](https://github.com/user-attachments/assets/b9be143f-ab5b-454c-9864-3f01c075ba2c)


All the compiled bytecode still has class file format version 61 (Java 17).