### PR TITLE
Prevent the use existing work dir

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -830,7 +830,11 @@ class TaskProcessor {
             try {
                 if( resumeDir != workDir )
                     exists = workDir.exists()
-                if( !exists && !workDir.mkdirs() )
+                if( exists ) {
+                    tries++
+                    continue
+                }
+                else if( !workDir.mkdirs() )
                     throw new IOException("Unable to create directory=$workDir -- check file system permissions")
             }
             finally {


### PR DESCRIPTION
This prevent the use of existing task work dir when launching a new task execution. 

This may happen when task execution already run but it failed to save the cache metadata and therefore it is not recognised as resume dir. 

Close https://github.com/nextflow-io/nextflow/issues/5595
 