### PR TITLE
Use Java API to read trace file

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -227,7 +227,7 @@ abstract class TaskHandler {
                 }
             }
 
-            def file = task.workDir?.resolve(TaskRun.CMD_TRACE)
+            final file = task.workDir?.resolve(TaskRun.CMD_TRACE)
             try {
                 if(file) record.parseTraceFile(file)
             }

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
@@ -16,6 +16,9 @@
 
 package nextflow.trace
 
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+
 import groovy.json.JsonSlurper
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -333,4 +336,12 @@ class TraceRecordTest extends Specification {
         'COMPLETED' | true
     }
 
+    def 'should throw file not found exception' () {
+        given:
+        def rec = new TraceRecord([:])
+        when:
+        rec.parseTraceFile(Path.of('unknown'))
+        then:
+        thrown(NoSuchFileException)
+    }
 }


### PR DESCRIPTION
This PR uses Java NIO API to read the trace file providing an alternative implementation to #5501