### PR TITLE
Use `/usr/bin/env -S bash` instead of `/bin/bash` on the host system

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
@@ -131,7 +131,7 @@ class LocalTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     protected ProcessBuilder localProcessBuilder() {
-        final cmd = new ArrayList<String>(BashWrapperBuilder.BASH) << wrapperFile.getName()
+        final cmd = new ArrayList<String>(BashWrapperBuilder.ENV_BASH) << wrapperFile.getName()
         log.debug "Launch cmd line: ${cmd.join(' ')}"
         // make sure it's a posix file system
         if( task.workDir.fileSystem != FileSystems.default )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -136,7 +136,7 @@ class TaskBean implements Serializable, Cloneable {
         this.useMicromamba = task.getCondaConfig()?.useMicromamba()
         this.spackEnv = task.getSpackEnv()
         this.moduleNames = task.config.getModule()
-        this.shell = task.config.getShell() ?: BashWrapperBuilder.BASH
+        this.shell = task.config.getShell(task.isContainerEnabled()) ?: BashWrapperBuilder.BASH
         this.script = task.getScript()
         this.beforeScript = task.config.getBeforeScript()
         this.afterScript = task.config.getAfterScript()

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -374,10 +374,10 @@ class TaskConfig extends LazyMap implements Cloneable {
         return (List<String>) get('secret')
     }
 
-    List<String> getShell() {
+    List<String> getShell(boolean isContainerEnabled = true) {
         final value = get('shell')
         if( !value )
-            return BashWrapperBuilder.BASH
+            return isContainerEnabled ? BashWrapperBuilder.BASH : BashWrapperBuilder.ENV_BASH
 
         if( value instanceof List )
             return (List)value

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -125,7 +125,6 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
     static final Map<String,Object> DEFAULT_CONFIG = [
             debug: false,
             cacheable: true,
-            shell: BashWrapperBuilder.BASH,
             maxRetries: 1,
             maxErrors: -1,
             errorStrategy: ErrorStrategy.TERMINATE
@@ -169,14 +168,15 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
      *
      * @param script The owner {@code BaseScript} configuration object
      */
-    protected ProcessConfig( BaseScript script ) {
+    protected ProcessConfig( BaseScript script, boolean isContainerEnabled = true) {
         ownerScript = script
         configProperties = new LinkedHashMap()
         configProperties.putAll( DEFAULT_CONFIG )
+        configProperties.put('shell', isContainerEnabled ? BashWrapperBuilder.BASH : BashWrapperBuilder.ENV_BASH)
     }
 
-    ProcessConfig( BaseScript script, String name ) {
-        this(script)
+    ProcessConfig( BaseScript script, String name, boolean isContainerEnabled = true) {
+        this(script, isContainerEnabled)
         this.processName = name
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -100,7 +100,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         assert processConfig==null
 
         // the config object
-        processConfig = new ProcessConfig(owner,processName)
+        processConfig = new ProcessConfig(owner,processName,session.getContainerConfig().isEnabled())
 
         // Invoke the code block which will return the script closure to the executed.
         // As side effect will set all the property declarations in the 'taskConfig' object.


### PR DESCRIPTION
On systems without `/bin/bash` (e.g. NixOS), invoking tasks may fail because of some hard-coded references to `/bin/bash`. Those references are either 
- fine (because the task runs in a container where /bin/bash *is* available),
- don't matter (because the shebang is ignored)
- or cause failure (if `/bin/bash` cannot be invoked).

This PR adapts Nextflow for the last scenario. Instead of invoking `/bin/bash`, `/usr/bin/env -S bash` is used where necessary. This approach (or similar) has been discussed previously:

* https://github.com/nextflow-io/nextflow/pull/2341
* https://github.com/nextflow-io/nextflow/issues/1598
* https://github.com/nextflow-io/nextflow/pull/1614
* https://github.com/nextflow-io/nextflow/issues/5420

However, compared the previous discussions/implementations, I specifically do *not* propose to change `/bin/bash` unless really necessary. By "necessary" I mean that `bash` is invoked on a local host system where it may not be available. Namely, when `<task>/.command.run` shall be invoked (always on the host) and when `<task>/.command.sh` is invoked in a non-container context (i.e. also on the host). I have *not* touched any other occurrences of `/bin/bash`, esp. not within the container.

I'm happy  to change the the code as requested. I have not added any comments since I expect (at least) change requests. Please review this with an unbiased mind set. Multiple people have expressed their intention to use `nextflow` on systems without `/bin/bash`.

I have tested solely on NixOS.