### PR TITLE
Remove redundant slash from s3 URI

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Path.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Path.java
@@ -410,8 +410,8 @@ public class S3Path implements Path, TagAwareFile {
 		builder.append("s3://");
 		if (fileSystem.getEndpoint() != null) {
 			builder.append(fileSystem.getEndpoint());
+    		builder.append("/");
 		}
-		builder.append("/");
 		builder.append(bucket);
 		builder.append(PATH_SEPARATOR);
 		builder.append(Joiner.on(PATH_SEPARATOR).join(parts));


### PR DESCRIPTION
Before this fix, calling the `toUri` method on an instance of nextflow.cloud.aws.nio.S3Path would print a triple-slash path:

```
s3:///bucket-name/path/to/SampleSheet.csv
```

This fix removes the redundant slash when there is no endpoint specified.