### PR TITLE
Fix Conda directive is not honoured by task array

### DIFF
--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -351,6 +351,11 @@ For cloud-based executors like AWS Batch, or when using Fusion with any executor
 - {ref}`process-container`
 - {ref}`process-containerOptions`
 
+When using Wave, the following additional directives must be uniform:
+
+- {ref}`process-conda`
+- {ref}`process-spack`
+
 (process-beforescript)=
 
 ### beforeScript

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -354,7 +354,6 @@ For cloud-based executors like AWS Batch, or when using Fusion with any executor
 When using Wave, the following additional directives must be uniform:
 
 - {ref}`process-conda`
-- {ref}`process-spack`
 
 (process-beforescript)=
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -44,6 +44,7 @@ class TaskArrayCollector {
             'accelerator',
             'arch',
             'clusterOptions',
+            'conda',
             'cpus',
             'disk',
             'machineType',

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -57,7 +57,6 @@ class TaskArrayCollector {
             'containerOptions',
             // only needed when using Wave
             'conda',
-            'spack',
     ]
 
     private TaskProcessor processor

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -44,7 +44,6 @@ class TaskArrayCollector {
             'accelerator',
             'arch',
             'clusterOptions',
-            'conda',
             'cpus',
             'disk',
             'machineType',
@@ -56,6 +55,9 @@ class TaskArrayCollector {
             // only needed for container-native executors and/or Fusion
             'container',
             'containerOptions',
+            // only needed when using Wave
+            'conda',
+            'spack',
     ]
 
     private TaskProcessor processor


### PR DESCRIPTION
This PR fixes the usage of `conda` directive with task arrays. 

Solves #5694