### PR TITLE
Open lineage observer

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     api 'dev.failsafe:failsafe:3.1.0'
     api 'org.bouncycastle:bcprov-ext-jdk18on:1.78.1'
     api 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+    api 'io.openlineage:openlineage-java:1.27.0'
+    api 'io.micrometer:micrometer-core:1.14.1'
+    api 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
 
     testImplementation 'org.subethamail:subethasmtp:3.1.7'
 

--- a/modules/nextflow/src/main/groovy/nextflow/prov/openlineage/OpenLineageEventFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/prov/openlineage/OpenLineageEventFactory.groovy
@@ -105,9 +105,9 @@ class OpenLineageEventFactory {
     }
 
 
-    private static OpenLineage.Job generatePublishJob(){
+    private OpenLineage.Job generatePublishJob(){
         final jobType = OL.newJobTypeJobFacet("BATCH", "Nextflow", "JOB")
-        return OL.newJobBuilder().namespace("io.nextflow").name("publish (${publishCount.getAndIncrement()})")
+        return OL.newJobBuilder().namespace(this.workflow.namespace).name("publish (${publishCount.getAndIncrement()})")
             .facets(OL.newJobFacetsBuilder().jobType(jobType).build())
             .build()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/prov/openlineage/OpenLineageEventFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/prov/openlineage/OpenLineageEventFactory.groovy
@@ -1,0 +1,209 @@
+package nextflow.prov.openlineage
+
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.openlineage.client.OpenLineage
+import nextflow.Session
+import nextflow.processor.TaskRun
+import nextflow.trace.TraceRecord
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.ZonedDateTime
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Factory for OpenLineage events
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+@Slf4j
+@CompileStatic
+class OpenLineageEventFactory {
+    private static final OpenLineage OL = new OpenLineage(URI.create("nextflow"))
+    private static final AtomicInteger publishCount = new AtomicInteger()
+    private OpenLineage.Job workflow
+    private OpenLineage.Run workflowRun
+
+    OpenLineageEventFactory(){ }
+
+    public void setWorkflowJobFromSession(Session session) {
+        final namespace = session.workflowMetadata.repository ? session.workflowMetadata.repository : session.workflowMetadata.scriptFile.parent.toUri().toString()
+        def name = session.workflowMetadata.manifest ? session.workflowMetadata.manifest.name : session.workflowMetadata.scriptFile.name
+        name = name ? name : "main.nf"
+        final workflowType = OL.newJobTypeJobFacet("BATCH", "Nextflow", "DAG")
+        this.workflow = OL.newJobBuilder().namespace(namespace).name(name)
+                .facets(OL.newJobFacetsBuilder().jobType(workflowType).build())
+                .build()
+        this.workflowRun = OL.newRunBuilder().runId(session.uniqueId).build()
+        log.debug("[Openlineage] Workflow $namespace.$name job created.")
+    }
+
+    public void setWorkflowRun(UUID runId){
+        this.workflowRun = OL.newRunBuilder().runId(runId).build()
+    }
+
+    public OpenLineage.RunEvent createWorkflowCompleteEvent(){
+        return OL.newRunEventBuilder()
+            .eventType(OpenLineage.RunEvent.EventType.COMPLETE)
+            .eventTime(ZonedDateTime.now()).job(workflow).run(workflowRun)
+            .build()
+
+    }
+
+    public OpenLineage.RunEvent createWorkflowStartEvent(){
+        return OL.newRunEventBuilder().eventTime(ZonedDateTime.now())
+            .eventType(OpenLineage.RunEvent.EventType.START)
+            .run(this.workflowRun).job(this.workflow)
+            .build()
+    }
+
+    public OpenLineage.RunEvent createWorkflowFailedEvent(){
+        OL.newRunEventBuilder()
+            .eventType(OpenLineage.RunEvent.EventType.FAIL)
+            .eventTime(ZonedDateTime.now()).job(workflow).run(workflowRun)
+            .build()
+    }
+
+    public OpenLineage.RunEvent createTaskStartEvent(TaskRun task, TraceRecord trace){
+        final job = generateTaskJob(task)
+        final jobRun = generateInitialTaskRun(task)
+        final inputs = getInputsFromTask(task)
+        return OL.newRunEventBuilder()
+            .eventType(OpenLineage.RunEvent.EventType.START)
+            .eventTime(ZonedDateTime.now()).job(job).run(jobRun).inputs(inputs).build()
+
+    }
+
+    public OpenLineage.RunEvent createTaskCompleteEvent(TaskRun task, TraceRecord trace){
+        final job = generateTaskJob(task)
+        final parent = generateParentFacet()
+        if( task.isSuccess() ){
+            return generateSuccessEvent(task, job, parent)
+        } else {
+            return generateFailEvent(task, job, parent)
+
+        }
+    }
+
+    public OpenLineage.RunEvent createTaskCachedEvent(TaskRun task, TraceRecord trace){
+        final job = generateTaskJob(task)
+        final parent = generateParentFacet()
+        return generateCachedEvent(task, job, parent)
+    }
+
+    public OpenLineage.RunEvent createPublishEvent(Path source, Path destination){
+        final job = generatePublishJob()
+        final parent = generateParentFacet()
+        final jobRun = OL.newRun(UUID.randomUUID(),
+            OL.newRunFacetsBuilder().parent(parent).build())
+        return OL.newRunEventBuilder()
+            .eventType(OpenLineage.RunEvent.EventType.COMPLETE)
+            .eventTime(ZonedDateTime.now()).job(job).run(jobRun)
+            .inputs(generateInputs([source])).outputs(generateOutputs([destination])).build()
+    }
+
+
+    private static OpenLineage.Job generatePublishJob(){
+        final jobType = OL.newJobTypeJobFacet("BATCH", "Nextflow", "JOB")
+        return OL.newJobBuilder().namespace("io.nextflow").name("publish (${publishCount.getAndIncrement()})")
+            .facets(OL.newJobFacetsBuilder().jobType(jobType).build())
+            .build()
+    }
+
+    private OpenLineage.Job generateTaskJob(TaskRun task){
+        final jobType = OL.newJobTypeJobFacet("BATCH", "Nextflow", "JOB")
+        return OL.newJobBuilder().namespace(this.workflow.namespace).name(task.name)
+            .facets(OL.newJobFacetsBuilder().jobType(jobType).build())
+            .build()
+    }
+
+    private OpenLineage.Run generateInitialTaskRun(TaskRun task){
+        final parentRun =  generateParentFacet()
+        final descFacet = generateRunFacet([hashcode: task.hash.toString(), id: task.id])
+        final jobRun = OL.newRun(UUID.nameUUIDFromBytes(task.hash.asBytes()),
+            OL.newRunFacetsBuilder().parent(parentRun).put("description", descFacet).build())
+        return jobRun
+    }
+
+    private OpenLineage.ParentRunFacet generateParentFacet() {
+        return OL.newParentRunFacet(OL.newParentRunFacetRun(this.workflowRun.getRunId()),
+            OL.newParentRunFacetJob(this.workflow.namespace, this.workflow.name))
+    }
+
+    private static OpenLineage.RunEvent generateSuccessEvent(TaskRun task, OpenLineage.Job job, OpenLineage.ParentRunFacet parent){
+        final jobRun = OL.newRunBuilder().runId(UUID.nameUUIDFromBytes(task.hash.asBytes()))
+                .facets(OL.newRunFacetsBuilder().parent(parent).build())
+                .build()
+        final outputs = getOutputsFromTask(task)
+        return OL.newRunEventBuilder()
+                .eventType(OpenLineage.RunEvent.EventType.COMPLETE)
+                .eventTime(ZonedDateTime.now())
+                .job(job).run(jobRun).outputs(outputs)
+                .build()
+    }
+
+    private static OpenLineage.RunEvent generateFailEvent(TaskRun task, OpenLineage.Job job, OpenLineage.ParentRunFacet parent){
+        def err = task.dumpStderr()
+        err = err ? err.join('\n'): ""
+        final jobRun = OL.newRunBuilder().runId(UUID.nameUUIDFromBytes(task.hash.asBytes()))
+                .facets(OL.newRunFacetsBuilder()
+                        .errorMessage(OL.newErrorMessageRunFacet("Task $task.name failed", "Nextflow", err))
+                        .parent(parent)
+                        .build())
+                .build()
+        return OL.newRunEventBuilder()
+                .eventType(OpenLineage.RunEvent.EventType.FAIL)
+                .eventTime(ZonedDateTime.now()).job(job).run(jobRun)
+                .build()
+    }
+
+    private static OpenLineage.RunEvent generateCachedEvent(TaskRun task, OpenLineage.Job job, OpenLineage.ParentRunFacet parent){
+        final jobRun = OL.newRunBuilder().runId(UUID.nameUUIDFromBytes(task.hash.asBytes()))
+                .facets(OL.newRunFacetsBuilder().parent(parent).put("abort", generateRunFacet([reason: "cached"])).build())
+                .build()
+        return OL.newRunEventBuilder()
+                .eventType(OpenLineage.RunEvent.EventType.ABORT)
+                .eventTime(ZonedDateTime.now()).job(job).run(jobRun)
+                .build()
+    }
+
+    private static OpenLineage.RunFacet generateRunFacet(Map props){
+        OpenLineage.RunFacet facet = OL.newRunFacet()
+        props.each {facet.getAdditionalProperties().put(it.key.toString(), it.value)}
+        return facet
+    }
+
+    private static List<OpenLineage.InputDataset> getInputsFromTask(TaskRun task){
+        final inputs = new LinkedList<OpenLineage.InputDataset>()
+        task.getInputFilesMap().each{ name,path -> inputs.add(OL.newInputDatasetBuilder()
+            .namespace(path.toFile().parent).name(path.toFile().name).build()) }
+        return inputs
+    }
+
+    private static List<OpenLineage.InputDataset> generateInputs(List<Path> inputPaths){
+        final inputs = new LinkedList<OpenLineage.InputDataset>()
+        inputPaths.each{ path -> inputs.add(OL.newInputDatasetBuilder()
+            .namespace(path.toFile().parent).name(path.toFile().name).build()) }
+        return inputs
+    }
+
+    private static List<OpenLineage.OutputDataset> getOutputsFromTask(TaskRun task){
+        final outputs = new LinkedList<OpenLineage.OutputDataset>()
+        task.getOutputFilesNames().each{
+            outputs.add(OL.newOutputDatasetBuilder()
+                .namespace(new URI(task.workDirStr).toString()).name(it).build()) }
+        return outputs
+    }
+
+    private static List<OpenLineage.OutputDataset> generateOutputs(List<Path> outputsPaths){
+        final outputs = new LinkedList<OpenLineage.OutputDataset>()
+        outputsPaths.each{ path -> outputs.add(OL.newOutputDatasetBuilder()
+                .namespace(path.getParent().toUri().toString())
+                .name(path.getName())
+                .build())
+        }
+        return outputs
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/prov/openlineage/OpenLineageObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/prov/openlineage/OpenLineageObserver.groovy
@@ -1,0 +1,96 @@
+package nextflow.prov.openlineage
+
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.openlineage.client.OpenLineage
+import io.openlineage.client.OpenLineageClient
+import io.openlineage.client.transports.HttpTransport
+import nextflow.Session
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskRun
+import nextflow.trace.TraceObserver
+import nextflow.trace.TraceRecord
+
+import java.nio.file.Path
+import java.time.ZonedDateTime
+
+/**
+ * OpenLineage events observer
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+@Slf4j
+@CompileStatic
+class OpenLineageObserver implements TraceObserver {
+    private OpenLineageClient client
+    private OpenLineageEventFactory factory
+    private Session session
+
+    OpenLineageObserver(String server){
+        this.client = OpenLineageClient.builder()
+                .transport(HttpTransport.builder().uri(server).build())
+                .build();
+    }
+
+    @Override
+    void onFlowCreate(Session session) {
+        this.session = session
+        this.factory = new OpenLineageEventFactory()
+        this.factory.setWorkflowJobFromSession(session)
+        this.factory.setWorkflowRun(session.uniqueId)
+    }
+
+    @Override
+    void onFlowComplete() {
+        if( factory ) {
+            final event = factory.createWorkflowCompleteEvent()
+            client.emit(event)
+            log.debug("[Openlineage] Workflow complete event sent.")
+        }
+    }
+
+    @Override
+    void onFlowBegin(){
+        final event = factory.createWorkflowStartEvent()
+        client.emit(event)
+        log.debug("[Openlineage] Workflow start event sent.")
+    }
+
+    @Override
+    void onProcessStart(TaskHandler handler, TraceRecord trace){
+        final event = factory.createTaskStartEvent(handler.task, trace)
+        client.emit(event)
+        log.debug("[Openlineage] Task ${handler.task.id} start event sent.")
+    }
+
+    @Override
+    void onProcessComplete(TaskHandler handler, TraceRecord trace){
+        final event = factory.createTaskCompleteEvent(handler.task, trace)
+        client.emit(event)
+        log.debug("[Openlineage] Task ${handler.task.id} complete event sent.")
+    }
+
+    @Override
+    void onProcessCached(TaskHandler handler, TraceRecord trace){
+        final event = factory.createTaskCachedEvent(handler.task, trace)
+        client.emit(event)
+        log.debug("[Openlineage] Task ${handler.task.id} cached event sent.")
+    }
+
+    @Override
+    void onFlowError(TaskHandler var1, TraceRecord var2){
+        if (factory) {
+            final event = factory.createWorkflowFailedEvent()
+            client.emit(event)
+            log.debug("[Openlineage] Workflow error event sent.")
+        }
+    }
+
+    @Override
+    void onFilePublish(Path destination, Path source){
+        final event = factory.createPublishEvent(source, destination)
+        client.emit(event)
+        log.debug("[Openlineage] File publish ")
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
@@ -1,5 +1,7 @@
 package nextflow.trace
 
+import nextflow.prov.openlineage.OpenLineageObserver
+
 import java.nio.file.Path
 
 import nextflow.Session
@@ -25,7 +27,18 @@ class DefaultObserverFactory implements TraceObserverFactory {
         createTimelineObserver(result)
         createDagObserver(result)
         createAnsiLogObserver(result)
+        createOpenLineageObserver(result)
         return result
+    }
+
+    protected void createOpenLineageObserver(Collection<TraceObserver> result){
+        final enabled = session.config.navigate('openLineage.enabled')
+        if (!enabled)
+            return
+        final server = session.config.navigate('openLineage.server') as String
+        if (!server)
+            throw new IllegalArgumentException("OpenLineage API Server must be specified for the nf-open-linage plugin")
+        result << new OpenLineageObserver(server)
     }
 
     protected void createAnsiLogObserver(Collection<TraceObserver> result) {


### PR DESCRIPTION
This PR adds an observer for [OpenLineage](https://openlineage.io/)

For each workflow task and publish notification, it generates an Openlineage RunEvent event and emits it to the OpenLineage server. In this case I have used Marquez as server that allow to store and visualize the data lineage.


### Limitations

- Marquez only shows the last execution of a job. So, when running a workflow that runs a process for several datasets, generating a set of datasets, only the latest execution was visualized and only the last used dataset was linked to a job. So, the other generated datasets appear as orphans in the visualization. Datasets are connected to runs but they are not visualized correctly. They are aware of this ([#2543](https://github.com/MarquezProject/marquez/issues/2543)) they called it static lineage. To overcome this situation, I had to create a job per task. The same happened for publishing files, I had to add a counter to be able to visualize all the file publications. Despite, it allows to visualize, a single execution, if we run again the workflow generating new datasets, for the same reason, Marque is not visualizing correctly de lineage of previous datasets.
- I haven’t see a way to see the whole graph in Marquez, but I think this is not the intention of the framework 
- Datasets and Jobs sections in Marquez are not showing anything, and no errors in logs.
- We are able to detect the dependencies there is a direct dependency  by files, we are losing the lineage when data is processed in operators (such as reading file lines, etc). Maybe it could be solved adding an observer for operator runs and manage the inputs and outputs in the same way as in #5639.