### PR TITLE
 Add note to document watchPath incompatibility with cloud URIs

### DIFF
--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -508,6 +508,11 @@ that it will cause your pipeline to run forever. Consider using the `take` or `u
 a certain condition is met (e.g. after receiving 10 files, receiving a file named `DONE`).
 :::
 
+:::{note}
+The `channel.watchPath` relies on the Java file watch API which and POSIX notify events.
+As such, `channel.watchPath` may not work with NFS network mounts and will not work for cloud provider URIs (e.g. `s3://.../*.txt`).
+:::
+
 See also: [channel.fromPath](#frompath) factory method.
 
 [glob]: http://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -510,7 +510,7 @@ a certain condition is met (e.g. after receiving 10 files, receiving a file name
 
 :::{note}
 The `channel.watchPath` relies on the Java file watch API which and POSIX notify events.
-As such, `channel.watchPath` may not work with NFS network mounts and will not work for cloud provider URIs (e.g. `s3://.../*.txt`).
+As such, `channel.watchPath` will not work with cloud URIs (e.g. `s3://.../*.txt`).
 :::
 
 See also: [channel.fromPath](#frompath) factory method.

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -509,8 +509,7 @@ a certain condition is met (e.g. after receiving 10 files, receiving a file name
 :::
 
 :::{note}
-The `channel.watchPath` relies on the Java file watch API which and POSIX notify events.
-As such, `channel.watchPath` will not work with cloud URIs (e.g. `s3://.../*.txt`).
+The `channel.watchPath` factory only works with local and shared filesystems. It does not support object storage such as S3.
 :::
 
 See also: [channel.fromPath](#frompath) factory method.


### PR DESCRIPTION
Changes:
- Updates docs, adding a note to document watchPath incompatibility with cloud URIs.
