### PR TITLE
Alternative for managing task array status in Google Batch

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -555,7 +555,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                 task.stderr = errorFile
             }
             status = TaskStatus.COMPLETED
-            if( belongsToArray )
+            if( isChild )
                 client.removeFromArrayTasks(jobId, taskId)
             return true
         }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -555,7 +555,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                 task.stderr = errorFile
             }
             status = TaskStatus.COMPLETED
-            if( isChild )
+            if( task.isChild )
                 client.removeFromArrayTasks(jobId, taskId)
             return true
         }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -50,11 +50,12 @@ import groovy.util.logging.Slf4j
 @Slf4j
 @CompileStatic
 class BatchClient {
-
+    private static long TASK_STATE_INVALID_TIME = 1_000
     protected String projectId
     protected String location
     protected BatchServiceClient batchServiceClient
     protected BatchConfig config
+    private Map<String, TaskStatusRecord> arrayTaskStatus = new HashMap<String, TaskStatusRecord>()
 
     BatchClient(BatchConfig config) {
         this.config = config
@@ -197,5 +198,41 @@ class BatchClient {
         final policy = retryPolicy(cond)
         // apply the action with
         return Failsafe.with(policy).get(action)
+    }
+
+
+    TaskStatus getTaskInArrayStatus(String jobId, String taskId) {
+        final taskName = generateTaskName(jobId,taskId)
+        final now = System.currentTimeMillis()
+        TaskStatusRecord record = arrayTaskStatus.get(taskName)
+        if( !record || now - record.timestamp > TASK_STATE_INVALID_TIME ){
+            log.debug("[GOOGLE BATCH] Updating tasks status for job $jobId")
+            updateArrayTasks(jobId, now)
+            record = arrayTaskStatus.get(taskName)
+        }
+        return record?.status
+    }
+
+    private void updateArrayTasks(String jobId, long now){
+        for( Task t: listTasks(jobId) ){
+            arrayTaskStatus.put(t.name, new TaskStatusRecord(t.status, now))
+        }
+
+    }
+
+    void removeFromArrayTasks(String jobId, String taskId){
+        final taskName = generateTaskName(jobId,taskId)
+        TaskStatusRecord record = arrayTaskStatus.remove(taskName)
+    }
+}
+
+@CompileStatic
+class TaskStatusRecord {
+    protected TaskStatus status
+    protected long timestamp
+
+    TaskStatusRecord(TaskStatus status, long timestamp) {
+        this.status = status
+        this.timestamp = timestamp
     }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -217,7 +217,6 @@ class BatchClient {
         for( Task t: listTasks(jobId) ){
             arrayTaskStatus.put(t.name, new TaskStatusRecord(t.status, now))
         }
-
     }
 
     void removeFromArrayTasks(String jobId, String taskId){

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -50,7 +50,7 @@ import groovy.util.logging.Slf4j
 @Slf4j
 @CompileStatic
 class BatchClient {
-    private static long TASK_STATE_INVALID_TIME = 1_000
+    private final static long TASK_STATE_INVALID_TIME = 1_000
     protected String projectId
     protected String location
     protected BatchServiceClient batchServiceClient

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchClientTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchClientTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package nextflow.cloud.google.batch.client
+
+import com.google.cloud.batch.v1.Task
+import com.google.cloud.batch.v1.TaskName
+import com.google.cloud.batch.v1.TaskStatus
+import spock.lang.Specification
+
+/**
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+class BatchClientTest extends Specification{
+
+
+
+    def 'should return task status with getTaskInArray' () {
+        given:
+        def project = 'project-id'
+        def location = 'location-id'
+        def job1 = 'job1-id'
+        def task1 = 'task1-id'
+        def task1Name = TaskName.of(project, location, job1, 'group0', task1).toString()
+        def job2 = 'job2-id'
+        def task2 = 'task2-id'
+        def task2Name = TaskName.of(project, location, job2, 'group0', task2).toString()
+        def job3 = 'job3-id'
+        def task3 = 'task3-id'
+        def task3Name = TaskName.of(project, location, job3, 'group0', task3).toString()
+        def now = System.currentTimeMillis()
+        def arrayTasks = new HashMap<String,TaskStatusRecord>()
+        def client = Spy( new BatchClient( projectId: project, location: location, arrayTaskStatus: arrayTasks ) )
+
+        when:
+        client.listTasks(job2) >> {
+            def list = new LinkedList<>()
+            list.add(makeTask(task2Name, TaskStatus.State.FAILED))
+            return list
+        }
+        client.listTasks(job3) >> {
+            def list = new LinkedList<>()
+            list.add(makeTask(task3Name, TaskStatus.State.SUCCEEDED))
+            return list
+        }
+        arrayTasks.put(task1Name, makeTaskStatusRecord(TaskStatus.State.RUNNING, System.currentTimeMillis()))
+        arrayTasks.put(task2Name, makeTaskStatusRecord(TaskStatus.State.PENDING, System.currentTimeMillis() - 1_001))
+
+        then:
+        // recent cached task
+        client.getTaskInArrayStatus(job1, task1).state == TaskStatus.State.RUNNING
+        // Outdated cached task
+        client.getTaskInArrayStatus(job2, task2).state == TaskStatus.State.FAILED
+        // no cached task
+        client.getTaskInArrayStatus(job3, task3).state == TaskStatus.State.SUCCEEDED
+    }
+
+    def TaskStatusRecord makeTaskStatusRecord(TaskStatus.State state, long timestamp) {
+        return new TaskStatusRecord(TaskStatus.newBuilder().setState(state).build(), timestamp)
+
+    }
+
+    def makeTask(String name, TaskStatus.State state){
+        Task.newBuilder().setName(name)
+            .setStatus(TaskStatus.newBuilder().setState(state).build())
+            .build()
+
+    }
+
+}


### PR DESCRIPTION
This PR is an alternative to process task status in task arrays. 
In the current status, every time that getTaskState is called, we perform two calls to the Google Batch client, one to retrieve the list of tasks(`listTasks`) and another to get the task state (`getTaskStatus`). This second call is problematic because it generates the NotFoundException and it is also redundant because the first call already provides the task descriptions including their states.

The BatchClient has a HashMap as a cache of array task status. A new method is created to retrieve the status of a task belonging to a task array. Instead of making the call to the Google Batch API, it checks the status in the cache. When the status is not in the cache or is outdated, the `listTasks` method is called to update all the array tasks statuses. So, the rest of the array tasks do not require querying the Google Batch API again. 

When there is no task status, it returns null and fallbacks to the `getJobStatus.` This is the same as we were doing when no tasks were retrieved from the job or there was a `NotFoundException`.

The invalidation time is 1 second because it is the same as the one in `GoogleBatchTaskHandler`. Another alternative is setting it with the same value as the polling interval.
