### PR TITLE
Update HyperQueueExecutor.groovy

### DIFF
--- a/docs/executor.md
+++ b/docs/executor.md
@@ -223,7 +223,7 @@ Resource requests and other job characteristics can be controlled via the follow
 - {ref}`process-memory`
 - {ref}`process-time`
 
-:::{note} As of Nextflow version 24.06.0-edge, HyperQueue version 0.17.0 or later is required.
+:::{note} HyperQueue version 0.20.0 or later is required.
 :::
 
 (k8s-executor)=

--- a/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/HyperQueueExecutor.groovy
@@ -59,7 +59,7 @@ class HyperQueueExecutor extends AbstractGridExecutor {
     protected List<String> getDirectives(TaskRun task, List<String> result) {
 
         result << '--name' << getJobNameFor(task)
-        result << '--log' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
+        result << '--stream' << quote(task.workDir.resolve(TaskRun.CMD_LOG))
         result << '--cwd' << quote(task.workDir)
 
         // No enforcement, Hq just makes sure that the allocated value is below the limit

--- a/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/HyperQueueExecutorTest.groovy
@@ -117,7 +117,7 @@ class HyperQueueExecutorTest extends Specification {
         then:
         executor.getHeaders(task) == '''
             #HQ --name nf-task-1
-            #HQ --log /work/dir/.command.log
+            #HQ --stream /work/dir/.command.log
             #HQ --cwd /work/dir
             '''
             .stripIndent().leftTrim()
@@ -131,7 +131,7 @@ class HyperQueueExecutorTest extends Specification {
         then:
         executor.getHeaders(task) == '''
             #HQ --name nf-task-1
-            #HQ --log /work/dir/.command.log
+            #HQ --stream /work/dir/.command.log
             #HQ --cwd /work/dir
             #HQ --resource mem=8192
             #HQ --cpus 4


### PR DESCRIPTION
nextflow 24.10 and 24.11 edge produce errors when using this executor and the error seems to be due to the --log directive not being recognized by hq

from reviewing hq 0.21.0 submit command flags, it looks like the logs flag should be replaced with the stream flag

these are the errors in question:

```sh
ERROR ~ Error executing process > 'NFCORE_RNASEQ:RNASEQ:CAT_FASTQ (4)'                                                                                                                                               
                                                                                                                                                                                                                     
Caused by:                                                                                                                                                                                                           
  Failed to submit process to grid scheduler for execution                                                                                                                                                           
                                                                                                                                                                                                                     
                                                                                                                                                                                                                     
Command executed:                                                                                                                                                                                                    
                                                                                                                                                                                                                     
  hq --output-mode=quiet submit --directives=file .command.run                                                                                                                                                       
                                                                                                                                                                                                                     
Command exit status:                                                                                                                                                                                                 
  1                                                                                                                                                                                                                  
                                                                                                                                                                                                                     
Command output:                                                                                                                                                                                                      
  Could not parse directives from .command.run: You have used invalid parameter(s) after a #HQ directive.                                                                                                            
  error: unexpected argument '--log' found                                                                                                                                                                           
                                                                                                                                                                                                                     
  Usage: #HQ <hq submit parameters>   
```