### PR TITLE
Disable cleanup on remote work dir

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -15,7 +15,7 @@ This page lists all of the available settings in the {ref}`Nextflow configuratio
   The use of the `cleanup` option will prevent the use of the *resume* feature on subsequent executions of that pipeline run.
   :::
   :::{warning}
-  The `cleanup` option is not supported for remote work directory such as Amazon S3, Google Cloud Storage, and Azure Blob Storage.
+  The `cleanup` option is not supported for remote work directories, such as Amazon S3, Google Cloud Storage, and Azure Blob Storage.
   :::
 
 `dumpHashes`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -12,7 +12,8 @@ This page lists all of the available settings in the {ref}`Nextflow configuratio
 : If `true`, on a successful completion of a run all files in *work* directory are automatically deleted.
 
   :::{warning}
-  The use of the `cleanup` option will prevent the use of the *resume* feature on subsequent executions of that pipeline run. Also, be aware that deleting all scratch files can take a lot of time, especially when using a shared file system or remote cloud storage.
+  The use of the `cleanup` option will prevent the use of the *resume* feature on subsequent executions of that pipeline run.
+  Also, this capability is not supported by remote work directory such as AWS S3, Google Storage and Azure Blob container.
   :::
 
 `dumpHashes`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -13,7 +13,9 @@ This page lists all of the available settings in the {ref}`Nextflow configuratio
 
   :::{warning}
   The use of the `cleanup` option will prevent the use of the *resume* feature on subsequent executions of that pipeline run.
-  Also, this capability is not supported by remote work directory such as AWS S3, Google Storage and Azure Blob container.
+  :::
+  :::{warning}
+  The `cleanup` option is not supported for remote work directory such as Amazon S3, Google Cloud Storage, and Azure Blob Storage.
   :::
 
 `dumpHashes`

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1209,8 +1209,8 @@ class Session implements ISession {
         if( aborted || cancelled || error )
             return
 
-        if( workDir.scheme!='file' ) {
-            log.warn "Clean-up setting is not supported by remote work directory: ${workDir.toUriString()}"
+        if( workDir.scheme != 'file' ) {
+            log.warn "The `cleanup` option is not supported for remote work directory: ${workDir.toUriString()}"
             return
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1209,6 +1209,11 @@ class Session implements ISession {
         if( aborted || cancelled || error )
             return
 
+        if( workDir.scheme!='file' ) {
+            log.warn "Clean-up setting is not supported by remote work directory: ${workDir.toUriString()}"
+            return
+        }
+
         log.trace "Cleaning-up workdir"
         try (CacheDB db = CacheFactory.create(uniqueId, runName).openForRead()) {
             db.eachRecord { HashCode hash, TraceRecord record ->


### PR DESCRIPTION
This PR disable the work dir clean-up when using a remote object storage since this capability is not supported.