### PR TITLE
Remove tip about shell block

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -78,10 +78,6 @@ process doOtherThings {
 
 In this example, `$MAX` is a Nextflow variable that must be defined elsewhere in the pipeline script. Nextflow replaces it with the actual value before executing the script. Meanwhile, `$DB` is a Bash variable that must exist in the execution environment, and Bash will replace it with the actual value during execution.
 
-:::{tip}
-Alternatively, you can use the {ref}`process-shell` block definition, which allows a script to contain both Bash and Nextflow variables without having to escape the first.
-:::
-
 ### Scripts *à la carte*
 
 The process script is interpreted by Nextflow as a Bash script by default, but you are not limited to Bash.


### PR DESCRIPTION
In the "script" section there was a tip recommending to use the `shell` directory, however as that has been deprecated the tip confusing.