### PR TITLE
Fix docs for `executor.submit.retry.reason` config option

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -695,7 +695,7 @@ The following settings are available:
   :::
 : Max delay when retrying failed job submissions (default: `30s`). Used only by grid executors.
 
-`executor.retry.reason`
+`executor.submit.retry.reason`
 : :::{versionadded} 22.03.0-edge
   :::
 : Regex pattern that when verified cause a failed submit operation to be re-tried (default: `Socket timed out`). Used only by grid executors.


### PR DESCRIPTION
Close #5095 

This config option was documented incorrectly: https://github.com/nextflow-io/nextflow/blob/8a714a4b90eac1a1209ec15c6930c301e6572175/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy#L149

This PR updates the docs to match the code. Alternatively, we could update the code to match the docs.