### PR TITLE
Add stub flag to task hash only if task has a stub

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -2243,7 +2243,7 @@ class TaskProcessor {
             }
         }
 
-        if( session.stubRun ) {
+        if( session.stubRun && task.config.getStubBlock() ) {
             keys.add('stub-run')
         }
 


### PR DESCRIPTION
Close #5446 

During a stub run, the stub flag is added to a task hash even if the specific process doesn't have a stub section. When a process doesn't have a stub section, it is executed normally. Therefore, the stub flag shouldn't be added in that case.