### PR TITLE
Document examples of directives with only named args

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1128,12 +1128,12 @@ The `emit` option can be used on a process output to define a name for the corre
 process FOO {
     output:
     path 'hello.txt', emit: hello
-    path 'bye.txt', emit: bye
+    stdout emit: bye
 
     script:
     """
     echo "hello" > hello.txt
-    echo "bye" > bye.txt
+    echo "bye"
     """
 }
 

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -795,6 +795,9 @@ printf 'Hello %s!\n', 'World'
 
 // positional and named args
 file 'hello.txt', checkIfExists: true
+
+// named args
+resourceLabels group: 'my-group', user: 'me'
 ```
 
 If the last argument is a closure, it can be specified outside of the parentheses:


### PR DESCRIPTION
Close #5680 

Provide some explicit examples of function calls with only named args, to show that no comma is required. Several people have been confused by this with the `stdout` directive.