### PR TITLE
Fix false error in variable visitor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/ast/VariableVisitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/VariableVisitor.groovy
@@ -72,11 +72,13 @@ class VariableVisitor extends ClassCodeVisitorSupport {
     void visitDeclarationExpression(DeclarationExpression expr) {
         declaration = true
         try {
-            super.visitDeclarationExpression(expr)
+            visit(expr.getLeftExpression())
         }
         finally {
             declaration = false
         }
+
+        visit(expr.getRightExpression())
     }
 
     @Override
@@ -107,7 +109,7 @@ class VariableVisitor extends ClassCodeVisitorSupport {
 
         if( declaration ) {
             if( fAllVariables.containsKey(name) )
-                sourceUnit.addError( new SyntaxException("Variable `$name` already defined in the process scope", line, coln))
+                sourceUnit.addError( new SyntaxException("Variable `$name` already declared in the process scope", line, coln))
             else
                 localDef.add(name)
         }

--- a/modules/nextflow/src/test/groovy/nextflow/ast/NextflowDSLImplTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/ast/NextflowDSLImplTest.groovy
@@ -151,4 +151,31 @@ class NextflowDSLImplTest extends Dsl2Spec {
         ScriptMeta.get(parser.getScript()).getProcessNames() == ['alpha', 'beta'] as Set
     }
 
+    def 'should fetch variable names' () {
+
+        given:
+        def config = createCompilerConfig()
+
+        def SCRIPT = '''
+            process alpha {
+                input:
+                val foo
+
+                exec:
+                if( foo == 'a' )
+                    log.info "foo is 'a'"
+                def bar = foo
+            }
+
+            workflow {
+                alpha('a')
+            }
+            '''
+
+        when:
+        new GroovyShell(config).parse(SCRIPT)
+        then:
+        noExceptionThrown()
+    }
+
 }


### PR DESCRIPTION
Close #804 

Test case:

```groovy
process VariableTesting {
    input:
    val foo

    exec:
    if( foo[0] == "a" )
        log.info "Found an A"
    def bar = foo.find { it == "d" }
}

workflow {
    inputs = Channel.from(["a", "b", "c"], ["d", "e", "f"])

    inputs | VariableTesting
}
```

Currently it fails with:
```
Script compilation error
- file : /path/to/main.nf
- cause: Variable `foo` already defined in the process scope @ line 28, column 15.
       def bar = foo.find {
                 ^

1 error
```

This is because the variable visitor was treating the `foo` in `foo.find` as a re-declaration of `foo` rather than merely a reference to it