### PR TITLE
feat(AzBatchService): Allow Azure Batch tasks to be submitted to different pools 

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -362,14 +362,18 @@ class AzBatchService implements Closeable {
         if( allJobIds.containsKey(mapKey)) {
             return allJobIds[mapKey]
         }
+        final jobId = createJob0(poolId,task)
+        // add to the map
+        allJobIds[mapKey] = jobId
+        return jobId
+    }
+
+    protected String createJob0(String poolId, TaskRun task) {
         log.debug "[AZURE BATCH] created job for ${task.processor.name} with pool ${poolId}"
         // create a batch job
         final jobId = makeJobId(task)
         final content = new BatchJobCreateContent(jobId, new BatchPoolInfo(poolId: poolId))
         apply(() -> client.createJob(content))
-        // add to the map
-        allJobIds[mapKey] = jobId
-        return jobId
     }
 
     String makeJobId(TaskRun task) {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -111,7 +111,7 @@ class AzBatchService implements Closeable {
 
     AzConfig config
 
-    Map<TaskProcessor,String> allJobIds = new HashMap<>(50)
+    Map<Tuple2<TaskProcessor,String>,String> allJobIds = new HashMap<>(50)
 
     AzBatchService(AzBatchExecutor executor) {
         assert executor
@@ -355,7 +355,9 @@ class AzBatchService implements Closeable {
     }
 
     synchronized String getOrCreateJob(String poolId, TaskRun task) {
-        final mapKey = task.processor
+        log.debug "[AZURE BATCH] getOrCreateJob for task ${task.processor} with poolId ${poolId}"
+        final mapKey = new Tuple2<>(task.processor, poolId)
+        log.debug "[AZURE BATCH] mapKey: $mapKey"
         if( allJobIds.containsKey(mapKey)) {
             return allJobIds[mapKey]
         }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -355,12 +355,11 @@ class AzBatchService implements Closeable {
     }
 
     synchronized String getOrCreateJob(String poolId, TaskRun task) {
-        log.debug "[AZURE BATCH] getOrCreateJob for task ${task.processor} with poolId ${poolId}"
         final mapKey = new Tuple2<>(task.processor, poolId)
-        log.debug "[AZURE BATCH] mapKey: $mapKey"
         if( allJobIds.containsKey(mapKey)) {
             return allJobIds[mapKey]
         }
+        log.debug "[AZURE BATCH] create job for ${task.processor} with poolId ${poolId}"
         // create a batch job
         final jobId = makeJobId(task)
         final content = new BatchJobCreateContent(jobId, new BatchPoolInfo(poolId: poolId))

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -359,7 +359,7 @@ class AzBatchService implements Closeable {
         if( allJobIds.containsKey(mapKey)) {
             return allJobIds[mapKey]
         }
-        log.debug "[AZURE BATCH] create job for ${task.processor} with poolId ${poolId}"
+        log.debug "[AZURE BATCH] create job for ${task.processor.name} with pool ${poolId}"
         // create a batch job
         final jobId = makeJobId(task)
         final content = new BatchJobCreateContent(jobId, new BatchPoolInfo(poolId: poolId))

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzJobKey.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzJobKey.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.azure.batch
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+import nextflow.processor.TaskProcessor
+/**
+ * Model a Batch job key for caching purposes
+ * 
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Canonical
+@CompileStatic
+class AzJobKey {
+    final TaskProcessor processor
+    final String poolId
+}

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -739,4 +739,54 @@ class AzBatchServiceTest extends Specification {
         [managedIdentity: [clientId: 'client-123']]     | 'client-123'
     }
 
+    def 'should cache job id' () {
+        given:
+        def exec = Mock(AzBatchExecutor)
+        def service = Spy(new AzBatchService(exec))
+        and:
+        def p1 = Mock(TaskProcessor)
+        def p2 = Mock(TaskProcessor)
+        def t1 = Mock(TaskRun) { getProcessor()>>p1 }
+        def t2 = Mock(TaskRun) { getProcessor()>>p2 }
+        def t3 = Mock(TaskRun) { getProcessor()>>p2 }
+
+        when:
+        def result = service.getOrCreateJob('foo',t1)
+        then:
+        1 * service.createJob0('foo',t1) >> 'job1'
+        and:
+        result == 'job1'
+
+        // second time is cached
+        when:
+        result = service.getOrCreateJob('foo',t1)
+        then:
+        0 * service.createJob0('foo',t1) >> null
+        and:
+        result == 'job1'
+
+        // changing pool id returns a new job id
+        when:
+        result = service.getOrCreateJob('bar',t1)
+        then:
+        1 * service.createJob0('bar',t1) >> 'job2'
+        and:
+        result == 'job2'
+
+        // changing process returns a new job id
+        when:
+        result = service.getOrCreateJob('bar',t2)
+        then:
+        1 * service.createJob0('bar',t2) >> 'job3'
+        and:
+        result == 'job3'
+
+        // change task with the same process, return cached job id
+        when:
+        result = service.getOrCreateJob('bar',t3)
+        then:
+        0 * service.createJob0('bar',t3) >> null
+        and:
+        result == 'job3'
+    }
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzJobKeyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzJobKeyTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.cloud.azure.batch
+
+import nextflow.processor.TaskProcessor
+import spock.lang.Specification
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class AzJobKeyTest extends Specification {
+
+    def 'should validate equals and hashcode' () {
+        given:
+        def p1 = Mock(TaskProcessor)
+        def p2 = Mock(TaskProcessor)
+        def k1 = new AzJobKey(p1, 'foo')
+        def k2 = new AzJobKey(p1, 'foo')
+        def k3 = new AzJobKey(p2, 'foo')
+        def k4 = new AzJobKey(p1, 'bar')
+
+        expect:
+        k1 == k2
+        k1 != k3
+        k1 != k4
+        and:
+        k1.hashCode() == k2.hashCode()
+        k1.hashCode() != k3.hashCode()
+        k1.hashCode() != k4.hashCode()
+    }
+
+}


### PR DESCRIPTION
context: https://nextflow.slack.com/archives/C02T98A23U7/p1738748591243169

Processes could not be submitted to different queues on Azure Batch because the logic looked for an existing job/pool before submitting and didn't check the queue details. This includes the pool ID so that it will now submit to different queues based on user configuration.

You can test it with the following main.nf:
```
process ECHO {
    queue { if (a == "a") "my_test_pool_1" else if (a == "b") "my_test_pool_2" else "my_test_pool_3" }
    container "ubuntu:2204"
    input:
        val a
    output:
        tuple val("sampleId"), val(a)

    script:
    """
    echo "a: ${a}"
    """
}


workflow {
    Channel.of("a", "b", "c")
    | ECHO
    | view
}
```

and nextflow.config (with credentials and details redacted):
```
azure {
    batch {
        copyToolInstallMode = 'node'
        deleteJobsOnCompletion = false
        deletePoolsOnCompletion = false
        autoPoolMode = false
        allowPoolCreation = true
        pools {
            my_test_pool_1 {
                vmType = 'Standard_e2d_v5'
                autoScale = true
                vmCount = 1
                maxVmCount = 4
            }
            my_test_pool_2 {
                vmType = 'Standard_e2d_v5'
                autoScale = true
                vmCount = 1
                maxVmCount = 4
            }
            my_test_pool_3 {
                vmType = 'Standard_e2d_v5'
                autoScale = true
                vmCount = 1
                maxVmCount = 4
            }
        }
   }
}
```

