### PR TITLE
Change the default make rule to `compile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,16 @@ else
 mm = 
 endif 
 
+compile:
+	./gradlew compile exportClasspath
+	@echo "DONE `date`"
+
+assemble:
+	./gradlew buildInfo compile assemble
+
+check:
+	./gradlew check
+
 clean:
 	rm -rf .nextflow*
 	rm -rf work 
@@ -37,16 +47,6 @@ clean:
 	rm -rf modules/*/build
 	rm -rf plugins/*/build
 	./gradlew clean
-
-compile:
-	./gradlew compile exportClasspath
-	@echo "DONE `date`"
-
-assemble:
-	./gradlew buildInfo compile assemble
-
-check:
-	./gradlew check
 
 #
 # install compiled artifacts in Maven local dir


### PR DESCRIPTION
Move `compile` to the top of the Makefile so that `make` equates to `make compile` instead of `make clean`