### PR TITLE
Task array improve

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -2185,7 +2185,7 @@ class TaskProcessor {
         session.filePorter.transfer(batch)
     }
 
-    final protected void makeTaskContextStage3( TaskRun task, HashCode hash, Path folder ) {
+    protected void makeTaskContextStage3( TaskRun task, HashCode hash, Path folder ) {
 
         // set hash-code & working directory
         task.hash = hash
@@ -2340,12 +2340,12 @@ class TaskProcessor {
 
         makeTaskContextStage3(task, hash, folder)
 
-        // add the task to the collection of running tasks
-        if( arrayCollector )
-            arrayCollector.collect(task)
-        else
+        // when no collector is define OR it's a task retry submit directly for execution
+        if( !arrayCollector || task.config.getAttempt() > 1 )
             executor.submit(task)
-
+        // add the task to the collection of running tasks
+        else
+            arrayCollector.collect(task)
     }
 
     protected boolean checkWhenGuard(TaskRun task) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -2340,7 +2340,7 @@ class TaskProcessor {
 
         makeTaskContextStage3(task, hash, folder)
 
-        // when no collector is define OR it's a task retry submit directly for execution
+        // when no collector is define OR it's a task retry, then submit directly for execution
         if( !arrayCollector || task.config.getAttempt() > 1 )
             executor.submit(task)
         // add the task to the collection of running tasks

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -355,6 +355,7 @@ class TaskRun implements Cloneable {
         taskClone.config = config.clone()
         taskClone.config.setContext(taskClone.context)
         taskClone.cache0.clear()
+        taskClone.isChild = false
         return taskClone
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
@@ -87,23 +87,6 @@ class TaskArrayCollectorTest extends Specification {
         1 * executor.submit(task)
     }
 
-    def 'should submit retried tasks directly' () {
-        given:
-        def executor = Mock(DummyExecutor)
-        def collector = Spy(new TaskArrayCollector(null, executor, 5))
-        and:
-        def task = Mock(TaskRun) {
-            getConfig() >> Mock(TaskConfig) {
-                getAttempt() >> 2
-            }
-        }
-
-        when:
-        collector.collect(task)
-        then:
-        1 * executor.submit(task)
-    }
-
     def 'should create task array' () {
         given:
         def exec = Mock(DummyExecutor) {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -455,11 +455,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
      * @return Retrieve the submitted task state
      */
     protected String getTaskState() {
-        if (task.isChild) {
-            return getStateFromTaskStatus()
-        } else {
-            return getStateFromJobStatus()
-        }
+        return task.isChild
+            ? getStateFromTaskStatus()
+            : getStateFromJobStatus()
     }
 
     protected String getStateFromTaskStatus() {


### PR DESCRIPTION
This PR tries to avoid the use of side-effect to change the state of `TaskRun.isChild` field. 

Overall logic: 
1. set the field only when `createTaskArray` is invoked 
2. when a task is retried reset the attribute in the `TaskRun.clone` method
3. skip the `TaskArrayCollector` when it's a task retry in any case 