### PR TITLE
feat(AzBatchService): Include cpu-shares and memory in docker run command

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -410,40 +410,40 @@ class AzBatchService implements Closeable {
             throw new IllegalStateException("Missing Azure Batch pool spec with id: $poolId")
 
         // container settings
-        def opts = new StringBuilder()
+        String opts = ""
         
         // Add CPU and memory constraints if specified
         if( task.config.getCpus() )
-            opts.append("--cpu-shares ${task.config.getCpus() * 1024} ")
+            opts += "--cpu-shares ${task.config.getCpus() * 1024} "
 
         if( task.config.getMemory() )
-            opts.append("--memory ${task.config.getMemory().toMega()}m ")
+            opts += "--memory ${task.config.getMemory().toMega()}m "
 
         // Mount host certificates for azcopy
-        opts.append("-v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro ")
+        opts += "-v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro "
 
         // Add any shared volume mounts
         final shares = getShareVolumeMounts(pool)
         if( shares )
-            opts.append(shares.join(' ')).append(' ')
+            opts += shares.join(' ') + ' '
 
         // Add custom container options
         if( task.config.getContainerOptions() )
-            opts.append(task.config.getContainerOptions()).append(' ')
+            opts += task.config.getContainerOptions() + ' '
 
         // Handle Fusion settings
         final fusionEnabled = FusionHelper.isFusionEnabled((Session)Global.session)
         final launcher = fusionEnabled ? FusionScriptLauncher.create(task.toTaskBean(), 'az') : null
         if( fusionEnabled ) {
-            opts.append("--privileged ")
+            opts += "--privileged "
             for( Map.Entry<String,String> it : launcher.fusionEnv() ) {
-                opts.append("-e $it.key=$it.value ")
+                opts += "-e $it.key=$it.value "
             }
         }
 
         // Create container settings
         final containerOpts = new BatchTaskContainerSettings(container)
-                .setContainerRunOptions(opts.toString())
+                .setContainerRunOptions(opts)
 
         // submit command line
         final String cmd = fusionEnabled

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -462,11 +462,9 @@ class AzBatchService implements Closeable {
 
         // container settings
         String opts = ""
-        
         // Add CPU and memory constraints if specified
         if( task.config.getCpus() )
             opts += "--cpu-shares ${task.config.getCpus() * 1024} "
-
         if( task.config.getMemory() )
             opts += "--memory ${task.config.getMemory().toMega()}m "
 
@@ -508,7 +506,6 @@ class AzBatchService implements Closeable {
             constraints.setMaxWallClockTime( Duration.of(task.config.getTime().toMillis(), ChronoUnit.MILLIS) )
 
         log.trace "[AZURE BATCH] Submitting task: $taskId, cpus=${task.config.getCpus()}, mem=${task.config.getMemory()?:'-'}, slots: $slots"
-
         return new BatchTaskCreateContent(taskId, cmd)
                 .setUserIdentity(userIdentity(pool.opts.privileged, pool.opts.runAs, AutoUserScope.TASK))
                 .setContainerSettings(containerOpts)
@@ -516,8 +513,6 @@ class AzBatchService implements Closeable {
                 .setOutputFiles(outputFileUrls(task, sas))
                 .setRequiredSlots(slots)
                 .setConstraints(constraints)
-                
-
     }
 
     AzTaskKey runTask(String poolId, String jobId, TaskRun task) {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -413,34 +413,31 @@ class AzBatchService implements Closeable {
         def opts = new StringBuilder()
         
         // Add CPU and memory constraints if specified
-        if(task.config.getCpus()) {
+        if( task.config.getCpus() )
             opts.append("--cpu-shares ${task.config.getCpus() * 1024} ")
-        }
-        if(task.config.getMemory()) {
+
+        if( task.config.getMemory() )
             opts.append("--memory ${task.config.getMemory().toMega()}m ")
-        }
 
         // Mount host certificates for azcopy
         opts.append("-v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro ")
 
         // Add any shared volume mounts
         final shares = getShareVolumeMounts(pool)
-        if(shares) {
+        if( shares )
             opts.append(shares.join(' ')).append(' ')
-        }
 
         // Add custom container options
-        if(task.config.getContainerOptions()) {
+        if( task.config.getContainerOptions() )
             opts.append(task.config.getContainerOptions()).append(' ')
-        }
 
         // Handle Fusion settings
         final fusionEnabled = FusionHelper.isFusionEnabled((Session)Global.session)
         final launcher = fusionEnabled ? FusionScriptLauncher.create(task.toTaskBean(), 'az') : null
-        if(fusionEnabled) {
+        if( fusionEnabled ) {
             opts.append("--privileged ")
-            launcher.fusionEnv().each { key, value -> 
-                opts.append("-e $key=$value ")
+            for( Map.Entry<String,String> it : launcher.fusionEnv() ) {
+                opts.append("-e $it.key=$it.value ")
             }
         }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -652,6 +652,8 @@ class AzBatchServiceTest extends Specification {
             getConfig() >> Mock(TaskConfig) {
                 getContainerOptions() >> '-v /foo:/foo'
                 getTime() >> Duration.of('24 h')
+                getCpus() >> 4
+                getMemory() >> MemoryUnit.of('8 GB')
             }
 
         }
@@ -672,7 +674,7 @@ class AzBatchServiceTest extends Specification {
         result.commandLine == "sh -c 'bash .command.run 2>&1 | tee .command.log'"
         and:
         result.containerSettings.imageName == 'ubuntu:latest'
-        result.containerSettings.containerRunOptions == '-v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro -v /mnt/batch/tasks/fsmounts/file1:mountPath1:rw -v /foo:/foo '
+        result.containerSettings.containerRunOptions == '--cpu-shares 4096 --memory 8192m -v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro -v /mnt/batch/tasks/fsmounts/file1:mountPath1:rw -v /foo:/foo '
         and:
         Duration.of(result.constraints.maxWallClockTime.toMillis()) == TASK.config.time
     }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -632,12 +632,12 @@ class AzBatchServiceTest extends Specification {
         result.containerSettings.containerRunOptions == '-v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro '
     }
 
-    def 'should create task for submit with extra options' () {
+    def 'should create task for submit with cpu and memory' () {
         given:
         def POOL_ID = 'my-pool'
         def SAS = '123'
 
-        def CONFIG = [storage: [sasToken: SAS, fileShares: [file1: [mountOptions: 'mountOptions1', mountPath: 'mountPath1']]]]
+        def CONFIG = [storage: [sasToken: SAS]]
         def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
         AzBatchService azure = Spy(new AzBatchService(exec))
         def session = Mock(Session) {
@@ -650,7 +650,6 @@ class AzBatchServiceTest extends Specification {
             getHash() >> HashCode.fromInt(2)
             getContainer() >> 'ubuntu:latest'
             getConfig() >> Mock(TaskConfig) {
-                getContainerOptions() >> '-v /foo:/foo'
                 getTime() >> Duration.of('24 h')
                 getCpus() >> 4
                 getMemory() >> MemoryUnit.of('8 GB')
@@ -674,7 +673,52 @@ class AzBatchServiceTest extends Specification {
         result.commandLine == "sh -c 'bash .command.run 2>&1 | tee .command.log'"
         and:
         result.containerSettings.imageName == 'ubuntu:latest'
-        result.containerSettings.containerRunOptions == '--cpu-shares 4096 --memory 8192m -v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro -v /mnt/batch/tasks/fsmounts/file1:mountPath1:rw -v /foo:/foo '
+        result.containerSettings.containerRunOptions == '--cpu-shares 4096 --memory 8192m -v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro '
+        and:
+        Duration.of(result.constraints.maxWallClockTime.toMillis()) == TASK.config.time
+    }
+
+    def 'should create task for submit with extra options' () {
+        given:
+        def POOL_ID = 'my-pool'
+        def SAS = '123'
+
+        def CONFIG = [storage: [sasToken: SAS, fileShares: [file1: [mountOptions: 'mountOptions1', mountPath: 'mountPath1']]]]
+        def exec = Mock(AzBatchExecutor) {getConfig() >> new AzConfig(CONFIG) }
+        AzBatchService azure = Spy(new AzBatchService(exec))
+        def session = Mock(Session) {
+            getConfig() >>[fusion:[enabled:false]]
+            statsEnabled >> true
+        }
+        Global.session = session
+        and:
+        def TASK = Mock(TaskRun) {
+            getHash() >> HashCode.fromInt(2)
+            getContainer() >> 'ubuntu:latest'
+            getConfig() >> Mock(TaskConfig) {
+                getContainerOptions() >> '-v /foo:/foo'
+                getTime() >> Duration.of('24 h')
+            }
+
+        }
+        and:
+        def SPEC = new AzVmPoolSpec(poolId: POOL_ID, vmType: Mock(AzVmType), opts: new AzPoolOpts([:]))
+
+        when:
+        def result = azure.createTask(POOL_ID, 'salmon', TASK)
+        then:
+        1 * azure.getPoolSpec(POOL_ID) >> SPEC
+        1 * azure.computeSlots(TASK, SPEC) >> 4
+        1 * azure.resourceFileUrls(TASK, SAS) >> []
+        1 * azure.outputFileUrls(TASK, SAS) >> []
+        and:
+        result.id == 'nf-02000000'
+        result.requiredSlots == 4
+        and:
+        result.commandLine == "sh -c 'bash .command.run 2>&1 | tee .command.log'"
+        and:
+        result.containerSettings.imageName == 'ubuntu:latest'
+        result.containerSettings.containerRunOptions == '-v /etc/ssl/certs:/etc/ssl/certs:ro -v /etc/pki:/etc/pki:ro -v /mnt/batch/tasks/fsmounts/file1:mountPath1:rw -v /foo:/foo '
         and:
         Duration.of(result.constraints.maxWallClockTime.toMillis()) == TASK.config.time
     }


### PR DESCRIPTION
The Azure Batch task did not include the `--cpu-shares` or `--memory` options of the docker run command, meaning resource allocation was only controlled by slots on the node. This PR introduces the additional options to the container run command, including `--cpu-shares` and `--memory`. The behaviour will now be more similar to AWS Batch which includes a soft limit on CPUs and hard limit on memory.