### PR TITLE
Bump ubuntu 22.04 as default SKU for Azure Batch

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -342,12 +342,12 @@ When Nextflow creates a pool of compute nodes, it selects:
 
 Together, these settings determine the Operating System and version installed on each node.
 
-By default, Nextflow creates pool nodes based on Ubuntu 20.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
+By default, Nextflow creates pool nodes based on Ubuntu 22.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
 
-- Ubuntu 20.04 (default):
+- Ubuntu 22.04 (default):
 
   ```groovy
-  azure.batch.pools.<name>.sku = "batch.node.ubuntu 20.04"
+  azure.batch.pools.<name>.sku = "batch.node.ubuntu 22.04"
   azure.batch.pools.<name>.offer = "ubuntu-server-container"
   azure.batch.pools.<name>.publisher = "microsoft-azure-batch"
   ```

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -344,7 +344,7 @@ Together, these settings determine the Operating System and version installed on
 
 By default, Nextflow creates pool nodes based on Ubuntu 22.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
 
-- Ubuntu 24.04 (default):
+- Ubuntu 22.04 (default):
 
   ```groovy
   azure.batch.pools.<name>.sku = "batch.node.ubuntu 22.04"

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -342,14 +342,14 @@ When Nextflow creates a pool of compute nodes, it selects:
 
 Together, these settings determine the Operating System and version installed on each node.
 
-By default, Nextflow creates pool nodes based on Ubuntu 24.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
+By default, Nextflow creates pool nodes based on Ubuntu 22.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
 
 - Ubuntu 24.04 (default):
 
   ```groovy
-  azure.batch.pools.<name>.sku = "batch.node.ubuntu 24.04"
-  azure.batch.pools.<name>.offer = "ubuntu-server-container"
-  azure.batch.pools.<name>.publisher = "microsoft-azure-batch"
+  azure.batch.pools.<name>.sku = "batch.node.ubuntu 22.04"
+  azure.batch.pools.<name>.offer = "ubuntu-hpc"
+  azure.batch.pools.<name>.publisher = "microsoft-dsvm"
   ```
 
 - CentOS 8:

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -342,12 +342,12 @@ When Nextflow creates a pool of compute nodes, it selects:
 
 Together, these settings determine the Operating System and version installed on each node.
 
-By default, Nextflow creates pool nodes based on Ubuntu 22.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
+By default, Nextflow creates pool nodes based on Ubuntu 24.04, but this behavior can be customised in the pool configuration. Below are configurations for image reference/SKU combinations to select two popular systems.
 
-- Ubuntu 22.04 (default):
+- Ubuntu 24.04 (default):
 
   ```groovy
-  azure.batch.pools.<name>.sku = "batch.node.ubuntu 22.04"
+  azure.batch.pools.<name>.sku = "batch.node.ubuntu 24.04"
   azure.batch.pools.<name>.offer = "ubuntu-server-container"
   azure.batch.pools.<name>.publisher = "microsoft-azure-batch"
   ```

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -35,10 +35,10 @@ import nextflow.util.Duration
 @CompileStatic
 class AzPoolOpts implements CacheFunnel {
 
-    static public final String DEFAULT_PUBLISHER = "microsoft-azure-batch"
-    static public final String DEFAULT_OFFER = "ubuntu-server-container"
-    static public final String DEFAULT_SKU = "batch.node.ubuntu 24.04"
-    static public final String DEFAULT_VM_TYPE = "Standard_D4_v3"
+    static public final String DEFAULT_PUBLISHER = "microsoft-dsvm"
+    static public final String DEFAULT_OFFER = "ubuntu-hpc"
+    static public final String DEFAULT_SKU = "batch.node.ubuntu 22.04"
+    static public final String DEFAULT_VM_TYPE = "Standard_D4a_v4"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final String DEFAULT_SHARE_ROOT_PATH = "/mnt/batch/tasks/fsmounts"
     static public final Duration DEFAULT_SCALE_INTERVAL = Duration.of('5 min')

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -37,7 +37,7 @@ class AzPoolOpts implements CacheFunnel {
 
     static public final String DEFAULT_PUBLISHER = "microsoft-azure-batch"
     static public final String DEFAULT_OFFER = "ubuntu-server-container"
-    static public final String DEFAULT_SKU = "batch.node.ubuntu 22.04"
+    static public final String DEFAULT_SKU = "batch.node.ubuntu 24.04"
     static public final String DEFAULT_VM_TYPE = "Standard_D4_v3"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final String DEFAULT_SHARE_ROOT_PATH = "/mnt/batch/tasks/fsmounts"

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -37,7 +37,7 @@ class AzPoolOpts implements CacheFunnel {
 
     static public final String DEFAULT_PUBLISHER = "microsoft-azure-batch"
     static public final String DEFAULT_OFFER = "ubuntu-server-container"
-    static public final String DEFAULT_SKU = "batch.node.ubuntu 20.04"
+    static public final String DEFAULT_SKU = "batch.node.ubuntu 22.04"
     static public final String DEFAULT_VM_TYPE = "Standard_D4_v3"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final String DEFAULT_SHARE_ROOT_PATH = "/mnt/batch/tasks/fsmounts"

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -452,7 +452,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-4b13d8b84fc3a3837be5660d66daec1f-Standard_X1'
+        spec.poolId == 'nf-pool-ea3f8ad6099d4e16f02692625f137486-Standard_X1'
         spec.metadata == [foo: 'bar']
 
     }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -452,7 +452,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-289d374ac1622e709cf863bce2570cab-Standard_X1'
+        spec.poolId == 'nf-pool-4b13d8b84fc3a3837be5660d66daec1f-Standard_X1'
         spec.metadata == [foo: 'bar']
 
     }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -452,7 +452,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-ea3f8ad6099d4e16f02692625f137486-Standard_X1'
+        spec.poolId == 'nf-pool-e3331cce25aa1563d6046b3de9ec2d93-Standard_X1'
         spec.metadata == [foo: 'bar']
 
     }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzureConfigTest.groovy
@@ -77,7 +77,7 @@ class AzureConfigTest extends Specification {
         cfg.batch().location == null
         cfg.batch().autoPoolMode == null
         cfg.batch().allowPoolCreation == null
-        cfg.batch().autoPoolOpts().vmType == 'Standard_D4_v3'
+        cfg.batch().autoPoolOpts().vmType == 'Standard_D4a_v4'
         cfg.batch().autoPoolOpts().vmCount == 1
         cfg.batch().autoPoolOpts().maxVmCount == 3
         cfg.batch().autoPoolOpts().scaleInterval == Duration.of('5 min')

--- a/validation/azure.config
+++ b/validation/azure.config
@@ -25,7 +25,6 @@ azure {
     pools {
       'nextflow-ci' {
           autoScale = true
-          vmType = 'Standard_D2_v3'
       }
     }
   }


### PR DESCRIPTION
This PR bumps Ubuntu 22.04 as default SKU for Azure Batch node pools. This is required because Ubuntu 20.04 is going to be retired by April 2025 (See below):
 

> Support for Ubuntu 20.04 LTS for Azure Batch pools will be retired on 23 April 2025
You're receiving this notice because you're currently using either an Ubuntu 20.04 LTS Marketplace or derived image with Azure Batch pools subject to support end of life.
> 
> Azure Batch typically follows standard end of life timelines set by publishers for supported images from the Azure Marketplace. Ubuntu 20.04 LTS is reaching the end of standard support life. Batch pools with Ubuntu 20.04 LTS VM images and the Batch node agent SKU batch.node.ubuntu 20.04 will no longer be supported in Batch after 23 April 2025.