### PR TITLE
Add known_hash file() option

### DIFF
--- a/docs/working-with-files.md
+++ b/docs/working-with-files.md
@@ -12,6 +12,30 @@ myFile = file('some/path/to/my_file.file')
 
 The `file()` method can reference both files and directories, depending on what the string path refers to in the file system.
 
+You can also verify file integrity by providing a hash value:
+
+```nextflow
+// Verify a file with MD5
+file('some/path/to/my_file.file', known_hash: 'md5:d41d8cd98f00b204e9800998ecf8427e')
+
+// Verify a file with SHA-256
+file('some/path/to/my_file.file', known_hash: 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+```
+
+The following hash algorithms are supported:
+
+-   MD5 (`md5:`)
+-   SHA-1 (`sha1:`)
+-   SHA-256 (`sha256:`)
+-   SHA-384 (`sha384:`)
+-   SHA-512 (`sha512:`)
+
+If the file's hash doesn't match the expected value, an error will be thrown.
+
+:::{note}
+Hash verification is not supported when using glob patterns that match multiple files.
+:::
+
 When using the wildcard characters `*`, `?`, `[]` and `{}`, the argument is interpreted as a [glob](http://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob) path matcher and the `file()` method returns a list object holding the paths of files whose names match the specified pattern, or an empty list if no match is found:
 
 ```nextflow
@@ -42,6 +66,7 @@ def sample2 = dir / 'sample.bam'
 def sample3 = file("$dir/sample.bam")           // correct (but verbose)
 def sample4 = "$dir/sample.bam"                 // incorrect
 ```
+
 :::
 
 ## Getting file attributes
@@ -230,10 +255,10 @@ In general, you should not need to manually copy files, because Nextflow will au
 
 Nextflow works with many types of remote files and objects using the same interface as for local files. The following protocols are supported:
 
-- HTTP(S)/FTP (`http://`, `https://`, `ftp://`)
-- Amazon S3 (`s3://`)
-- Azure Blob Storage (`az://`)
-- Google Cloud Storage (`gs://`)
+-   HTTP(S)/FTP (`http://`, `https://`, `ftp://`)
+-   Amazon S3 (`s3://`)
+-   Azure Blob Storage (`az://`)
+-   Google Cloud Storage (`gs://`)
 
 To reference a remote file, simply specify the URL when opening the file:
 

--- a/modules/nf-commons/src/main/nextflow/file/FileHashVerifier.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHashVerifier.groovy
@@ -53,6 +53,10 @@ class FileHashVerifier {
             return file
         }
 
+        if (Files.isDirectory(file)) {
+            throw new IllegalArgumentException("Cannot verify hash of a directory: ${file.toString()}")
+        }
+
         def parts = knownHash.split(':', 2)
         if (parts.length != 2) {
             throw new IllegalArgumentException("Invalid hash format. Expected 'algorithm:hash', got: ${knownHash}")

--- a/modules/nf-commons/src/main/nextflow/file/FileHashVerifier.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHashVerifier.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.file
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
+/**
+ * Implements file hash verification functionality
+ *
+ * @author Edmund Miller <edmund.miller@seqera.io>
+ */
+@Slf4j
+@CompileStatic
+class FileHashVerifier {
+
+    private static final Map<String, String> SUPPORTED_ALGORITHMS = [
+        'md5': 'MD5',
+        'sha1': 'SHA-1',
+        'sha256': 'SHA-256',
+        'sha384': 'SHA-384',
+        'sha512': 'SHA-512'
+    ]
+
+    /**
+     * Verify a file's hash matches the expected value
+     *
+     * @param file The file to verify
+     * @param knownHash The expected hash in format 'algorithm:hash'
+     * @return The file if verification succeeds
+     * @throws IllegalArgumentException if hash format is invalid or verification fails
+     */
+    static Path verifyHash(Path file, String knownHash) {
+        if (!knownHash) {
+            return file
+        }
+
+        def parts = knownHash.split(':', 2)
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid hash format. Expected 'algorithm:hash', got: ${knownHash}")
+        }
+
+        String algorithm = parts[0].toLowerCase()
+        String expectedHash = parts[1].toLowerCase()
+
+        if (!SUPPORTED_ALGORITHMS.containsKey(algorithm)) {
+            throw new IllegalArgumentException("Unsupported hash algorithm: ${algorithm}. Supported algorithms: ${SUPPORTED_ALGORITHMS.keySet().join(', ')}")
+        }
+
+        String actualHash = calculateHash(file, SUPPORTED_ALGORITHMS[algorithm])
+        if (actualHash != expectedHash) {
+            throw new IllegalArgumentException(
+                "Hash verification failed for file: ${file.toString()}\n" +
+                "Expected: ${expectedHash}\n" +
+                "Actual: ${actualHash}"
+            )
+        }
+
+        return file
+    }
+
+    /**
+     * Calculate hash for a file using the specified algorithm
+     *
+     * @param file The file to hash
+     * @param algorithm The hash algorithm to use
+     * @return The calculated hash as a hex string
+     */
+    private static String calculateHash(Path file, String algorithm) {
+        def digest = MessageDigest.getInstance(algorithm)
+        Files.newInputStream(file).withStream { input ->
+            byte[] buffer = new byte[8192]
+            int read
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().encodeHex().toString()
+    }
+}

--- a/modules/nf-commons/src/test/nextflow/file/FileHashVerifierTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/file/FileHashVerifierTest.groovy
@@ -19,6 +19,7 @@ package nextflow.file
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.io.IOException
 
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -153,5 +154,26 @@ class FileHashVerifierTest extends Specification {
 
         cleanup:
         file?.deleteDir()
+    }
+
+    def 'should throw exception when verifying hash of a directory'() {
+        given:
+        def dir = Files.createTempDirectory('test-dir')
+        def content = 'test content'
+        def file1 = dir.resolve('file1.txt')
+        def file2 = dir.resolve('file2.txt')
+        file1.text = content
+        file2.text = content
+        def sha256Hash = MessageDigest.getInstance("SHA-256").digest(content.bytes).encodeHex().toString()
+
+        when:
+        FileHashVerifier.verifyHash(dir, "sha256:${sha256Hash}")
+
+        then:
+        def e = thrown(IOException)
+        e.message == "Is a directory"
+
+        cleanup:
+        dir?.deleteDir()
     }
 }

--- a/modules/nf-commons/src/test/nextflow/file/FileHashVerifierTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/file/FileHashVerifierTest.groovy
@@ -170,8 +170,8 @@ class FileHashVerifierTest extends Specification {
         FileHashVerifier.verifyHash(dir, "sha256:${sha256Hash}")
 
         then:
-        def e = thrown(IOException)
-        e.message == "Is a directory"
+        def e = thrown(IllegalArgumentException)
+        e.message == "Cannot verify hash of a directory: ${dir.toString()}"
 
         cleanup:
         dir?.deleteDir()

--- a/modules/nf-commons/src/test/nextflow/file/FileHashVerifierTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/file/FileHashVerifierTest.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.file
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for FileHashVerifier
+ *
+ * @author Edmund Miller <edmund.miller@seqera.io>
+ */
+class FileHashVerifierTest extends Specification {
+
+    def 'should return file when no hash is provided'() {
+        given:
+        def file = Files.createTempFile('test', '.txt')
+        file.text = 'test content'
+
+        when:
+        def result = FileHashVerifier.verifyHash(file, null)
+
+        then:
+        result == file
+
+        cleanup:
+        file?.deleteDir()
+    }
+
+    def 'should verify file hash with MD5'() {
+        given:
+        def content = 'test content'
+        def file = Files.createTempFile('test', '.txt')
+        file.text = content
+        def md5Hash = MessageDigest.getInstance("MD5").digest(content.bytes).encodeHex().toString()
+
+        when:
+        def result = FileHashVerifier.verifyHash(file, "md5:${md5Hash}")
+
+        then:
+        result == file
+
+        cleanup:
+        file?.deleteDir()
+    }
+
+    def 'should verify file hash with SHA-256'() {
+        given:
+        def content = 'test content'
+        def file = Files.createTempFile('test', '.txt')
+        file.text = content
+        def sha256Hash = MessageDigest.getInstance("SHA-256").digest(content.bytes).encodeHex().toString()
+
+        when:
+        def result = FileHashVerifier.verifyHash(file, "sha256:${sha256Hash}")
+
+        then:
+        result == file
+
+        cleanup:
+        file?.deleteDir()
+    }
+
+    def 'should throw exception on hash mismatch'() {
+        given:
+        def file = Files.createTempFile('test', '.txt')
+        file.text = 'test content'
+
+        when:
+        FileHashVerifier.verifyHash(file, "md5:invalidhash")
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.startsWith("Hash verification failed for file:")
+
+        cleanup:
+        file?.deleteDir()
+    }
+
+    def 'should throw exception on invalid hash format'() {
+        given:
+        def file = Files.createTempFile('test', '.txt')
+        file.text = 'test content'
+
+        when:
+        FileHashVerifier.verifyHash(file, "invalid:hash")
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.startsWith("Unsupported hash algorithm: invalid")
+
+        cleanup:
+        file?.deleteDir()
+    }
+
+    @Unroll
+    def 'should support different hash algorithms: #algorithm'() {
+        given:
+        def content = 'test content'
+        def file = Files.createTempFile('test', '.txt')
+        file.text = content
+        def hash = MessageDigest.getInstance(javaAlgorithm).digest(content.bytes).encodeHex().toString()
+
+        when:
+        def result = FileHashVerifier.verifyHash(file, "${algorithm}:${hash}")
+
+        then:
+        result == file
+
+        cleanup:
+        file?.deleteDir()
+
+        where:
+        algorithm | javaAlgorithm
+        'md5'     | 'MD5'
+        'sha1'    | 'SHA-1'
+        'sha256'  | 'SHA-256'
+        'sha384'  | 'SHA-384'
+        'sha512'  | 'SHA-512'
+    }
+
+    def 'should handle large files'() {
+        given:
+        def file = Files.createTempFile('test', '.txt')
+        def content = new StringBuilder()
+        10000.times { content.append('test content\n') }
+        file.text = content.toString()
+        def sha256Hash = MessageDigest.getInstance("SHA-256").digest(content.toString().bytes).encodeHex().toString()
+
+        when:
+        def result = FileHashVerifier.verifyHash(file, "sha256:${sha256Hash}")
+
+        then:
+        result == file
+
+        cleanup:
+        file?.deleteDir()
+    }
+}


### PR DESCRIPTION
## Overview
This PR adds a new file hash verification feature to Nextflow's `file()` operator. This feature allows users to verify file integrity by checking file hashes against expected values. This feature is particularly useful when working with downloaded files or when ensuring data integrity is critical.

## Implementation Details
- Added `FileHashVerifier` class that supports multiple hash algorithms:
  - MD5
  - SHA-1
  - SHA-256
  - SHA-384
  - SHA-512
- Extended the `file()` operator to accept a `known_hash` parameter in the format `algorithm:hash`
- Added comprehensive test coverage in `FileHashVerifierTest`
- Updated documentation in `working-with-files.md`

## Usage Example

```nextflow
// Verify a file with MD5
file('data.txt', known_hash: 'md5:d41d8cd98f00b204e9800998ecf8427e')
// Verify a file with SHA-256
file('data.txt', known_hash: 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
```

## Limitations
- Hash verification is not supported when using glob patterns that match multiple files
- Throws an `IllegalArgumentException` if:
  - Hash format is invalid
  - Hash algorithm is not supported
  - File hash doesn't match the expected value
  
  ## Inspiration
This feature was inspired by the [Pooch library](https://www.fatiando.org/pooch/latest/), which provides similar functionality for Python.