### PR TITLE
Fix Google Batch autoRetryExitCodes bug

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -17,6 +17,8 @@
 
 package nextflow.cloud.google.batch
 
+import nextflow.cloud.google.batch.client.BatchConfig
+
 import java.nio.file.Path
 import java.util.regex.Pattern
 
@@ -268,7 +270,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                     LifecyclePolicy.newBuilder()
                         .setActionCondition(
                             LifecyclePolicy.ActionCondition.newBuilder()
-                                .addExitCodes(50001)
+                                .addAllExitCodes(executor.config.autoRetryExitCodes)
                         )
                         .setAction(LifecyclePolicy.Action.RETRY_TASK)
                 )

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -17,8 +17,6 @@
 
 package nextflow.cloud.google.batch
 
-import nextflow.cloud.google.batch.client.BatchConfig
-
 import java.nio.file.Path
 import java.util.regex.Pattern
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -146,6 +146,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
                 getBootDiskImage() >> BOOT_IMAGE
                 getCpuPlatform() >> CPU_PLATFORM
                 getMaxSpotAttempts() >> 5
+                getAutoRetryExitCodes() >> [50001,50002]
                 getSpot() >> true
                 getNetwork() >> 'net-1'
                 getServiceAccountEmail() >> 'foo@bar.baz'
@@ -198,7 +199,9 @@ class GoogleBatchTaskHandlerTest extends Specification {
         taskSpec.getMaxRunDuration().getSeconds() == TIMEOUT.seconds
         taskSpec.getVolumes(0).getMountPath() == '/tmp'
         taskSpec.getMaxRetryCount() == 5
+        taskSpec.getLifecyclePolicies(0).getActionCondition().getExitCodesCount() == 2
         taskSpec.getLifecyclePolicies(0).getActionCondition().getExitCodes(0) == 50001
+        taskSpec.getLifecyclePolicies(0).getActionCondition().getExitCodes(1) == 50002
         taskSpec.getLifecyclePolicies(0).getAction().toString() == 'RETRY_TASK'
         and:
         runnable.getContainer().getCommandsList().join(' ') == '/bin/bash -o pipefail -c bash .command.run'


### PR DESCRIPTION
close #5827 

The autoretry exit code set in the google Batch Job request was hardcoded to the default value. This branch fixes it, setting the codes specified in the configuration.