### PR TITLE
Consider AWS china as custom endpoint

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
@@ -123,6 +123,6 @@ class AwsS3Config {
     }
 
     boolean isCustomEndpoint() {
-        endpoint && !endpoint.contains(".amazonaws.com")
+        endpoint && !endpoint.endsWith(".amazonaws.com")
     }
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsS3ConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsS3ConfigTest.groovy
@@ -154,5 +154,8 @@ class AwsS3ConfigTest extends Specification {
         false       | [:]
         false       | [endpoint: 'https://s3.us-east-2.amazonaws.com']
         true        | [endpoint: 'https://foo.com']
+        // consider AWS china as custom ednpoint
+        // see https://github.com/nextflow-io/nextflow/issues/5836
+        true        | [endpoint: 'https://xxxx.s3.cn-north-1.vpce.amazonaws.com.cn']
     }
 }


### PR DESCRIPTION
This PR consider AWS china as a custom endpoint to prevent the use of default AWS global endpoint in some operations. 

Closes https://github.com/nextflow-io/nextflow/issues/5836