### PR TITLE
fix: Remove azure.managedIdentity.tenantId which was not valid

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -410,9 +410,6 @@ The following settings are available:
 `azure.managedIdentity.system`
 : When `true`, use the system-assigned [managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) to authenticate Azure resources. See {ref}`azure-managed-identities` for more details.
 
-`azure.managedIdentity.tenantId`
-: The Azure tenant ID
-
 `azure.registry.server`
 : Specify the container registry from which to pull the Docker images (default: `docker.io`).
 


### PR DESCRIPTION
There was an additional config option for azure.managedIdentity which wasn't used anywhere. It probably crept in during development with the previous version of the SDK. We sshould remove it to prevent confusion.

Signed-off-by: adamrtalbot <12817534+adamrtalbot@users.noreply.github.com>

Hi! Thanks for contributing to Nextflow.

When submitting a Pull Request, please sign-off the DCO [1] to certify that you are the author of the contribution and you adhere to Nextflow's open source license [2] by adding a `Signed-off-by` line to the contribution commit message. See [3] for more details.

1. https://developercertificate.org/
2. https://github.com/nextflow-io/nextflow/blob/master/COPYING
3. https://github.com/apps/dco
