### PR TITLE
Add container platform to docker command

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -473,27 +473,11 @@ workflow {
 }
 ```
 
-:::{versionadded} 23.09.0-edge
-:::
-
-By default, `path` inputs will accept any number of files and stage them accordingly. The `arity` option can be used to enforce the expected number of files, either as a number or a range.
-
-For example:
-
-```nextflow
-input:
-    path('one.txt', arity: '1')         // exactly one file is expected
-    path('pair_*.txt', arity: '2')      // exactly two files are expected
-    path('many_*.txt', arity: '1..*')   // one or more files are expected
-```
-
-When a task is executed, Nextflow will check whether the received files for each path input match the declared arity, and fail if they do not.
-
 :::{note}
 Process `path` inputs have nearly the same interface as described in {ref}`stdlib-types-path`, with one difference which is relevant when files are staged into a subdirectory. Given the following input:
 
 ```nextflow
-path x, name: 'my-dir/*'
+path x, name: 'my-dir/file.txt'
 ```
 
 In this case, `x.name` returns the file name with the parent directory (e.g. `my-dir/file.txt`), whereas normally it would return the file name (e.g. `file.txt`). You can use `x.fileName.name` to get the file name.
@@ -532,12 +516,12 @@ seq1 seq2 seq3
 
 The target input file name may contain the `*` and `?` wildcards, which can be used to control the name of staged files. The following table shows how the wildcards are replaced depending on the cardinality of the received input collection.
 
-| Cardinality | Name pattern | Staged file names                                                                                       |
+| Arity       | Name pattern | Staged file names                                                                                       |
 | ----------- | ------------ | ------------------------------------------------------------------------------------------------------- |
 | any         | `*`          | named as the source file                                                                                |
-| 1           | `file*.ext`  | `file.ext`                                                                                              |
-| 1           | `file?.ext`  | `file1.ext`                                                                                             |
-| 1           | `file??.ext` | `file01.ext`                                                                                            |
+| one         | `file*.ext`  | `file.ext`                                                                                              |
+| one         | `file?.ext`  | `file1.ext`                                                                                             |
+| one         | `file??.ext` | `file01.ext`                                                                                            |
 | many        | `file*.ext`  | `file1.ext`, `file2.ext`, `file3.ext`, ..                                                               |
 | many        | `file?.ext`  | `file1.ext`, `file2.ext`, `file3.ext`, ..                                                               |
 | many        | `file??.ext` | `file01.ext`, `file02.ext`, `file03.ext`, ..                                                            |
@@ -567,6 +551,22 @@ workflow {
 :::{note}
 Rewriting input file names according to a named pattern is an extra feature and not at all required. The normal file input syntax introduced in the {ref}`process-input-path` section is valid for collections of multiple files as well. To handle multiple input files while preserving the original file names, use a variable identifier or the `*` wildcard.
 :::
+
+:::{versionadded} 23.09.0-edge
+:::
+
+The `arity` option can be used to enforce the expected number of files, either as a number or a range.
+
+For example:
+
+```nextflow
+input:
+path('one.txt', arity: '1')         // exactly one file is expected
+path('pair_*.txt', arity: '2')      // exactly two files are expected
+path('many_*.txt', arity: '1..*')   // one or more files are expected
+```
+
+When a task is executed, Nextflow will check whether the received files for each path input match the declared arity, and fail if they do not. When the arity is `'1'`, the corresponding input variable will be a single file; otherwise, it will be a list of files.
 
 ### Dynamic input file names
 
@@ -921,22 +921,6 @@ In the above example, the `randomNum` process creates a file named `result.txt` 
 
 Refer to the {ref}`process reference <process-reference-outputs>` for the list of available options for `path` outputs.
 
-:::{versionadded} 23.09.0-edge
-:::
-
-By default, `path` outputs will accept any number of matching files from the task directory. The `arity` option can be used to enforce the expected number of files, either as a number or a range.
-
-For example:
-
-```nextflow
-output:
-path('one.txt', arity: '1')         // exactly one file is expected
-path('pair_*.txt', arity: '2')      // exactly two files are expected
-path('many_*.txt', arity: '1..*')   // one or more files are expected
-```
-
-When a task completes, Nextflow will check whether the produced files for each path output match the declared arity, and fail if they do not.
-
 ### Multiple output files
 
 When an output file name contains a `*` or `?` wildcard character, it is interpreted as a [glob][glob] path matcher. This allows you to capture multiple files into a list and emit the list as a single value. For example:
@@ -980,6 +964,22 @@ Although the input files matching a glob output declaration are not included in 
 :::
 
 Read more about glob syntax at the following link [What is a glob?][glob]
+
+:::{versionadded} 23.09.0-edge
+:::
+
+The `arity` option can be used to enforce the expected number of files, either as a number or a range.
+
+For example:
+
+```nextflow
+output:
+path('one.txt', arity: '1')         // exactly one file is expected
+path('pair_*.txt', arity: '2')      // exactly two files are expected
+path('many_*.txt', arity: '1..*')   // one or more files are expected
+```
+
+When a task completes, Nextflow will check whether the produced files for each path output match the declared arity, and fail if they do not. When the arity is `'1'`, the corresponding output will be a single file; otherwise, it will be a list of files.
 
 ### Dynamic output file names
 

--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerBuilder.groovy
@@ -84,6 +84,8 @@ abstract class ContainerBuilder<V extends ContainerBuilder> {
 
     protected boolean privileged
 
+    protected  String platform
+
     String getImage() { image }
 
     V addRunOptions(String str) {
@@ -118,6 +120,11 @@ abstract class ContainerBuilder<V extends ContainerBuilder> {
         else
             throw new IllegalArgumentException("Not a supported memory value")
 
+        return (V)this
+    }
+
+    V setPlatform(String platform) {
+        this.platform = platform
         return (V)this
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/container/ContainerBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/ContainerBuilder.groovy
@@ -84,7 +84,7 @@ abstract class ContainerBuilder<V extends ContainerBuilder> {
 
     protected boolean privileged
 
-    protected  String platform
+    protected String platform
 
     String getImage() { image }
 

--- a/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy
@@ -141,6 +141,9 @@ class DockerBuilder extends ContainerBuilder<DockerBuilder> {
         if( memory )
             result << "--memory ${memory} "
 
+        if( platform )
+            result << "--platform ${platform} "
+
         if( tty )
             result << '-t '
 

--- a/modules/nextflow/src/main/groovy/nextflow/container/PodmanBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/PodmanBuilder.groovy
@@ -137,6 +137,10 @@ class PodmanBuilder extends ContainerBuilder<PodmanBuilder> {
             result << "--memory ${memory} "
         }
 
+        if( platform ) {
+            result << "--platform ${platform} "
+        }
+
         // the name is after the user option so it has precedence over any options provided by the user
         if ( name )
             result << '--name ' << name << ' '

--- a/modules/nextflow/src/main/groovy/nextflow/container/resolver/ContainerResolver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/resolver/ContainerResolver.groovy
@@ -32,6 +32,16 @@ import org.pf4j.ExtensionPoint
 interface ContainerResolver extends ExtensionPoint {
 
     /**
+     * @return {@code true} when this resolved is enabled, or {@code false} otherwise
+     */
+    boolean enabled()
+
+    /**
+     * @return The default container platform define by this provider or {@code null} if not default is defined
+     */
+    String defaultContainerPlatform()
+
+    /**
      * Resolve a container name to the fully qualified name. This method
      * can extend the specified container name with engine specific
      * protocol prefixes and container registry specified in the

--- a/modules/nextflow/src/main/groovy/nextflow/container/resolver/ContainerResolverProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/resolver/ContainerResolverProvider.groovy
@@ -35,10 +35,12 @@ class ContainerResolverProvider {
      * @return The {@link ContainerResolver} instance
      */
     static synchronized ContainerResolver load() {
-        final resolvers = Plugins.getPriorityExtensions(ContainerResolver)
-        if( !resolvers )
+        final resolver = Plugins
+            .getPriorityExtensions(ContainerResolver)
+            .find( it-> it.enabled() )
+        if( !resolver )
             throw new IllegalStateException("Cannot load ${ContainerResolver.class.simpleName}")
-        return resolvers.first()
+        return resolver
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/container/resolver/DefaultContainerResolver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/resolver/DefaultContainerResolver.groovy
@@ -32,6 +32,25 @@ import nextflow.processor.TaskRun
 @CompileStatic
 class DefaultContainerResolver implements ContainerResolver {
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    final boolean enabled() {
+        return true
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String defaultContainerPlatform() {
+        return null
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     ContainerInfo resolveImage(TaskRun task, String imageName) {
         if( !imageName ) {
@@ -55,6 +74,9 @@ class DefaultContainerResolver implements ContainerResolver {
         return new ContainerInfo(imageName, ret, hashKey)
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     boolean isContainerReady(String key) {
         return true

--- a/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy
@@ -701,6 +701,9 @@ class BashWrapperBuilder {
         if( this.containerCpuset )
             builder.addRunOptions(containerCpuset)
 
+        if( this.containerPlatform )
+            builder.setPlatform(this.containerPlatform)
+
         // export task work directory
         builder.addEnv('NXF_TASK_WORKDIR')
         // export the nextflow script debug variable

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -153,7 +153,7 @@ class TaskBean implements Serializable, Cloneable {
         this.containerNative = task.isContainerNative()
         this.containerEnabled = task.isContainerEnabled()
         this.containerOptions = task.config.getContainerOptions()
-        this.containerPlatform = task.config.getContainerPlatform()
+        this.containerPlatform = task.getContainerPlatform()
         // secret management
         this.secretNative = task.isSecretNative()
         this.secretNames = task.config.getSecret()

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskBean.groovy
@@ -24,7 +24,6 @@ import nextflow.container.ContainerConfig
 import nextflow.executor.BashWrapperBuilder
 import nextflow.executor.TaskArrayExecutor
 import nextflow.util.MemoryUnit
-
 /**
  * Serializable task value object. Holds configuration values required to
  * launch the task execution
@@ -87,6 +86,8 @@ class TaskBean implements Serializable, Cloneable {
     boolean containerEnabled
 
     String containerOptions
+
+    String containerPlatform
 
     Map<String,Path> inputFiles
 
@@ -152,6 +153,7 @@ class TaskBean implements Serializable, Cloneable {
         this.containerNative = task.isContainerNative()
         this.containerEnabled = task.isContainerEnabled()
         this.containerOptions = task.config.getContainerOptions()
+        this.containerPlatform = task.config.getContainerPlatform()
         // secret management
         this.secretNative = task.isSecretNative()
         this.secretNames = task.config.getSecret()

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -36,8 +36,6 @@ import nextflow.util.CmdLineHelper
 import nextflow.util.CmdLineOptionMap
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
-import nextflow.util.SysHelper
-
 /**
  * Task local configuration properties
  *
@@ -450,11 +448,6 @@ class TaskConfig extends LazyMap implements Cloneable {
         if( value != null )
             throw new IllegalArgumentException("Invalid `arch` directive value: $value [${value.getClass().getName()}]")
         return null
-    }
-
-    String getContainerPlatform() {
-        final result = getArchitecture()
-        return result ? result.getDockerArch() : SysHelper.DEFAULT_DOCKER_PLATFORM
     }
 
     def getClusterOptions() {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -36,6 +36,8 @@ import nextflow.util.CmdLineHelper
 import nextflow.util.CmdLineOptionMap
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
+import nextflow.util.SysHelper
+
 /**
  * Task local configuration properties
  *
@@ -448,6 +450,11 @@ class TaskConfig extends LazyMap implements Cloneable {
         if( value != null )
             throw new IllegalArgumentException("Invalid `arch` directive value: $value [${value.getClass().getName()}]")
         return null
+    }
+
+    String getContainerPlatform() {
+        final result = getArchitecture()
+        return result ? result.getDockerArch() : SysHelper.DEFAULT_DOCKER_PLATFORM
     }
 
     def getClusterOptions() {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -16,8 +16,6 @@
 
 package nextflow.processor
 
-import nextflow.conda.CondaConfig
-
 import java.nio.file.FileSystems
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -29,6 +27,7 @@ import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.conda.CondaCache
+import nextflow.conda.CondaConfig
 import nextflow.container.ContainerConfig
 import nextflow.container.resolver.ContainerInfo
 import nextflow.container.resolver.ContainerResolver
@@ -670,7 +669,7 @@ class TaskRun implements Cloneable {
 
     protected ContainerInfo containerInfo() {
         // note: use an explicit function instead of a closure or lambda syntax, otherwise
-        // when calling this method from a subclass it will result into a MissingMethodExeception
+        // when calling this method from a subclass it will result into a MissingMethodException
         // see  https://issues.apache.org/jira/browse/GROOVY-2433
         cache0.computeIfAbsent('containerInfo', new Function<String,ContainerInfo>() {
             @Override
@@ -719,6 +718,12 @@ class TaskRun implements Cloneable {
        return containerKey
             ? containerResolver().isContainerReady(containerKey)
             : true
+    }
+
+    @Memoized
+    String getContainerPlatform() {
+        final result = config.getArchitecture()
+        return result ? result.dockerArch : containerResolver().defaultContainerPlatform()
     }
 
     ResourcesBundle getModuleBundle() {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -720,7 +720,6 @@ class TaskRun implements Cloneable {
             : true
     }
 
-    @Memoized
     String getContainerPlatform() {
         final result = config.getArchitecture()
         return result ? result.dockerArch : containerResolver().defaultContainerPlatform()

--- a/modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
@@ -188,6 +188,23 @@ class DockerBuilderTest extends Specification {
                 .runCommand == 'docker run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" --device /dev/fuse --cap-add SYS_ADMIN fedora'
     }
 
+    def 'test container platform' () {
+        expect:
+        new DockerBuilder('fedora')
+            .build()
+            .runCommand == 'docker run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" fedora'
+
+        new DockerBuilder('fedora')
+            .setPlatform('amd64')
+            .build()
+            .runCommand == 'docker run -i --platform amd64 -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" fedora'
+
+        new DockerBuilder('fedora')
+            .setPlatform('linux/arm64')
+            .build()
+            .runCommand == 'docker run -i --platform linux/arm64 -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" fedora'
+    }
+
     def 'test add mount'() {
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/container/PodmanBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/PodmanBuilderTest.groovy
@@ -240,4 +240,21 @@ class PodmanBuilderTest extends Specification {
                 .runCommand == 'podman run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" --cpu-shares 1024 --memory 400m fedora'
 
     }
+
+    def 'test container platform' () {
+        expect:
+        new PodmanBuilder('fedora')
+            .build()
+            .runCommand == 'podman run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" fedora'
+
+        new PodmanBuilder('fedora')
+            .setPlatform('amd64')
+            .build()
+            .runCommand == 'podman run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" --platform amd64 fedora'
+
+        new PodmanBuilder('fedora')
+            .setPlatform('linux/arm64')
+            .build()
+            .runCommand == 'podman run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" --platform linux/arm64 fedora'
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -213,6 +213,7 @@ class BashWrapperBuilderTest extends Specification {
         bash.getContainerCpus() >> null
         bash.getContainerCpuset() >> null
         bash.getContainerOptions() >> null
+        bash.getContainerPlatform() >> 'amd64'
         bash.isSecretNative() >> false
         bash.getSecretNames() >> []
 

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -93,7 +93,6 @@ class BashWrapperBuilderTest extends Specification {
 
 
     def 'should create bash launcher files' () {
-
         given:
         def folder = Files.createTempDirectory('test')
 
@@ -124,7 +123,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should create bash launcher files with trace' () {
-
         given:
         def folder = Files.createTempDirectory('test')
 
@@ -195,7 +193,6 @@ class BashWrapperBuilderTest extends Specification {
         wrapper.moduleLoad('foo/bar/')  == 'nxf_module_load foo/bar '
     }
 
-
     def 'should create container env' () {
         given:
         def bash = Spy(BashWrapperBuilder)
@@ -224,7 +221,6 @@ class BashWrapperBuilderTest extends Specification {
         builder.env == ['NXF_TASK_WORKDIR', 'FOO','BAR']
         builder.workDir == Paths.get('/my/work/dir')
         builder.mounts == [ Paths.get('/my/bin') ]
-        
     }
 
     def 'should add resolved inputs'() {
@@ -254,7 +250,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should render launcher script' () {
-
         given:
         def folder = Files.createTempDirectory('test')
 
@@ -278,7 +273,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should render launcher script with trace' () {
-
         given:
         def folder = Files.createTempDirectory('test')
 
@@ -300,7 +294,6 @@ class BashWrapperBuilderTest extends Specification {
 
     @Unroll
     def 'test change to scratchDir' () {
-
         setup:
         def builder = newBashWrapperBuilder()
 
@@ -317,7 +310,6 @@ class BashWrapperBuilderTest extends Specification {
         '$SOME_DIR' | 'NXF_SCRATCH="$(set +u; nxf_mktemp $SOME_DIR)"'
         '/my/temp'  | 'NXF_SCRATCH="$(set +u; nxf_mktemp /my/temp)"'
         'ram-disk'  | 'NXF_SCRATCH="$(nxf_mktemp /dev/shm)"'
-
     }
 
     def 'should return task name' () {
@@ -337,7 +329,6 @@ class BashWrapperBuilderTest extends Specification {
         bash = newBashWrapperBuilder(headerScript: '#BSUB -x 1\n#BSUB -y 2')
         then:
         bash.makeBinding().header_script == '#BSUB -x 1\n#BSUB -y 2'
-
     }
 
     def 'should create task metadata string' () {
@@ -429,7 +420,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should copy control files' () {
-
         when:
         def binding = newBashWrapperBuilder(scratch: false).makeBinding()
         then:
@@ -452,11 +442,9 @@ class BashWrapperBuilderTest extends Specification {
                 cp .command.err /work/dir/.command.err || true
                 cp .command.trace /work/dir/.command.trace || true
                 '''.stripIndent()
-
     }
 
     def 'should stage inputs' () {
-
         given:
         def folder = Paths.get('/work/dir')
         def inputs = [
@@ -532,7 +520,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should unstage outputs' () {
-
         given:
         def folder = Paths.get('/work/dir')
         def outputs = ['test.bam','test.bai']
@@ -584,7 +571,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should create env' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -633,7 +619,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should create secret env' () {
-
         when:
         def binding0 = newBashWrapperBuilder().makeBinding()
         then:
@@ -661,7 +646,6 @@ class BashWrapperBuilderTest extends Specification {
         binding2.secrets_env == null
     }
 
-
     def 'should enable trace feature' () {
         when:
         def binding = newBashWrapperBuilder(statsEnabled: false).makeBinding()
@@ -686,7 +670,6 @@ class BashWrapperBuilderTest extends Specification {
                         cp .command.err /work/dir/.command.err || true
                         cp .command.trace /work/dir/.command.trace || true
                         '''.stripIndent()
-
     }
 
     def 'should enable trace feature with custom shell' () {
@@ -718,11 +701,9 @@ class BashWrapperBuilderTest extends Specification {
         binding = newBashWrapperBuilder(statsEnabled: true, shell: ['/usr/local/bin/bash', '-ue']).makeBinding()
         then:
         binding.launch_cmd == '/usr/local/bin/bash -ue /work/dir/.command.run nxf_trace'
-
     }
 
     def 'should create launcher command with input' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -763,7 +744,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should create module load snippet' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -795,11 +775,9 @@ class BashWrapperBuilderTest extends Specification {
                 }
                 
                 '''.stripIndent()
-
     }
 
     def 'should create conda activate snippet' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -817,7 +795,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should create micromamba activate snippet' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -835,7 +812,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should create spack activate snippet' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -854,7 +830,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should cleanup scratch dir' () {
-
         when:
         def binding = newBashWrapperBuilder().makeBinding()
         then:
@@ -1023,6 +998,20 @@ class BashWrapperBuilderTest extends Specification {
         binding.launch_cmd == 'docker run -i -e "NXF_TASK_WORKDIR" -v /work/dir:/work/dir -w "$NXF_TASK_WORKDIR" -v /foo:/bar --name $NXF_BOXID busybox /bin/bash -ue /work/dir/.command.sh'
         binding.kill_cmd == 'docker stop $NXF_BOXID'
         binding.cleanup_cmd == 'docker rm $NXF_BOXID &>/dev/null || true\n'
+    }
+
+    def 'should create wrapper with container platform' () {
+        when:
+        def binding = newBashWrapperBuilder(
+            containerImage: 'busybox',
+            containerEnabled: true,
+            containerPlatform: 'linux/arm64',
+            containerConfig: [engine: 'docker', temp: 'auto', enabled: true] ).makeBinding()
+
+        then:
+        binding.launch_cmd == 'docker run -i --platform linux/arm64 -e "NXF_TASK_WORKDIR" -v $(nxf_mktemp):/tmp -v /work/dir:/work/dir -w "$NXF_TASK_WORKDIR" --name $NXF_BOXID busybox /bin/bash -ue /work/dir/.command.sh'
+        binding.cleanup_cmd == 'docker rm $NXF_BOXID &>/dev/null || true\n'
+        binding.kill_cmd == 'docker stop $NXF_BOXID'
     }
 
     def 'should create wrapper with sarus'() {
@@ -1221,7 +1210,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should include fix ownership command' () {
-
         given:
         def bean = Mock(TaskBean) {
             inputFiles >> [:]
@@ -1260,7 +1248,6 @@ class BashWrapperBuilderTest extends Specification {
         binding.after_script == null
         binding.containsKey('after_script')
     }
-
 
     def 'should get output env capture snippet' () {
         given:
@@ -1356,7 +1343,6 @@ class BashWrapperBuilderTest extends Specification {
     }
 
     def 'should get stage and unstage commands' () {
-
         when:
         def builder = newBashWrapperBuilder()
         then:
@@ -1368,7 +1354,6 @@ class BashWrapperBuilderTest extends Specification {
         then:
         binding.stage_cmd == 'nxf_stage'
         binding.unstage_cmd == 'nxf_unstage'
-        
     }
 
     def 'should get unstage control script'(){
@@ -1410,7 +1395,6 @@ class BashWrapperBuilderTest extends Specification {
                 cp .command.env /work/dir/.command.env || true
                 '''.stripIndent()
     }
-
 
     def 'should create wrapper with podman' () {
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -655,14 +655,13 @@ class TaskConfigTest extends Specification {
         def config = new TaskConfig(CONFIG)
 
         expect:
-        config.getArchitecture()?.arch == ARCH
-        config.getContainerPlatform() == PLAT
+        config.getArchitecture() == ARCH
 
         where:
-        CONFIG              | ARCH       | PLAT
-        [:]                 | null       | 'linux/amd64'
-        [arch:'amd64']      | 'amd64'    | 'linux/amd64'
-        [arch:'arm64']      | 'arm64'    | 'linux/arm64'
+        CONFIG              | ARCH
+        [:]                 | null
+        [arch:'amd64']      | new Architecture(name:'amd64')
+        [arch:'arm64']      | new Architecture(name:'arm64')
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -33,7 +33,6 @@ import spock.lang.Specification
 class TaskConfigTest extends Specification {
 
     def testShell() {
-
         when:
         def config = new TaskConfig().setContext(my_shell: 'hello')
         config.shell = value
@@ -54,7 +53,6 @@ class TaskConfigTest extends Specification {
     }
 
     def testErrorStrategy() {
-
         when:
         def config = new TaskConfig(map)
 
@@ -71,11 +69,9 @@ class TaskConfigTest extends Specification {
         ErrorStrategy.IGNORE        | [errorStrategy: 'Ignore']
         ErrorStrategy.RETRY         | [errorStrategy: 'retry']
         ErrorStrategy.RETRY         | [errorStrategy: 'Retry']
-
     }
 
     def testErrorStrategy2() {
-
         when:
         def config = new TaskConfig()
         config.context = [x:1]
@@ -95,11 +91,9 @@ class TaskConfigTest extends Specification {
         ErrorStrategy.RETRY         | 'Retry'
         ErrorStrategy.RETRY         | { x == 1 ? 'retry' : 'ignore' }
         ErrorStrategy.FINISH        | 'finish'
-
     }
 
     def testModules() {
-
         given:
         def config
         def local
@@ -141,12 +135,9 @@ class TaskConfigTest extends Specification {
         then:
         local.module == ['b/2','c/3']
         local.getModule() == ['b/2','c/3']
-
-
     }
 
     def testMaxRetries() {
-
         when:
         def config = new TaskConfig()
         config.maxRetries = value
@@ -161,10 +152,10 @@ class TaskConfigTest extends Specification {
         1       | 1
         '3'     | 3
         10      | 10
-
     }
 
     def testMaxRetriesDefault() {
+        given:
         TaskConfig config
 
         when:
@@ -195,7 +186,6 @@ class TaskConfigTest extends Specification {
     }
 
     def testMaxErrors() {
-
         when:
         def config = new TaskConfig()
         config.maxErrors = value
@@ -210,12 +200,9 @@ class TaskConfigTest extends Specification {
         1       | 1
         '3'     | 3
         10      | 10
-
     }
 
-
     def testGetTime() {
-
         when:
         def config = new TaskConfig().setContext(ten: 10)
         config.time = value
@@ -232,11 +219,9 @@ class TaskConfigTest extends Specification {
         new Duration('2h')  || '2h'
         new Duration('10h') || { "$ten hours" }
         new Duration('24h') || '48h'
-
     }
 
     def 'test max submit await'() {
-
         when:
         def config = new TaskConfig()
         config.maxSubmitAwait = value
@@ -250,11 +235,9 @@ class TaskConfigTest extends Specification {
         null                || null
         new Duration('1s')  || 1000
         new Duration('2h')  || '2h'
-
     }
 
     def testGetMemory() {
-
         when:
         def config = new TaskConfig().setContext(ten: 10)
         config.memory = value
@@ -271,11 +254,9 @@ class TaskConfigTest extends Specification {
         new MemoryUnit('2M')    || '2M'
         new MemoryUnit('10G')   || { "$ten G" }
         new MemoryUnit('16G')   || '32G'
-
     }
 
     def testGetDisk() {
-
         when:
         def config = new TaskConfig().setContext(x: 20)
         config.disk = value
@@ -294,11 +275,9 @@ class TaskConfigTest extends Specification {
         new MemoryUnit('20G')   || { "$x G" }
         new MemoryUnit('30G')   || MemoryUnit.of('30G')
         new MemoryUnit('100G')  || '200G'
-
     }
 
     def testGetCpus() {
-
         when:
         def config = new TaskConfig().setContext(ten: 10)
         config.cpus = value
@@ -316,11 +295,9 @@ class TaskConfigTest extends Specification {
         8            | true     | 8
         10           | true     | { ten ?: 0  }
         24           | true     | 32
-
     }
 
     def testGetStore() {
-
         when:
         def config = new TaskConfig()
         config.storeDir = value
@@ -334,7 +311,6 @@ class TaskConfigTest extends Specification {
         null                                || null
         Paths.get('/data/path/')            || '/data/path'
         Paths.get('hello').toAbsolutePath() || 'hello'
-
     }
 
     def testClusterOptionsAsString() {
@@ -354,7 +330,6 @@ class TaskConfigTest extends Specification {
     }
 
     def testGetClusterOptionsAsList() {
-
         when:
         def config = new TaskConfig()
         config.clusterOptions = value
@@ -371,7 +346,6 @@ class TaskConfigTest extends Specification {
     }
 
     def testIsDynamic() {
-
         given:
         def config = new TaskConfig()
 
@@ -401,12 +375,9 @@ class TaskConfigTest extends Specification {
         config = new TaskConfig( alpha:1, beta: "${->foo}" )
         then:
         config.isDynamic()
-
-
     }
 
     def 'should return a new value when changing context' () {
-
         given:
         def config = new TaskConfig()
         config.alpha = 'Simple string'
@@ -432,7 +403,6 @@ class TaskConfigTest extends Specification {
     }
 
     def 'should return the guard condition' () {
-
         given:
         def config = new TaskConfig()
         def closure = new TaskClosure({ x == 'Hello' && count==1 }, '{closure source code}')
@@ -453,11 +423,9 @@ class TaskConfigTest extends Specification {
         config.context = [x: 'Hello', count: 3]
         then:
         !config.getGuard('when')
-
     }
 
     def 'should create ext config properties' () {
-
         given:
         def config = new TaskConfig()
         config.ext.alpha = 'AAAA'
@@ -478,12 +446,9 @@ class TaskConfigTest extends Specification {
         config.ext.alpha == 'AAAA'
         config.ext.delta == 'dddd'
         config.ext.omega == 'oooo'
-
     }
 
-
     def 'should create publishDir object' () {
-
         setup:
         def script = Mock(BaseScript)
         ProcessConfig process
@@ -528,11 +493,9 @@ class TaskConfigTest extends Specification {
         dirs[0].pattern == null
         dirs[1].path == Paths.get('/there')
         dirs[1].pattern == '*.fq'
-
     }
 
     def 'should create publishDir with local variables' () {
-
         given:
         TaskConfig config
 
@@ -542,11 +505,9 @@ class TaskConfigTest extends Specification {
         config.setContext( foo: 'world', bar: 'hello', x: 'copy' )
         then:
         config.getPublishDir() == [ PublishDir.create(path: 'world/hello', mode: 'copy') ]
-
     }
 
     def 'should invoke dynamic cpus property only when cloning the config object' () {
-
         given:
         def config = new TaskConfig()
 
@@ -571,7 +532,6 @@ class TaskConfigTest extends Specification {
     }
 
     def 'should configure pod options'()  {
-
         given:
         def script = Mock(BaseScript)
 
@@ -588,11 +548,9 @@ class TaskConfigTest extends Specification {
         process.createTaskConfig().getPodOptions() == new PodOptions([
                     [secret: 'foo', mountPath: '/this'],
                     [secret: 'bar', env: 'BAR_XXX'] ])
-
     }
 
     def 'should get gpu resources' () {
-
         given:
         def script = Mock(BaseScript)
 
@@ -615,7 +573,6 @@ class TaskConfigTest extends Specification {
     }
 
     def 'should configure secrets'()  {
-
         given:
         def script = Mock(BaseScript)
 
@@ -629,11 +586,9 @@ class TaskConfigTest extends Specification {
         and:
         process.createTaskConfig().secret == ['alpha', 'omega']
         process.createTaskConfig().getSecret() == ['alpha', 'omega']
-
     }
 
     def 'should configure resourceLabels options'()  {
-
         given:
         def script = Mock(BaseScript)
 
@@ -694,4 +649,20 @@ class TaskConfigTest extends Specification {
 //        then:
 //        thrown(IllegalArgumentException)
     }
+
+    def 'should get arch and container platform' () {
+        given:
+        def config = new TaskConfig(CONFIG)
+
+        expect:
+        config.getArchitecture()?.arch == ARCH
+        config.getContainerPlatform() == PLAT
+
+        where:
+        CONFIG              | ARCH       | PLAT
+        [:]                 | null       | 'linux/amd64'
+        [arch:'amd64']      | 'amd64'    | 'linux/amd64'
+        [arch:'arm64']      | 'arm64'    | 'linux/arm64'
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
@@ -844,7 +844,6 @@ class TaskRunTest extends Specification {
         and:
         config == new ContainerConfig(engine:'docker')
 
-
         when:
         config = task.getContainerConfig()
         then:

--- a/modules/nf-commons/src/main/nextflow/util/SysHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/SysHelper.groovy
@@ -35,6 +35,8 @@ import nextflow.file.FileHelper
 @CompileStatic
 class SysHelper {
 
+    public static final String DEFAULT_DOCKER_PLATFORM = 'linux/amd64'
+
     private static String DATE_FORMAT = 'dd-MMM-yyyy HH:mm'
 
     /**
@@ -195,4 +197,5 @@ class SysHelper {
 
         return buffer.toString()
     }
+
 }

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -171,8 +171,6 @@ class WaveClient {
 
     WaveConfig config() { return config }
 
-    Boolean enabled() { return config.enabled() }
-
     protected ContainerLayer makeLayer(ResourcesBundle bundle) {
         final result = packer.layer(bundle.content())
         return result
@@ -473,7 +471,7 @@ class WaveClient {
         // get the bundle
         final bundle = task.getModuleBundle()
         // get the architecture
-        final dockerArch = task.config.getContainerPlatform()
+        final dockerArch = task.getContainerPlatform()
         // compose the request attributes
         def attrs = new HashMap<String,String>()
         attrs.container = containerImage

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -71,6 +71,8 @@ import nextflow.util.SysHelper
 import nextflow.util.Threads
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import static nextflow.util.SysHelper.DEFAULT_DOCKER_PLATFORM
+
 /**
  * Wave client service
  *
@@ -92,8 +94,6 @@ class WaveClient {
     private static Logger log = LoggerFactory.getLogger(WaveClient)
 
     public static final List<String> DEFAULT_CONDA_CHANNELS = ['conda-forge','bioconda']
-
-    private static final String DEFAULT_DOCKER_PLATFORM = 'linux/amd64'
 
     final private HttpClient httpClient
 
@@ -473,8 +473,7 @@ class WaveClient {
         // get the bundle
         final bundle = task.getModuleBundle()
         // get the architecture
-        final arch = task.config.getArchitecture()
-        final dockerArch = arch? arch.dockerArch : DEFAULT_DOCKER_PLATFORM
+        final dockerArch = task.config.getContainerPlatform()
         // compose the request attributes
         def attrs = new HashMap<String,String>()
         attrs.container = containerImage

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -464,7 +464,7 @@ class WaveClientTest extends Specification {
     def 'should create asset with image' () {
         given:
         def session = Mock(Session) { getConfig() >> [:]}
-        def task = Mock(TaskRun) { getConfig() >> [arch:'amd64'] }
+        def task = Mock(TaskRun) { getConfig()>>[:]; getContainerPlatform()>>'linux/amd64' }
         def IMAGE = 'foo:latest'
         and:
         def client = new WaveClient(session)
@@ -473,28 +473,8 @@ class WaveClientTest extends Specification {
         def assets = client.resolveAssets(task, IMAGE, false)
         then:
         assets.containerImage == IMAGE
-        !assets.moduleResources
-        !assets.containerFile
-        !assets.containerConfig
-        !assets.packagesSpec
-        !assets.projectResources
         assets.containerPlatform == 'linux/amd64'
-    }
-
-    def 'should create asset with image and platform' () {
-        given:
-        def ARCH = 'linux/arm64'
-        def session = Mock(Session) { getConfig() >> [:] }
-        def task = Mock(TaskRun) { getConfig() >> [arch:ARCH.toString()] }
-        def IMAGE = 'foo:latest'
         and:
-        def client = new WaveClient(session)
-
-        when:
-        def assets = client.resolveAssets(task, IMAGE, false)
-        then:
-        assets.containerImage == IMAGE
-        assets.containerPlatform == 'linux/arm64'
         !assets.moduleResources
         !assets.containerFile
         !assets.containerConfig
@@ -531,7 +511,7 @@ class WaveClientTest extends Specification {
         def CONTAINER_CONFIG = new ContainerConfig(entrypoint: ['entry.sh'], layers: [new ContainerLayer(location: 'http://somewhere')])
         and:
         def session = Mock(Session) { getConfig() >> [:]}
-        def task = Mock(TaskRun) { getConfig() >> [arch:ARCH.toString()]; getModuleBundle() >> BUNDLE }
+        def task = Mock(TaskRun) { getConfig() >> [:]; getContainerPlatform()>>ARCH; getModuleBundle() >> BUNDLE }
         and:
         WaveClient client = Spy(WaveClient, constructorArgs:[session])
 
@@ -736,7 +716,7 @@ class WaveClientTest extends Specification {
         def BIN_DIR = Path.of('/something/bin')
         def ARCH = 'linux/arm64'
         and:
-        def task = Mock(TaskRun) {getModuleBundle() >> MODULE_RES; getConfig() >> [arch:ARCH.toString()] }
+        def task = Mock(TaskRun) {getModuleBundle() >> MODULE_RES; getConfig()>>[:]; getContainerPlatform()>>ARCH }
         and:
         def session = Mock(Session) {
             getConfig() >> [wave: [bundleProjectResources: true]]

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveFactoryTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveFactoryTest.groovy
@@ -50,6 +50,29 @@ class WaveFactoryTest extends Specification {
     }
 
     @Unroll
+    def 'should get wave enable status' () {
+        given:
+        SysEnv.push(ENV)
+        def session = Mock(Session) { getConfig() >> CONFIG }
+
+        when:
+        def result = WaveFactory.shouldEnable(session)
+        then:
+        result == ENABLED
+        CONFIG == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        ENABLED | ENV                               | CONFIG                        | EXPECTED
+        false   | [:]                               | [:]                           | [:]
+        true    | [:]                               | [wave:[enabled:true]]         | [wave:[enabled:true]]
+        true    | [:]                               | [wave:[enabled:true], fusion:[enabled:true]]     | [wave:[enabled:true,bundleProjectResources:true], fusion:[enabled:true]]
+        false   | [NXF_DISABLE_WAVE_SERVICE: 'true']| [wave:[enabled:true], fusion:[enabled:true]]     | [wave:[enabled:false], fusion:[enabled:true]]
+    }
+
+    @Unroll
     def 'should check s5cmd is enabled' () {
         given:
         def factory = new WaveFactory()
@@ -65,6 +88,7 @@ class WaveFactoryTest extends Specification {
         [aws:[batch:[platformType:'Fargate']]]   | true
 
     }
+
     def 'should fail when wave is disabled' () {
         given:
         def CONFIG = [wave:[:], fusion:[enabled:true]]
@@ -93,7 +117,9 @@ class WaveFactoryTest extends Specification {
         0 * session.setDisableRemoteBinDir(true) >> null
         and:
         CONFIG == [wave:[:], fusion:[enabled:true]]
-    }
 
+        cleanup:
+        SysEnv.pop()
+    }
 
 }

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/resolver/WaveContainerResolverTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/resolver/WaveContainerResolverTest.groovy
@@ -52,7 +52,7 @@ class WaveContainerResolverTest extends Specification {
         when:
         def result = resolver.resolveImage(task, CONTAINER_NAME)
         then:
-        resolver.client() >> Mock(WaveClient) { enabled()>>true; config()>>Mock(WaveConfig) }
+        resolver.client() >> Mock(WaveClient) { config()>>Mock(WaveConfig) }
         _ * task.getContainerConfig() >> Mock(ContainerConfig) { getEngine()>>'docker' }
         and:
         1 * resolver.waveContainer(task, CONTAINER_NAME, false) >> WAVE_CONTAINER
@@ -63,7 +63,7 @@ class WaveContainerResolverTest extends Specification {
         when:
         result = resolver.resolveImage(task, CONTAINER_NAME)
         then:
-        resolver.client() >> Mock(WaveClient) { enabled()>>true; config()>>Mock(WaveConfig) }
+        resolver.client() >> Mock(WaveClient) { config()>>Mock(WaveConfig) }
         _ * task.getContainerConfig() >> Mock(ContainerConfig) { getEngine()>>'singularity'; isEnabled()>>true }
         and:
         1 * resolver.waveContainer(task, CONTAINER_NAME, false) >> WAVE_CONTAINER
@@ -75,7 +75,7 @@ class WaveContainerResolverTest extends Specification {
         when:
         result = resolver.resolveImage(task, CONTAINER_NAME)
         then:
-        resolver.client() >> Mock(WaveClient) { enabled()>>true; config()>>Mock(WaveConfig) { freezeMode()>>true } }
+        resolver.client() >> Mock(WaveClient) { config()>>Mock(WaveConfig) { freezeMode()>>true } }
         _ * task.getContainerConfig() >> Mock(ContainerConfig) { getEngine()>>'singularity'; isEnabled()>>true }
         and:
         1 * resolver.waveContainer(task, CONTAINER_NAME, true) >> ORAS_CONTAINER

--- a/plugins/nf-wave/src/test/nextflow/processor/TaskRunTest2.groovy
+++ b/plugins/nf-wave/src/test/nextflow/processor/TaskRunTest2.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.processor
+
+import nextflow.Global
+import nextflow.Session
+import nextflow.executor.Executor
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class TaskRunTest2 extends Specification {
+
+    @Unroll
+    def 'should get container platform' () {
+        given:
+        def session = Global.session = Mock(Session) { getConfig()>>SESSION }
+        def executor = Mock(Executor) { getSession()>>session }
+        def processor = Mock(TaskProcessor) { getExecutor()>>executor; getSession()>>session }
+        and:
+        def config = new TaskConfig(CONFIG)
+        def task = new TaskRun(config: config, processor: processor)
+
+        expect:
+        task.getContainerPlatform() == EXPECTED
+
+        where:
+        CONFIG          | SESSION                   | EXPECTED
+        [:]             | [:]                       | null
+        [arch:'amd64']  | [:]                       | 'linux/amd64'
+        [arch:'arm64']  | [:]                       | 'linux/arm64'
+        and:
+        [:]             | [wave:[enabled:true]]     | 'linux/amd64'
+        [arch:'amd64']  | [wave:[enabled:true]]     | 'linux/amd64'
+        [arch:'arm64']  | [wave:[enabled:true]]     | 'linux/arm64'
+    }
+
+}


### PR DESCRIPTION
This PR improves the handling of container platform in two ways: 

* Add explicitly the platform to be used to Docker and Podman commands. This is needed to solve the ambiguity on some OS (e.g. macOS) where a container can be executed both as ARM (using silicon) and AMD (via emulation) 
* Default to `linux/amd64` when no `process.arch` is specified for consistency with Wave defaults. 
