### PR TITLE
Fix bugs with v2 config parser

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
@@ -53,7 +53,7 @@ class ConfigParserV2 implements ConfigParser {
 
     private List<String> appliedProfiles
 
-    private Set<String> parsedProfiles = []
+    private Set<String> parsedProfiles
 
     private GroovyShell groovyShell
 
@@ -129,20 +129,14 @@ class ConfigParserV2 implements ConfigParser {
 
         script.setBinding(new Binding(bindingVars))
         script.setParams(paramVars)
+        script.setProfiles(appliedProfiles)
         script.run()
 
-        final result = Bolts.toConfigObject(script.getTarget())
-        final profiles = (result.profiles ?: [:]) as ConfigObject
-        parsedProfiles.addAll(profiles.keySet())
-        if( appliedProfiles ) {
-            for( final profile : appliedProfiles ) {
-                if( profile in profiles.keySet() )
-                    result.merge(profiles[profile] as ConfigObject)
-            }
-            result.remove('profiles')
-        }
-
-        return result
+        final target = script.getTarget()
+        if( !target.params )
+            target.remove('params')
+        parsedProfiles = script.getParsedProfiles()
+        return Bolts.toConfigObject(target)
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigToGroovyVisitor.java
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigToGroovyVisitor.java
@@ -69,8 +69,8 @@ public class ConfigToGroovyVisitor extends ConfigVisitorSupport {
 
     protected Statement transformConfigAssign(ConfigAssignNode node) {
         if( node instanceof ConfigAppendNode ) {
-            var name = node.names.get(0);
-            return stmt(callThisX("append", args(constX(name), node.value)));
+            var method = node.names.get(0);
+            return stmt(callThisX(method, args(node.value)));
         }
         var names = listX(
             node.names.stream()


### PR DESCRIPTION
This PR fixes a few issues I encountered while testing the v2 config parser against some nf-core configs

- make sure config file passes its params to included configs
- make sure profiles are evaluated only if they were enabled, to prevent unnecessary config inclusions (for [example](https://github.com/nf-core/configs/blob/master/nfcore_custom.config))
- factor out DSLs for `plugins`, `process`, and `profiles` block to make the code easier to read

This PR definitely should be merged before the next edge release, so that the v2 config parser is usable by nf-core