### PR TITLE
Fix Fusion symlink test

### DIFF
--- a/tests/checks/fusion-symlink.nf/.checks
+++ b/tests/checks/fusion-symlink.nf/.checks
@@ -1,43 +1,5 @@
 #!/bin/bash
 
-# Retry a command with exponential backoff. The function returns 0 if the command was successful
-# on its first attempt, 1 if the command failed after all attempts, and 2 if the command was successful
-# after one or more retries.
-function _retry {
-
-  if [[ $# -lt 4 ]]; then
-    echo "Usage: _retry <max_attempts> <initial_delay> <max_delay> <cmd>"
-    return 1
-  fi
-
-  local max_attempts="$1"; shift
-  local initial_delay="$1"; shift
-  local max_delay="$1"; shift
-  local cmd=( "$@" )
-  local attempt_num=1
-  local max_attempts=${max_attempts}
-  local max_delay=${max_delay}
-  local initial_delay=${initial_delay}
-  local exit_code=0
-
-  until "${cmd[@]}"; do
-    exit_code=2
-    if (( attempt_num == max_attempts )); then
-      echo "-- [$attempt_num/$max_attempts] attempt failed! No more attempts left."
-      return 1
-    fi
-    echo "-- [$attempt_num/$max_attempts] attempt failed! Retrying in ${initial_delay}s..."
-    sleep "$initial_delay"
-    (( attempt_num++ ))
-    (( initial_delay *= 2 ))
-    if (( initial_delay > max_delay )); then
-      initial_delay=$max_delay
-    fi
-  done
-  echo "-- [$attempt_num/$max_attempts] attempt succeeded!"
-  return $exit_code
-}
-
 # Skip test if AWS keys are missing
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
   echo "Missing AWS credentials -- Skipping test"
@@ -49,12 +11,9 @@ fi
 #
 echo initial run
 $NXF_RUN -c .config
+RUN_ID=$($NXF_CMD log | tail -n1 | awk '{ print $7 }')
 
-_retry 5 1 16 "$NXF_CMD" fs cp s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt data.txt
-if [ $? -eq 2 ]; then
-  echo "succeeded on retry"
-  false
-fi
+$NXF_CMD fs cp "s3://nextflow-ci/work/ci-test/fusion-symlink/${RUN_ID}/data.txt" data.txt
 cmp data.txt .expected || false
 
 #
@@ -63,10 +22,5 @@ cmp data.txt .expected || false
 echo resumed run
 $NXF_RUN -c .config -resume
 
-_retry 5 1 16 "$NXF_CMD" fs cp s3://nextflow-ci/work/ci-test/fusion-symlink/data.txt data.txt
-if [ $? -eq 2 ]; then
-  echo "succeeded on retry"
-  false
-
-fi
+$NXF_CMD fs cp "s3://nextflow-ci/work/ci-test/fusion-symlink/${RUN_ID}/data.txt" data.txt
 cmp data.txt .expected || false

--- a/tests/checks/fusion-symlink.nf/.checks
+++ b/tests/checks/fusion-symlink.nf/.checks
@@ -6,21 +6,22 @@ if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   exit 0
 fi
 
+OUTDIR="s3://nextflow-ci/work/ci-test/fusion-symlink/$(uuidgen)"
+
 #
 # normal run
 #
 echo initial run
-$NXF_RUN -c .config
-RUN_ID=$($NXF_CMD log | tail -n1 | awk '{ print $7 }')
+$NXF_RUN -c .config --outdir "$OUTDIR"
 
-$NXF_CMD fs cp "s3://nextflow-ci/work/ci-test/fusion-symlink/${RUN_ID}/data.txt" data.txt
+$NXF_CMD fs cp "$OUTDIR/data.txt" data.txt
 cmp data.txt .expected || false
 
 #
 # resume run
 #
 echo resumed run
-$NXF_RUN -c .config -resume
+$NXF_RUN -c .config --outdir "$OUTDIR" -resume
 
-$NXF_CMD fs cp "s3://nextflow-ci/work/ci-test/fusion-symlink/${RUN_ID}/data.txt" data.txt
+$NXF_CMD fs cp "$OUTDIR/data.txt" data.txt
 cmp data.txt .expected || false

--- a/tests/checks/publish-s3-kms.nf/.checks
+++ b/tests/checks/publish-s3-kms.nf/.checks
@@ -1,5 +1,11 @@
+#!/bin/bash
+
+BUCKET="nf-kms-xyz"
+PREFIX="work/ci-test/publish-s3/$(uuidgen)"
+OUTDIR="s3://$BUCKET/$PREFIX"
+
 function check_kms_key() {
-  aws s3api head-object --bucket nf-kms-xyz --key work/ci-test/publish-s3/HELLO.tsv | grep -c e5109f93-b42d-4c26-89ee-8b251029a41d
+  aws s3api head-object --bucket "$BUCKET" --key "$PREFIX/HELLO.tsv" | grep -c e5109f93-b42d-4c26-89ee-8b251029a41d
 }
 
 # Skip test if AWS keys are missing
@@ -11,14 +17,14 @@ fi
 #
 # run normal mode 
 #
-$NXF_RUN -c .config | tee .stdout
-[[ `grep INFO .nextflow.log | grep -c 'Submitted process'` == 1 ]] || false
-[[ `check_kms_key` == 1 ]] || false
+$NXF_RUN -c .config --outdir "$OUTDIR" | tee .stdout
+[[ $(grep INFO .nextflow.log | grep -c 'Submitted process') == 1 ]] || false
+[[ $(check_kms_key) == 1 ]] || false
 
 #
 # run resume mode 
 #
-$NXF_RUN -c .config  -resume | tee .stdout
-[[ `grep INFO .nextflow.log | grep -c 'Cached process'` == 1 ]] || false
-[[ `check_kms_key` == 1 ]] || false
+$NXF_RUN -c .config --outdir "$OUTDIR"  -resume | tee .stdout
+[[ $(grep INFO .nextflow.log | grep -c 'Cached process') == 1 ]] || false
+[[ $(check_kms_key) == 1 ]] || false
 

--- a/tests/fusion-symlink.nf
+++ b/tests/fusion-symlink.nf
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+params.outdir = 'results'
 
 process CREATE {
 
@@ -42,7 +43,7 @@ process FORWARD {
 }
 
 process PUBLISH {
-    publishDir "s3://nextflow-ci/work/ci-test/fusion-symlink/${workflow.sessionId}"
+    publishDir params.outdir
 
     input:
     path "data.txt"

--- a/tests/fusion-symlink.nf
+++ b/tests/fusion-symlink.nf
@@ -42,7 +42,7 @@ process FORWARD {
 }
 
 process PUBLISH {
-    publishDir "s3://nextflow-ci/work/ci-test/fusion-symlink"
+    publishDir "s3://nextflow-ci/work/ci-test/fusion-symlink/${workflow.sessionId}"
 
     input:
     path "data.txt"

--- a/tests/publish-s3-kms.nf
+++ b/tests/publish-s3-kms.nf
@@ -1,6 +1,8 @@
 
+params.outdir = 'results'
+
 process my_process {
-    publishDir "s3://nf-kms-xyz/work/ci-test/publish-s3"
+    publishDir params.outdir
 
     input:
     val(param)


### PR DESCRIPTION
This PR attempts to fix the race condition for `fusion-symlink.nf`. Each run of this test will now publish to a unique S3 directory using the session ID, which can be obtained after the first run using the `nextflow log` command.