### PR TITLE
Improve operator summary

### DIFF
--- a/docs/channel.md
+++ b/docs/channel.md
@@ -80,33 +80,27 @@ See {ref}`channel-factory` for the full list of channel factories.
 
 ## Operators
 
-Operators are methods that consume and produce channels. Because channels are asynchronous, operators are necessary to manipulate the values in a channel, without using a process. As a result, operators are useful for implementing the "glue logic" between processes.
+Channel operators, or "operators" for short, are functions that consume and produce channels. Because channels are asynchronous, operators are necessary to manipulate the values in a channel, aside from using a process. As a result, operators are useful for implementing the "glue logic" between processes.
 
-See {ref}`operator-page` for the full list of operators. If you are new to Nextflow, here are some commonly-used operators to learn first:
-
-Filtering:
-
-- {ref}`operator-filter`: select all values in a channel that satisfy a condition
-- {ref}`operator-first`: select the first value in a channel
-- {ref}`operator-take`: select the first *n* values in a channel
-- {ref}`operator-unique`: select the unique values in a channel (i.e. remove duplicates)
-
-Transforming:
-
-- {ref}`operator-collect`: collect the values from a channel into a list
-- {ref}`operator-grouptuple`: group the values from a channel based on a grouping key
-- {ref}`operator-map`: transform each value from a channel with a mapping function
-- {ref}`operator-reduce`: accumulate each value from a channel into a single value
-
-Combining multiple channels:
+Here are some of the most commonly-used operators:
 
 - {ref}`operator-combine`: emit the combinations of two channels
-- {ref}`operator-concat`: emit the values from multiple channels (in the order in which the channels were given)
+
+- {ref}`operator-collect`: collect the values from a channel into a list
+
+- {ref}`operator-filter`: select the values in a channel that satisfy a condition
+
+- {ref}`operator-flatMap`: transform each value from a channel into a list and emit each list 
+element separately
+
+- {ref}`operator-grouptuple`: group the values from a channel based on a grouping key
+
 - {ref}`operator-join`: join the values from two channels based on a matching key
-- {ref}`operator-mix`: emit the values from multiple channels (in the order in which items arrive)
 
-Miscellaneous:
+- {ref}`operator-map`: transform each value from a channel with a mapping function
 
-- {ref}`operator-ifempty`: emit a channel, or a default value if the channel is empty
-- {ref}`operator-set`: assign a channel to a variable
+- {ref}`operator-mix`: emit the values from multiple channels
+
 - {ref}`operator-view`: print each value in a channel to standard output
+
+See {ref}`operator-page` for the full list of operators.

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -80,9 +80,9 @@ See {ref}`channel-factory` for the full list of channel factories.
 
 ## Operators
 
-Channel operators, or "operators" for short, are functions that consume and produce channels. Because channels are asynchronous, operators are necessary to manipulate the values in a channel, aside from using a process. As a result, operators are useful for implementing the "glue logic" between processes.
+Channel operators, or _operators_ for short, are functions that consume and produce channels. Because channels are asynchronous, operators are necessary to manipulate the values in a channel, aside from using a process. As a result, operators are useful for implementing the _glue logic_ between processes.
 
-Here are some of the most commonly-used operators:
+Commonly used operators include:
 
 - {ref}`operator-combine`: emit the combinations of two channels
 


### PR DESCRIPTION
This PR simplifies the operator summary further to emphasize the "core" set of operators. This core set covers the entire functionality of the operator library, instead of the categories like "filtering" and "transforming" which aren't very helpful. Many of the linked operators already have "see also" links in their respective sections to suggest alternatives where appropriate.