### PR TITLE
Fix false "process already defined" error

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -139,9 +139,9 @@ class IncludeDef {
      * When using the strict syntax, the included script will already
      * have been compiled, so simply execute it to load its definitions.
      *
-     * @param path
-     * @param params
-     * @param session
+     * @param path    The included script path
+     * @param params  The params of the including script
+     * @param session The current workflow run
      */
     @PackageScope
     @Memoized
@@ -158,9 +158,9 @@ class IncludeDef {
      * When not using the strict syntax, compile and execute the
      * included script to load its definitions.
      *
-     * @param path
-     * @param params
-     * @param session
+     * @param path    The included script path
+     * @param params  The params of the including script
+     * @param session The current workflow run
      */
     @PackageScope
     @Memoized

--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -111,7 +111,9 @@ class IncludeDef {
         // -- resolve the concrete against the current script
         final moduleFile = realModulePath(path).normalize()
         // -- load the module
-        final moduleScript = loadModule0(moduleFile, resolveParams(ownerParams), session)
+        final moduleScript = NF.getSyntaxParserVersion() == 'v2'
+            ? loadModuleV2(moduleFile, ownerParams, session)
+            : loadModuleV1(moduleFile, resolveParams(ownerParams), session)
         // -- add it to the inclusions
         for( Module module : modules ) {
             meta.addModule(moduleScript, module.name, module.alias)
@@ -133,19 +135,37 @@ class IncludeDef {
     @PackageScope
     Path getOwnerPath() { getMeta().getScriptPath() }
 
+    /**
+     * When using the strict syntax, the included script will already
+     * have been compiled, so simply execute it to load its definitions.
+     *
+     * @param path
+     * @param params
+     * @param session
+     */
     @PackageScope
     @Memoized
-    static BaseScript loadModule0(Path path, Map params, Session session) {
+    static BaseScript loadModuleV2(Path path, Map params, Session session) {
         final script = ScriptMeta.getScriptByPath(path)
-        if( script ) {
-            script.getBinding().setParams(params)
-            script.run()
-            return script
-        }
+        if( !script )
+            throw new IllegalStateException()
+        script.getBinding().setParams(params)
+        script.run()
+        return script
+    }
 
+    /**
+     * When not using the strict syntax, compile and execute the
+     * included script to load its definitions.
+     *
+     * @param path
+     * @param params
+     * @param session
+     */
+    @PackageScope
+    @Memoized
+    static BaseScript loadModuleV1(Path path, Map params, Session session) {
         final binding = new ScriptBinding() .setParams(params)
-
-        // the execution of a library file has as side effect the registration of declared processes
         new ScriptLoaderV1(session)
                 .setModule(true)
                 .setBinding(binding)


### PR DESCRIPTION
This PR fixes a regression caused by #4613 .

The strict syntax requires some new include logic because it includes modules in a slightly different way. My original change was minimal but had a side-effect on the v1 script loader. So I went back and separated the logic more explicitly.

This change is easy to confirm with sarek:
```bash
make pack
./build/releases/nextflow-25.02.0-edge-dist inspect nf-core/sarek -r 3.4.2
```