### PR TITLE
Fancy ANSI formatting for `lint` and `format` log outputs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
@@ -187,7 +187,7 @@ class CmdFormat extends CmdBase {
         for( final message : errorMessages ) {
             if( message instanceof SyntaxErrorMessage ) {
                 final cause = message.getCause()
-                term.fg(Color.RED).a(Attribute.INTENSITY_BOLD).a("error").fg(Color.DEFAULT).a(": ")
+                term.fg(Color.RED).bold().a("error").fg(Color.DEFAULT).a(": ")
                 term.a("Failed to parse ${source.getName()}").a(Attribute.INTENSITY_BOLD_OFF)
                 term.a(":${cause.getStartLine()}:${cause.getStartColumn()}: ")
                 term = highlightString(cause.getOriginalMessage(), term)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
@@ -106,9 +106,13 @@ class CmdFormat extends CmdBase {
         ]
         def rnd = new Random()
         final term = ansi().cursorUp(1).eraseLine()
-        term.fg(Color.GREEN).a("${numFilesChanged} file${numFilesChanged==1 ? '':'s'} reformatted, ")
-        term.fg(Color.BLUE).a("${numFilesUnchanged} file${numFilesUnchanged==1 ? '':'s'} left unchanged ")
-        term.a("${emojis[rnd.nextInt(emojis.size())]}").newline()
+        term.bold().a("Nextflow code formatting complete! ${emojis[rnd.nextInt(emojis.size())]}").reset().newline()
+        if(numFilesChanged > 0)
+            term.fg(Color.GREEN).a(" ${numFilesChanged} file${numFilesChanged==1 ? '':'s'} reformatted").newline()
+        if(numFilesUnchanged > 0)
+            term.fg(Color.BLUE).a(" ${numFilesUnchanged} file${numFilesUnchanged==1 ? '':'s'} left unchanged").newline()
+        if(numFilesChanged == 0 && numFilesUnchanged == 0)
+            term.a(" No files found to process").newline()
         AnsiConsole.out.print(term)
         AnsiConsole.out.flush()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
@@ -151,7 +151,7 @@ class CmdFormat extends CmdBase {
             printErrors(source)
         }
         else {
-            log.debug "Formatting config ${file}"
+            log.debug "Formatting config ${file.getPath().replaceFirst(/^\.\//, '')}"
             printStatus(file)
             final formatter = new ConfigFormattingVisitor(source, formattingOptions)
             formatter.visit()
@@ -167,7 +167,7 @@ class CmdFormat extends CmdBase {
 
     private void printStatus(File file) {
         final str = ansi().cursorUp(1).eraseLine()
-        str.a(Attribute.INTENSITY_FAINT).a("Formatting: ${file}")
+        str.a(Attribute.INTENSITY_FAINT).a("Formatting: ${file.getPath().replaceFirst(/^\.\//, '')}")
         str.reset().newline().toString()
         AnsiConsole.out.print(str)
         AnsiConsole.out.flush()
@@ -192,7 +192,7 @@ class CmdFormat extends CmdBase {
             if( message instanceof SyntaxErrorMessage ) {
                 final cause = message.getCause()
                 term.fg(Color.RED).bold().a("error").fg(Color.DEFAULT).a(": ")
-                term.a("Failed to parse ${source.getName()}").a(Attribute.INTENSITY_BOLD_OFF)
+                term.a("Failed to parse ${source.getName().replaceFirst(/^\.\//, '')}").a(Attribute.INTENSITY_BOLD_OFF)
                 term.a(":${cause.getStartLine()}:${cause.getStartColumn()}: ")
                 term = highlightString(cause.getOriginalMessage(), term)
                 term.newline()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
@@ -97,18 +97,18 @@ class CmdFormat extends CmdBase {
             file.eachFileRecurse(FileType.FILES, this.&format)
         }
         final emojis = [
-            "🧽 🫧",
+            "🪣 🫧",
+            "🧽 ✨",
+            "✍️ 💫",
+            "🪄 📄",
             "🧼 🎉",
-            "🧹 💨",
-            "📝 ✨"
+            "🧹 💨"
         ]
         def rnd = new Random()
         final term = ansi().cursorUp(1).eraseLine()
-        term.fg(Color.GREEN).a(Attribute.INTENSITY_BOLD)
-        term.a("${numFilesChanged} file${numFilesChanged==1 ? '':'s'} reformatted, ")
-        term.a(Attribute.INTENSITY_BOLD_OFF)
-        term.a("${numFilesUnchanged} file${numFilesUnchanged==1 ? '':'s'} left unchanged ")
-        term.a("${emojis[rnd.nextInt(4)]}").reset().newline()
+        term.fg(Color.GREEN).a("${numFilesChanged} file${numFilesChanged==1 ? '':'s'} reformatted, ")
+        term.fg(Color.BLUE).a("${numFilesUnchanged} file${numFilesUnchanged==1 ? '':'s'} left unchanged ")
+        term.a("${emojis[rnd.nextInt(emojis.size())]}").newline()
         AnsiConsole.out.print(term)
         AnsiConsole.out.flush()
     }
@@ -169,15 +169,28 @@ class CmdFormat extends CmdBase {
         AnsiConsole.out.flush()
     }
 
+    private Ansi highlightString(String str, Ansi term) {
+        def matcher = str =~ /^(.*)([`'][^`']+[`'])(.*)$/
+        if (matcher.find()) {
+            term.a(matcher.group(1))
+                .fg(Color.CYAN).a(matcher.group(2)).fg(Color.DEFAULT)
+                .a(matcher.group(3))
+        } else {
+            term.a(str)
+        }
+        return term
+    }
+
     private void printErrors(SourceUnit source) {
         final errorMessages = source.getErrorCollector().getErrors()
-        final term = ansi().cursorUp(1).eraseLine()
+        def term = ansi().cursorUp(1).eraseLine()
         for( final message : errorMessages ) {
             if( message instanceof SyntaxErrorMessage ) {
                 final cause = message.getCause()
                 term.fg(Color.RED).a(Attribute.INTENSITY_BOLD).a("error").fg(Color.DEFAULT).a(": ")
                 term.a("Failed to parse ${source.getName()}").a(Attribute.INTENSITY_BOLD_OFF)
-                term.a(":${cause.getStartLine()}:${cause.getStartColumn()}: ${cause.getOriginalMessage()}")
+                term.a(":${cause.getStartLine()}:${cause.getStartColumn()}: ")
+                term = highlightString(cause.getOriginalMessage(), term)
                 term.newline()
             }
         }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFormat.groovy
@@ -162,7 +162,9 @@ class CmdFormat extends CmdBase {
     }
 
     private void printStatus(File file) {
-        final str = ansi().cursorUp(1).eraseLine().a(Attribute.INTENSITY_FAINT).a("Formatting: ${file}").reset().newline().toString()
+        final str = ansi().cursorUp(1).eraseLine()
+        str.a(Attribute.INTENSITY_FAINT).a("Formatting: ${file}")
+        str.reset().newline().toString()
         AnsiConsole.out.print(str)
         AnsiConsole.out.flush()
     }
@@ -176,10 +178,11 @@ class CmdFormat extends CmdBase {
                 term.fg(Color.RED).a(Attribute.INTENSITY_BOLD).a("error").fg(Color.DEFAULT).a(": ")
                 term.a("Failed to parse ${source.getName()}").a(Attribute.INTENSITY_BOLD_OFF)
                 term.a(":${cause.getStartLine()}:${cause.getStartColumn()}: ${cause.getOriginalMessage()}")
+                term.newline()
             }
         }
         // Double newline as next status update will chomp back one
-        term.fg(Color.DEFAULT).newline().newline()
+        term.fg(Color.DEFAULT).newline()
         AnsiConsole.out.print(term.toString())
         AnsiConsole.out.flush()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -96,7 +96,7 @@ class CmdLint extends CmdBase {
         for( final message : errorMessages ) {
             if( message instanceof SyntaxErrorMessage ) {
                 final cause = message.getCause()
-                System.err.println "${source.getName()} at line ${cause.getStartLine()}, column ${cause.getStartColumn()}: ${cause.getOriginalMessage()}"
+                System.err.println "LINT ERROR: ${source.getName()} at line ${cause.getStartLine()}, column ${cause.getStartColumn()}: ${cause.getOriginalMessage()}"
             }
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -191,6 +191,7 @@ interface ErrorListener {
 }
 
 
+@CompileStatic
 class AnsiErrorListener implements ErrorListener {
     private String format
 
@@ -317,7 +318,7 @@ class AnsiErrorListener implements ErrorListener {
     }
 
     @Memoized
-    private String getSourceText(SourceUnit source) {
+    private List<String> getSourceText(SourceUnit source) {
         return source.getSource().getReader().readLines()
     }
 
@@ -357,6 +358,7 @@ class AnsiErrorListener implements ErrorListener {
 }
 
 
+@CompileStatic
 class JsonErrorListener implements ErrorListener {
 
     private List<Map> errors = []

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -60,7 +60,7 @@ class CmdLint extends CmdBase {
     @Override
     void run() {
         if( !args )
-            throw new AbortOperationException("No input files specified")
+            throw new AbortOperationException("Error: No input files specified")
 
         scriptParser = new ScriptParser()
         configParser = new ConfigParser()
@@ -79,6 +79,21 @@ class CmdLint extends CmdBase {
         configParser.analyze()
         checkErrors(scriptParser.compiler())
         checkErrors(configParser.compiler())
+
+        final emojis = [
+            "🔍 📋",
+            "🕵🏻‍♂️ 🔎",
+            "🔬 👨🏻‍💻",
+            "📑 ☑️",
+            "🧾 ✔️"
+        ]
+        def rnd = new Random()
+        final term = ansi().cursorUp(1).eraseLine()
+        term.a(Attribute.INTENSITY_BOLD).a("Nextflow code lint complete! ${emojis[rnd.nextInt(emojis.size())]}").reset().newline()
+        term.fg(Color.RED).a(" ❌ ${numErrors} errors found in ${numFilesWithErrors} files").newline()
+        term.fg(Color.BLUE).a(" ✅ ${numFilesWithoutErrors} files had no errors").newline()
+        AnsiConsole.out.print(term)
+        AnsiConsole.out.flush()
     }
 
     void parse(File file) {
@@ -106,7 +121,7 @@ class CmdLint extends CmdBase {
     }
 
     private void printStatus(File file) {
-        final str = ansi().cursorUp(1).eraseLine().a(Attribute.INTENSITY_FAINT).a("Formatting: ${file}").reset().newline().toString()
+        final str = ansi().cursorUp(1).eraseLine().a(Attribute.INTENSITY_FAINT).a("Checking: ${file}").reset().newline().toString()
         AnsiConsole.out.print(str)
         AnsiConsole.out.flush()
     }
@@ -130,7 +145,6 @@ class CmdLint extends CmdBase {
             if( message instanceof SyntaxErrorMessage ) {
                 numErrors += 1
                 final cause = message.getCause()
-                term.fg(Color.RED).a(Attribute.INTENSITY_BOLD).a("error").fg(Color.DEFAULT).a(": ")
                 term.a("${source.getName()}").a(Attribute.INTENSITY_BOLD_OFF)
                 term.a(":${cause.getStartLine()}:${cause.getStartColumn()}: ")
                 term = highlightString(cause.getOriginalMessage(), term)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -163,7 +163,8 @@ class CmdLint extends CmdBase {
         for( final message : errorMessages ) {
             if( message instanceof SyntaxErrorMessage ) {
                 final cause = message.getCause()
-                errorListener.onError(cause, source)
+                final filename = source.getName().replaceFirst(/^\.\//, '')
+                errorListener.onError(cause, filename, source)
                 summary.errors += 1
             }
         }
@@ -185,7 +186,7 @@ interface ErrorListener {
     void beforeAll()
     void beforeFile(File file)
     void beforeErrors()
-    void onError(SyntaxException error, SourceUnit source)
+    void onError(SyntaxException error, String filename, SourceUnit source)
     void afterErrors()
     void afterAll(LintSummary summary)
 }
@@ -224,8 +225,8 @@ class AnsiErrorListener implements ErrorListener {
     }
 
     @Override
-    void onError(SyntaxException error, SourceUnit source) {
-        term.bold().a("${source.getName().replaceFirst(/^\.\//, '')}").reset()
+    void onError(SyntaxException error, String filename, SourceUnit source) {
+        term.bold().a(filename).reset()
         term.a(":${error.getStartLine()}:${error.getStartColumn()}: ")
         term = highlightString(error.getOriginalMessage(), term)
         if( format != 'concise' ) {
@@ -376,9 +377,9 @@ class JsonErrorListener implements ErrorListener {
     }
 
     @Override
-    void onError(SyntaxException error, SourceUnit source) {
+    void onError(SyntaxException error, String filename, SourceUnit source) {
         errors.add([
-            filename: source.getName(),
+            filename: filename,
             startLine: error.getStartLine(),
             startColumn: error.getStartColumn(),
             message: error.getOriginalMessage()

--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
@@ -20,12 +20,14 @@ import java.nio.file.Path
 
 import groovy.transform.CompileStatic
 import nextflow.Session
+import nextflow.cli.AnsiErrorListener
 import nextflow.exception.ScriptCompilationException
 import nextflow.script.BaseScript
 import nextflow.script.ScriptBinding
 import nextflow.script.ScriptLoader
 import nextflow.script.ScriptMeta
 import org.codehaus.groovy.control.CompilationFailedException
+import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.runtime.InvokerHelper
 /**
  * Script parser/loader that uses the strict syntax.
@@ -114,24 +116,31 @@ class ScriptLoaderV2 implements ScriptLoader {
             })
         }
         catch( CompilationFailedException e ) {
-            final builder = new StringBuilder()
+            final errorListener = new AnsiErrorListener('full')
+            println()
+            errorListener.beforeErrors()
             for( final message : compiler.getErrors() ) {
                 final cause = message.getCause()
-                final filename = getRelativePath(cause.getSourceLocator(), scriptPath, compiler)
-                builder.append("${filename} at ${cause.getStartLine()}, ${cause.getStartColumn()}: ${cause.getOriginalMessage()}\n")
+                final source = getSource(cause.getSourceLocator(), compiler)
+                final filename = getRelativePath(source, scriptPath)
+                errorListener.onError(cause, filename, source)
             }
-            throw new ScriptCompilationException(builder.toString(), e)
+            errorListener.afterErrors()
+            throw new ScriptCompilationException("Script compilation failed", e)
         }
     }
 
-    private String getRelativePath(String sourceLocator, Path scriptPath, ScriptCompiler compiler) {
+    private SourceUnit getSource(String sourceLocator, ScriptCompiler compiler) {
         for( final su : compiler.getSources() ) {
-            if( sourceLocator == su.getName() ) {
-                final uri = su.getSource().getURI()
-                return scriptPath.getParent().relativize(Path.of(uri)).toString()
-            }
+            if( sourceLocator == su.getName() )
+                return su
         }
         return null
+    }
+
+    private String getRelativePath(SourceUnit source, Path scriptPath) {
+        final uri = source.getSource().getURI()
+        return scriptPath.getParent().relativize(Path.of(uri)).toString()
     }
 
     private BaseScript createScript(Class clazz, ScriptBinding binding, Path path, boolean module) {

--- a/modules/nf-lang/src/main/java/nextflow/util/PathUtils.java
+++ b/modules/nf-lang/src/main/java/nextflow/util/PathUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.util;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.List;
+
+public class PathUtils {
+
+    public static boolean isPathExcluded(Path path, List<String> excludePatterns) {
+        if( excludePatterns == null )
+            return false;
+        return excludePatterns.stream()
+            .anyMatch((pattern) -> {
+                if( pattern.contains("*") || pattern.contains("?") || pattern.contains("[") ) {
+                    var matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
+                    return matcher.matches(path);
+                }
+                else {
+                    var prefix = Path.of(pattern);
+                    return path.getNameCount() >= prefix.getNameCount() && prefix.equals(path.subpath(0, prefix.getNameCount()));
+                }
+            });
+    }
+
+}


### PR DESCRIPTION
Nicer output from the new `nextflow format` and `nextflow lint` commands. @bentsherman you will probably want to clean up my crappy Groovy code, but I'm happy with the outputs now.

TODO:

- [ ] Replicate the `.gitignore` exclusions to `format`
- [ ] Refactor code to avoid duplication
- [ ] @bentsherman to clean up my crappy groovy code
- [ ] _[Maybe]: Improve `.gitignore` code to work when launching from anywhere in the project tree_

# Format

https://github.com/user-attachments/assets/a44a7049-689c-4e49-a953-16198f1963af

# Lint

https://github.com/user-attachments/assets/c73fc2bb-8f09-4125-99e1-86d985d572ae
