### PR TITLE
Mermaid DAG export: Fix operator infer subgraph key

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/dag/DAG.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/DAG.groovy
@@ -30,6 +30,7 @@ import nextflow.NF
 import nextflow.extension.CH
 import nextflow.extension.DataflowHelper
 import nextflow.processor.TaskProcessor
+import nextflow.script.ExecutionStack
 import nextflow.script.params.DefaultInParam
 import nextflow.script.params.DefaultOutParam
 import nextflow.script.params.EachInParam
@@ -159,7 +160,8 @@ class DAG {
      */
     @PackageScope
     Vertex createVertex( Type type, String label, Object extra=null ) {
-        def result = new Vertex(type, label)
+        final workflow = ExecutionStack.workflow()?.name ?: ""
+        final result = new Vertex(type, label, workflow)
         if( extra instanceof TaskProcessor ) {
             result.process = extra
             result.operators = [ extra.operator ]
@@ -388,6 +390,11 @@ class DAG {
         String label
 
         /**
+         * The name of the enclosing workflow
+         */
+        String workflow
+
+        /**
          * The vertex type
          */
         Type type
@@ -409,10 +416,12 @@ class DAG {
          *
          * @param type A {@link Type} value
          * @param label A descriptive string to label this vertex
+         * @param workflow The name of the enclosing workflow
          */
-        Vertex( Type type, String label = null ) {
+        Vertex( Type type, String label = null, String workflow = null ) {
             assert type
             this.label = label
+            this.workflow = workflow
             this.type = type
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/dag/MermaidRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/MermaidRenderer.groovy
@@ -420,7 +420,7 @@ class MermaidRenderer implements DagRenderer {
                 process = outputs[0]
             else { 
                 // No inputs and no outputs processes with identified path.
-                // No subgraph associated to this process.
+                // No subgraph associated to this operator.
             }
 
             // extract keys from fully qualified process name

--- a/modules/nextflow/src/main/groovy/nextflow/dag/MermaidRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dag/MermaidRenderer.groovy
@@ -525,7 +525,7 @@ class MermaidRenderer implements DagRenderer {
 
         nodeTree.each { key, value ->
             if( value instanceof Map ) {
-                final id = fqName ? "${fqName}::${key}".toString() : key
+                final id = fqName ? "${fqName}:${key}".toString() : key
                 renderNodeTree(lines, key, id, value)
             }
             else if( value instanceof Node ) {


### PR DESCRIPTION
# Summary
Fix and improve the corrupted export of DAGs in the mermaid format.
Fix issue #5855.

# Issue fixed
The issue comes from the way the _key_ of the hierarchical subgraphs for operators are inferred in the mermaid DAG printer.
Unlike regular process, the DAG given to the printer does not contain the complete hierarchical path (i.e. the _key_) to the channel operators. Because of this, the printer attempts to recover this information automatically prior to printing the subgraph, so as to print operators in the scope they were originally declared. 

The current version of the code fails to recover the correct subgraphs in many situations, as it assumes that:
* All interconnected channel operators share the same subgraph.
* The subgraph associated to a (group of) channel operator is an input (or output) process of the (first) operator (of the group).

Because of this issue, in the non-verbose mode where the DAG printer attempts to collapse all connected channel operators into a single operators, the failed association of operators to the right subgraph may lead to the creation of cycles in the exported DAG, as exemplified in #5855.

Unfortunately, as described in issue #5855, finding the original scope might not always be possible in ambiguous situations where two distinct pipelines lead to the exact same DAG.

# How
Here is a list of the changes made in the code:
* **Infer keys at the start**:  Because in the non-verbose mode, operators are collapsed at the start of the printing tasks, the channel operator subgraph keys need to be known from the start. A call to the `inferSubgraphKeys()` function is made at the start of the printer, and its result is stored in the `operatorSubgraphKeys` map for later use/update by the `collapseOperators()` and the `getNodeTree()` functions.
* **`collapseOperators()`**: Instead of assuming that all connected operators can be collapsed, the function now limit the collapsing to connected operators from the same subgraph. 
*  **`collapseSubgraph()`**: Function now returns the Node resulting from the collapse to make it possible to update the `operatorSubgraphKeys` map when a subgraph of operators is collapsed.
* **`getNodeTree`**:  Take the pre-computed subgraph keys as an input.
* **`inferSubgraphKeys()`**: The subgraph of each operator is searched individually, as interconnected operators may be in distinct subgraphs. The algorithm used to infer the correct subgraph is completely redesigned with three distinct strategies applied successively. 
  1. [Low complexity] Assuming the DAG nodes are (mostly) in topological order, if an operator is surrounded by two processus in the list which share a common subgraph key, then this operator must be in the same subgraph.
  2. [Med complexity] If an operator contains process of the same subgraph in both its input and output processus, then the operator must be in the same subgraph, or in a lower level of hierarchy nested within this subgraph. In case several pairs of processus satisfy this predicate, the most nested pair is used to determine the operator's subgraph.
  3. [Low complexity] Legacy technique associating the operator to an input or output process' subgraph.

The code is a bit longer than before, but the runtime remains negligible for a reasonably large DAG with several hundreds of nodes.
