### PR TITLE
Add gpu metrics to TraceRecord

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -314,6 +314,31 @@ The following table shows the fields that can be included in the execution repor
   :::
 : The name of the CPU model used to execute the task. This data is read from file `/proc/cpuinfo`.
 
+`gpu_model`
+: :::{versionadded} 25.02.1-edge
+  :::
+: The name/model of the GPU device used to execute the task. This data is read using the `nvidia-smi` command.
+
+`gpu_mem`
+: :::{versionadded} 25.02.1-edge
+  :::
+: The total GPU memory available on the device. This data is read using the `nvidia-smi` command.
+
+`gpu_driver`
+: :::{versionadded} 25.02.1-edge
+  :::
+: The NVIDIA driver version installed on the system. This data is read using the `nvidia-smi` command.
+
+`%gpu`
+: :::{versionadded} 25.02.1-edge
+  :::
+: The average GPU utilization percentage during task execution. This data is read using the `nvidia-smi` command.
+
+`%gpu_mem`
+: :::{versionadded} 25.02.1-edge
+  :::
+: The average GPU memory usage as a percentage of total available memory during task execution. This data is read using the `nvidia-smi` command.
+
 :::{note}
 These metrics provide an estimation of the resources used by running tasks. They are not an alternative to low-level performance analysis tools, and they may not be completely accurate, especially for very short-lived tasks (running for less than a few seconds).
 :::

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -105,10 +105,11 @@ class TraceRecord implements Serializable {
             hostname: 'str',
             cpu_model:  'str',
             gpu_model:  'str',
-            gpu_mem_total: 'str',
-            gpu_driver: 'str',
-            avg_gpu_util: 'perc',   // -- Average GPU utilization percentage
-            avg_gpu_mem: 'mem',     // -- Average GPU memory usage in MiB
+            gpu_mem:    'str',      // -- Total GPU memory in MiB
+            gpu_driver: 'str',      // -- GPU driver version
+            '%gpu':      'perc',    // -- Average GPU utilization percentage
+            '%gpu_mem':  'perc',    // -- Average GPU memory usage as percentage of total available
+            avg_gpu_mem: 'mem',      // -- Average GPU memory usage in MiB
             avg_gpu_mem_perc: 'perc' // -- Average GPU memory usage as percentage of total available
     ]
 
@@ -448,11 +449,11 @@ class TraceRecord implements Serializable {
                         this.put(name, parseInt(value, file, name) / 10F)
                         break
                         
-                    case 'avg_gpu_util':
+                    case '%gpu':
                         this.put(name, parseInt(value, file, name))
                         break
 
-                    case 'avg_gpu_mem_perc':
+                    case '%gpu_mem':
                         this.put(name, parseFloat(value, file, name))
                         break
 
@@ -467,7 +468,7 @@ class TraceRecord implements Serializable {
                         break
 
                     case 'gpu_model':
-                    case 'gpu_mem_total':
+                    case 'gpu_mem':
                     case 'gpu_driver':
                     case 'cpu_model':
                         this.put(name, value)

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -103,7 +103,10 @@ class TraceRecord implements Serializable {
             vol_ctxt: 'num',        // -- /proc/$pid/status field 'voluntary_ctxt_switches'
             inv_ctxt: 'num',        // -- /proc/$pid/status field 'nonvoluntary_ctxt_switches'
             hostname: 'str',
-            cpu_model:  'str'
+            cpu_model:  'str',
+            gpu_model:  'str',
+            gpu_mem_total: 'str',
+            gpu_driver: 'str'
     ]
 
     static public Map<String,Closure<String>> FORMATTER = [
@@ -451,6 +454,9 @@ class TraceRecord implements Serializable {
                         this.put(name, val)
                         break
 
+                    case 'gpu_model':
+                    case 'gpu_mem_total':
+                    case 'gpu_driver':
                     case 'cpu_model':
                         this.put(name, value)
                         break

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -130,15 +130,18 @@ nxf_write_trace() {
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
         "cpu_model=$cpu_model" \
-        "gpu_model=$gpu_model" \
-        "gpu_mem=$gpu_mem_total" \
-        "gpu_driver=$gpu_driver" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
         "syscr=${io_stat1[2]}" \
         "syscw=${io_stat1[3]}" \
         "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+        "write_bytes=${io_stat1[5]}" \
+        "gpu_model=$gpu_model" \
+        "gpu_mem=$gpu_mem_total" \
+        "gpu_driver=$gpu_driver" \
+        "%gpu=$gpu_util" \
+        "%gpu_mem=$gpu_mem_perc" \
+        "avg_gpu_mem=$gpu_avg_mem" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
 }
 
 nxf_trace_mac() {
@@ -175,6 +178,7 @@ nxf_gpu_watch() {
     local timeout
     local DONE
     local STOP=''
+    local temp_file="${trace_file}.gpu.tmp"
 
     # Check nvidia-smi availability at the start
     if ! command -v nvidia-smi &>/dev/null; then
@@ -235,24 +239,32 @@ nxf_gpu_watch() {
     if [ $gpu_samples -gt 0 ]; then
         local avg_gpu_util=$((gpu_util_sum / gpu_samples))
         # Calculate average memory usage in MiB
-        local gpu_mem=$((gpu_mem_sum / gpu_samples))
+        local avg_gpu_mem=$((gpu_mem_sum / gpu_samples))
         # Calculate average memory percentage
         local avg_gpu_mem_perc=$(awk -v sum=$gpu_mem_perc_sum -v samples=$gpu_samples 'BEGIN {printf "%.1f", sum/samples}')
         
-        [ $NXF_DEBUG = 1 ] && echo "Final averages - util: $avg_gpu_util%, mem: $gpu_mem MiB, mem_perc: $avg_gpu_mem_perc%"
+        [ $NXF_DEBUG = 1 ] && echo "Final averages - util: $avg_gpu_util%, mem: $avg_gpu_mem MiB, mem_perc: $avg_gpu_mem_perc%"
         
-        # Write values directly to the trace file
+        # Write values to the temporary trace file
         printf "%s\n" \
             "%gpu=$avg_gpu_util" \
-            "gpu_mem=$(nxf_format_mem $((gpu_mem * 1024)))" \
-            "%gpu_mem=$avg_gpu_mem_perc" >> "$trace_file"
+            "%gpu_mem=$avg_gpu_mem_perc" \
+            "avg_gpu_mem=$avg_gpu_mem" > "$temp_file"
+        
+        # Append to the main trace file
+        cat "$temp_file" >> "$trace_file"
+        rm -f "$temp_file"
     else
         [ $NXF_DEBUG = 1 ] && echo "Warning: No GPU samples collected"
-        # Write zero values if no samples collected
+        # Create temporary file with zero values
         printf "%s\n" \
             "%gpu=0" \
-            "gpu_mem=$(nxf_format_mem 0)" \
-            "%gpu_mem=0" >> "$trace_file"
+            "%gpu_mem=0" \
+            "avg_gpu_mem=0" > "$temp_file"
+        
+        # Append to the main trace file
+        cat "$temp_file" >> "$trace_file"
+        rm -f "$temp_file"
     fi
 }
 
@@ -273,15 +285,21 @@ nxf_trace_linux() {
     trap 'kill $mem_proc $gpu_proc' ERR
 
     ## check if nvidia-smi is available and capture GPU metrics if it is
+    local gpu_model="unknown"
     local gpu_mem_total=0
+    local gpu_driver="unknown"
+    local gpu_util=0
+    local gpu_mem_perc=0
+    local gpu_avg_mem=0
+    
     if command -v nvidia-smi &>/dev/null; then
         local gpu_stats=$(nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader)
         [ $NXF_DEBUG = 1 ] && echo "+++ GPU STATS: $gpu_stats"
         
         # Extract individual metrics from gpu_stats
-        local gpu_model=$(echo "$gpu_stats" | awk -F, '{print $1}' | xargs)
+        gpu_model=$(echo "$gpu_stats" | awk -F, '{print $1}' | xargs)
         gpu_mem_total=$(echo "$gpu_stats" | awk -F, '{print $2}' | sed 's/MiB//' | xargs)
-        local gpu_driver=$(echo "$gpu_stats" | awk -F, '{print $3}' | xargs)
+        gpu_driver=$(echo "$gpu_stats" | awk -F, '{print $3}' | xargs)
         
         [ $NXF_DEBUG = 1 ] && echo "+++ GPU METRICS: name=$gpu_model, mem_total=$gpu_mem_total, driver=$gpu_driver"
     fi
@@ -320,33 +338,18 @@ nxf_trace_linux() {
     local wall_time=$((end_millis-start_millis))
     [ $NXF_DEBUG = 1 ] && echo "+++ STATS %CPU=$ucpu TIME=$wall_time I/O=${io_stat1[*]}"
 
-    printf "%s\n" \
-        "nextflow.trace/v2" \
-        "realtime=$wall_time" \
-        "%cpu=$ucpu" \
-        "cpu_model=$cpu_model" \
-        "gpu_model=$gpu_model" \
-        "gpu_mem=$(nxf_format_mem $((gpu_mem_total * 1024)))" \
-        "gpu_driver=$gpu_driver" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
-    
-    # Default GPU values if GPU monitoring didn't run
-    if [ -z "$gpu_proc" ]; then
-        printf "%s\n" \
-            "gpu_mem=$(nxf_format_mem 0)" \
-            "gpu_model=unknown" \
-            "gpu_driver=unknown" \
-            "%gpu=0" \
-            "%gpu_mem=0" >> "$trace_file"
+    # If GPU metrics were collected, update the values from the temp file
+    if [ ! -z "$gpu_proc" ]; then
+        # Parse GPU metrics from temp file if available
+        [ -e "$trace_file" ] && {
+            gpu_util=$(grep "^%gpu=" "$trace_file" | cut -d= -f2 || echo "0")
+            gpu_mem_perc=$(grep "^%gpu_mem=" "$trace_file" | cut -d= -f2 || echo "0")
+            gpu_avg_mem=$(grep "^avg_gpu_mem=" "$trace_file" | cut -d= -f2 || echo "0")
+        }
     fi
-    
-    # Append the remaining metrics
-    printf "%s\n" \
-        "rchar=${io_stat1[0]}" \
-        "wchar=${io_stat1[1]}" \
-        "syscr=${io_stat1[2]}" \
-        "syscw=${io_stat1[3]}" \
-        "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" >> "$trace_file" || >&2 echo "Error: Failed to append to file: $trace_file"
+
+    # Write all metrics at once using the write_trace function
+    nxf_write_trace
 
     ## join nxf_mem_watch
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -130,8 +130,8 @@ nxf_write_trace() {
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
         "cpu_model=$cpu_model" \
-        "gpu_model=$gpu_name" \
-        "gpu_mem_total=$gpu_mem_total" \
+        "gpu_model=$gpu_model" \
+        "gpu_mem=$gpu_mem_total" \
         "gpu_driver=$gpu_driver" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
@@ -166,6 +166,7 @@ nxf_gpu_watch() {
     set -o pipefail
     local pid=$1
     local trace_file={{trace_file}}
+    local gpu_mem_total=$2
     local count=0
     local gpu_util_sum=0
     local gpu_mem_sum=0
@@ -174,7 +175,6 @@ nxf_gpu_watch() {
     local timeout
     local DONE
     local STOP=''
-    local gpu_mem_total=0
 
     # Check nvidia-smi availability at the start
     if ! command -v nvidia-smi &>/dev/null; then
@@ -182,11 +182,7 @@ nxf_gpu_watch() {
         return 0
     fi
 
-    # Get the total GPU memory for percentage calculation
-    if local gpu_info=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null); then
-        gpu_mem_total=$(echo "$gpu_info" | sed 's/MiB//' | xargs)
-        [ $NXF_DEBUG = 1 ] && echo "Total GPU memory: $gpu_mem_total MiB"
-    fi
+    [ $NXF_DEBUG = 1 ] && echo "Total GPU memory: $gpu_mem_total MiB"
 
     while true; do
         # Collect GPU metrics with error handling
@@ -228,9 +224,6 @@ nxf_gpu_watch() {
         read -t $timeout -r DONE || true
         ## make sure to not enter an infinite loop
         [[ $DONE ]] && break
-        ## this likely could be removed since the process is killed
-        ## by the trap on error condition introduced by the patch for #1344
-        ## keeping as extra check to prevent hanging
         if [ ! -e /proc/$pid ]; then
             [ ! $STOP ] && STOP=$(nxf_date)
             [ $(($(nxf_date)-STOP)) -gt 10000 ] && break
@@ -241,25 +234,25 @@ nxf_gpu_watch() {
     # Calculate averages if we have samples
     if [ $gpu_samples -gt 0 ]; then
         local avg_gpu_util=$((gpu_util_sum / gpu_samples))
-        # Calculate average memory usage in MiB (still needed for records)
-        local avg_gpu_mem=$((gpu_mem_sum / gpu_samples))
+        # Calculate average memory usage in MiB
+        local gpu_mem=$((gpu_mem_sum / gpu_samples))
         # Calculate average memory percentage
         local avg_gpu_mem_perc=$(awk -v sum=$gpu_mem_perc_sum -v samples=$gpu_samples 'BEGIN {printf "%.1f", sum/samples}')
         
-        [ $NXF_DEBUG = 1 ] && echo "Final averages - util: $avg_gpu_util%, mem: $avg_gpu_mem MiB, mem_perc: $avg_gpu_mem_perc%"
+        [ $NXF_DEBUG = 1 ] && echo "Final averages - util: $avg_gpu_util%, mem: $gpu_mem MiB, mem_perc: $avg_gpu_mem_perc%"
         
         # Write values directly to the trace file
         printf "%s\n" \
-            "avg_gpu_util=$avg_gpu_util" \
-            "avg_gpu_mem=$avg_gpu_mem" \
-            "avg_gpu_mem_perc=$avg_gpu_mem_perc" >> "$trace_file"
+            "%gpu=$avg_gpu_util" \
+            "gpu_mem=$(nxf_format_mem $((gpu_mem * 1024)))" \
+            "%gpu_mem=$avg_gpu_mem_perc" >> "$trace_file"
     else
         [ $NXF_DEBUG = 1 ] && echo "Warning: No GPU samples collected"
         # Write zero values if no samples collected
         printf "%s\n" \
-            "avg_gpu_util=0" \
-            "avg_gpu_mem=0" \
-            "avg_gpu_mem_perc=0" >> "$trace_file"
+            "%gpu=0" \
+            "gpu_mem=$(nxf_format_mem 0)" \
+            "%gpu_mem=0" >> "$trace_file"
     fi
 }
 
@@ -280,16 +273,17 @@ nxf_trace_linux() {
     trap 'kill $mem_proc $gpu_proc' ERR
 
     ## check if nvidia-smi is available and capture GPU metrics if it is
+    local gpu_mem_total=0
     if command -v nvidia-smi &>/dev/null; then
         local gpu_stats=$(nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader)
         [ $NXF_DEBUG = 1 ] && echo "+++ GPU STATS: $gpu_stats"
         
         # Extract individual metrics from gpu_stats
-        local gpu_name=$(echo "$gpu_stats" | awk -F, '{print $1}' | xargs)
-        local gpu_mem_total=$(echo "$gpu_stats" | awk -F, '{print $2}' | xargs)
+        local gpu_model=$(echo "$gpu_stats" | awk -F, '{print $1}' | xargs)
+        gpu_mem_total=$(echo "$gpu_stats" | awk -F, '{print $2}' | sed 's/MiB//' | xargs)
         local gpu_driver=$(echo "$gpu_stats" | awk -F, '{print $3}' | xargs)
         
-        [ $NXF_DEBUG = 1 ] && echo "+++ GPU METRICS: name=$gpu_name, mem_total=$gpu_mem_total, driver=$gpu_driver"
+        [ $NXF_DEBUG = 1 ] && echo "+++ GPU METRICS: name=$gpu_model, mem_total=$gpu_mem_total, driver=$gpu_driver"
     fi
     
     ## run task script
@@ -305,7 +299,7 @@ nxf_trace_linux() {
     local gpu_proc
     if command -v nvidia-smi &>/dev/null; then
         gpu_fd=$(nxf_fd)
-        eval "exec $gpu_fd> >(nxf_gpu_watch $task)"
+        eval "exec $gpu_fd> >(nxf_gpu_watch $task $gpu_mem_total)"
         gpu_proc=$!
     fi
 
@@ -331,16 +325,18 @@ nxf_trace_linux() {
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
         "cpu_model=$cpu_model" \
-        "gpu_model=$gpu_name" \
-        "gpu_mem_total=$gpu_mem_total" \
+        "gpu_model=$gpu_model" \
+        "gpu_mem=$(nxf_format_mem $((gpu_mem_total * 1024)))" \
         "gpu_driver=$gpu_driver" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
     
     # Default GPU values if GPU monitoring didn't run
     if [ -z "$gpu_proc" ]; then
         printf "%s\n" \
-            "avg_gpu_util=0" \
-            "avg_gpu_mem=0" \
-            "avg_gpu_mem_perc=0" >> "$trace_file"
+            "gpu_mem=$(nxf_format_mem 0)" \
+            "gpu_model=unknown" \
+            "gpu_driver=unknown" \
+            "%gpu=0" \
+            "%gpu_mem=0" >> "$trace_file"
     fi
     
     # Append the remaining metrics

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -130,6 +130,7 @@ nxf_write_trace() {
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
         "cpu_model=$cpu_model" \
+        "gpu_model=$gpu_name" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
         "syscr=${io_stat1[2]}" \
@@ -174,6 +175,19 @@ nxf_trace_linux() {
     local start_millis=$(nxf_date)
     ## capture error and kill mem watcher
     trap 'kill $mem_proc' ERR
+
+    ## check if nvidia-smi is available and capture GPU metrics if it is
+    if command -v nvidia-smi &>/dev/null; then
+        local gpu_stats=$(nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total,driver_version --format=csv,noheader)
+        [ $NXF_DEBUG = 1 ] && echo "+++ GPU STATS: $gpu_stats"
+        
+        # Extract individual metrics from gpu_stats
+        local gpu_name=$(echo "$gpu_stats" | awk -F, '{print $1}' | xargs)
+        local gpu_mem_total=$(echo "$gpu_stats" | awk -F, '{print $4}' | xargs)
+        local gpu_driver=$(echo "$gpu_stats" | awk -F, '{print $5}' | xargs)
+        
+        [ $NXF_DEBUG = 1 ] && echo "+++ GPU METRICS: name=$gpu_name, util=$gpu_utilization, mem_used=$gpu_memory_used, mem_total=$gpu_memory_total, driver=$gpu_driver_version"
+    fi
     
     ## run task script
     {{trace_cmd}} &
@@ -206,6 +220,9 @@ nxf_trace_linux() {
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
         "cpu_model=$cpu_model" \
+        "gpu_model=$gpu_name" \
+        "gpu_mem_total=$gpu_mem_total" \
+        "gpu_driver=$gpu_driver" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
         "syscr=${io_stat1[2]}" \

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -131,6 +131,8 @@ nxf_write_trace() {
         "%cpu=$ucpu" \
         "cpu_model=$cpu_model" \
         "gpu_model=$gpu_name" \
+        "gpu_mem_total=$gpu_mem_total" \
+        "gpu_driver=$gpu_driver" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
         "syscr=${io_stat1[2]}" \
@@ -160,6 +162,107 @@ nxf_fd() {
     echo $FD
 }
 
+nxf_gpu_watch() {
+    set -o pipefail
+    local pid=$1
+    local trace_file={{trace_file}}
+    local count=0
+    local gpu_util_sum=0
+    local gpu_mem_sum=0
+    local gpu_mem_perc_sum=0
+    local gpu_samples=0
+    local timeout
+    local DONE
+    local STOP=''
+    local gpu_mem_total=0
+
+    # Check nvidia-smi availability at the start
+    if ! command -v nvidia-smi &>/dev/null; then
+        [ $NXF_DEBUG = 1 ] && echo "Warning: nvidia-smi not found"
+        return 0
+    fi
+
+    # Get the total GPU memory for percentage calculation
+    if local gpu_info=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null); then
+        gpu_mem_total=$(echo "$gpu_info" | sed 's/MiB//' | xargs)
+        [ $NXF_DEBUG = 1 ] && echo "Total GPU memory: $gpu_mem_total MiB"
+    fi
+
+    while true; do
+        # Collect GPU metrics with error handling
+        if ! local gpu_stats=$(nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader 2>/dev/null); then
+            # If nvidia-smi fails, skip this iteration but continue monitoring
+            [ $NXF_DEBUG = 1 ] && echo "Warning: nvidia-smi command failed, skipping metrics collection"
+            nxf_sleep 1
+            continue
+        fi
+
+        [ $NXF_DEBUG = 1 ] && echo "Raw GPU stats: $gpu_stats"
+
+        # Strip units and extract numeric values
+        local gpu_util=$(echo "$gpu_stats" | awk -F, '{print $1}' | sed 's/%//' | xargs)
+        local gpu_mem=$(echo "$gpu_stats" | awk -F, '{print $2}' | sed 's/MiB//' | xargs)
+        
+        # Calculate percentage of GPU memory used if total is available
+        local gpu_mem_perc=0
+        if [ $gpu_mem_total -gt 0 ]; then
+            gpu_mem_perc=$(awk -v used=$gpu_mem -v total=$gpu_mem_total 'BEGIN {printf "%.1f", used/total*100}')
+        fi
+        
+        [ $NXF_DEBUG = 1 ] && echo "Parsed values - util: $gpu_util, mem: $gpu_mem, mem_perc: $gpu_mem_perc%"
+        
+        # Add to running sums
+        gpu_util_sum=$((gpu_util_sum + gpu_util))
+        gpu_mem_sum=$((gpu_mem_sum + gpu_mem))
+        gpu_mem_perc_sum=$(awk -v curr=$gpu_mem_perc_sum -v new=$gpu_mem_perc 'BEGIN {printf "%.1f", curr+new}')
+        gpu_samples=$((gpu_samples + 1))
+
+        [ $NXF_DEBUG = 1 ] && echo "Running sums - util: $gpu_util_sum, mem: $gpu_mem_sum, mem_perc: $gpu_mem_perc_sum, samples: $gpu_samples"
+
+        ## compute time
+        if [ $count -lt 10 ]; then timeout=1;
+        elif [ $count -lt 120 ]; then timeout=5;
+        else timeout=30;
+        fi
+        ## wait for termination message
+        read -t $timeout -r DONE || true
+        ## make sure to not enter an infinite loop
+        [[ $DONE ]] && break
+        ## this likely could be removed since the process is killed
+        ## by the trap on error condition introduced by the patch for #1344
+        ## keeping as extra check to prevent hanging
+        if [ ! -e /proc/$pid ]; then
+            [ ! $STOP ] && STOP=$(nxf_date)
+            [ $(($(nxf_date)-STOP)) -gt 10000 ] && break
+        fi
+        count=$((count+1))
+    done
+
+    # Calculate averages if we have samples
+    if [ $gpu_samples -gt 0 ]; then
+        local avg_gpu_util=$((gpu_util_sum / gpu_samples))
+        # Calculate average memory usage in MiB (still needed for records)
+        local avg_gpu_mem=$((gpu_mem_sum / gpu_samples))
+        # Calculate average memory percentage
+        local avg_gpu_mem_perc=$(awk -v sum=$gpu_mem_perc_sum -v samples=$gpu_samples 'BEGIN {printf "%.1f", sum/samples}')
+        
+        [ $NXF_DEBUG = 1 ] && echo "Final averages - util: $avg_gpu_util%, mem: $avg_gpu_mem MiB, mem_perc: $avg_gpu_mem_perc%"
+        
+        # Write values directly to the trace file
+        printf "%s\n" \
+            "avg_gpu_util=$avg_gpu_util" \
+            "avg_gpu_mem=$avg_gpu_mem" \
+            "avg_gpu_mem_perc=$avg_gpu_mem_perc" >> "$trace_file"
+    else
+        [ $NXF_DEBUG = 1 ] && echo "Warning: No GPU samples collected"
+        # Write zero values if no samples collected
+        printf "%s\n" \
+            "avg_gpu_util=0" \
+            "avg_gpu_mem=0" \
+            "avg_gpu_mem_perc=0" >> "$trace_file"
+    fi
+}
+
 nxf_trace_linux() {
     local pid=$$
     command -v ps &>/dev/null || { >&2 echo "Command 'ps' required by nextflow to collect task metrics cannot be found"; exit 1; }
@@ -174,19 +277,19 @@ nxf_trace_linux() {
     local io_stat0=($(2> /dev/null < /proc/$pid/io sed 's/^.*:\s*//' | head -n 6 | tr '\n' ' ' || echo -n '0 0 0 0 0 0'))
     local start_millis=$(nxf_date)
     ## capture error and kill mem watcher
-    trap 'kill $mem_proc' ERR
+    trap 'kill $mem_proc $gpu_proc' ERR
 
     ## check if nvidia-smi is available and capture GPU metrics if it is
     if command -v nvidia-smi &>/dev/null; then
-        local gpu_stats=$(nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total,driver_version --format=csv,noheader)
+        local gpu_stats=$(nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader)
         [ $NXF_DEBUG = 1 ] && echo "+++ GPU STATS: $gpu_stats"
         
         # Extract individual metrics from gpu_stats
         local gpu_name=$(echo "$gpu_stats" | awk -F, '{print $1}' | xargs)
-        local gpu_mem_total=$(echo "$gpu_stats" | awk -F, '{print $4}' | xargs)
-        local gpu_driver=$(echo "$gpu_stats" | awk -F, '{print $5}' | xargs)
+        local gpu_mem_total=$(echo "$gpu_stats" | awk -F, '{print $2}' | xargs)
+        local gpu_driver=$(echo "$gpu_stats" | awk -F, '{print $3}' | xargs)
         
-        [ $NXF_DEBUG = 1 ] && echo "+++ GPU METRICS: name=$gpu_name, util=$gpu_utilization, mem_used=$gpu_memory_used, mem_total=$gpu_memory_total, driver=$gpu_driver_version"
+        [ $NXF_DEBUG = 1 ] && echo "+++ GPU METRICS: name=$gpu_name, mem_total=$gpu_mem_total, driver=$gpu_driver"
     fi
     
     ## run task script
@@ -197,6 +300,14 @@ nxf_trace_linux() {
     mem_fd=$(nxf_fd)
     eval "exec $mem_fd> >(nxf_mem_watch $task)"
     local mem_proc=$!
+
+    ## run gpu stat if nvidia-smi is available
+    local gpu_proc
+    if command -v nvidia-smi &>/dev/null; then
+        gpu_fd=$(nxf_fd)
+        eval "exec $gpu_fd> >(nxf_gpu_watch $task)"
+        gpu_proc=$!
+    fi
 
     wait $task
 
@@ -222,13 +333,24 @@ nxf_trace_linux() {
         "cpu_model=$cpu_model" \
         "gpu_model=$gpu_name" \
         "gpu_mem_total=$gpu_mem_total" \
-        "gpu_driver=$gpu_driver" \
+        "gpu_driver=$gpu_driver" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+    
+    # Default GPU values if GPU monitoring didn't run
+    if [ -z "$gpu_proc" ]; then
+        printf "%s\n" \
+            "avg_gpu_util=0" \
+            "avg_gpu_mem=0" \
+            "avg_gpu_mem_perc=0" >> "$trace_file"
+    fi
+    
+    # Append the remaining metrics
+    printf "%s\n" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
         "syscr=${io_stat1[2]}" \
         "syscw=${io_stat1[3]}" \
         "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+        "write_bytes=${io_stat1[5]}" >> "$trace_file" || >&2 echo "Error: Failed to append to file: $trace_file"
 
     ## join nxf_mem_watch
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true
@@ -236,6 +358,14 @@ nxf_trace_linux() {
     ## Bash prior 4.4 wait on a process substitution returns an error
     ## fallback on a while loop checking the proc pseudo file system
     while [ -e /proc/$mem_proc ]; do nxf_sleep 0.1; done
+
+    ## join nxf_gpu_watch if it was running
+    if [ ! -z "$gpu_proc" ]; then
+        [ -e /proc/$gpu_proc ] && eval "echo 'DONE' >&$gpu_fd" || true
+        wait $gpu_proc 2>/dev/null || true
+        while [ -e /proc/$gpu_proc ]; do nxf_sleep 0.1; done
+    fi
+
     {{fix_ownership}}
 }
 


### PR DESCRIPTION
# Description

This PR implements feature requests from #4286 .

The current implementation adds the following fields to the TraceRecord:
- gpu_model
- gpu_mem
- gpu_driver: 'str'
- -'%gpu'
- %gpu_mem
- avg_gpu_mem

This is accomplished by implementing a new `nxf_gpu_watch()` in  `command-trace.txt `, similar to `nxf_mem_watch()`. This allows to access GPU metrics in the Tracefile, by adding the following lines to the nextflow.config:
```
trace{
fields = 'gpu_model,gpu_mem,gpu_driver,%gpu,%gpu_mem,avg_gpu_mem'
}
```

# Limitations

A current limitation of this approach is that if using Nextflow with an executor (for example local) and a local GPU that is operating system wide, the usage metrics are not task specific but include background processes. For example, on my local Ubuntu machine with an `NVIDIA GeForce GTX 1650` even a cpu only task reported some GPU usage, due to background GPU processes utilizing the GPU. This should not be the case when running on instances where GPUs are assigned to specific tasks using accelerator, however I haven't tested this on multi-GPU machines on AWS or other cloud executors.