### PR TITLE
Improve deprecation warnings

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/ast/NextflowDSLImpl.groovy
@@ -742,7 +742,7 @@ class NextflowDSLImpl implements ASTTransformation {
          * closure expression and set a `when` directive in the process configuration properties.
          *
          * See {@link nextflow.script.ProcessConfig#configProperties}
-         * See {@link nextflow.processor.TaskConfig#getGuard(java.lang.String)}
+         * See {@link nextflow.processor.TaskConfig#getWhenGuard()}
          */
         protected BlockStatement addWhenGuardCall( List<Statement> statements, StringBuilder source, BlockStatement parent ) {
             createBlock0(PROCESS_WHEN, statements, source, parent)

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -550,17 +550,17 @@ class TaskConfig extends LazyMap implements Cloneable {
     }
 
     /**
-     * Get a closure guard condition and evaluate to a boolean result
+     * Get the when guard condition if present and evaluate it
      *
-     * @param name The name of the guard to test e.g. {@code when}
      * @return {@code true} when the condition is verified
      */
-    protected boolean getGuard( String name, boolean defValue=true ) throws FailedGuardException {
+    protected boolean getWhenGuard(boolean defValue=true) throws FailedGuardException {
 
-        final code = target.get(name)
+        final code = target.get(NextflowDSLImpl.PROCESS_WHEN)
         if( code == null )
             return defValue
 
+        log.warn1 "The `when` process section is deprecated -- use conditional logic in the calling workflow instead"
         String source = null
         try {
             if( code instanceof Closure ) {
@@ -571,7 +571,7 @@ class TaskConfig extends LazyMap implements Cloneable {
             return code as Boolean
         }
         catch( Throwable e ) {
-            throw new FailedGuardException("Cannot evaluate `$name` expression", source, e)
+            throw new FailedGuardException("Cannot evaluate `when` expression", source, e)
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -54,7 +54,6 @@ import groovyx.gpars.group.PGroup
 import nextflow.NF
 import nextflow.Nextflow
 import nextflow.Session
-import nextflow.ast.NextflowDSLImpl
 import nextflow.ast.TaskCmdXform
 import nextflow.ast.TaskTemplateVarsXform
 import nextflow.cloud.CloudSpotTerminationException
@@ -310,7 +309,7 @@ class TaskProcessor {
         this.config = config
         this.taskBody = taskBody
         if( taskBody.isShell )
-            log.warn "Process ${name} > the `shell` block is deprecated, use `script` instead"
+            log.warn1 "The `shell` process section is deprecated -- use the `script` section instead"
         this.name = name
         this.maxForks = config.maxForks && config.maxForks>0 ? config.maxForks as int : 0
         this.forksCount = maxForks ? new LongAdder() : null
@@ -2350,7 +2349,7 @@ class TaskProcessor {
     protected boolean checkWhenGuard(TaskRun task) {
 
         try {
-            def pass = task.config.getGuard(NextflowDSLImpl.PROCESS_WHEN)
+            def pass = task.config.getWhenGuard()
             if( pass ) {
                 return true
             }

--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -80,13 +80,13 @@ class IncludeDef {
     }
 
     IncludeDef params(Map args) {
-        log.warn "Include with `params()` is deprecated -- pass params as a workflow or process input instead"
+        log.warn1 "Include with `params()` is deprecated -- pass params as a workflow or process input instead"
         this.params = args != null ? new HashMap(args) : null
         return this
     }
 
     IncludeDef addParams(Map args) {
-        log.warn "Include with `addParams()` is deprecated -- pass params as a workflow or process input instead"
+        log.warn1 "Include with `addParams()` is deprecated -- pass params as a workflow or process input instead"
         this.addedParams = args
         return this
     }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -409,7 +409,7 @@ class TaskConfigTest extends Specification {
         config.put('when', closure)
 
         when:
-        config.getGuard('when')
+        config.getWhenGuard()
         then:
         FailedGuardException ex = thrown()
         ex.source == '{closure source code}'
@@ -417,12 +417,12 @@ class TaskConfigTest extends Specification {
         when:
         config.context = [x: 'Hello', count: 1]
         then:
-        config.getGuard('when')
+        config.getWhenGuard()
 
         when:
         config.context = [x: 'Hello', count: 3]
         then:
-        !config.getGuard('when')
+        !config.getWhenGuard()
     }
 
     def 'should create ext config properties' () {


### PR DESCRIPTION
We deprecated several language features since 24.10:
- include `addParams`
- Process `when` section
- Process `shell` section

Some users find these warnings intrusive, and users who run pipelines but don't write Nextflow are confused to receive a warning even though the pipeline still works correctly.

This PR makes these warnings less intrusive by ensuring that they are logged only once per run instead of once per occurrence.