### PR TITLE
Print process dictionary in logs (#5940)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -55,6 +55,7 @@ import nextflow.processor.TaskProcessor
 import nextflow.script.BaseScript
 import nextflow.script.ProcessConfig
 import nextflow.script.ProcessFactory
+import nextflow.script.ProcessDef
 import nextflow.script.ScriptBinding
 import nextflow.script.ScriptFile
 import nextflow.script.ScriptMeta
@@ -871,6 +872,8 @@ class Session implements ISession {
             final names = ScriptMeta.allProcessNames()
             final ver = "dsl${NF.dsl1 ?'1' :'2'}"
             log.debug "Workflow process names [$ver]: ${names.join(', ')}"
+            final processDefs = ScriptMeta.allProcessDefinitions()
+            log.debug "Workflow process definitions [$ver]: ${processDefs.entrySet().collect{"${it.key} ${it.value}"}.join(', ')}"
             validateConfig(names)
         }
         else {

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -871,9 +871,11 @@ class Session implements ISession {
         if( enabled ) {
             final names = ScriptMeta.allProcessNames()
             final ver = "dsl${NF.dsl1 ?'1' :'2'}"
-            log.debug "Workflow process names [$ver]: ${names.join(', ')}"
             final processDefs = ScriptMeta.allProcessDefinitions()
             log.debug "Workflow process definitions [$ver]: ${processDefs.entrySet().collect{"${it.key} ${it.value}"}.join(', ')}"
+            final resolvedNames = ScriptMeta.allResolvedProcessNames()
+            log.debug "Resolved process names: ${resolvedNames.entrySet().collect{"${it.key} ${it.value}"}.join(', ')}"         
+
             validateConfig(names)
         }
         else {

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -874,7 +874,9 @@ class Session implements ISession {
             final processDefs = ScriptMeta.allProcessDefinitions()
             log.debug "Workflow process definitions [$ver]: ${processDefs.entrySet().collect{"${it.key} ${it.value}"}.join(', ')}"
             final resolvedNames = ScriptMeta.allResolvedProcessNames()
-            log.debug "Resolved process names: ${resolvedNames.entrySet().collect{"${it.key} ${it.value}"}.join(', ')}"         
+            final mainScriptMeta = ScriptMeta.get(script)
+            final unaliasedProcessNames = mainScriptMeta.getLocalProcessNames() // Process in main file are not aliased.
+            log.debug "Resolved process names: ${unaliasedProcessNames.collect{"$it ${mainScriptMeta.getScriptPath()}:$it"}.join(', ')} ${resolvedNames.entrySet().collect{"${it.key} ${it.value}"}.join(', ')}"         
 
             validateConfig(names)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -600,7 +600,14 @@ class TaskProcessor {
             return
         }
         session.addIgniter {
-            log.debug "Starting process > $name"
+            // Closure to get the (nested) list of param_type:param_name
+            def getParamNamesAndTypes 
+            getParamNamesAndTypes = { paramList ->
+                paramList.collect{param ->
+                    "${(param instanceof InParam)? param.getTypeName() : param.class.simpleName}:${(param !instanceof TupleInParam && param !instanceof TupleOutParam)? param.name : "[${getParamNamesAndTypes(param.getInner())}]"}"}.join(', ')
+            }
+            // Print process name with associated input and outputs
+            log.debug "Starting process > $name (${getParamNamesAndTypes(getConfig().getInputs())}) -> (${getParamNamesAndTypes(getConfig().getOutputs())})"
             op.start()
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -127,7 +127,8 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
 
     @Override
     ProcessDef cloneWithName(String name) {
-        ScriptMeta.addResolvedName(name)
+        final path =  ScriptMeta.get(owner).getScriptPath()
+        ScriptMeta.addResolvedName(name, path, this.baseName)
         def result = clone()
         result.@processName = name
         result.@simpleName = stripScope(name)

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -86,6 +86,22 @@ class ScriptMeta {
         return result
     }
 
+    /** 
+     * Returns a map of all local process definitions per script path.
+     * @return Map of script path and a list of process names
+     *         defined in that script
+     *         ie. [scriptPath -> [processName1, processName2]]
+     */
+    static Map<Path, List<String>> allProcessDefinitions() {
+        final result = new HashMap()
+         for( final entry : REGISTRY.values() ) {
+            final processes = entry.getDefinitions().findAll { d -> d instanceof ProcessDef }
+            final processNames = processes.collect { d -> d.getName() }
+            result.put(entry.getScriptPath(), processNames)
+        }
+        return result
+    }
+
     static void addResolvedName(String name) {
         resolvedProcessNames.add(name)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -50,7 +50,7 @@ class ScriptMeta {
 
     static private Map<Path,BaseScript> scriptsByPath = new HashMap<>(10)
 
-    static private Set<String> resolvedProcessNames = new HashSet<>(20)
+    static private Map<String,Map.Entry<Path,String>> resolvedProcessNames = new HashMap<>(20)
 
     @TestOnly
     static void reset() {
@@ -73,7 +73,7 @@ class ScriptMeta {
         for( ScriptMeta entry : REGISTRY.values() )
             result.addAll( entry.getProcessNames() )
         // add all resolved names
-        result.addAll(resolvedProcessNames)
+        result.addAll(resolvedProcessNames.keySet())
         return result
     }
 
@@ -95,15 +95,22 @@ class ScriptMeta {
     static Map<Path, List<String>> allProcessDefinitions() {
         final result = new HashMap()
          for( final entry : REGISTRY.values() ) {
-            final processes = entry.getDefinitions().findAll { d -> d instanceof ProcessDef }
-            final processNames = processes.collect { d -> d.getName() }
-            result.put(entry.getScriptPath(), processNames)
+            result.put(entry.getScriptPath(), entry.getLocalProcessNames())
         }
         return result
     }
 
-    static void addResolvedName(String name) {
-        resolvedProcessNames.add(name)
+    /** 
+     * Returns a map of all resolved process names, with their corresponding 
+     * script path and original process names.
+     * @return Map of process name and a map of script path and original process name
+     */
+     static Map<String, Map.Entry<Path, String>> allResolvedProcessNames() {
+        return resolvedProcessNames
+    }
+
+    static void addResolvedName(String name, Path path, String baseName) {
+        resolvedProcessNames.put(name, new AbstractMap.SimpleEntry<>(path, baseName))
     }
 
     static Map<String,Path> allScriptNames() {


### PR DESCRIPTION
## What
Update the logs in the following manner:
1. Replace workflow process name list, which mixes defined process names and aliased process names
   ```
   [main] DEBUG nextflow.Session - Workflow process names [dsl2]: a
   ```
   with two lists: one of process definitions from each file, one of aliases used for each process.
   ```
   [main] DEBUG nextflow.Session - Workflow process definitions [dsl2]: main.nf [a, other_process, ...], sub.nf [a, ...]
   [main] DEBUG nextflow.Session - Workflow resolved process names: a[main.nf:a], sub:a[sub.nf:a], x[sub.nf:a]  
   ```

2. Complement the following log line:
   ```
   [main] DEBUG nextflow.processor.TaskProcessor - Starting process > x
   ```
   with typed list of inputs and outputs of the process.
   ```
   Starting process > x (type:ArgName, ..., default:$) -> (type:OutName, ...)
   ```

## Motivations
See #5940 