### PR TITLE
Fix validation of plugin config options

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -24,6 +24,7 @@ import com.beust.jcommander.Parameters
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
+import nextflow.NF
 import nextflow.config.ConfigBuilder
 import nextflow.config.ConfigValidator
 import nextflow.exception.AbortOperationException
@@ -117,8 +118,10 @@ class CmdConfig extends CmdBase {
         final config = builder.buildConfigObject()
 
         // -- validate config options
-        Plugins.load(config)
-        new ConfigValidator().validate(config)
+        if( NF.getSyntaxParserVersion() == 'v2' ) {
+            Plugins.load(config)
+            new ConfigValidator().validate(config)
+        }
 
         // -- print config options
         if( printValue ) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -117,6 +117,7 @@ class CmdConfig extends CmdBase {
         final config = builder.buildConfigObject()
 
         // -- validate config options
+        Plugins.load(config)
         new ConfigValidator().validate(config)
 
         // -- print config options

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -340,7 +340,8 @@ class CmdRun extends CmdBase implements HubOptions {
         Plugins.load(cfg)
 
         // -- validate config options
-        new ConfigValidator().validate(config)
+        if( NF.getSyntaxParserVersion() == 'v2' )
+            new ConfigValidator().validate(config)
 
         // -- create a new runner instance
         final runner = new ScriptRunner(config)

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
@@ -18,7 +18,6 @@ package nextflow.config
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import nextflow.NF
 import nextflow.config.schema.ConfigScope
 import nextflow.config.schema.SchemaNode
 import nextflow.config.schema.ScopeName
@@ -74,14 +73,10 @@ class ConfigValidator {
     }
 
     void validate(ConfigMap config) {
-        if( NF.getSyntaxParserVersion() != 'v2' )
-            return
         validate(config.toConfigObject())
     }
 
     void validate(ConfigObject config) {
-        if( NF.getSyntaxParserVersion() != 'v2' )
-            return
         final flatConfig = config.flatten()
         for( String key : flatConfig.keySet() ) {
             final names = key.tokenize('.')

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigValidatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigValidatorTest.groovy
@@ -16,7 +16,6 @@
 
 package nextflow.config
 
-import nextflow.SysEnv
 import org.junit.Rule
 import spock.lang.Specification
 import test.OutputCapture
@@ -28,14 +27,6 @@ class ConfigValidatorTest extends Specification {
 
     @Rule
     OutputCapture capture = new OutputCapture()
-
-    def setupSpec() {
-        SysEnv.push(NXF_SYNTAX_PARSER: 'v2')
-    }
-
-    def cleanupSpec() {
-        SysEnv.pop()
-    }
 
     def 'should warn about invalid config options' () {
         given:


### PR DESCRIPTION
I am testing the ability to declare config options in a plugin (https://github.com/nextflow-io/nf-prov/pull/44). It works with the `run` command, but the `config` command isn't working because it never loads the plugins. This PR fixes that issue. I have confirmed that it works with the nf-prov PR.