### PR TITLE
Prefer `toList` over `collect` operator

### DIFF
--- a/docs/channel.md
+++ b/docs/channel.md
@@ -86,8 +86,6 @@ Commonly used operators include:
 
 - {ref}`operator-combine`: emit the combinations of two channels
 
-- {ref}`operator-collect`: collect the values from a channel into a list
-
 - {ref}`operator-filter`: select the values in a channel that satisfy a condition
 
 - {ref}`operator-flatMap`: transform each value from a channel into a list and emit each list 
@@ -100,6 +98,8 @@ element separately
 - {ref}`operator-map`: transform each value from a channel with a mapping function
 
 - {ref}`operator-mix`: emit the values from multiple channels
+
+- {ref}`operator-tolist`: collect the values from a channel into a list
 
 - {ref}`operator-view`: print each value in a channel to standard output
 

--- a/docs/reference/operator.md
+++ b/docs/reference/operator.md
@@ -1528,6 +1528,8 @@ map { v -> v as Integer }
 You can also use `toLong`, `toFloat`, and `toDouble` to convert to other numerical types.
 :::
 
+(operator-tolist)=
+
 ## toList
 
 *Returns: value channel*


### PR DESCRIPTION
Promote `toList` in the operator summary instead of `collect`

- `toList` mirrors the `fromList` channel factory
- avoid confusion with [Iterable::collect()](https://nextflow.io/docs/latest/reference/stdlib.html#iterable-e)
- avoid weird behaviors with `collect` like flattening by default and emitting nothing instead of an empty list