### PR TITLE
Add support for Fusion Snapshots

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -792,6 +792,12 @@ The following settings are available:
 : Enable privileged containers for Fusion (default: `true`)
 : Non-privileged use is supported only on Kubernetes with the [k8s-fuse-plugin](https://github.com/nextflow-io/k8s-fuse-plugin) or a similar FUSE device plugin.
 
+`fusion.snapshots`
+: :::{versionadded} 25.03.0-edge
+  :::
+: Enable the snapshotting capability provided by Fusion (preview). This feature allows the automatic restoring the state of jobs interrupted by a spot-preemption (default: `false`)
+: Note: currently is only supported by AWS Batch executor.
+
 `fusion.tags`
 : Pattern for applying tags to files created via the Fusion client (default: `[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)`).
 : Set to `false` to disable.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -795,8 +795,8 @@ The following settings are available:
 `fusion.snapshots`
 : :::{versionadded} 25.03.0-edge
   :::
-: Enable the snapshotting capability provided by Fusion (preview). This feature allows the automatic restoring the state of jobs interrupted by a spot-preemption (default: `false`)
-: Note: currently is only supported by AWS Batch executor.
+: *Currently only supported for AWS Batch*
+: Enable Fusion snapshotting (preview, default: `false`). This feature allows Fusion to automatically restore a job when it is interrupted by a spot reclamation.
 
 `fusion.tags`
 : Pattern for applying tags to files created via the Fusion client (default: `[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)`).

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
@@ -36,6 +36,8 @@ class FusionConfig {
 
     final static public String DEFAULT_FUSION_AMD64_URL = 'https://fusionfs.seqera.io/releases/v2.5-amd64.json'
     final static public String DEFAULT_FUSION_ARM64_URL = 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
+    final static public String DEFAULT_SNAPSHOT_AMD64_URL = 'https://fusionfs.seqera.io/releases/v2.5-snap_amd64.json'
+
     final static public String DEFAULT_TAGS = "[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)"
 
     final static public String FUSION_PATH = '/usr/bin/fusion'
@@ -54,6 +56,7 @@ class FusionConfig {
     final private String tagsPattern
     final private boolean privileged
     final private MemoryUnit cacheSize
+    final private boolean snapshots
 
     boolean enabled() { enabled }
 
@@ -75,6 +78,8 @@ class FusionConfig {
 
     MemoryUnit cacheSize() { cacheSize }
 
+    boolean snapshotsEnabled() { snapshots }
+
     URL containerConfigUrl() {
         this.containerConfigUrl ? new URL(this.containerConfigUrl) : null
     }
@@ -94,6 +99,7 @@ class FusionConfig {
         this.tagsPattern = (opts.tags==null || (opts.tags instanceof Boolean && opts.tags)) ? DEFAULT_TAGS : ( opts.tags !instanceof Boolean ? opts.tags as String : null )
         this.privileged = opts.privileged==null || opts.privileged.toString()=='true'
         this.cacheSize = opts.cacheSize as MemoryUnit
+        this.snapshots = opts.snapshots as Boolean
         if( containerConfigUrl && !validProtocol(containerConfigUrl))
             throw new IllegalArgumentException("Fusion container config URL should start with 'http:' or 'https:' protocol prefix - offending value: $containerConfigUrl")
     }

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
@@ -36,7 +36,7 @@ class FusionConfig {
 
     final static public String DEFAULT_FUSION_AMD64_URL = 'https://fusionfs.seqera.io/releases/v2.4-amd64.json'
     final static public String DEFAULT_FUSION_ARM64_URL = 'https://fusionfs.seqera.io/releases/v2.4-arm64.json'
-    final static public String DEFAULT_SNAPSHOT_AMD64_URL = 'https://fusionfs.seqera.io/releases/v4.5-snap_amd64.json'
+    final static public String DEFAULT_SNAPSHOT_AMD64_URL = 'https://fusionfs.seqera.io/releases/v2.4-snap_amd64.json'
 
     final static public String DEFAULT_TAGS = "[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)"
 

--- a/modules/nextflow/src/test/groovy/nextflow/fusion/FusionConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/fusion/FusionConfigTest.groovy
@@ -138,6 +138,7 @@ class FusionConfigTest extends Specification {
         FUSION_URL                              | EXPECTED
         FusionConfig.DEFAULT_FUSION_AMD64_URL   | '2.5'
         FusionConfig.DEFAULT_FUSION_ARM64_URL   | '2.5'
+        FusionConfig.DEFAULT_SNAPSHOT_AMD64_URL | '2.5'
         'https://foo.com/releases/v3.0-amd.json'| '3.0'
     }
 

--- a/modules/nf-lang/src/main/java/nextflow/config/scopes/FusionConfig.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/scopes/FusionConfig.java
@@ -66,7 +66,7 @@ public class FusionConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        Enable the snapshotting capability provided by Fusion (preview). This feature allows the automatic restoring the state of jobs interrupted by a spot-preemption (default: `false`).
+        Enable Fusion snapshotting (preview, default: `false`). This feature allows Fusion to automatically restore a job when it is interrupted by a spot reclamation.
     """)
     public boolean snapshots;
 

--- a/modules/nf-lang/src/main/java/nextflow/config/scopes/FusionConfig.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/scopes/FusionConfig.java
@@ -66,6 +66,12 @@ public class FusionConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        Enable the snapshotting capability provided by Fusion (preview). This feature allows the automatic restoring the state of jobs interrupted by a spot-preemption (default: `false`).
+    """)
+    public boolean snapshots;
+
+    @ConfigOption
+    @Description("""
         The pattern that determines how tags are applied to files created via the Fusion client (default: `[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)`). Set to `false` to disable tags.
     """)
     public String tags;

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -696,7 +696,12 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
     }
 
     protected int maxSpotAttempts() {
-        return executor.awsOptions.maxSpotAttempts
+        final result = executor.awsOptions.maxSpotAttempts
+        if( result )
+            return result
+        // when fusion snapshot is enabled max attempt should be > 0
+        // to enable to allow snapshot retry the job execution in a new ec2 instance
+        return fusionEnabled() && fusionConfig().snapshotsEnabled() ? 5 : 0
     }
 
     protected String getJobName(TaskRun task) {

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsOptions.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsOptions.groovy
@@ -105,7 +105,7 @@ class AwsOptions implements CloudTransferOptions {
         return awsConfig.batchConfig.getMaxTransferAttempts()
     }
 
-    int getMaxSpotAttempts() {
+    Integer getMaxSpotAttempts() {
         return awsConfig.batchConfig.getMaxSpotAttempts()
     }
 

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsBatchConfig.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsBatchConfig.groovy
@@ -36,8 +36,6 @@ import nextflow.util.Duration
 @CompileStatic
 class AwsBatchConfig implements CloudTransferOptions {
 
-    public static final int DEFAULT_MAX_SPOT_ATTEMPTS = 0
-
     public static final int DEFAULT_AWS_MAX_ATTEMPTS = 5
 
     private int maxParallelTransfers = MAX_TRANSFER
@@ -106,7 +104,7 @@ class AwsBatchConfig implements CloudTransferOptions {
         maxParallelTransfers = opts.maxParallelTransfers as Integer ?: MAX_TRANSFER
         maxTransferAttempts = opts.maxTransferAttempts as Integer ?: defaultMaxTransferAttempts()
         delayBetweenAttempts = opts.delayBetweenAttempts as Duration ?: DEFAULT_DELAY_BETWEEN_ATTEMPTS
-        maxSpotAttempts = opts.maxSpotAttempts!=null ? opts.maxSpotAttempts as Integer : DEFAULT_MAX_SPOT_ATTEMPTS
+        maxSpotAttempts = opts.maxSpotAttempts!=null ? opts.maxSpotAttempts as Integer : null
         volumes = makeVols(opts.volumes)
         jobRole = opts.jobRole
         logsGroup = opts.logsGroup

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsBatchConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsBatchConfigTest.groovy
@@ -34,7 +34,7 @@ class AwsBatchConfigTest extends Specification {
         batch.maxParallelTransfers == AwsBatchConfig.MAX_TRANSFER
         batch.maxTransferAttempts == AwsBatchConfig.DEFAULT_AWS_MAX_ATTEMPTS
         batch.delayBetweenAttempts == AwsBatchConfig.DEFAULT_DELAY_BETWEEN_ATTEMPTS
-        batch.maxSpotAttempts == AwsBatchConfig.DEFAULT_MAX_SPOT_ATTEMPTS
+        batch.maxSpotAttempts == null
         batch.retryMode == 'standard'
         and:
         !batch.cliPath

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -366,8 +366,20 @@ class WaveClient {
     protected URL defaultFusionUrl(String platform) {
         final isArm = platform.tokenize('/')?.contains('arm64')
         return isArm
-                ? new URL(FusionConfig.DEFAULT_FUSION_ARM64_URL)
-                : new URL(FusionConfig.DEFAULT_FUSION_AMD64_URL)
+                ? fusionArm64(fusion.snapshotsEnabled())
+                : fusionAmd64(fusion.snapshotsEnabled())
+    }
+
+    protected URL fusionAmd64(boolean snapshots) {
+        return snapshots
+                ? URI.create(FusionConfig.DEFAULT_SNAPSHOT_AMD64_URL).toURL()
+                : URI.create(FusionConfig.DEFAULT_FUSION_AMD64_URL).toURL()
+    }
+
+    protected URL fusionArm64(boolean snapshots) {
+        if( snapshots )
+            throw new IllegalArgumentException("Fusion does not support arm64 snapshots (yet)")
+        return URI.create(FusionConfig.DEFAULT_FUSION_ARM64_URL).toURL()
     }
 
     protected URL defaultS5cmdUrl(String platform) {

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -948,7 +948,7 @@ class WaveClientTest extends Specification {
     @Unroll
     def 'should get fusion default url' () {
         given:
-        def sess = Mock(Session) {getConfig() >> [:] }
+        def sess = Mock(Session) {getConfig() >> [fusion:[snapshots:SNAP]] }
         and:
         def wave = Spy(new WaveClient(sess))
 
@@ -956,12 +956,14 @@ class WaveClientTest extends Specification {
         wave.defaultFusionUrl(ARCH).toURI().toString() == EXPECTED
         
         where:
-        ARCH                | EXPECTED
-        'linux/amd64'       | 'https://fusionfs.seqera.io/releases/v2.5-amd64.json'
-        'linux/x86_64'      | 'https://fusionfs.seqera.io/releases/v2.5-amd64.json'
-        'arm64'             | 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
-        'linux/arm64'       | 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
-        'linux/arm64/v8'    | 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
+        ARCH                | SNAP  | EXPECTED
+        'linux/amd64'       | null  | 'https://fusionfs.seqera.io/releases/v2.5-amd64.json'
+        'linux/x86_64'      | null  | 'https://fusionfs.seqera.io/releases/v2.5-amd64.json'
+        'arm64'             | null  | 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
+        'linux/arm64'       | null  | 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
+        'linux/arm64/v8'    | null  | 'https://fusionfs.seqera.io/releases/v2.5-arm64.json'
+        and:
+        'linux/amd64'       | true  | 'https://fusionfs.seqera.io/releases/v2.5-snap_amd64.json'
     }
 
     @Unroll


### PR DESCRIPTION
This PR adds support for Fusion snapshots by adding a config setting: 

```
fusion.snapshots=true|false
```

When enabled Fusion snapshots restores automatically AWS Batch jobs interrupted by a spot reclamation. 

The number of restarts is determined by the setting `aws.batch.maxSpotAttempts` (default `5` when Fusion Snapshots is enabled) 
