### PR TITLE
Allow WireMock to select a random port in tests

### DIFF
--- a/modules/nf-httpfs/src/test/nextflow/file/http/HttpFilesTests.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/HttpFilesTests.groovy
@@ -42,12 +42,13 @@ import test.TestHelper
 class HttpFilesTests extends Specification {
 
     @Rule
-    WireMockRule wireMockRule = new WireMockRule(18080)
+    WireMockRule wireMockRule = new WireMockRule(0)
 
     def 'should read http file from WireMock' () {
 
         given:
-        def wireMock = new WireMockGroovy(18080)
+        def wireMock = new WireMockGroovy(wireMockRule.port())
+        def localhost = "http://localhost:${wireMockRule.port()}"
         wireMock.stub {
             request {
                 method "GET"
@@ -69,13 +70,13 @@ class HttpFilesTests extends Specification {
         }
 
         when:
-        def path = Paths.get(new URI('http://localhost:18080/index.html'))
+        def path = Paths.get(new URI("${localhost}/index.html"))
         then:
         Files.size(path) == 10
         Files.getLastModifiedTime(path).toString() == "2016-11-04T21:50:34Z"
 
         when:
-        def path2 = Paths.get(new URI('http://localhost:18080/missing.html'))
+        def path2 = Paths.get(new URI("${localhost}missing.html"))
         then:
         !Files.exists(path2)
     }
@@ -207,7 +208,8 @@ class HttpFilesTests extends Specification {
 
     def 'should read with a newByteChannel' () {
         given:
-        def wireMock = new WireMockGroovy(18080)
+        def wireMock = new WireMockGroovy(wireMockRule.port())
+        def localhost = "http://localhost:${wireMockRule.port()}"
         wireMock.stub {
             request {
                 method "GET"
@@ -225,7 +227,7 @@ class HttpFilesTests extends Specification {
         }
 
         when:
-        def path = Paths.get(new URI('http://localhost:18080/index.txt'))
+        def path = Paths.get(new URI("${localhost}/index.txt"))
         def sbc = Files.newByteChannel(path)
         def buffer = new ByteArrayOutputStream()
         ByteBuffer bf = ByteBuffer.allocate(15)

--- a/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
@@ -158,12 +158,13 @@ class XFileSystemProviderTest extends Specification {
     }
 
     @Rule
-    WireMockRule wireMockRule = new WireMockRule(18080)
+    WireMockRule wireMockRule = new WireMockRule(0)
 
     @Unroll
     def 'should follow a redirect when read a http file '() {
         given:
-        def wireMock = new WireMockGroovy(18080)
+        def wireMock = new WireMockGroovy(wireMockRule.port())
+        def localhost = "http://localhost:${wireMockRule.port()}"
         wireMock.stub {
             request {
                 method "GET"
@@ -172,7 +173,7 @@ class XFileSystemProviderTest extends Specification {
             response {
                 status HTTP_CODE
                 headers {
-                    "Location" "http://localhost:18080${REDIRECT_TO}"
+                    "Location" "${localhost}${REDIRECT_TO}"
                 }
             }
         }
@@ -184,7 +185,7 @@ class XFileSystemProviderTest extends Specification {
             response {
                 status HTTP_CODE
                 headers {
-                    "Location" "http://localhost:18080/target.html"
+                    "Location" "${localhost}/target.html"
                 }
             }
         }
@@ -210,7 +211,7 @@ class XFileSystemProviderTest extends Specification {
         and:
         def provider = new HttpFileSystemProvider()
         when:
-        def path = provider.getPath(new URI('http://localhost:18080/index.html'))
+        def path = provider.getPath(new URI("${localhost}/index.html"))
         then:
         path
         Files.size(path) == EXPECTED

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerFusionEnvTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerFusionEnvTest.groovy
@@ -23,7 +23,7 @@ class TowerFusionEnvTest extends Specification {
     WireMockServer wireMockServer
 
     def setupSpec() {
-        wireMockServer = new WireMockServer(18080)
+        wireMockServer = new WireMockServer(0)
         wireMockServer.start()
     }
 
@@ -249,7 +249,7 @@ class TowerFusionEnvTest extends Specification {
         Global.session = Mock(Session) {
             config >> [
                 tower: [
-                    endpoint   : 'http://localhost:18080',
+                    endpoint   : wireMockServer.baseUrl(),
                     accessToken: 'abc123'
                 ]
             ]
@@ -295,7 +295,7 @@ class TowerFusionEnvTest extends Specification {
         Global.session = Mock(Session) {
             config >> [
                 tower: [
-                    endpoint   : 'http://localhost:18080',
+                    endpoint   : wireMockServer.baseUrl(),
                     accessToken: 'abc123'
                 ]
             ]


### PR DESCRIPTION
This should prevent an occasional `java.net.BindException` when running the tests locally, caused by two tests trying to start WireMock on the same port.