### PR TITLE
Fix repeated warning for local executor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
@@ -188,7 +188,7 @@ class ExecutorFactory {
         def clazz = getExecutorClass(name)
 
         if( !isTypeSupported(script.type, clazz) ) {
-            log.warn "Process '$processName' cannot be executed by '$name' executor -- Using 'local' executor instead"
+            log.warn1 "Process '$processName' cannot be executed by '$name' executor -- Using 'local' executor instead"
             name = 'local'
             clazz = LocalExecutor.class
         }


### PR DESCRIPTION
A user in Slack reported that this warning was being repeated for every task of a certain process, leading to 1000s of repeated warnings hogging the console output. This warning only needs to be logged once per process