### PR TITLE
Add support for container build compression 

### DIFF
--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.google.code.gson:gson:2.10.1'
     api 'org.yaml:snakeyaml:2.2'
-    api 'io.seqera:wave-api:0.15.1'
+    api 'io.seqera:wave-api:0.16.0'
     api 'io.seqera:wave-utils:0.15.1'
 
     testImplementation(testFixtures(project(":nextflow")))

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/SubmitContainerTokenRequest.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/SubmitContainerTokenRequest.groovy
@@ -21,6 +21,7 @@ package io.seqera.wave.plugin
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
+import io.seqera.wave.api.BuildCompression
 import io.seqera.wave.api.ImageNameStrategy
 import io.seqera.wave.api.PackagesSpec
 import io.seqera.wave.api.ScanLevel
@@ -153,5 +154,10 @@ class SubmitContainerTokenRequest {
      * Empty or null means no vulnerabilities are allowed.
      */
     List<ScanLevel> scanLevels
+
+    /**
+     * Model build compression option
+     */
+    BuildCompression buildCompression
 
 }

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -230,7 +230,8 @@ class WaveClient {
                 dryRun: ContainerInspectMode.dryRun(),
                 mirror: config.mirrorMode(),
                 scanMode: config.scanMode(),
-                scanLevels: config.scanAllowedLevels()
+                scanLevels: config.scanAllowedLevels(),
+                buildCompression: config.buildCompression()
         )
     }
 
@@ -257,7 +258,8 @@ class WaveClient {
                 dryRun: ContainerInspectMode.dryRun(),
                 mirror: config.mirrorMode(),
                 scanMode: config.scanMode(),
-                scanLevels: config.scanAllowedLevels()
+                scanLevels: config.scanAllowedLevels(),
+                buildCompression: config.buildCompression()
         )
         return sendRequest(request)
     }


### PR DESCRIPTION
This PR adds the support for images compression options for Wave container builds. 

The following options are support:

```
wave.build.compression.mode = 'gzip'|'estargz'|'zstd'
wave.build.compression.level = <int>
wave.build.compression.force = false|true
```


 