### PR TITLE
Support downloading plugins using ORAS

### DIFF
--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     api 'dev.failsafe:failsafe:3.1.0'
     // patch gson dependency required by pf4j
     api 'com.google.code.gson:gson:2.10.1'
+    implementation 'land.oras:oras-java-sdk:0.2.4'
 
     /* testImplementation inherited from top gradle build file */
     testImplementation(testFixtures(project(":nextflow")))

--- a/modules/nf-commons/src/main/nextflow/plugin/OrasPluginDownloader.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/OrasPluginDownloader.groovy
@@ -1,0 +1,66 @@
+package nextflow.plugin
+
+import groovy.transform.CompileStatic
+import land.oras.ContainerRef
+import land.oras.Manifest
+import land.oras.Registry
+import org.pf4j.PluginRuntimeException
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Support downloading plugins from an ORAS (OCI Registry As Storage)
+ * location.
+ *
+ * NOTE: logically this should implement pf4j's FileDownloader interface,
+ * but unfortunately that interface uses java.net.URL which doesn't support
+ * custom URI protocols.
+ *
+ * See https://oras.land/
+ */
+@CompileStatic
+class OrasPluginDownloader {
+    private static final String PROTOCOL = "oras://"
+    private static final String ARTIFACT_TYPE = "application/vnd.nextflow.plugin+zip"
+
+    static boolean canDownload(String uri) {
+        return uri.startsWith(PROTOCOL)
+    }
+
+    Path downloadFile(String uri) throws IOException {
+        if (!canDownload(uri)) {
+            throw new PluginRuntimeException("URI protocol not supported by ORAS downloader: {}", uri);
+        }
+        return downloadOras(uri)
+    }
+
+    private static Path downloadOras(String uri) {
+        Path destination = Files.createTempDirectory("oras-update-downloader")
+        destination.toFile().deleteOnExit()
+
+        // strip the oras:// prefix since it's just a marker
+        ContainerRef source = ContainerRef.parse(uri.replaceFirst("oras://", ""))
+        Registry registry = Registry.Builder.builder()
+            // use http on localhost, require https everywhere else
+            .withInsecure(source.registry.startsWith("localhost:"))
+            .build()
+
+        // grab oras metadata about the url
+        Manifest manifest = registry.getManifest(source)
+        String type = manifest.getArtifactType()
+        if (type != ARTIFACT_TYPE) {
+            throw new PluginRuntimeException("Not a nextflow plugin: {}", uri)
+        }
+        // get the filename of the plugin artifact, which should be in layer 0
+        def layers = manifest.getLayers()
+        if (layers.size() < 1) {
+            throw new PluginRuntimeException("Unable to find nextflow plugin at: {}", uri)
+        }
+        String filename = layers[0].annotations['org.opencontainers.image.title']
+
+        // download the plugin artifact
+        registry.pullArtifact(source, destination, true)
+        return destination.resolve(filename)
+    }
+}


### PR DESCRIPTION
ORAS (OCI Registry As Storage) is a way to store arbitrary artifacts in OCI Registries (see https://oras.land/).

This change adds support for downloading Nextflow plugins stored using ORAS. When a plugin download url starts with the protocol `oras://` the download is handled by a new OrasPluginDownloader class instead of the default pf4j FileDownloader.

It also defines an ORAS artifact type (`application/vnd.nextflow.plugin+zip`) and checks that the metadata of the given ORAS url matches this type.

This change should have no impact on any other download urls or plugin download mechanism.