### PR TITLE
feat: Add support for custom fuse mount options in GoogleBatchScriptL…

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -145,8 +145,8 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
         final result = new ArrayList(10)
         for( String it : buckets ) {
             final mountOptions = ['-o rw', '-implicit-dirs']
-            if( config && config.fuseMountOptions && !config.fuseMountOptions.isEmpty() )
-                mountOptions.addAll(config.fuseMountOptions)
+            if( config && config.fuseOptions && !config.fuseOptions.isEmpty() )
+                mountOptions.addAll(config.fuseOptions)
             if( config && config.googleOpts.enableRequesterPaysBuckets )
                 mountOptions << "--billing-project ${config.googleOpts.projectId}".toString()
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -145,6 +145,8 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
         final result = new ArrayList(10)
         for( String it : buckets ) {
             final mountOptions = ['-o rw', '-implicit-dirs']
+            if( config && config.fuseMountOptions && !config.fuseMountOptions.isEmpty() )
+                mountOptions.addAll(config.fuseMountOptions)
             if( config && config.googleOpts.enableRequesterPaysBuckets )
                 mountOptions << "--billing-project ${config.googleOpts.projectId}".toString()
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -145,7 +145,7 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
         final result = new ArrayList(10)
         for( String it : buckets ) {
             final mountOptions = ['-o rw', '-implicit-dirs']
-            if( config && config.fuseOptions && !config.fuseOptions.isEmpty() )
+            if( config?.fuseOptions )
                 mountOptions.addAll(config.fuseOptions)
             if( config && config.googleOpts.enableRequesterPaysBuckets )
                 mountOptions << "--billing-project ${config.googleOpts.projectId}".toString()

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -51,6 +51,7 @@ class BatchConfig {
     private String serviceAccountEmail
     private BatchRetryConfig retryConfig
     private List<Integer> autoRetryExitCodes
+    private List<String> fuseMountOptions
 
     GoogleOpts getGoogleOpts() { return googleOpts }
     GoogleCredentials getCredentials() { return credentials }
@@ -68,6 +69,7 @@ class BatchConfig {
     String getServiceAccountEmail() { serviceAccountEmail }
     BatchRetryConfig getRetryConfig() { retryConfig }
     List<Integer> getAutoRetryExitCodes() { autoRetryExitCodes }
+    List<String> getFuseMountOptions() { fuseMountOptions }
 
     static BatchConfig create(Session session) {
         final result = new BatchConfig()
@@ -87,6 +89,7 @@ class BatchConfig {
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
         result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
+        result.fuseMountOptions = session.config.navigate('google.batch.fuseMountOptions', []) as List<String>
         return result
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -89,7 +89,7 @@ class BatchConfig {
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
         result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
-        result.fuseMountOptions = session.config.navigate('google.batch.fuseMountOptions', []) as List<String>
+        result.fuseMountOptions = session.config.navigate('google.batch.fuseMountOptions', List.of()) as List<String>
         return result
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -51,7 +51,7 @@ class BatchConfig {
     private String serviceAccountEmail
     private BatchRetryConfig retryConfig
     private List<Integer> autoRetryExitCodes
-    private List<String> fuseMountOptions
+    private List<String> fuseOptions
 
     GoogleOpts getGoogleOpts() { return googleOpts }
     GoogleCredentials getCredentials() { return credentials }
@@ -69,7 +69,7 @@ class BatchConfig {
     String getServiceAccountEmail() { serviceAccountEmail }
     BatchRetryConfig getRetryConfig() { retryConfig }
     List<Integer> getAutoRetryExitCodes() { autoRetryExitCodes }
-    List<String> getFuseMountOptions() { fuseMountOptions }
+    List<String> getFuseOptions() { fuseOptions }
 
     static BatchConfig create(Session session) {
         final result = new BatchConfig()
@@ -89,7 +89,7 @@ class BatchConfig {
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
         result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
-        result.fuseMountOptions = session.config.navigate('google.batch.fuseMountOptions', List.of()) as List<String>
+        result.fuseOptions = session.config.navigate('google.batch.fuseOptions', List.of()) as List<String>
         return result
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
@@ -56,7 +56,7 @@ class GoogleBatchScriptLauncherTest extends Specification{
                 getProjectId() >> 'my-project'
                 getEnableRequesterPaysBuckets() >> true
             }
-            getFuseMountOptions() >> ['-o allow_other', '--uid=1000']
+            getFuseOptions() >> ['-o allow_other', '--uid=1000']
         }
         and:
         def PATH1 = CloudStorageFileSystem.forBucket('alpha').getPath('/data/sample1.bam')

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
@@ -56,6 +56,7 @@ class GoogleBatchScriptLauncherTest extends Specification{
                 getProjectId() >> 'my-project'
                 getEnableRequesterPaysBuckets() >> true
             }
+            getFuseMountOptions() >> ['-o allow_other', '--uid=1000']
         }
         and:
         def PATH1 = CloudStorageFileSystem.forBucket('alpha').getPath('/data/sample1.bam')
@@ -80,10 +81,10 @@ class GoogleBatchScriptLauncherTest extends Specification{
         volumes.size() == 2
         volumes[0].getGcs().getRemotePath() == 'alpha'
         volumes[0].getMountPath() == '/mnt/disks/alpha'
-        volumes[0].getMountOptionsList() == ['-o rw', '-implicit-dirs', '--billing-project my-project']
+        volumes[0].getMountOptionsList() == ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000', '--billing-project my-project']
         volumes[1].getGcs().getRemotePath() == 'omega'
         volumes[1].getMountPath() == '/mnt/disks/omega'
-        volumes[1].getMountOptionsList() == ['-o rw', '-implicit-dirs', '--billing-project my-project']
+        volumes[1].getMountOptionsList() == ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000', '--billing-project my-project']
     }
 
 }


### PR DESCRIPTION
…auncher

Add a new config pathway for users to control additional options set on the GCP Batch Fuse Volume mount


This PR aims to resolve https://github.com/nextflow-io/nextflow/issues/4880

Two example values that work well for non-root user access are:

```nextflow.config
google.batch.fuseMountOptions = [
        '-o allow_other',
        '--uid=1000', // The user ID appropriately configured for the running process.container 
]
```

```nextflow.config
google.batch.fuseMountOptions = [
        '-o allow_other',
        '--file-mode=777',
        '--dir-mode=777',
]
```

