### PR TITLE
Update shell block deprecation notice

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -209,7 +209,7 @@ Template scripts are generally discouraged due to the caveats described above. T
 ### Shell
 
 :::{deprecated} 24.11.0-edge
-Use the `script` block instead. Consider using the {ref}`VS Code extension <vscode-page>`, which provides syntax highlighting and error checking to distinguish Nextflow variables from Bash variables in the process script.
+Use the `script` block instead. Consider using the {ref}`strict syntax <strict-syntax>`, which provides error checking to help distinguish between Nextflow variables and Bash variables in the process script.
 :::
 
 The `shell` block is a string expression that defines the script that is executed by the process. It is an alternative to the {ref}`process-script` definition with one important difference: it uses the exclamation mark `!` character, instead of the usual dollar `$` character, to denote Nextflow variables.

--- a/docs/updating-syntax.md
+++ b/docs/updating-syntax.md
@@ -530,7 +530,7 @@ The process `when` section is deprecated. Use conditional logic, such as an `if`
 
 <h4>Process shell section</h4>
 
-The process `shell` section is deprecated. Use the `script` block instead. The VS Code extension provides syntax highlighting and error checking to help distinguish between Nextflow variables and Bash variables.
+The process `shell` section is deprecated. Use the `script` block instead. The strict syntax provides error checking to help distinguish between Nextflow variables and Bash variables.
 
 (updating-config-syntax)=
 


### PR DESCRIPTION
Update the shell block deprecation notices to recommend the strict syntax instead of the VS Code extension. This way it is less intrusive as a suggestion to users who don't use VS Code (based on user feedback).