### PR TITLE
Fix bugs in workflow outputs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowBinding.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowBinding.groovy
@@ -159,8 +159,11 @@ class WorkflowBinding extends Binding  {
     }
 
     void _publish_(String name, Object source) {
-        if( source instanceof ChannelOut )
-            throw new ScriptRuntimeException("Cannot assign a multi-channel to a workflow output: $name")
+        if( source instanceof ChannelOut ) {
+            if( source.size() > 1 )
+                throw new ScriptRuntimeException("Cannot assign a multi-channel to a workflow output: $name")
+            source = source[0]
+        }
 
         owner.session.outputs[name] = source instanceof DataflowWriteChannel
             ? source

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -489,6 +489,8 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
 
         private void visitPathDirective(MethodCallExpression node) {
             var code = asDslBlock(node, 1);
+            if( code == null )
+                return;
             for( var stmt : code.getStatements() ) {
                 if( visitPublishStatement(stmt) )
                     hasPublishStatements = true;

--- a/tests/checks/output-dsl.nf/.checks
+++ b/tests/checks/output-dsl.nf/.checks
@@ -21,6 +21,7 @@ $NXF_RUN --save_bam_bai | tee stdout
 [[ -L results/quant/beta ]] || false
 [[ -L results/quant/delta ]] || false
 [[ -f results/samples.csv ]] || false
+[[ -f results/summary.txt ]] || false
 
 
 #
@@ -46,6 +47,7 @@ $NXF_RUN --save_bam_bai | tee stdout
 [[ -L results/quant/beta ]] || false
 [[ -L results/quant/delta ]] || false
 [[ -f results/samples.csv ]] || false
+[[ -f results/summary.txt ]] || false
 
 
 #
@@ -73,3 +75,4 @@ $NXF_RUN --save_bam_bai -resume | tee stdout
 [[ -L results/quant/beta ]] || false
 [[ -L results/quant/delta ]] || false
 [[ -f results/samples.csv ]] || false
+[[ -f results/summary.txt ]] || false

--- a/tests/output-dsl.nf
+++ b/tests/output-dsl.nf
@@ -62,6 +62,19 @@ process quant {
   '''
 }
 
+process summary {
+  input:
+  path logs
+
+  output:
+  path('summary.txt'), emit: report
+
+  script:
+  '''
+  ls -1 *.log > summary.txt
+  '''
+}
+
 workflow {
   main:
   ids = Channel.of('alpha', 'beta', 'delta')
@@ -83,8 +96,15 @@ workflow {
       ]
     }
 
+  ch_logs = ch_samples
+    .map { sample -> sample.fastqc }
+    .collect()
+
+  summary(ch_logs)
+
   publish:
   samples = ch_samples
+  summary = summary.out
 }
 
 output {
@@ -100,5 +120,9 @@ output {
       header true
       sep ','
     }
+  }
+
+  summary {
+    path '.'
   }
 }


### PR DESCRIPTION
- Fix false error when publishing a ChannelOut with only one channel
- Fix compiler bug when output `path` directive is specified without a closure
- Update `output-dsl.nf` to test these cases