### PR TITLE
Fix false error in workflow output

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -59,12 +59,12 @@ class OutputDsl {
 
         // make sure every output was assigned
         for( final name : declarations.keySet() ) {
-            if( name !in outputs )
+            if( !outputs.containsKey(name) )
                 throw new ScriptRuntimeException("Workflow output '${name}' was declared in the output block but not assigned in the workflow")
         }
 
         for( final name : outputs.keySet() ) {
-            if( name !in declarations )
+            if( !declarations.containsKey(name) )
                 throw new ScriptRuntimeException("Workflow output '${name}' was assigned in the workflow but not declared in the output block")
         }
 


### PR DESCRIPTION
Fix bug discovered in https://github.com/nextflow-io/rnaseq-nf/pull/31 where a workflow output declared with an empty block (see `summary` in that PR) causes a false error.