### PR TITLE
Fix stack overflow error with workflow metadata

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -350,16 +350,6 @@ class WorkflowMetadata {
     }
 
     /**
-     * Dynamic getter for workflow metadata attributes
-     *
-     * @param field
-     * @return The value associated to the specified field
-     */
-    def get(String field) {
-        InvokerHelper.getProperty(this,field)
-    }
-
-    /**
      * Implements the following idiom in the pipeline script:
      * <pre>
      *     workflow.onError = {


### PR DESCRIPTION
Close #5986

To be fair, I'm not entirely sure why this getter was here in the first place. Looking at [this commit](https://github.com/nextflow-io/nextflow/commit/596f00fc70ba918ab015963a36d44d5b5b9f0de8) it seems to be related to the execution report. I guess we'll see what the tests have to say...