### PR TITLE
Add Google Batch gcsfuseOptions

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -862,7 +862,7 @@ The following settings are available for Google Cloud Batch:
 `google.batch.gcsfuseOptions`
 : :::{versionadded} 25.03.0-edge
   :::
-: Defines one or more custom  mount options. Multiple options can be specified using a list e.g. `google.batch.gcsfuseOptions = ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000']` (default: `['-o rw', '-implicit-dirs']`).
+: Defines one or more custom  mount options. Multiple options can be specified using a list, e.g. `google.batch.gcsfuseOptions = ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000']` (default: `['-o rw', '-implicit-dirs']`).
 
 `google.batch.maxSpotAttempts`
 : :::{versionadded} 23.11.0-edge

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -859,6 +859,11 @@ The following settings are available for Google Cloud Batch:
 `google.batch.cpuPlatform`
 : Set the minimum CPU Platform, e.g. `'Intel Skylake'`. See [Specifying a minimum CPU Platform for VM instances](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications) (default: none).
 
+`google.batch.gcsfuseOptions`
+: :::{versionadded} 25.03.0-edge
+  :::
+: Defines one or more custom  mount options. Multiple options can be specified using a list e.g. `google.batch.gcsfuseOptions = ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000']` (default: `['-o rw', '-implicit-dirs']`).
+
 `google.batch.maxSpotAttempts`
 : :::{versionadded} 23.11.0-edge
   :::

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -862,7 +862,7 @@ The following settings are available for Google Cloud Batch:
 `google.batch.gcsfuseOptions`
 : :::{versionadded} 25.03.0-edge
   :::
-: Defines one or more custom  mount options. Multiple options can be specified using a list, e.g. `google.batch.gcsfuseOptions = ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000']` (default: `['-o rw', '-implicit-dirs']`).
+: Defines a list of custom mount options for `gcsfuse` (default: `['-o rw', '-implicit-dirs']`).
 
 `google.batch.maxSpotAttempts`
 : :::{versionadded} 23.11.0-edge

--- a/modules/nf-lang/src/main/java/nextflow/config/scopes/GoogleBatchConfig.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/scopes/GoogleBatchConfig.java
@@ -48,6 +48,12 @@ public class GoogleBatchConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        List of custom mount options for `gcsfuse` (default: `['-o rw', '-implicit-dirs']`).
+    """)
+    public List<String> gcsfuseOptions;
+
+    @ConfigOption
+    @Description("""
         Max number of execution attempts of a job interrupted by a Compute Engine spot reclaim event (default: `5`).
     """)
     public int maxSpotAttempts;

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -144,7 +144,9 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
     List<Volume> getVolumes() {
         final result = new ArrayList(10)
         for( String it : buckets ) {
-            final mountOptions = ['-o rw', '-implicit-dirs']
+            final mountOptions = new LinkedList<String>()
+            if( config && config.gcsfuseOptions )
+                mountOptions.addAll(config.gcsfuseOptions)
             if( config && config.googleOpts.enableRequesterPaysBuckets )
                 mountOptions << "--billing-project ${config.googleOpts.projectId}".toString()
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -35,6 +35,8 @@ class BatchConfig {
     
     static final private List<Integer> DEFAULT_RETRY_LIST = List.of(50001)
 
+    static final private List<String> DEFAULT_GCS_OPTS = List.<String>of('-o rw', '-implicit-dirs')
+
     private GoogleOpts googleOpts
     private GoogleCredentials credentials
     private List<String> allowedLocations
@@ -51,6 +53,7 @@ class BatchConfig {
     private String serviceAccountEmail
     private BatchRetryConfig retryConfig
     private List<Integer> autoRetryExitCodes
+    private List<String> gcsfuseOptions
 
     GoogleOpts getGoogleOpts() { return googleOpts }
     GoogleCredentials getCredentials() { return credentials }
@@ -68,6 +71,7 @@ class BatchConfig {
     String getServiceAccountEmail() { serviceAccountEmail }
     BatchRetryConfig getRetryConfig() { retryConfig }
     List<Integer> getAutoRetryExitCodes() { autoRetryExitCodes }
+    List<String> getGcsfuseOptions() { gcsfuseOptions }
 
     static BatchConfig create(Session session) {
         final result = new BatchConfig()
@@ -87,6 +91,7 @@ class BatchConfig {
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
         result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
+        result.gcsfuseOptions = session.config.navigate('google.batch.gcsfuseOptions', DEFAULT_GCS_OPTS) as List<String>
         return result
     }
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -35,7 +35,7 @@ class BatchConfig {
     
     static final private List<Integer> DEFAULT_RETRY_LIST = List.of(50001)
 
-    static final private List<String> DEFAULT_GCS_OPTS = List.<String>of('-o rw', '-implicit-dirs')
+    static final private List<String> DEFAULT_GCSFUSE_OPTS = List.<String>of('-o rw', '-implicit-dirs')
 
     private GoogleOpts googleOpts
     private GoogleCredentials credentials
@@ -91,7 +91,7 @@ class BatchConfig {
         result.serviceAccountEmail = session.config.navigate('google.batch.serviceAccountEmail')
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
         result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
-        result.gcsfuseOptions = session.config.navigate('google.batch.gcsfuseOptions', DEFAULT_GCS_OPTS) as List<String>
+        result.gcsfuseOptions = session.config.navigate('google.batch.gcsfuseOptions', DEFAULT_GCSFUSE_OPTS) as List<String>
         return result
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
@@ -56,6 +56,7 @@ class GoogleBatchScriptLauncherTest extends Specification{
                 getProjectId() >> 'my-project'
                 getEnableRequesterPaysBuckets() >> true
             }
+            getGcsfuseOptions() >> ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000']
         }
         and:
         def PATH1 = CloudStorageFileSystem.forBucket('alpha').getPath('/data/sample1.bam')
@@ -80,10 +81,10 @@ class GoogleBatchScriptLauncherTest extends Specification{
         volumes.size() == 2
         volumes[0].getGcs().getRemotePath() == 'alpha'
         volumes[0].getMountPath() == '/mnt/disks/alpha'
-        volumes[0].getMountOptionsList() == ['-o rw', '-implicit-dirs', '--billing-project my-project']
+        volumes[0].getMountOptionsList() == ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000', '--billing-project my-project']
         volumes[1].getGcs().getRemotePath() == 'omega'
         volumes[1].getMountPath() == '/mnt/disks/omega'
-        volumes[1].getMountOptionsList() == ['-o rw', '-implicit-dirs', '--billing-project my-project']
+        volumes[1].getMountOptionsList() == ['-o rw', '-implicit-dirs', '-o allow_other', '--uid=1000', '--billing-project my-project']
     }
 
 }


### PR DESCRIPTION
This PR adds the `google.batch`gcsfuseOptions` to fine control the mount settings when using [gcsfuse](https://cloud.google.com/storage/docs/cloud-storage-fuse/overview) with Google Batch

