### PR TITLE
nf-lang: Add unit tests for formatting

### DIFF
--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -238,6 +238,14 @@ The following functions are available in Nextflow scripts:
 `multiMapCriteria( criteria: Closure ) -> Closure`
 : Create a multi-map criteria to use with the {ref}`operator-multiMap` operator.
 
+`print( value )`
+: Print a value to standard output.
+
+`printf( format: String, values... )`
+
+`println( value )`
+: Print a value to standard output with a newline.
+
 `sendMail( [options] )`
 : Send an email. See {ref}`mail-page` for more information.
 

--- a/docs/reference/stdlib.md
+++ b/docs/reference/stdlib.md
@@ -242,6 +242,7 @@ The following functions are available in Nextflow scripts:
 : Print a value to standard output.
 
 `printf( format: String, values... )`
+: Print a formatted string with the given values to standard output.
 
 `println( value )`
 : Print a value to standard output with a newline.

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -337,7 +337,7 @@ def x = 42
 Multiple variables can be declared in a single statement if the initializer is a [list literal](#list) with the same number of elements and declared variables:
 
 ```nextflow
-def (x, y) = [ 1, 2 ]
+def (x, y) = [1, 2]
 ```
 
 Each variable has a *scope*, which is the region of code in which the variable can be used.
@@ -387,7 +387,7 @@ The target expression must be a [variable](#variable), [index](#binary-expressio
 Multiple variables can be assigned in a single statement as long as the source expression is a [list literal](#list) with the same number of elements and assigned variables:
 
 ```nextflow
-(x, y) = [ 1, 2 ]
+(x, y) = [1, 2]
 ```
 
 ### Expression statement
@@ -640,7 +640,7 @@ If the expression is a name or simple property expression (one or more identifie
 
 ```nextflow
 def name = [first: '<FIRST_NAME>', last: '<LAST_NAME>']
-println "Hello, ${name.first} ${name.last}!"
+println "Hello, $name.first $name.last!"
 // -> Hello, <FIRST_NAME> <LAST_NAME>!
 ```
 

--- a/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
@@ -833,27 +833,33 @@ public class ConfigAstBuilder {
     }
 
     private Expression integerLiteral(IntegerLiteralAltContext ctx) {
+        var text = ctx.getText();
         Number num = null;
         try {
-            num = Numbers.parseInteger(ctx.getText());
+            num = Numbers.parseInteger(text);
         }
         catch( Exception e ) {
             numberFormatError = new Tuple2(ctx, e);
         }
 
-        return constX(num, true);
+        var result = constX(num, true);
+        result.putNodeMetaData(ASTNodeMarker.VERBATIM_TEXT, text);
+        return result;
     }
 
     private Expression floatingPointLiteral(FloatingPointLiteralAltContext ctx) {
+        var text = ctx.getText();
         Number num = null;
         try {
-            num = Numbers.parseDecimal(ctx.getText());
+            num = Numbers.parseDecimal(text);
         }
         catch( Exception e ) {
             numberFormatError = new Tuple2(ctx, e);
         }
 
-        return constX(num, true);
+        var result = constX(num, true);
+        result.putNodeMetaData(ASTNodeMarker.VERBATIM_TEXT, text);
+        return result;
     }
 
     private ConstantExpression string(ParserRuleContext ctx) {

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ScriptDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ScriptDsl.java
@@ -132,7 +132,12 @@ public interface ScriptDsl extends DslScope {
     @Description("""
         Print a value to standard output.
     """)
-    void print(Object object);
+    void print(Object value);
+
+    @Description("""
+        Print a formatted string with the given values to standard output.
+    """)
+    void printf(String format, Object... values);
 
     @Description("""
         Print a newline to standard output.
@@ -142,7 +147,7 @@ public interface ScriptDsl extends DslScope {
     @Description("""
         Print a value to standard output with a newline.
     """)
-    void println(Object object);
+    void println(Object value);
 
     @Description("""
         Send an email.
@@ -155,7 +160,7 @@ public interface ScriptDsl extends DslScope {
     void sleep(long milliseconds);
 
     @Description("""
-        Create a tuple object from the given arguments.
+        Create a tuple from the given arguments.
     """)
     List<?> tuple(Object... args);
 

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
@@ -217,7 +217,7 @@ public class Formatter extends CodeVisitorSupport {
         append("assert ");
         visit(node.getBooleanExpression());
         if( !(node.getMessageExpression() instanceof ConstantExpression ce && ce.isNullExpression()) ) {
-            append(", ");
+            append(" : ");
             visit(node.getMessageExpression());
         }
         appendNewLine();

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -1180,27 +1180,33 @@ public class ScriptAstBuilder {
     }
 
     private Expression integerLiteral(IntegerLiteralAltContext ctx) {
+        var text = ctx.getText();
         Number num = null;
         try {
-            num = Numbers.parseInteger(ctx.getText());
+            num = Numbers.parseInteger(text);
         }
         catch( Exception e ) {
             numberFormatError = new Tuple2(ctx, e);
         }
 
-        return constX(num, true);
+        var result = constX(num, true);
+        result.putNodeMetaData(ASTNodeMarker.VERBATIM_TEXT, text);
+        return result;
     }
 
     private Expression floatingPointLiteral(FloatingPointLiteralAltContext ctx) {
+        var text = ctx.getText();
         Number num = null;
         try {
-            num = Numbers.parseDecimal(ctx.getText());
+            num = Numbers.parseDecimal(text);
         }
         catch( Exception e ) {
             numberFormatError = new Tuple2(ctx, e);
         }
 
-        return constX(num, true);
+        var result = constX(num, true);
+        result.putNodeMetaData(ASTNodeMarker.VERBATIM_TEXT, text);
+        return result;
     }
 
     private ConstantExpression string(ParserRuleContext ctx) {


### PR DESCRIPTION
This PR adds more unit tests for formatting statements and expressions (and fixes a few bugs I found along the way)

As a bonus it also tests that these code snippets are parsed correctly

From now on, if someone reports a parsing/formatting bug, we need only add a regression test to this test suite