### PR TITLE
Infer output-dir from pipeline params [ci fast]

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -381,7 +381,7 @@ class Session implements ISession {
         this.dag = new DAG()
 
         // -- init output dir
-        this.outputDir = FileHelper.toCanonicalPath(config.outputDir ?: 'results')
+        this.outputDir = FileHelper.toCanonicalPath(config.outputDir ?: config.navigate('params.outdir')  ?: 'results')
 
         // -- init work dir
         this.workDir = FileHelper.toCanonicalPath(config.workDir ?: 'work')


### PR DESCRIPTION
This PR attempts to infer the workflow output directory from the pipeline conventional `outdir` parameter 