### PR TITLE
Trace observer v2

### DIFF
--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -329,6 +329,10 @@ class MyExecutor extends Executor {
 
 ### Trace observers
 
+:::{versionchanged} 25.04
+The `TraceObserver` interface is now deprecated. Use [TraceObserverV2](https://github.com/nextflow-io/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy) and [TraceObserverFactoryV2](https://github.com/nextflow-io/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverFactoryV2.groovy) instead.
+:::
+
 A *trace observer* in Nextflow is an entity that can listen and react to workflow events, such as when a workflow starts, a task completes, a file is published, etc. Several components in Nextflow, such as the execution report and DAG visualization, are implemented as trace observers.
 
 Plugins can define custom trace observers that react to workflow events with custom behavior. To implement a trace observer, create a class that implements the `TraceObserver` trait and another class that implements the `TraceObserverFactory` interface. Implement any of the hooks defined in `TraceObserver`, and implement the `create()` method in your observer factory:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -628,7 +628,7 @@ See [Output directives](#output-directives) for the list of available index dire
 The following directives are available for each output in the output block:
 
 `annotations`
-: Specify key-value pairs to be be applied to every published file. Can be a map or a closure that returns a map.
+: Specify annotations to be be applied to every published file. Can be a map or a closure that returns a map.
 
 `index`
 : Create an index file which will contain a record of each published value.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -627,6 +627,9 @@ See [Output directives](#output-directives) for the list of available index dire
 
 The following directives are available for each output in the output block:
 
+`annotations`
+: Specify key-value pairs to be be applied to every published file. Can be a map or a closure that returns a map.
+
 `index`
 : Create an index file which will contain a record of each published value.
 

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -439,7 +439,7 @@ class Session implements ISession {
         this.disableRemoteBinDir = getExecConfigProp(null, 'disableRemoteBinDir', false)
         this.classesDir = FileHelper.createLocalDir()
         this.executorFactory = new ExecutorFactory(Plugins.manager)
-        this.observersV1 = createObservers()
+        this.observersV1 = createObserversV1()
         this.observersV2 = createObserversV2()
         this.statsEnabled = observersV1.any { ob -> ob.enableMetrics() } || observersV2.any { ob -> ob.enableMetrics() }
         this.workflowMetadata = new WorkflowMetadata(this, scriptFile)
@@ -469,7 +469,7 @@ class Session implements ISession {
      * @return A list of {@link TraceObserver} objects or an empty list
      */
     @PackageScope
-    List<TraceObserver> createObservers() {
+    List<TraceObserver> createObserversV1() {
 
         final result = new ArrayList(10)
 

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1006,19 +1006,19 @@ class Session implements ISession {
     }
 
     void notifyProcessCreate(TaskProcessor process) {
-        notifyAll(observersV1, ob -> ob.onProcessCreate(process))
-        notifyAll(observersV2, ob -> ob.onProcessCreate(process))
+        notifyEvent(observersV1, ob -> ob.onProcessCreate(process))
+        notifyEvent(observersV2, ob -> ob.onProcessCreate(process))
     }
 
     void notifyProcessTerminate(TaskProcessor process) {
-        notifyAll(observersV1, ob -> ob.onProcessTerminate(process))
-        notifyAll(observersV2, ob -> ob.onProcessTerminate(process))
+        notifyEvent(observersV1, ob -> ob.onProcessTerminate(process))
+        notifyEvent(observersV2, ob -> ob.onProcessTerminate(process))
     }
 
     void notifyTaskPending( TaskHandler handler ) {
         final trace = handler.getTraceRecord()
-        notifyAll(observersV1, ob -> ob.onProcessPending(handler, trace))
-        notifyAll(observersV2, ob -> ob.onTaskPending(new TaskEvent(handler, trace)))
+        notifyEvent(observersV1, ob -> ob.onProcessPending(handler, trace))
+        notifyEvent(observersV2, ob -> ob.onTaskPending(new TaskEvent(handler, trace)))
     }
 
     /**
@@ -1031,8 +1031,8 @@ class Session implements ISession {
         cache.putIndexAsync(handler)
 
         final trace = handler.getTraceRecord()
-        notifyAll(observersV1, ob -> ob.onProcessSubmit(handler, trace))
-        notifyAll(observersV2, ob -> ob.onTaskSubmit(new TaskEvent(handler, trace)))
+        notifyEvent(observersV1, ob -> ob.onProcessSubmit(handler, trace))
+        notifyEvent(observersV2, ob -> ob.onTaskSubmit(new TaskEvent(handler, trace)))
     }
 
     /**
@@ -1040,8 +1040,8 @@ class Session implements ISession {
      */
     void notifyTaskStart( TaskHandler handler ) {
         final trace = handler.getTraceRecord()
-        notifyAll(observersV1, ob -> ob.onProcessStart(handler, trace))
-        notifyAll(observersV2, ob -> ob.onTaskStart(new TaskEvent(handler, trace)))
+        notifyEvent(observersV1, ob -> ob.onProcessStart(handler, trace))
+        notifyEvent(observersV2, ob -> ob.onTaskStart(new TaskEvent(handler, trace)))
     }
 
     /**
@@ -1060,8 +1060,8 @@ class Session implements ISession {
             failOnIgnore = true
         }
 
-        notifyAll(observersV1, ob -> ob.onProcessComplete(handler, trace))
-        notifyAll(observersV2, ob -> ob.onTaskComplete(new TaskEvent(handler, trace)))
+        notifyEvent(observersV1, ob -> ob.onProcessComplete(handler, trace))
+        notifyEvent(observersV2, ob -> ob.onTaskComplete(new TaskEvent(handler, trace)))
     }
 
     void notifyTaskCached( TaskHandler handler ) {
@@ -1072,8 +1072,8 @@ class Session implements ISession {
             cache.cacheTaskAsync(handler)
         }
 
-        notifyAll(observersV1, ob -> ob.onProcessCached(handler, trace))
-        notifyAll(observersV2, ob -> ob.onTaskCached(new TaskEvent(handler, trace)))
+        notifyEvent(observersV1, ob -> ob.onProcessCached(handler, trace))
+        notifyEvent(observersV2, ob -> ob.onTaskCached(new TaskEvent(handler, trace)))
     }
 
     void notifyBeforeWorkflowExecution() {
@@ -1085,27 +1085,27 @@ class Session implements ISession {
     }
 
     void notifyFlowBegin() {
-        notifyAll(observersV1, ob -> ob.onFlowBegin())
-        notifyAll(observersV2, ob -> ob.onFlowBegin())
+        notifyEvent(observersV1, ob -> ob.onFlowBegin())
+        notifyEvent(observersV2, ob -> ob.onFlowBegin())
     }
 
     void notifyFlowCreate() {
-        notifyAll(observersV1, ob -> ob.onFlowCreate(this))
-        notifyAll(observersV2, ob -> ob.onFlowCreate(this))
+        notifyEvent(observersV1, ob -> ob.onFlowCreate(this))
+        notifyEvent(observersV2, ob -> ob.onFlowCreate(this))
     }
 
     void notifyWorkflowOutput(WorkflowOutputEvent event) {
-        notifyAll(observersV2, ob -> ob.onWorkflowOutput(event))
+        notifyEvent(observersV2, ob -> ob.onWorkflowOutput(event))
     }
 
     void notifyFilePublish(FilePublishEvent event) {
-        notifyAll(observersV1, ob -> ob.onFilePublish(event.target, event.source))
-        notifyAll(observersV2, ob -> ob.onFilePublish(event))
+        notifyEvent(observersV1, ob -> ob.onFilePublish(event.target, event.source))
+        notifyEvent(observersV2, ob -> ob.onFilePublish(event))
     }
 
     void notifyFlowComplete() {
-        notifyAll(observersV1, ob -> ob.onFlowComplete())
-        notifyAll(observersV2, ob -> ob.onFlowComplete())
+        notifyEvent(observersV1, ob -> ob.onFlowComplete())
+        notifyEvent(observersV2, ob -> ob.onFlowComplete())
     }
 
     /**
@@ -1117,8 +1117,8 @@ class Session implements ISession {
     void notifyError( TaskHandler handler ) {
 
         final trace = handler?.safeTraceRecord()
-        notifyAll(observersV1, ob -> ob.onFlowError(handler, trace))
-        notifyAll(observersV2, ob -> ob.onFlowError(new TaskEvent(handler, trace)))
+        notifyEvent(observersV1, ob -> ob.onFlowError(handler, trace))
+        notifyEvent(observersV2, ob -> ob.onFlowError(new TaskEvent(handler, trace)))
 
         if( !errorAction )
             return
@@ -1131,7 +1131,7 @@ class Session implements ISession {
         }
     }
 
-    private static <T> void notifyAll(List<T> observers, Consumer<T> action) {
+    private static <T> void notifyEvent(List<T> observers, Consumer<T> action) {
         for ( int i=0; i<observers.size(); i++) {
             final observer = observers.get(i)
             try {

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -254,6 +254,7 @@ class Session implements ISession {
 
     private int poolSize
 
+    @Deprecated
     private List<TraceObserver> observersV1 = Collections.emptyList()
 
     private List<TraceObserverV2> observersV2 = Collections.emptyList()

--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -196,6 +196,8 @@ class PublishOp {
      * @param value
      */
     protected static Map getAnnotations(annotations, value) {
+        if( annotations == null )
+            return [:]
         if( annotations instanceof Map )
             return annotations
         if( annotations instanceof Closure ) {

--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -25,6 +25,8 @@ import nextflow.Session
 import nextflow.exception.ScriptRuntimeException
 import nextflow.file.FileHelper
 import nextflow.processor.PublishDir
+import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.WorkflowOutputEvent
 import nextflow.util.CsvWriter
 /**
  * Publish a workflow output.
@@ -93,14 +95,13 @@ class PublishOp {
             return
 
         // create publisher
-        final overrides = targetResolver instanceof Closure
-            ? [saveAs: targetResolver]
-            : [path: targetResolver]
+        final overrides = new LinkedHashMap()
+        if( targetResolver instanceof Closure )
+            overrides.saveAs = targetResolver
+        else
+            overrides.path = targetResolver
+        overrides.annotations = getAnnotations(publishOpts.annotations, value)
 
-        if( publishOpts.annotations instanceof Closure ) {
-            final annotations = publishOpts.annotations as Closure
-            overrides.annotations = annotations.call(value) as Map
-        }
         final publisher = PublishDir.create(publishOpts + overrides)
 
         // publish files
@@ -189,42 +190,53 @@ class PublishOp {
     }
 
     /**
-     * Once all values have been published, publish the index
-     * and write it to a file (if enabled).
+     * Get or resolve the annotations of a workflow output.
+     *
+     * @param annotations Map | Closure<Map>
+     * @param value
+     */
+    protected static Map getAnnotations(annotations, value) {
+        if( annotations instanceof Map )
+            return annotations
+        if( annotations instanceof Closure ) {
+            final result = annotations.call(value)
+            if( result instanceof Map )
+                return result
+        }
+        throw new ScriptRuntimeException("Invalid output `annotations` directive -- it should be either a Map or a closure that returns a Map")
+    }
+
+    /**
+     * Once all channel values have been published, publish the final
+     * workflow output and index file (if enabled).
      */
     protected void onComplete(nope) {
         // publish individual record if source is a value channel
-        final index = CH.isValue(source)
+        final value = CH.isValue(source)
             ? indexRecords.first()
             : indexRecords
 
         // publish workflow output
-        session.notifyWorkflowPublish(name, index)
+        final indexPath = indexOpts ? indexOpts.path : null
+        session.notifyWorkflowOutput(new WorkflowOutputEvent(name, null, value, indexPath))
 
-        // write index file
-        if( indexOpts && index ) {
-            log.trace "Saving records to index file: ${index}"
-            final indexPath = indexOpts.path
+        // write value to index file
+        if( indexOpts ) {
             final ext = indexPath.getExtension()
             indexPath.parent.mkdirs()
             if( ext == 'csv' ) {
                 new CsvWriter(header: indexOpts.header, sep: indexOpts.sep).apply(indexRecords, indexPath)
             }
             else if( ext == 'json' ) {
-                indexPath.text = DumpHelper.prettyPrintJson(index)
+                indexPath.text = DumpHelper.prettyPrintJson(value)
             }
             else if( ext == 'yaml' || ext == 'yml' ) {
-                indexPath.text = DumpHelper.prettyPrintYaml(index)
+                indexPath.text = DumpHelper.prettyPrintYaml(value)
             }
             else {
                 log.warn "Invalid extension '${ext}' for index file '${indexPath}' -- should be CSV, JSON, or YAML"
             }
-            def annotations = publishOpts.annotations
-            if( publishOpts.annotations instanceof Closure ) {
-                final annotationClosure = publishOpts.annotations as Closure
-                annotations = annotationClosure.call() as Map
-            }
-            session.notifyFilePublish(indexPath, null, annotations as Map)
+            session.notifyFilePublish(new FilePublishEvent(null, indexPath))
         }
 
         log.trace "Publish operator complete"

--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -220,7 +220,7 @@ class PublishOp {
 
         // publish workflow output
         final indexPath = indexOpts ? indexOpts.path : null
-        session.notifyWorkflowOutput(new WorkflowOutputEvent(name, null, value, indexPath))
+        session.notifyWorkflowOutput(new WorkflowOutputEvent(name, value, indexPath))
 
         // write value to index file
         if( indexOpts ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -49,6 +49,7 @@ import nextflow.SysEnv
 import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.file.TagAwareFile
+import nextflow.trace.event.FilePublishEvent
 import nextflow.util.HashBuilder
 import nextflow.util.PathTrie
 /**
@@ -589,7 +590,7 @@ class PublishDir {
     }
 
     protected void notifyFilePublish(Path destination, Path source=null) {
-        session.notifyFilePublish(destination, source, annotations)
+        session.notifyFilePublish(new FilePublishEvent(source, destination, annotations))
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserver.groovy
@@ -15,12 +15,13 @@
  */
 
 package nextflow.trace
+
+import java.nio.file.Path
+
 import groovy.transform.CompileStatic
 import nextflow.Session
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskProcessor
-
-import java.nio.file.Path
 
 /**
  * Defines the defaults method for application flow observer
@@ -28,32 +29,33 @@ import java.nio.file.Path
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @CompileStatic
-interface TraceObserver {
+@Deprecated
+trait TraceObserver {
 
     /**
      * This method is invoked when the flow is going to start
      */
-    default void onFlowCreate(Session session) {}
+    void onFlowCreate(Session session) {}
 
     /**
      * This method is invoked when the flow is going to start
      */
-    default void onFlowBegin() {}
+    void onFlowBegin() {}
 
     /**
      * This method is invoked when the flow is going to complete
      */
-    default void onFlowComplete() {}
+    void onFlowComplete() {}
 
     /*
      * Invoked when the process is created.
      */
-    default void onProcessCreate( TaskProcessor process ){}
+    void onProcessCreate( TaskProcessor process ){}
 
     /*
       * Invoked when all tak have been executed and process ends.
       */
-    default void onProcessTerminate( TaskProcessor process ){}
+    void onProcessTerminate( TaskProcessor process ){}
 
     /**
      * This method when a new task is created and submitted in the nextflow
@@ -63,7 +65,7 @@ interface TraceObserver {
      * @param handler
      * @param trace
      */
-    default void onProcessPending(TaskHandler handler, TraceRecord trace){}
+    void onProcessPending(TaskHandler handler, TraceRecord trace){}
 
     /**
      * This method is invoked before a process run is going to be submitted
@@ -73,7 +75,7 @@ interface TraceObserver {
      * @param trace
      *      The associated {@link TraceRecord} for the current task.
      */
-    default void onProcessSubmit(TaskHandler handler, TraceRecord trace){}
+    void onProcessSubmit(TaskHandler handler, TraceRecord trace){}
 
     /**
      * This method is invoked when a process run is going to start
@@ -83,7 +85,7 @@ interface TraceObserver {
      * @param trace
      *      The associated {@link TraceRecord} for the current task.
      */
-    default void onProcessStart(TaskHandler handler, TraceRecord trace){}
+    void onProcessStart(TaskHandler handler, TraceRecord trace){}
 
     /**
      * This method is invoked when a process run completes
@@ -93,7 +95,7 @@ interface TraceObserver {
      * @param trace
      *      The associated {@link TraceRecord} for the current task.
      */
-    default void onProcessComplete(TaskHandler handler, TraceRecord trace){}
+    void onProcessComplete(TaskHandler handler, TraceRecord trace){}
 
     /**
      * method invoked when a task execution is skipped because the result is cached (already computed)
@@ -105,12 +107,12 @@ interface TraceObserver {
      *      The trace record for the cached trace. When this event is invoked for a store task
      *      the {@code trace} record is expected to be {@code null}
      */
-    default void onProcessCached(TaskHandler handler, TraceRecord trace){}
+    void onProcessCached(TaskHandler handler, TraceRecord trace){}
 
     /**
      * @return {@code true} whenever this observer requires to collect task execution metrics
      */
-    default boolean enableMetrics(){ false }
+    boolean enableMetrics(){ false }
 
     /**
      * Method that is invoked, when a workflow fails.
@@ -120,18 +122,17 @@ interface TraceObserver {
      * @param trace
      *      The associated {@link TraceRecord} for the current task.
      */
-    default void onFlowError(TaskHandler handler, TraceRecord trace){}
+    void onFlowError(TaskHandler handler, TraceRecord trace){}
 
     /**
-     * Method that is invoked when a workflow output is published.
+     * Method that is invoked when a value is published from a channel.
      *
-     * @param name
-     *      The name of the workflow output
+     * NOTE: This method is no longer used.
+     *
      * @param value
-     *      A list if the published channel was a queue channel,
-     *      otherwise an object if the channel was a value channel
      */
-    default void onWorkflowPublish(String name, Object value){}
+    @Deprecated
+    void onWorkflowPublish(Object value){}
 
     /**
      * Method that is invoke when an output file is published
@@ -140,7 +141,7 @@ interface TraceObserver {
      * @param destination
      *      The destination path at `publishDir` folder.
      */
-    default void onFilePublish(Path destination){}
+    void onFilePublish(Path destination){}
 
     /**
      * Method that is invoke when an output file is published
@@ -151,22 +152,7 @@ interface TraceObserver {
      * @param source
      *      The source path at `workDir` folder.
      */
-    default void onFilePublish(Path destination, Path source){
+    void onFilePublish(Path destination, Path source){
         onFilePublish(destination)
     }
-
-    /**
-     * Method that is invoke when an output file is published.
-     *
-     * @param destination
-     *      The destination path at `publishDir` folder.
-     * @param source
-     *      The source path at `workDir` folder.
-     * @param annotations
-     *      The annotations attached to this file
-     */
-    default void onFilePublish(Path destination, Path source, Map annotations) {
-        onFilePublish(destination, source)
-    }
-
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverFactory.groovy
@@ -7,6 +7,7 @@ import org.pf4j.ExtensionPoint
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
+@Deprecated
 interface TraceObserverFactory extends ExtensionPoint {
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverFactoryV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverFactoryV2.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.trace
+
+import nextflow.Session
+import org.pf4j.ExtensionPoint
+/**
+ * Factory class for creating {@link TraceObserverV2} instances
+ *
+ * @author Ben Shermann <bentshermann@gmail.com>
+ */
+interface TraceObserverFactoryV2 extends ExtensionPoint {
+
+    /**
+     * Register a collection of observers with the given session.
+     *
+     * @param session
+     */
+    Collection<TraceObserverV2> create(Session session)
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.trace
+
+import groovy.transform.CompileStatic
+import nextflow.Session
+import nextflow.processor.TaskProcessor
+import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.TaskEvent
+import nextflow.trace.event.WorkflowOutputEvent
+
+/**
+ * Interface for consuming workflow lifecycle events.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@CompileStatic
+interface TraceObserverV2 {
+
+    /**
+     * Invoked when the run is created (before script execution).
+     *
+     * @param session
+     */
+    default void onFlowCreate(Session session) {}
+
+    /**
+     * Invoked when the workflow DAG is ignited (after script execution).
+     */
+    default void onFlowBegin() {}
+
+    /**
+     * Invoked when the workflow is complete:
+     *
+     * - all tasks have completed (or aborted)
+     * - all files have been published (or aborted)
+     * - all workflow onComplete handlers have been executed
+     */
+    default void onFlowComplete() {}
+
+    /**
+     * Invoked when a process is created in the workflow DAG.
+     *
+     * @param process
+     */
+    default void onProcessCreate(TaskProcessor process) {}
+
+    /**
+     * Invoked when a process is terminated (all process tasks have completed).
+     *
+     * @param process
+     */
+    default void onProcessTerminate(TaskProcessor process) {}
+
+    /**
+     * Invoked when a task is created and submitted to an executor
+     * (but not the execution backend such as the underlying scheduler).
+     *
+     * @param event
+     */
+    default void onTaskPending(TaskEvent event) {}
+
+    /**
+     * Invoked when a task is submitted by an executor to the
+     * underlying execution backend.
+     *
+     * @param event
+     */
+    default void onTaskSubmit(TaskEvent event) {}
+
+    /**
+     * Invoked when a task is running in the underlying execution backend.
+     *
+     * @param event
+     */
+    default void onTaskStart(TaskEvent event) {}
+
+    /**
+     * Invoked when a task completes.
+     *
+     * @param event
+     */
+    default void onTaskComplete(TaskEvent event) {}
+
+    /**
+     * Invoked when a task execution is skipped because the result is cached (already computed)
+     * or stored (using the `storeDir` directive).
+     *
+     * @param event
+     */
+    default void onTaskCached(TaskEvent event) {}
+
+    /**
+     * Whether this observer requires task execution metrics to be collected.
+     */
+    default boolean enableMetrics() {
+        return false
+    }
+
+    /**
+     * Invoked when a workflow run fails due to a task failure.
+     *
+     * @param event
+     */
+    default void onFlowError(TaskEvent event) {}
+
+    /**
+     * Invoked when a workflow output is published.
+     *
+     * @param event
+     */
+    default void onWorkflowOutput(WorkflowOutputEvent event) {}
+
+    /**
+     * Invoked when a file is published, either by a `publishDir` directive
+     * or a workflow output.
+     *
+     * @param event
+     */
+    default void onFilePublish(FilePublishEvent event) {}
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.trace
 
+import com.google.common.annotations.Beta
 import groovy.transform.CompileStatic
 import nextflow.Session
 import nextflow.processor.TaskProcessor
@@ -28,6 +29,7 @@ import nextflow.trace.event.WorkflowOutputEvent
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
+@Beta
 @CompileStatic
 interface TraceObserverV2 {
 

--- a/modules/nextflow/src/main/groovy/nextflow/trace/event/FilePublishEvent.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/event/FilePublishEvent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025, Seqera Labs
+ * Copyright 2013-2024, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,31 @@
  * limitations under the License.
  */
 
-package nextflow.lineage
+package nextflow.trace.event
 
+import java.nio.file.Path
+
+import groovy.transform.Canonical
 import groovy.transform.CompileStatic
-import nextflow.Session
-import nextflow.trace.TraceObserverV2
-import nextflow.trace.TraceObserverFactoryV2
 
 /**
- * Implements factory for {@link LinObserver} object
+ * Models a file publish event.
  *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Ben Sherman <bentshermann@gmail.com>
  */
+@Canonical
 @CompileStatic
-class LinObserverFactory implements TraceObserverFactoryV2 {
-
-    @Override
-    Collection<TraceObserverV2> create(Session session) {
-        final result = new ArrayList<TraceObserverV2>(1)
-        final store = LinStoreFactory.getOrCreate(session)
-        if( store )
-            result.add( new LinObserver(session, store) )
-        return result
-    }
-
+class FilePublishEvent {
+    /**
+     * The source path.
+     */
+    Path source
+    /**
+     * The target path.
+     */
+    Path target
+    /**
+     * Annotations associated with the published file.
+     */
+    Map<String,String> annotations
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/event/TaskEvent.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/event/TaskEvent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025, Seqera Labs
+ * Copyright 2013-2024, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,27 @@
  * limitations under the License.
  */
 
-package nextflow.lineage
+package nextflow.trace.event
 
+import groovy.transform.Canonical
 import groovy.transform.CompileStatic
-import nextflow.Session
-import nextflow.trace.TraceObserverV2
-import nextflow.trace.TraceObserverFactoryV2
+import nextflow.processor.TaskHandler
+import nextflow.trace.TraceRecord
 
 /**
- * Implements factory for {@link LinObserver} object
+ * Models a task lifecycle event.
  *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Ben Sherman <bentshermann@gmail.com>
  */
+@Canonical
 @CompileStatic
-class LinObserverFactory implements TraceObserverFactoryV2 {
-
-    @Override
-    Collection<TraceObserverV2> create(Session session) {
-        final result = new ArrayList<TraceObserverV2>(1)
-        final store = LinStoreFactory.getOrCreate(session)
-        if( store )
-            result.add( new LinObserver(session, store) )
-        return result
-    }
-
+class TaskEvent {
+    /**
+     * The task handler for the given task.
+     */
+    TaskHandler handler
+    /**
+     * The trace record for the given task.
+     */
+    TraceRecord trace
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/event/WorkflowOutputEvent.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/event/WorkflowOutputEvent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025, Seqera Labs
+ * Copyright 2013-2024, Seqera Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,35 @@
  * limitations under the License.
  */
 
-package nextflow.lineage
+package nextflow.trace.event
 
+import java.nio.file.Path
+
+import groovy.transform.Canonical
 import groovy.transform.CompileStatic
-import nextflow.Session
-import nextflow.trace.TraceObserverV2
-import nextflow.trace.TraceObserverFactoryV2
 
 /**
- * Implements factory for {@link LinObserver} object
+ * Models a workflow output event.
  *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Ben Sherman <bentshermann@gmail.com>
  */
+@Canonical
 @CompileStatic
-class LinObserverFactory implements TraceObserverFactoryV2 {
-
-    @Override
-    Collection<TraceObserverV2> create(Session session) {
-        final result = new ArrayList<TraceObserverV2>(1)
-        final store = LinStoreFactory.getOrCreate(session)
-        if( store )
-            result.add( new LinObserver(session, store) )
-        return result
-    }
-
+class WorkflowOutputEvent {
+    /**
+     * The name of the workflow output.
+     */
+    String name
+    /**
+     * The type of the workflow output.
+     */
+    String type
+    /**
+     * The value of the workflow output. It will be null if the index file was specified.
+     */
+    Object value
+    /**
+     * The optional index file for the workflow output.
+     */
+    Path index
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/event/WorkflowOutputEvent.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/event/WorkflowOutputEvent.groovy
@@ -34,10 +34,6 @@ class WorkflowOutputEvent {
      */
     String name
     /**
-     * The type of the workflow output.
-     */
-    String type
-    /**
      * The value of the workflow output. It will be null if the index file was specified.
      */
     Object value

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -246,7 +246,7 @@ class SessionTest extends Specification {
 
         when:
         session = [:] as Session
-        result = session.createObservers()
+        result = session.createObserversV1()
         then:
         result.size()==1
         result.any { it instanceof WorkflowStatsObserver }
@@ -254,7 +254,7 @@ class SessionTest extends Specification {
         when:
         session = [:] as Session
         session.config = [trace: [enabled: true, file:'name.txt']]
-        result = session.createObservers()
+        result = session.createObserversV1()
         observer = result[1] as TraceFileObserver
         then:
         result.size() == 2
@@ -264,7 +264,7 @@ class SessionTest extends Specification {
         when:
         session = [:] as Session
         session.config = [trace: [enabled: true, sep: 'x', fields: 'task_id,name,exit', file: 'alpha.txt']]
-        result = session.createObservers()
+        result = session.createObserversV1()
         observer = result[1] as TraceFileObserver
         then:
         result.size() == 2
@@ -275,14 +275,14 @@ class SessionTest extends Specification {
         when:
         session = [:] as Session
         session.config = [trace: [sep: 'x', fields: 'task_id,name,exit']]
-        result = session.createObservers()
+        result = session.createObserversV1()
         then:
         !result.any { it instanceof TraceFileObserver }
 
         when:
         session = [:] as Session
         session.config = [trace: [enabled: true, fields: 'task_id,name,exit,vmem']]
-        result = session.createObservers()
+        result = session.createObserversV1()
         observer = result[1] as TraceFileObserver
         then:
         result.size() == 2
@@ -310,7 +310,8 @@ class SessionTest extends Specification {
         !session.workDir.toString().contains('..')
         session.scriptName == 'pipeline.nf'
         session.classesDir.exists()
-        session.observers != null
+        session.observersV1 != null
+        session.observersV2 != null
         session.workflowMetadata != null
         
         cleanup:

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -86,8 +86,8 @@ class OutputDslTest extends Specification {
         and:
         1 * session.notifyFilePublish(new FilePublishEvent(file1, outputDir.resolve('foo/file1.txt'), [:]))
         1 * session.notifyFilePublish(new FilePublishEvent(file2, outputDir.resolve('barbar/file2.txt'), [:]))
-        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('foo', null, [outputDir.resolve('foo/file1.txt')], null))
-        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('bar', null, [outputDir.resolve('barbar/file2.txt')], outputDir.resolve('index.csv')))
+        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('foo', [outputDir.resolve('foo/file1.txt')], null))
+        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('bar', [outputDir.resolve('barbar/file2.txt')], outputDir.resolve('index.csv')))
         1 * session.notifyFilePublish(new FilePublishEvent(null, outputDir.resolve('index.csv'), null))
 
         cleanup:
@@ -126,7 +126,7 @@ class OutputDslTest extends Specification {
         outputDir.resolve('file1.txt').text == 'Hello'
         and:
         1 * session.notifyFilePublish(new FilePublishEvent(file1, outputDir.resolve('file1.txt'), [:]))
-        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('foo', null, [outputDir.resolve('file1.txt')], null))
+        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('foo', [outputDir.resolve('file1.txt')], null))
 
         cleanup:
         SysEnv.pop()

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -8,6 +8,8 @@ import nextflow.Channel
 import nextflow.Global
 import nextflow.Session
 import nextflow.SysEnv
+import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.WorkflowOutputEvent
 import spock.lang.Specification
 /**
  *
@@ -82,9 +84,11 @@ class OutputDslTest extends Specification {
             "${outputDir}/barbar/file2.txt"
             """.stripIndent()
         and:
-        1 * session.notifyFilePublish(outputDir.resolve('foo/file1.txt'), file1, null)
-        1 * session.notifyFilePublish(outputDir.resolve('barbar/file2.txt'), file2, null)
-        1 * session.notifyFilePublish(outputDir.resolve('index.csv'), null, null)
+        1 * session.notifyFilePublish(new FilePublishEvent(file1, outputDir.resolve('foo/file1.txt'), [:]))
+        1 * session.notifyFilePublish(new FilePublishEvent(file2, outputDir.resolve('barbar/file2.txt'), [:]))
+        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('foo', null, [outputDir.resolve('foo/file1.txt')], null))
+        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('bar', null, [outputDir.resolve('barbar/file2.txt')], outputDir.resolve('index.csv')))
+        1 * session.notifyFilePublish(new FilePublishEvent(null, outputDir.resolve('index.csv'), null))
 
         cleanup:
         SysEnv.pop()
@@ -121,7 +125,8 @@ class OutputDslTest extends Specification {
         then:
         outputDir.resolve('file1.txt').text == 'Hello'
         and:
-        1 * session.notifyFilePublish(outputDir.resolve('file1.txt'), file1, null)
+        1 * session.notifyFilePublish(new FilePublishEvent(file1, outputDir.resolve('file1.txt'), [:]))
+        1 * session.notifyWorkflowOutput(new WorkflowOutputEvent('foo', null, [outputDir.resolve('file1.txt')], null))
 
         cleanup:
         SysEnv.pop()

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/OutputDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/OutputDsl.java
@@ -40,6 +40,12 @@ public interface OutputDsl extends DslScope {
     Map<String,Object> getParams();
 
     @Description("""
+        Specify annotations to be be applied to every published file. Can be a map or a closure that returns a map.
+    """)
+    /* Map | Closure */
+    void annotations(Object value);
+
+    @Description("""
         *Currently only supported for S3.*
 
         Specify the media type a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types) of published files (default: `false`). Can be a string (e.g. `'text/html'`), or `true` to infer the content type from the file extension.

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -389,7 +389,7 @@ class LinObserver implements TraceObserverV2 {
 
     @Override
     void onWorkflowOutput(WorkflowOutputEvent event) {
-        final type = event.type ?: getParameterType(event.value)
+        final type = getParameterType(event.value)
         workflowOutput.output.add(new Parameter(type, event.name, convertPathsToLidReferences(event.value)))
     }
 

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -390,7 +390,8 @@ class LinObserver implements TraceObserverV2 {
     @Override
     void onWorkflowOutput(WorkflowOutputEvent event) {
         final type = getParameterType(event.value)
-        workflowOutput.output.add(new Parameter(type, event.name, convertPathsToLidReferences(event.value)))
+        final value = convertPathsToLidReferences(event.index ?: event.value)
+        workflowOutput.output.add(new Parameter(type, event.name, value))
     }
 
     protected static String getParameterType(Object param) {
@@ -422,11 +423,9 @@ class LinObserver implements TraceObserverV2 {
                 return value
             }
         }
-
         if( value instanceof Collection ) {
             return value.collect { el -> convertPathsToLidReferences(el) }
         }
-
         if( value instanceof Map ) {
             return value
                 .findAll { k, v -> v != null }

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
@@ -17,11 +17,32 @@
 
 package nextflow.lineage
 
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+
+import com.google.common.hash.HashCode
+import nextflow.Session
+import nextflow.file.FileHolder
+import nextflow.lineage.model.Checksum
+import nextflow.lineage.model.FileOutput
+import nextflow.lineage.model.DataPath
 import nextflow.lineage.model.Parameter
 import nextflow.lineage.model.TaskOutput
-import nextflow.file.FileHolder
+import nextflow.lineage.model.Workflow
+import nextflow.lineage.model.WorkflowOutput
+import nextflow.lineage.model.WorkflowRun
+import nextflow.lineage.serde.LinEncoder
+import nextflow.lineage.config.LineageConfig
+import nextflow.processor.TaskConfig
 import nextflow.processor.TaskHandler
+import nextflow.processor.TaskId
+import nextflow.processor.TaskProcessor
+import nextflow.processor.TaskRun
+import nextflow.script.ScriptBinding
+import nextflow.script.ScriptMeta
 import nextflow.script.TokenVar
+import nextflow.script.WorkflowMetadata
 import nextflow.script.params.EnvOutParam
 import nextflow.script.params.FileInParam
 import nextflow.script.params.FileOutParam
@@ -31,35 +52,16 @@ import nextflow.script.params.StdInParam
 import nextflow.script.params.StdOutParam
 import nextflow.script.params.ValueInParam
 import nextflow.script.params.ValueOutParam
-import spock.lang.Shared
-
-import static nextflow.lineage.fs.LinPath.*
-
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.attribute.BasicFileAttributes
-
-import com.google.common.hash.HashCode
-import nextflow.Session
-import nextflow.lineage.model.Checksum
-import nextflow.lineage.model.FileOutput
-import nextflow.lineage.model.DataPath
-import nextflow.lineage.model.Workflow
-import nextflow.lineage.model.WorkflowOutput
-import nextflow.lineage.model.WorkflowRun
-import nextflow.lineage.serde.LinEncoder
-import nextflow.lineage.config.LineageConfig
-import nextflow.processor.TaskConfig
-import nextflow.processor.TaskId
-import nextflow.processor.TaskProcessor
-import nextflow.processor.TaskRun
-import nextflow.script.ScriptBinding
-import nextflow.script.ScriptMeta
-import nextflow.script.WorkflowMetadata
+import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.TaskEvent
+import nextflow.trace.event.WorkflowOutputEvent
 import nextflow.util.CacheHelper
 import nextflow.util.PathNormalizer
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static nextflow.lineage.fs.LinPath.*
 
 /**
  *
@@ -306,7 +308,7 @@ class LinObserverTest extends Specification {
             "lid://1234567890", "lid://hash", "lid://1234567890", attrs2.size(), LinUtils.toDate(attrs2.creationTime()), LinUtils.toDate(attrs2.lastModifiedTime()) )
 
         when:
-        observer.onProcessComplete(handler, null )
+        observer.onTaskComplete(new TaskEvent(handler, null))
         def taskRunResult = store.load("${hash.toString()}")
         def dataOutputResult1 = store.load("${hash}/fileOut1.txt") as FileOutput
         def dataOutputResult2 = store.load("${hash}/fileOut2.txt") as FileOutput
@@ -524,8 +526,8 @@ class LinObserverTest extends Specification {
             def sourceFile1 = workDir.resolve('12/3987/file.bam')
             Files.createDirectories(sourceFile1.parent)
             sourceFile1.text = 'some data1'
-            observer.onFilePublish(outFile1, sourceFile1)
-            observer.onWorkflowPublish("a", outFile1)
+            observer.onFilePublish(new FilePublishEvent(sourceFile1, outFile1))
+            observer.onWorkflowOutput(new WorkflowOutputEvent("a", null, outFile1))
 
         then: 'check file 1 output metadata in lid store'
             def attrs1 = Files.readAttributes(outFile1, BasicFileAttributes)
@@ -541,8 +543,8 @@ class LinObserverTest extends Specification {
             outFile2.text = 'some data2'
             def attrs2 = Files.readAttributes(outFile2, BasicFileAttributes)
             def fileHash2 = CacheHelper.hasher(outFile2).hash().toString()
-            observer.onFilePublish(outFile2)
-            observer.onWorkflowPublish("b", outFile2)
+            observer.onFilePublish(new FilePublishEvent(null, outFile2))
+            observer.onWorkflowOutput(new WorkflowOutputEvent("b", null, outFile2))
         then: 'Check outFile2 metadata in lid store'
             def output2 = new FileOutput(outFile2.toString(), new Checksum(fileHash2, "nextflow", "standard"),
                 "lid://${observer.executionHash}" , "lid://${observer.executionHash}", null,

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
@@ -527,7 +527,7 @@ class LinObserverTest extends Specification {
             Files.createDirectories(sourceFile1.parent)
             sourceFile1.text = 'some data1'
             observer.onFilePublish(new FilePublishEvent(sourceFile1, outFile1))
-            observer.onWorkflowOutput(new WorkflowOutputEvent("a", null, outFile1))
+            observer.onWorkflowOutput(new WorkflowOutputEvent("a", outFile1))
 
         then: 'check file 1 output metadata in lid store'
             def attrs1 = Files.readAttributes(outFile1, BasicFileAttributes)
@@ -544,7 +544,7 @@ class LinObserverTest extends Specification {
             def attrs2 = Files.readAttributes(outFile2, BasicFileAttributes)
             def fileHash2 = CacheHelper.hasher(outFile2).hash().toString()
             observer.onFilePublish(new FilePublishEvent(null, outFile2))
-            observer.onWorkflowOutput(new WorkflowOutputEvent("b", null, outFile2))
+            observer.onWorkflowOutput(new WorkflowOutputEvent("b", outFile2))
         then: 'Check outFile2 metadata in lid store'
             def output2 = new FileOutput(outFile2.toString(), new Checksum(fileHash2, "nextflow", "standard"),
                 "lid://${observer.executionHash}" , "lid://${observer.executionHash}", null,


### PR DESCRIPTION
- Add new TraceObserverV2 interface, replacing method overloads with custom event types
- Revert TraceObserver to be compatible with Nextflow 24.10
- Update Session to accept v1 and v2 trace observers
- Update lineage observer to use TraceObserverV2
- Fix issues with workflow output annotations

TODO:
- [x] how to handle workflow output value vs index?