### PR TITLE
Separate language and runtime reference docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,18 +114,25 @@ fusion
 
 ```{toctree}
 :hidden:
-:caption: Reference
+:caption: Language Reference
 :maxdepth: 1
 
-reference/syntax
-reference/cli
-reference/config
-reference/env-vars
 reference/feature-flags
+reference/syntax
 reference/stdlib
 reference/process
 reference/channel
 reference/operator
+```
+
+```{toctree}
+:hidden:
+:caption: Runtime Reference
+:maxdepth: 1
+
+reference/cli
+reference/config
+reference/env-vars
 ```
 
 ```{toctree}

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -21,7 +21,7 @@ A block comment starts with `/*` and includes all subsequent characters up to th
 println 'Hello again!'
 ```
 
-## Top-level declarations
+## Script declarations
 
 A Nextflow script may contain the following top-level declarations:
 
@@ -37,7 +37,7 @@ A Nextflow script may contain the following top-level declarations:
 
 Script declarations are in turn composed of statements and expressions.
 
-If there are no top-level declarations, a script may contain one or more [statements](#statements), in which case the entire script is treated as an entry workflow. For example:
+If there are no script declarations, a script may contain one or more [statements](#statements), in which case the entire script is treated as an entry workflow. For example:
 
 ```nextflow
 println 'Hello world!'
@@ -52,7 +52,7 @@ workflow {
 ```
 
 :::{warning}
-Statements and top-level declarations can not be mixed at the same level. If your script has top-level declarations, all statements must be contained within top-level declarations such as the entry workflow.
+Statements and script declarations can not be mixed at the same level.
 :::
 
 ### Shebang
@@ -169,7 +169,7 @@ workflow {
 
 - The publish section consists of one or more *publish statements*. A publish statement is a [right-shift expression](#binary-expressions), where the left-hand side is an expression that refers to a value in the workflow body, and the right-hand side is an expression that returns a string.
 
-In order for a script to be executable, it must either define an entry workflow or use the implicit workflow syntax described [above](#top-level-declarations).
+In order for a script to be executable, it must either define an entry workflow or be a code snippet as described [above](#script-declarations).
 
 Entry workflow definitions are ignored when a script is included as a module. This way, the same script can be included as a module or executed as a pipeline.
 


### PR DESCRIPTION
Spun out from our discussion in #5993 

@christopher-hakkaart I think this split is a good improvement over the current section, even if it's not perfect. It also creates some space for future expansions like a "runtime API" or CLI v2.

Also make a few small edits on the syntax page that I noticed after the split