### PR TITLE
Fix typo docs splitFastq

### DIFF
--- a/docs/reference/operator.md
+++ b/docs/reference/operator.md
@@ -1202,7 +1202,7 @@ See also: [countFasta](#countfasta)
 
 *Returns: queue channel*
 
-The `splitFasta` operator splits [FASTQ formatted](http://en.wikipedia.org/wiki/FASTQ_format) text from a source channel into individual sequences.
+The `splitFastq` operator splits [FASTQ formatted](http://en.wikipedia.org/wiki/FASTQ_format) text from a source channel into individual sequences.
 
 The `by` option can be used to group sequences into chunks of a given size. The following example shows how to read a FASTQ file and split it into chunks of 10 sequences each:
 


### PR DESCRIPTION
Found a small typo