### PR TITLE
Bring topic channels out of preview

### DIFF
--- a/docs/migrations/25-04.md
+++ b/docs/migrations/25-04.md
@@ -37,6 +37,10 @@ The third preview of workflow outputs introduces the following breaking changes 
 
 See {ref}`workflow-output-def` to learn more about the workflow output definition.
 
+<h3>Topic channels (out of preview)</h3>
+
+{ref}`Topic channels <channel-topic>`, introduced in Nextflow 24.04 as a preview feature, have been brought out of preview, which means that they can be used without the `nextflow.preview.topic` feature flag.
+
 <h3>Data lineage</h3>
 
 This release introduces built-in provenance tracking, also known as *data lineage*. When `lineage.enabled` is set to `true` in your configuration, Nextflow will record every workflow run, task execution, output file, and the links between them.

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -444,7 +444,7 @@ See also: [channel.fromList](#fromlist) factory method.
 :::
 
 :::{note}
-This feature requires the `nextflow.preview.topic` feature flag to be enabled.
+In versions of Nextflow prior to 25.04, this feature requires the `nextflow.preview.topic` feature flag to be enabled.
 :::
 
 A *topic channel* is a queue channel that can receive values from many source channels *implicitly* based on a matching *topic name*.

--- a/docs/reference/feature-flags.md
+++ b/docs/reference/feature-flags.md
@@ -61,5 +61,7 @@ Feature flags are used to introduce experimental or other opt-in features. They 
 `nextflow.preview.topic`
 : :::{versionadded} 23.11.0-edge
   :::
-: *Experimental: may change in a future release.*
+: :::{versionchanged} 25.04.0
+  This feature flag is no longer required to use topic channels.
+  :::
 : When `true`, enables {ref}`topic channels <channel-topic>` feature.

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -68,7 +68,7 @@ The first line of a script can be a [shebang](https://en.wikipedia.org/wiki/Sheb
 A feature flag declaration is an assignment. The target should be a valid {ref}`feature flag <config-feature-flags>` and the source should be a literal (i.e. number, string, boolean):
 
 ```nextflow
-nextflow.preview.topic = true
+nextflow.preview.recursion = true
 ```
 
 ### Include

--- a/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Channel.groovy
@@ -124,8 +124,6 @@ class Channel  {
     }
 
     static DataflowWriteChannel topic(String name) {
-        if( !NF.topicChannelEnabled )
-            throw new IllegalStateException("Channel.topic() requires the `nextflow.preview.topic` feature flag")
         return CH.topic(name)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/NF.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NF.groovy
@@ -83,8 +83,4 @@ class NF {
     static boolean isRecurseEnabled() {
         NextflowMeta.instance.preview.recursion
     }
-
-    static boolean isTopicChannelEnabled() {
-        NextflowMeta.instance.preview.topic
-    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
@@ -44,7 +44,6 @@ class NextflowMeta {
         @Deprecated boolean strict
         boolean output
         boolean recursion
-        boolean topic
         boolean moduleBinaries
 
         @Deprecated
@@ -68,12 +67,6 @@ class NextflowMeta {
             if( recursion )
                 log.warn "NEXTFLOW RECURSION IS A PREVIEW FEATURE - SYNTAX AND FUNCTIONALITY CAN CHANGE IN FUTURE RELEASES"
             this.recursion = recursion
-        }
-
-        void setTopic(Boolean topic) {
-            if( topic )
-                log.warn "CHANNEL TOPICS ARE A PREVIEW FEATURE - SYNTAX AND FUNCTIONALITY CAN CHANGE IN FUTURE RELEASES"
-            this.topic = topic
         }
     }
 

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/FeatureFlagDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/FeatureFlagDsl.java
@@ -55,10 +55,4 @@ public class FeatureFlagDsl {
     """)
     public boolean previewRecursion;
 
-    @FeatureFlag("nextflow.preview.topic")
-    @Description("""
-        When `true`, enables the use of [topic channels](https://nextflow.io/docs/latest/reference/channel.html#topic).
-    """)
-    public boolean previewTopic;
-
 }

--- a/tests/topic-channel.nf
+++ b/tests/topic-channel.nf
@@ -1,6 +1,4 @@
 
-nextflow.preview.topic = true
-
 process foo {
   input:
   val(index)


### PR DESCRIPTION
This PR brings topic channels out of preview, making them a first-class language feature that can be used without a feature flag.