### PR TITLE
Data lineage fix find command arguments check

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -272,7 +272,7 @@ class CmdLineage extends CmdBase implements UsageAware {
         }
 
         void apply(List<String> args) {
-            if (args.size() != 1) {
+            if (args.size() < 1) {
                 println("ERROR: Incorrect number of parameters")
                 usage()
                 return

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdLineageTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdLineageTest.groovy
@@ -278,12 +278,12 @@ class CmdLineageTest extends Specification {
         def encoder = new LinEncoder().withPrettyPrint(true)
         def time = OffsetDateTime.now()
         def entry = new FileOutput("path/to/file",new Checksum("45372qe","nextflow","standard"),
-                "lid://123987/file.bam", "lid://12345", "lid://123987/", 1234, time, time, null)
+                "lid://123987/file.bam", "lid://12345", "lid://123987/", 1234, time, time, ['foo', 'bar'])
         def jsonSer = encoder.encode(entry)
         def expectedOutput = '[\n  "lid://12345"\n]'
         lidFile.text = jsonSer
         when:
-        def lidCmd = new CmdLineage(launcher: launcher, args: ["find", "type=FileOutput"])
+        def lidCmd = new CmdLineage(launcher: launcher, args: ["find", "type=FileOutput", "labels=foo"])
         lidCmd.run()
         def stdout = capture
             .toString()


### PR DESCRIPTION
This PR fixes a bug when checking the number of parameters in the `lineage find` command. It was not updated with the latest changes