### PR TITLE
Improve output labels

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -192,24 +192,25 @@ class PublishOp {
      * Get or resolve the labels of a workflow output.
      *
      * @param labels List | Closure<List>
-     * @param value
+     * @param context
      */
-    protected static List<String> getLabels(labels, value) {
+    protected static List<String> getLabels(Object labels, Object context) {
         if( labels == null )
             return []
+        if( labels instanceof CharSequence )
+            return [labels.toString()]
         if( labels instanceof List<String> )
             return labels
         if( labels instanceof Closure ) {
             try {
-                final result = labels.call(value)
-                if( result instanceof List<String> )
-                    return result
-            } catch (Throwable e) {
-                log.warn("Exception while evaluating dynamic `labels` directive for value '$value' -- ${e.getMessage()}")
+                return getLabels(labels.call(context), Map.of())
+            }
+            catch (Throwable e) {
+                log.warn("Exception while evaluating dynamic `labels` directive for value '$context' -- ${e.getMessage()}")
                 return []
             }
         }
-        throw new ScriptRuntimeException("Invalid output `labels` directive -- it should be either a List or a closure that returns a List")
+        throw new ScriptRuntimeException("Invalid output `labels` directive -- offending value: ${context}")
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -16,17 +16,13 @@
 
 package nextflow.script
 
-import java.nio.file.Path
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import groovyx.gpars.dataflow.DataflowWriteChannel
 import nextflow.Session
 import nextflow.exception.ScriptRuntimeException
 import nextflow.extension.CH
-import nextflow.extension.MixOp
 import nextflow.extension.PublishOp
-import nextflow.file.FileHelper
 /**
  * Implements the DSL for publishing workflow outputs
  *
@@ -139,6 +135,19 @@ class OutputDsl {
 
         void labels(Closure value) {
             setOption('labels', value)
+        }
+
+        void labels(CharSequence value) {
+            setOption('labels', value)
+        }
+
+        void label(CharSequence value) {
+            final opts = getOptions()
+            final current = opts.get('labels')
+            if( current instanceof List )
+                current.add(value)
+            else
+                opts.put('labels', [value])
         }
 
         void mode(String value) {

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -163,6 +163,18 @@ class OutputDslTest extends Specification {
         ]
     }
 
+    def 'should add labels one by one' () {
+        given:
+        def dsl2 = new OutputDsl.DeclareDsl()
+
+        when:
+        dsl2.label('foo')
+        dsl2.label('bar')
+
+        then:
+        dsl2.options.labels == ['foo','bar']
+    }
+
     def 'should set index directives' () {
         when:
         def dsl1 = new OutputDsl.IndexDsl()


### PR DESCRIPTION
Improve output labels definition so that it also allows a single string value, for example 

```
logs { path 'logs/'; labels('foo') }
```

Moreover it also add `label` shortcut that allows repeating the label definition for consistency with the process definition, ie. 

```
logs { 
   path 'logs/'
   label 'foo' 
   label 'bar
}
```

