### PR TITLE
Data Lineage workflow outputs fixes

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -40,8 +40,8 @@ class CmdLineage extends CmdBase implements UsageAware {
     private static final String NAME = 'lineage'
 
     interface LinCommand extends ExtensionPoint {
-        void log(ConfigMap config)
-        void describe(ConfigMap config, List<String> args)
+        void list(ConfigMap config)
+        void view(ConfigMap config, List<String> args)
         void render(ConfigMap config, List<String> args)
         void diff(ConfigMap config, List<String> args)
         void find(ConfigMap config, List<String> args)
@@ -61,8 +61,8 @@ class CmdLineage extends CmdBase implements UsageAware {
     private ConfigMap config
 
     CmdLineage() {
-        commands << new CmdLog()
-        commands << new CmdDescribe()
+        commands << new CmdList()
+        commands << new CmdView()
         commands << new CmdRender()
         commands << new CmdDiff()
         commands << new CmdFind()
@@ -148,7 +148,7 @@ class CmdLineage extends CmdBase implements UsageAware {
         throw new AbortOperationException(msg)
     }
 
-    class CmdLog implements SubCmd {
+    class CmdList implements SubCmd {
 
         @Override
         String getName() {
@@ -167,7 +167,7 @@ class CmdLineage extends CmdBase implements UsageAware {
                 usage()
                 return
             }
-            operation.log(config)
+            operation.list(config)
         }
 
         @Override
@@ -177,7 +177,7 @@ class CmdLineage extends CmdBase implements UsageAware {
         }
     }
 
-    class CmdDescribe implements SubCmd{
+    class CmdView implements SubCmd{
 
         @Override
         String getName() {
@@ -196,7 +196,7 @@ class CmdLineage extends CmdBase implements UsageAware {
                 return
             }
 
-            operation.describe(config, args)
+            operation.view(config, args)
         }
 
         @Override

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -123,7 +123,7 @@ class LinObserver implements TraceObserverV2 {
 
     @Override
     void onFlowComplete(){
-        if( this.workflowOutput && this.workflowOutput.output ){
+        if(workflowOutput?.output ){
             workflowOutput.createdAt = OffsetDateTime.now()
             final key = executionHash + '#output'
             this.store.save(key, workflowOutput)

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -123,7 +123,7 @@ class LinObserver implements TraceObserverV2 {
 
     @Override
     void onFlowComplete(){
-        if (this.workflowOutput){
+        if( this.workflowOutput && this.workflowOutput.output ){
             workflowOutput.createdAt = OffsetDateTime.now()
             final key = executionHash + '#output'
             this.store.save(key, workflowOutput)

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinUtils.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinUtils.groovy
@@ -105,7 +105,7 @@ class LinUtils {
             // When asking for a Workflow or task output retrieve the outputs description
             final outputs = store.load("${key}#output")
             if (!outputs)
-                return null
+                return []
             return navigate(outputs, children.join('.'))
         }
         return navigate(record, children.join('.'))

--- a/modules/nf-lineage/src/main/nextflow/lineage/cli/LinCommandImpl.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/cli/LinCommandImpl.groovy
@@ -62,7 +62,7 @@ class LinCommandImpl implements CmdLineage.LinCommand {
     static final private String ERR_NOT_LOADED = 'Error lineage store not loaded - Check Nextflow configuration'
     
     @Override
-    void log(ConfigMap config) {
+    void list(ConfigMap config) {
         final session = new Session(config)
         final store = LinStoreFactory.getOrCreate(session)
         if (store) {
@@ -90,7 +90,7 @@ class LinCommandImpl implements CmdLineage.LinCommand {
     }
 
     @Override
-    void describe(ConfigMap config, List<String> args) {
+    void view(ConfigMap config, List<String> args) {
         if( !isLidUri(args[0]) )
             throw new Exception("Identifier is not a lineage URL")
         final store = LinStoreFactory.getOrCreate(new Session(config))
@@ -100,7 +100,7 @@ class LinCommandImpl implements CmdLineage.LinCommand {
         }
         try {
             def entry = LinUtils.getMetadataObject(store, new URI(args[0]))
-            if( !entry ) {
+            if( entry == null ) {
                 println "No entry found for ${args[0]}"
                 return
             }

--- a/modules/nf-lineage/src/main/nextflow/lineage/exception/OutputRelativePathException.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/exception/OutputRelativePathException.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lineage.exception
+
+/**
+ * Exception to indicate the an output path is not relative to the output dir.
+ * It is used to detect the cases where publishDir is used with Data Lineage.
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+class OutputRelativePathException extends Exception {
+}

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
@@ -17,6 +17,8 @@
 
 package nextflow.lineage
 
+import nextflow.lineage.exception.OutputRelativePathException
+
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
@@ -474,8 +476,7 @@ class LinObserverTest extends Specification {
             def observer = new LinObserver(session, store)
             observer.getWorkflowRelative(PATH)
         then:
-            def e = thrown(IllegalArgumentException)
-            e.message == "Cannot access relative path for workflow output '$PATH'"
+            thrown(OutputRelativePathException)
         where:
         OUTPUT_DIR                      | PATH                                  | EXPECTED
         Path.of('/path/to/outDir')      | Path.of('/another/path/')             | "relative"

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinUtilsTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinUtilsTest.groovy
@@ -72,13 +72,16 @@ class LinUtilsTest extends Specification{
         def uniqueId = UUID.randomUUID()
         def mainScript = new DataPath("file://path/to/main.nf", new Checksum("78910", "nextflow", "standard"))
         def workflow = new Workflow([mainScript], "https://nextflow.io/nf-test/", "123456")
-        def key = "testKey"
+        def key1 = "testKey"
         def value1 = new WorkflowRun(workflow, uniqueId.toString(), "test_run", [new Parameter("String", "param1", "value1"), new Parameter("String", "param2", "value2")])
         def outputs1 = new WorkflowOutput(OffsetDateTime.now(), "lid://testKey", [new Parameter( "String", "output", "name")] )
+        def key2 = "testKey2"
+        def value2 = new WorkflowRun(workflow, uniqueId.toString(), "test_run2", [new Parameter("String", "param1", "value1"), new Parameter("String", "param2", "value2")])
         def lidStore = new DefaultLinStore()
         lidStore.open(config)
-        lidStore.save(key, value1)
-        lidStore.save("$key#output", outputs1)
+        lidStore.save(key1, value1)
+        lidStore.save("$key1#output", outputs1)
+        lidStore.save(key2, value2)
 
         when:
         def params = LinUtils.getMetadataObject(lidStore, new URI('lid://testKey#params'))
@@ -92,6 +95,12 @@ class LinUtilsTest extends Specification{
         outputs instanceof List<Parameter>
         def param = (outputs as List)[0] as Parameter
         param.name == "output"
+
+        when:
+        outputs = LinUtils.getMetadataObject(lidStore, new URI('lid://testKey2#output'))
+        then:
+        outputs instanceof List
+        (outputs as List).isEmpty()
 
         when:
         LinUtils.getMetadataObject(lidStore, new URI('lid://testKey#no-exist'))


### PR DESCRIPTION
This PR includes some fixes about how the data lineage module works when there aren't outputs.

- Do not write the `#outputs` entry if there aren't workflow outputs
- lineage `view` command returns an empty list if there aren't workflow outputs

Other minor fixes:
 - Fixes the return of fragment including empty lists
 - Rename `LinCommand` methods `log` and `describe` to `list` and `view` and subclasses `CmdLog `and `CmdDescribe` to CmdList and CmdView