### PR TITLE
Make config parser v2 compatible with AssetManager

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
@@ -130,18 +130,23 @@ class ConfigParserV2 implements ConfigParser {
             return Bolts.toConfigObject(target)
         }
         catch( CompilationFailedException e ) {
-            final source = compiler.getSource()
-            final errorListener = new StandardErrorListener('full', false)
-            println()
-            errorListener.beforeErrors()
-            for( final message : compiler.getErrors() ) {
-                final cause = message.getCause()
-                final filename = getRelativePath(source, path)
-                errorListener.onError(cause, filename, source)
-            }
-            errorListener.afterErrors()
+            if( path )
+                printErrors(path)
             throw new ConfigParseException("Config parsing failed", e)
         }
+    }
+
+    private void printErrors(Path path) {
+        final source = compiler.getSource()
+        final errorListener = new StandardErrorListener('full', false)
+        println()
+        errorListener.beforeErrors()
+        for( final message : compiler.getErrors() ) {
+            final cause = message.getCause()
+            final filename = getRelativePath(source, path)
+            errorListener.onError(cause, filename, source)
+        }
+        errorListener.afterErrors()
     }
 
     private String getRelativePath(SourceUnit source, Path path) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -29,7 +29,7 @@ import groovy.transform.TupleConstructor
 import groovy.util.logging.Slf4j
 import nextflow.cli.HubOptions
 import nextflow.config.Manifest
-import nextflow.config.parser.v1.ConfigParserV1
+import nextflow.config.ConfigParserFactory
 import nextflow.exception.AbortOperationException
 import nextflow.exception.AmbiguousPipelineNameException
 import nextflow.script.ScriptFile
@@ -455,11 +455,11 @@ class AssetManager {
         }
 
         if( text ) try {
-            def config = new ConfigParserV1().setIgnoreIncludes(true).setStrict(false).parse(text)
+            def config = ConfigParserFactory.create().setIgnoreIncludes(true).setStrict(false).parse(text)
             result = (ConfigObject)config.manifest
         }
         catch( Exception e ) {
-            throw new AbortOperationException("Project config file is malformed -- Cause: ${e.message ?: e}", e)
+            log.warn "Cannot read project manifest -- Cause:  ${e.message ?: e}"
         }
 
         // by default return an empty object


### PR DESCRIPTION
Close #6027 

When the asset manaager parses a config file as raw text, config includes are automatically disabled, and compilation errors are not printed, since they don't have filename information.

I also changed the asset manager's exception to a warning, so that the runtime proceeds to parse the config file like normal and prints the actual error messages. Otherwise, you would never see config errors because it would always be short-circuited by the asset manager.