### PR TITLE
Add allowed plugins list

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -145,6 +145,11 @@ The following environment variables control the configuration of the Nextflow ru
 `NXF_PID_FILE`
 : Name of the file where the process PID is saved when Nextflow is launched in background.
 
+`NXF_PLUGINS_ALLOWED`
+: :::{versionadded} 25.04.0
+  :::
+: Comma separated list of plugin IDs that can be used in a workflow executions e.g. `NXF_PLUGINS_ALLOWED=nf-amazon,nf-tower,nf-wave`. Use empty string to disallow all plugins.
+
 `NXF_PLUGINS_DEFAULT`
 : Whether to use the default plugins when no plugins are specified in the Nextflow configuration (default: `true`).
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -528,7 +528,7 @@ class PluginsFacade implements PluginStateListener {
         return isAllowed(plugin.id)
     }
 
-    protected allowedPluginsString() {
+    private String allowedPluginsString() {
         final list = getAllowedPlugins()
         if( list == null )
             return '(all)'

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginsFacadeTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginsFacadeTest.groovy
@@ -469,4 +469,37 @@ class PluginsFacadeTest extends Specification {
 
     }
 
+    @Unroll
+    def 'should parse allowed plugins' () {
+        given:
+        def facade  = new PluginsFacade()
+
+        expect:
+        facade.parseAllowedPlugins(ENV) == EXPECTED
+
+        where:
+        ENV                             | EXPECTED
+        [:]                             | null
+        [NXF_PLUGINS_ALLOWED:'']                    | []
+        [NXF_PLUGINS_ALLOWED:'nf-amazon,nf-google'] | [PluginSpec.parse('nf-amazon'), PluginSpec.parse('nf-google')]
+    }
+
+    @Unroll
+    def 'should should validate is allowed' () {
+        given:
+        def facade  = new PluginsFacade(env:ENV)
+
+        expect:
+        facade.isAllowed(REQUEST) == EXPECTED
+        facade.isAllowed(PluginSpec.parse(REQUEST)) == EXPECTED
+
+        where:
+        ENV                                         | REQUEST       | EXPECTED
+        [:]                                         | 'nf-amz'      | true
+        [NXF_PLUGINS_ALLOWED:'']                    | 'nf-amz'      | false
+        [NXF_PLUGINS_ALLOWED:'nf-amz,nf-gcp']       | 'nf-amz'      | true
+        [NXF_PLUGINS_ALLOWED:'nf-amz,nf-gcp']       | 'nf-gcp'      | true
+        [NXF_PLUGINS_ALLOWED:'nf-amz,nf-gcp']       | 'nf-foo'      | false
+    }
+
 }


### PR DESCRIPTION
This adds the ability to define a list of allowed plugins that can be used by nextflow by using the env variable `NXF_PLUGINS_ALLOWED` specified a comma separate list of plugin IDs that can be used. For example 

```
NXF_PLUGINS_ALLOWED=nf-amazon,nf-google
```

Only the amazon and google plugins can be used 

```
NXF_PLUGINS_ALLOWED='' 
``` 

Empty string means no plugin is allowed 


