### PR TITLE
Fix concurrent modification error in `lint` command

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptParser.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptParser.java
@@ -16,6 +16,7 @@
 package nextflow.script.control;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 
 import groovy.lang.GroovyClassLoader;
@@ -65,7 +66,8 @@ public class ScriptParser {
     }
 
     public void analyze() {
-        for( var source : compiler.getSources().values() ) {
+        var sources = new ArrayList<>(compiler.getSources().values());
+        for( var source : sources ) {
             new ModuleResolver(compiler()).resolve(source, (uri) -> compiler.createSourceUnit(new File(uri)));
         }
 


### PR DESCRIPTION
Fixes an error that was found by linting the entire nf-core modules repo:

```bash
git clone https://github.com/nf-core/modules
cd modules
nextflow lint -output full modules/nf-core/**/main.nf | tee lint.log
```

The root cause is that `ScriptParser` iterates over the compiler sources while adding new sources via `ModuleResolver`