### PR TITLE
Support fromPath with pattern in Lineage Pseudo-FS

### DIFF
--- a/modules/nf-lineage/src/main/nextflow/lineage/DefaultLinStore.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/DefaultLinStore.groovy
@@ -74,26 +74,26 @@ class DefaultLinStore implements LinStore {
     LinSerializable load(String key) {
         final path = location.resolve("$key/$METADATA_FILE")
         log.debug("Loading from path $path")
-        if (path.exists())
+        if( path.exists() )
             return encoder.decode(path.text) as LinSerializable
         log.debug("File for key $key not found")
         return null
     }
 
-    Path getLocation(){
+    Path getLocation() {
         return location
     }
 
     @Override
-    LinHistoryLog getHistoryLog(){
+    LinHistoryLog getHistoryLog() {
         return historyLog
     }
 
     @Override
-    void close() throws IOException { }
+    void close() throws IOException {}
 
     @Override
-    Map<String, LinSerializable> search(Map<String,List<String>> params) {
+    Map<String, LinSerializable> search(Map<String, List<String>> params) {
         final results = new HashMap<String, LinSerializable>()
 
         Files.walkFileTree(location, new FileVisitor<Path>() {
@@ -105,9 +105,9 @@ class DefaultLinStore implements LinStore {
 
             @Override
             FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                if (file.name.startsWith('.data.json') ) {
+                if( file.name.startsWith('.data.json') ) {
                     final lidObject = encoder.decode(file.text)
-                    if (LinUtils.checkParams(lidObject, params)){
+                    if( LinUtils.checkParams(lidObject, params) ) {
                         results.put(location.relativize(file.getParent()).toString(), lidObject as LinSerializable)
                     }
                 }
@@ -125,6 +125,38 @@ class DefaultLinStore implements LinStore {
             }
         })
 
+        return results
+    }
+
+    @Override
+    List<String> getSubKeys(String parentKey) {
+        final results = new LinkedList<String>()
+        final startPath = location.resolve(parentKey)
+        Files.walkFileTree(startPath, new FileVisitor<Path>() {
+
+            @Override
+            FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if( file.name.startsWith('.data.json') && file.parent != startPath ) {
+                    results << location.relativize(file.parent).toString()
+                }
+                FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                FileVisitResult.CONTINUE
+            }
+        })
         return results
     }
 }

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinStore.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinStore.groovy
@@ -19,6 +19,9 @@ package nextflow.lineage
 import groovy.transform.CompileStatic
 import nextflow.lineage.serde.LinSerializable
 import nextflow.lineage.config.LineageConfig
+
+import java.nio.file.Path
+
 /**
  * Interface for the lineage store
  *
@@ -60,4 +63,10 @@ interface LinStore extends Closeable {
      */
     Map<String,LinSerializable> search(Map<String, List<String>> params)
 
+    /**
+     * Search for keys starting with a parent key.
+     * @param parentKey
+     * @return list of keys
+     */
+    List<String> getSubKeys(String parentKey)
 }

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinStore.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinStore.groovy
@@ -65,6 +65,10 @@ interface LinStore extends Closeable {
 
     /**
      * Search for keys starting with a parent key.
+     * For example, if a LinStore contains the following keys: '123abc', '123abc/samples/file1.txt' and '123abc/summary',
+     * The execution of the function with parentKey='123abc' will return a list with '123abc/samples/file1.txt' and '123abc/summary'.
+     * Similarly, the execution of the function with parentKey='123abc/samples' will just return '123abc/samples/file1.txt"
+     *
      * @param parentKey
      * @return list of keys
      */

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinUtils.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinUtils.groovy
@@ -59,34 +59,19 @@ class LinUtils {
             throw new IllegalArgumentException("Cannot get record from the root LID URI")
         if ( uri.query )
             log.warn("Query string is not supported for Lineage URI: `$uri` -- it will be ignored")
-
-        final children = parseChildrenFromFragment(uri.fragment)
-        return getMetadataObject0(store, key, children )
+        return getMetadataObject0(store, key, uri.fragment )
     }
 
-    private static Object getMetadataObject0(LinStore store, String key, String[] children = []) {
+    private static Object getMetadataObject0(LinStore store, String key, String fragment) {
         final record = store.load(key)
-        if (!record) {
+        if( !record ) {
             throw new FileNotFoundException("Lineage record $key not found")
         }
-        if (children && children.size() > 0) {
-            return getSubObject(store, key, record, children)
+        if( fragment ) {
+            new LinPropertyValidator().validate(fragment.tokenize('.'))
+            return getSubObject(store, key, record, fragment)
         }
         return record
-    }
-
-    /**
-     * Get the array of the search path children elements from the fragment string
-     *
-     * @param fragment String containing the elements separated by '.'
-     * @return array with the parsed element
-     */
-    static String[] parseChildrenFromFragment(String fragment) {
-        if( !fragment )
-            return EMPTY_ARRAY
-        final children = fragment.tokenize('.')
-        new LinPropertyValidator().validate(children)
-        return children as String[]
     }
 
     /**
@@ -97,29 +82,29 @@ class LinUtils {
      * @param store Store to retrieve lineage records.
      * @param key Parent key.
      * @param record Parent record.
-     * @param children Array of string in indicating the properties to navigate to get the sub-record.
+     * @param fragment String in indicating the properties to navigate to get the sub-record.
      * @return Sub-record or null in it does not exist.
      */
-    static Object getSubObject(LinStore store, String key, LinSerializable record, String[] children) {
-        if( isSearchingOutputs(record, children) ) {
+    static Object getSubObject(LinStore store, String key, LinSerializable record, String fragment) {
+        if( isSearchingOutputs(record, fragment) ) {
             // When asking for a Workflow or task output retrieve the outputs description
             final outputs = store.load("${key}#output")
             if (!outputs)
                 return []
-            return navigate(outputs, children.join('.'))
+            return navigate(outputs, fragment)
         }
-        return navigate(record, children.join('.'))
+        return navigate(record, fragment)
     }
 
     /**
      * Check if the Lid pseudo path or query is for Task or Workflow outputs.
      *
      * @param record Parent lineage record
-     * @param children Array of string in indicating the properties to navigate to get the sub-record.
-     * @return return 'true' if the parent is a Task/Workflow run and the first element in children is 'outputs'. Otherwise 'false'
+     * @param fragment Fragment indicating the properties to navigate to get the sub-record.
+     * @return return 'true' if the parent is a Task/Workflow run and the first element in fragment is 'output'. Otherwise 'false'
      */
-    static boolean isSearchingOutputs(LinSerializable record, String[] children) {
-        return (record instanceof WorkflowRun || record instanceof TaskRun) && children && children[0] == 'output'
+    static boolean isSearchingOutputs(LinSerializable record, String fragment) {
+        return (record instanceof WorkflowRun || record instanceof TaskRun) && fragment && fragment.tokenize('.')[0] == 'output'
     }
 
     /**

--- a/modules/nf-lineage/src/main/nextflow/lineage/fs/LinFileSystemProvider.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/fs/LinFileSystemProvider.groovy
@@ -34,13 +34,11 @@ import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileAttribute
 import java.nio.file.attribute.FileAttributeView
-import java.nio.file.attribute.FileTime
 import java.nio.file.spi.FileSystemProvider
 
 import groovy.transform.CompileStatic
 import nextflow.lineage.config.LineageConfig
 
-import java.time.Instant
 
 /**
  * File System Provider for LID Paths
@@ -213,7 +211,7 @@ class LinFileSystemProvider extends FileSystemProvider {
     @Override
     DirectoryStream<Path> newDirectoryStream(Path path, DirectoryStream.Filter<? super Path> filter) throws IOException {
         final lid = toLinPath(path)
-        final real = lid.getTargetPath()
+        final real = lid.getTargetOrIntermediatePath()
         if (real instanceof LinIntermediatePath)
             return getDirectoryStreamFromSubPath(lid)
         return getDirectoryStreamFromRealPath(real, lid)
@@ -377,10 +375,10 @@ class LinFileSystemProvider extends FileSystemProvider {
     }
 
     private <A extends BasicFileAttributes> A readAttributes0(LinPath lid, Class<A> type, LinkOption... options) throws IOException {
-        final real = lid.getTargetPath()
-        if (real instanceof LinMetadataPath)
-            return (real as LinMetadataPath).readAttributes(type)
-        return real.fileSystem.provider().readAttributes(real, type, options)
+        final target = lid.getTargetOrIntermediatePath()
+        if (target instanceof LinIntermediatePath)
+            return (target as LinIntermediatePath).readAttributes(type)
+        return target.fileSystem.provider().readAttributes(target, type, options)
     }
 
     @Override

--- a/modules/nf-lineage/src/main/nextflow/lineage/fs/LinIntermediatePath.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/fs/LinIntermediatePath.groovy
@@ -7,8 +7,8 @@ import java.time.Instant
 
 class LinIntermediatePath extends LinMetadataPath{
 
-    LinIntermediatePath(LinFileSystem fs, String path, String[] children) {
-        super("", FileTime.from(Instant.now()), fs, path + children.join('/'), null)
+    LinIntermediatePath(LinFileSystem fs, String path) {
+        super("", FileTime.from(Instant.now()), fs, path, null)
     }
 
     @Override

--- a/modules/nf-lineage/src/main/nextflow/lineage/fs/LinIntermediatePath.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/fs/LinIntermediatePath.groovy
@@ -1,0 +1,53 @@
+package nextflow.lineage.fs
+
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+
+class LinIntermediatePath extends LinMetadataPath{
+
+    LinIntermediatePath(LinFileSystem fs, String path, String[] children) {
+        super("", FileTime.from(Instant.now()), fs, path + children.join('/'), null)
+    }
+
+    @Override
+    InputStream newInputStream() {
+        throw new UnsupportedOperationException()
+    }
+    @Override
+    SeekableByteChannel newSeekableByteChannel(){
+        throw new UnsupportedOperationException()
+    }
+    @Override
+    <A extends BasicFileAttributes> A readAttributes(Class<A> type){
+        return (A) new BasicFileAttributes() {
+            @Override
+            long size() { return 0 }
+
+            @Override
+            FileTime lastModifiedTime() { FileTime.from(Instant.now()) }
+
+            @Override
+            FileTime lastAccessTime() { FileTime.from(Instant.now()) }
+
+            @Override
+            FileTime creationTime() { FileTime.from(Instant.now()) }
+
+            @Override
+            boolean isRegularFile() { return false }
+
+            @Override
+            boolean isDirectory() { return true }
+
+            @Override
+            boolean isSymbolicLink() { return false }
+
+            @Override
+            boolean isOther() { return false }
+
+            @Override
+            Object fileKey() { return null }
+        }
+    }
+}

--- a/modules/nf-lineage/src/main/nextflow/lineage/fs/LinMetadataPath.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/fs/LinMetadataPath.groovy
@@ -32,8 +32,8 @@ class LinMetadataPath extends LinPath {
     private byte[] results
     private FileTime creationTime
 
-    LinMetadataPath(String resultsObject, FileTime creationTime, LinFileSystem fs, String path, String[] childs) {
-        super(fs, "${path}${childs ? '#'+ childs.join('.') : ''}")
+    LinMetadataPath(String resultsObject, FileTime creationTime, LinFileSystem fs, String path, String fragment) {
+        super(fs, "${path}${fragment ? '#'+ fragment : ''}")
         this.results = resultsObject.getBytes("UTF-8")
         this.creationTime = creationTime
     }

--- a/modules/nf-lineage/src/main/nextflow/lineage/fs/LinPath.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/fs/LinPath.groovy
@@ -21,6 +21,7 @@ import groovy.util.logging.Slf4j
 import nextflow.file.FileHelper
 import nextflow.file.LogicalDataPath
 import nextflow.lineage.LinPropertyValidator
+import nextflow.lineage.LinStore
 import nextflow.lineage.model.Checksum
 import nextflow.lineage.model.FileOutput
 import nextflow.lineage.model.TaskRun
@@ -166,17 +167,25 @@ class LinPath implements Path, LogicalDataPath {
 
     /**
      * Finds the target path of a LinPath.
+     * This method return the different types depending on the type of metadata pointing:
+     * - When the LinPath point to FileOutput metadata or a subpath, it returns the real path.
+     * - When it points other lineage metadata or a fragment of a lineage metadata and asMetadata is true, it returns a LinMetadataPath
+     *   which contains in memory the lineage metadata description or the requested fragment of this description.
+     * - When it points to a WorkflowRun or TaskRun metadata or subpath and asIntermediate is set to true. LinIntermediatePath, which is representing a directory
+     * In other cases it will return a FileNotFoundException
      *
      * @param fs LinFileSystem associated to the LinPath to find
-     * @param filePath Path associated to the LinPath to find
-     * @param resultsAsPath True to return metadata descriptions as LinMetadataPath
-     * @param children Sub-object/path inside the description
-     * @return Path or LinMetadataPath associated to the LinPath
+     * @param filePath Path to look for the target path
+     * @param fragment String with path to sub-object inside the description
+     * @param asMetadata Flag to indicate if other metadata descriptions must be returned as LinMetadataPath.
+     * @param asIntermediate Flag to indicate if WorkflowRun and TaskRun subpaths must be returned as LinIntermediatePath.
+     * @param subpath subpath associated to the target path to find. Used when looking for a parent path
+     * @return Real Path, LinMetadataPath or LinIntermediatePath path associated to the LinPath
      * @throws Exception
      *      IllegalArgumentException if the filepath, filesystem or its LinStore are null.
-     *      FileNotFoundException if the filePath or children are not found in the LinStore.
+     *      FileNotFoundException if the filePath, subpath and fragment is not found.
      */
-    protected static Path findTarget(LinFileSystem fs, String filePath, boolean resultsAsPath, String[] children = []) throws Exception {
+    protected static Path findTarget(LinFileSystem fs, String filePath, String fragment, boolean asMetadata, boolean asIntermediate) throws Exception {
         if( !fs )
             throw new IllegalArgumentException("Cannot get target path for a relative lineage path")
         if( filePath.isEmpty() || filePath == SEPARATOR )
@@ -184,40 +193,68 @@ class LinPath implements Path, LogicalDataPath {
         final store = fs.getStore()
         if( !store )
             throw new Exception("Lineage store not found - Check Nextflow configuration")
+        findTarget0(fs, store, filePath, fragment, asMetadata, asIntermediate, [])
+    }
+    
+    private static Path findTarget0(LinFileSystem fs, LinStore store, String filePath, String fragment, boolean asMetadata, boolean asIntermediate, List<String> subpath) {
         final object = store.load(filePath)
         if( object ) {
-            if( object instanceof FileOutput ) {
-                return getTargetPathFromOutput(object, children)
-            }
-            if( resultsAsPath ) {
-                return getMetadataAsTargetPath(object, fs, filePath, children)
-            }
-            if( object instanceof WorkflowRun || object instanceof TaskRun ) {
-                return new LinIntermediatePath(fs, filePath, children)
-            }
+            return getTargetPathFromObject(object, fs, filePath, fragment, asMetadata, asIntermediate, subpath)
         } else {
-            // If there isn't metadata check the parent to check if it is a subfolder of a task/workflow output
-            final currentPath = Path.of(filePath)
-            final parent = Path.of(filePath).getParent()
-            if( parent ) {
-                ArrayList<String> newChildren = new ArrayList<String>()
-                newChildren.add(currentPath.getFileName().toString())
-                newChildren.addAll(children)
-                //resultsAsPath set to false because parent paths are only inspected for DataOutputs
-                return findTarget(fs, parent.toString(), false, newChildren as String[])
+            if( fragment ) {
+                // If object doesn't exit, it's not possible to get fragment.
+                throw new FileNotFoundException("Target path '$filePath#$fragment' does not exist")
             }
+            return findTargetFromParent(fs, store, filePath, asIntermediate, subpath)
         }
-        throw new FileNotFoundException("Target path '$filePath' does not exist")
     }
 
-    protected static Path getMetadataAsTargetPath(LinSerializable results, LinFileSystem fs, String filePath, String[] children) {
+    private static Path findTargetFromParent(LinFileSystem fs, LinStore store, String filePath, boolean asIntermediate, List<String> subpath) {
+        final currentPath = Path.of(filePath)
+        final parent = Path.of(filePath).getParent()
+        if( !parent ) {
+            throw new FileNotFoundException("Target path '$filePath/${subpath.join('/')} does not exist")
+        }
+        ArrayList<String> newChildren = new ArrayList<String>()
+        newChildren.add(currentPath.getFileName().toString())
+        newChildren.addAll(subpath)
+        //As Metadata set as false because parent path only inspected for FileOutput or intermediate.
+        return findTarget0(fs, store, parent.toString(), null, false, asIntermediate, newChildren)
+    }
+
+    private static Path getTargetPathFromObject(LinSerializable object, LinFileSystem fs, String filePath, String fragment, boolean asMetadataPath, boolean asIntermediatePath,List<String> subpath) {
+        // It's not possible to get a target path with both fragment and subpath
+        if( fragment && subpath ) {
+            throw new FileNotFoundException("Unable to get a target path for '$filePath' with fragments and subpath")
+        }
+        // If metadata flag is active and looks for a fragment returns the metadata despite the type of object
+        if( asMetadataPath && fragment ){
+           return getMetadataAsTargetPath(object, fs, filePath, fragment)
+        }
+        // Return real files when FileOutput sub-path
+        if( object instanceof FileOutput ) {
+            return getTargetPathFromOutput(object, subpath)
+        }
+        // Intermediate run case
+        if( asIntermediatePath && (object instanceof WorkflowRun || object instanceof TaskRun) ) {
+            return new LinIntermediatePath(fs, "$filePath/${subpath.join('/')}")
+        }
+
+        // It is not possible to get a metadata path with subpath. For other cases return metadata path if activated or throw exception
+        if( asMetadataPath && !subpath)
+            return getMetadataAsTargetPath(object, fs, filePath, fragment)
+        else
+            throw new FileNotFoundException("Target path '${filePath}/${subpath ? '/' + subpath.join('/') : ''}${fragment ? '#' + fragment : ''}' does not exist")
+    }
+
+    protected static Path getMetadataAsTargetPath(LinSerializable results, LinFileSystem fs, String filePath, String fragment) {
         if( !results ) {
             throw new FileNotFoundException("Target path '$filePath' does not exist")
         }
-        if( children && children.size() > 0 ) {
-            return getSubObjectAsPath(fs, filePath, results, children)
+        if( fragment ) {
+            return getSubObjectAsPath(fs, filePath, results, fragment)
         } else {
-            return generateLinMetadataPath(fs, filePath, results, children)
+            return generateLinMetadataPath(fs, filePath, results, fragment)
         }
     }
 
@@ -231,29 +268,29 @@ class LinPath implements Path, LogicalDataPath {
      * @param children Array of string in indicating the properties to navigate to get the sub-object.
      * @return LinMetadataPath or null in it does not exist
      */
-    static LinMetadataPath getSubObjectAsPath(LinFileSystem fs, String key, LinSerializable object, String[] children) {
-        if( isSearchingOutputs(object, children) ) {
+    static LinMetadataPath getSubObjectAsPath(LinFileSystem fs, String key, LinSerializable object, String fragment) {
+        if( isSearchingOutputs(object, fragment) ) {
             // When asking for a Workflow or task output retrieve the outputs description
             final outputs = fs.store.load("${key}#output")
             if( !outputs ) {
                 throw new FileNotFoundException("Target path '$key#output' does not exist")
             }
-            return generateLinMetadataPath(fs, key, outputs, children)
+            return generateLinMetadataPath(fs, key, outputs, fragment)
         } else {
-            return generateLinMetadataPath(fs, key, object, children)
+            return generateLinMetadataPath(fs, key, object, fragment)
         }
     }
 
-    private static LinMetadataPath generateLinMetadataPath(LinFileSystem fs, String key, Object object, String[] children) {
+    private static LinMetadataPath generateLinMetadataPath(LinFileSystem fs, String key, Object object, String fragment) {
         def creationTime = toFileTime(navigate(object, 'createdAt') as OffsetDateTime ?: OffsetDateTime.now())
-        final output = children ? navigate(object, children.join('.')) : object
+        final output = fragment ? navigate(object, fragment) : object
         if( !output ) {
-            throw new FileNotFoundException("Target path '$key#${children.join('.')}' does not exist")
+            throw new FileNotFoundException("Target path '$key#${fragment}' does not exist")
         }
-        return new LinMetadataPath(encodeSearchOutputs(output, true), creationTime, fs, key, children)
+        return new LinMetadataPath(encodeSearchOutputs(output, true), creationTime, fs, key, fragment)
     }
 
-    private static Path getTargetPathFromOutput(FileOutput object, String[] children) {
+    private static Path getTargetPathFromOutput(FileOutput object, List<String> children) {
         final lidObject = object as FileOutput
         // return the real path stored in the metadata
         validateDataOutput(lidObject)
@@ -475,17 +512,27 @@ class LinPath implements Path, LogicalDataPath {
      * @throws FileNotFoundException if the record does not exist or its type is not a FileOutput.
      */
     protected Path getTargetPath() {
-        return findTarget(fileSystem, filePath, false, parseChildrenFromFragment(fragment))
+        return findTarget(fileSystem, filePath, fragment, false, false)
+    }
+
+    /**
+     * Get the path associated with a FileOutput record or an intermediate subpath.
+     *
+     * @return Path associated with a FileOutput record or a LinIntermediatePath if LinPath points to a workflow and task run subpath.
+     * @throws FileNotFoundException if the record does not exist or its type is not a FileOutput or a intermediate directory
+     */
+    protected Path getTargetOrIntermediatePath() {
+        return findTarget(fileSystem, filePath, fragment, false, true)
     }
 
     /**
      * Get the path associated with a lineage record.
      *
-     * @return Path associated with a FileOutput record, or LinMetadataFile with the lineage record for other types.
+     * @return Path associated with a FileOutput record or a LinMetadataFile with the lineage record for other types, or a intermediate directory
      * @throws FileNotFoundException if the record does not exist
      */
     protected Path getTargetOrMetadataPath() {
-        return findTarget(fileSystem, filePath, true, parseChildrenFromFragment(fragment))
+        return findTarget(fileSystem, filePath, fragment,true, false)
     }
 
     @Override

--- a/modules/nf-lineage/src/test/nextflow/lineage/DefaultLinStoreTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/DefaultLinStoreTest.groovy
@@ -131,5 +131,33 @@ class DefaultLinStoreTest extends Specification {
         results[key3] == value3
     }
 
+    def 'should search subkeys' () {
+         given:
+         def uniqueId = UUID.randomUUID()
+         def time = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1234567), ZoneOffset.UTC)
+         def mainScript = new DataPath("file://path/to/main.nf", new Checksum("78910", "nextflow", "standard"))
+         def workflow = new Workflow([mainScript], "https://nextflow.io/nf-test/", "123456")
+         def key = "testKey"
+         def value1 = new WorkflowRun(workflow, uniqueId.toString(), "test_run", [new Parameter("String", "param1", "value1"), new Parameter("String", "param2", "value2")])
+         def key2 = "testKey/file1"
+         def value2 = new FileOutput("/path/file1", new Checksum("78910", "nextflow", "standard"), "testkey", "testkey", null, 1234, time, time, ["value1", "value2"])
+         def key3 = "testKey/subfolder/file3"
+         def value3 = new FileOutput("/path//file2", new Checksum("78910", "nextflow", "standard"), "testkey", "testkey", null, 1234, time, time, ["value2", "value3"])
+         def key4 = "testKey2/file2"
+         def value4 = new FileOutput("/path/tp/file", new Checksum("78910", "nextflow", "standard"), "testkey", "testkey", null, 1234, time, time, ["value4", "value3"])
+
+         def lidStore = new DefaultLinStore()
+         lidStore.open(config)
+         lidStore.save(key, value1)
+         lidStore.save(key2, value2)
+         lidStore.save(key3, value3)
+         lidStore.save(key4, value4)
+
+         when:
+         def results = lidStore.getSubKeys("testKey")
+         then:
+         results.size() == 2
+         results.containsAll([key2, key3])
+     }
 
 }

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinUtilsTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinUtilsTest.groovy
@@ -115,19 +115,7 @@ class LinUtilsTest extends Specification{
         when:
         LinUtils.getMetadataObject(lidStore, new URI('lid://no-exist#something'))
         then:
-        thrown(IllegalArgumentException)
-    }
-
-    def "should parse children elements form Fragment string"() {
-        expect:
-        LinUtils.parseChildrenFromFragment(FRAGMENT) == EXPECTED as String[]
-
-        where:
-        FRAGMENT                | EXPECTED
-        "workflow"              | ["workflow"]
-        "workflow.repository"   | ["workflow", "repository"]
-        null                    | []
-        ""                      | []
+        thrown(FileNotFoundException)
     }
 
 

--- a/modules/nf-lineage/src/test/nextflow/lineage/fs/LinFileSystemProviderTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/fs/LinFileSystemProviderTest.groovy
@@ -290,6 +290,7 @@ class LinFileSystemProviderTest extends Specification {
         def provider = new LinFileSystemProvider()
         def lid = provider.getPath(LinPath.asUri('lid://12345/output1'))
         def lid2 = provider.getPath(LinPath.asUri('lid://12345'))
+        def lid3 = provider.getPath(LinPath.asUri('lid://678'))
 
         expect:
         Files.exists(lid)
@@ -298,7 +299,7 @@ class LinFileSystemProviderTest extends Specification {
         Files.exists(lid.resolve('file3.txt'))
 
         when:
-        provider.newDirectoryStream(lid2, (p) -> true)
+        provider.newDirectoryStream(lid3, (p) -> true)
         then:
         thrown(FileNotFoundException)
 
@@ -312,6 +313,14 @@ class LinFileSystemProviderTest extends Specification {
             lid.resolve('file2.txt'),
             lid.resolve('file3.txt')
         ] as Set
+
+        when:
+        stream = provider.newDirectoryStream(lid2, (p) -> true)
+        and:
+        result = stream.toList()
+        then:
+        result.size() == 1
+        result[0] ==  lid2.resolve('output1')
 
         cleanup:
         wdir.resolve('12345').deleteDir()

--- a/modules/nf-lineage/src/test/nextflow/lineage/fs/LinPathTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/fs/LinPathTest.groovy
@@ -208,8 +208,18 @@ class LinPathTest extends Specification {
         then:
         thrown(FileNotFoundException)
 
+        when: 'LinPath is not an output data description but is a workflow/task run'
+        def result = new LinPath(lidFs, '12345').getTargetOrIntermediatePath()
+        then:
+        result instanceof LinIntermediatePath
+
+        when: 'LinPath is a subpath of a workflow/task run data description'
+        result = new LinPath(lidFs, '12345/path').getTargetOrIntermediatePath()
+        then:
+        result instanceof LinIntermediatePath
+
         when: 'Lid description'
-        def result = new LinPath(lidFs, '5678').getTargetOrMetadataPath()
+        result = new LinPath(lidFs, '5678').getTargetOrMetadataPath()
         then:
         result instanceof LinMetadataPath
         result.text == wfResultsMetadata
@@ -232,7 +242,7 @@ class LinPathTest extends Specification {
         def wf = new WorkflowRun(new Workflow([],"repo", "commit"), "sessionId", "runId", [new Parameter("String", "param1", "value1")])
 
         when: 'workflow repo in workflow run'
-        Path p = LinPath.getMetadataAsTargetPath(wf, lidFs, "123456", ["workflow", "repository"] as String[])
+        Path p = LinPath.getMetadataAsTargetPath(wf, lidFs, "123456", "workflow.repository")
         then:
         p instanceof LinMetadataPath
         p.text == '"repo"'
@@ -240,25 +250,25 @@ class LinPathTest extends Specification {
         when: 'outputs'
         def outputs = new WorkflowOutput(OffsetDateTime.now(), "lid://123456", [new Parameter("Collection", "samples", ["sample1", "sample2"])])
         lidFs.store.save("123456#output", outputs)
-        Path p2 = LinPath.getMetadataAsTargetPath(wf, lidFs, "123456", ["output"] as String[])
+        Path p2 = LinPath.getMetadataAsTargetPath(wf, lidFs, "123456", "output")
         then:
         p2 instanceof LinMetadataPath
         p2.text == LinUtils.encodeSearchOutputs([new Parameter("Collection", "samples", ["sample1", "sample2"])], true)
 
         when: 'child does not exists'
-        LinPath.getMetadataAsTargetPath(wf, lidFs, "123456", ["no-exist"] as String[])
+        LinPath.getMetadataAsTargetPath(wf, lidFs, "123456", "no-exist")
         then:
         def exception = thrown(FileNotFoundException)
         exception.message == "Target path '123456#no-exist' does not exist"
 
         when: 'outputs does not exists'
-        LinPath.getMetadataAsTargetPath(wf, lidFs, "6789", ["output"] as String[])
+        LinPath.getMetadataAsTargetPath(wf, lidFs, "6789", "output")
         then:
         def exception1 = thrown(FileNotFoundException)
         exception1.message == "Target path '6789#output' does not exist"
 
         when: 'null object'
-        LinPath.getMetadataAsTargetPath(null, lidFs, "123456", ["no-exist"] as String[])
+        LinPath.getMetadataAsTargetPath(null, lidFs, "123456", "no-exist")
         then:
         def exception2 = thrown(FileNotFoundException)
         exception2.message == "Target path '123456' does not exist"


### PR DESCRIPTION
In the current version, patterns can be used for subpaths of a `FileOutput`. For instance, if a workflow publishes `lid://abscd364/samples/quant`, a user can use the `fromPath` factory to get all the files in this folder.

```
channel.formPath(“lid://abscd364/samples/quant/*”)
```

However, it can’t be used in the parent paths of the `FileOutput` such as:

```
channel.formPath(“lid://abscd364/samples/*/*.sf”)
```

This PR allows to use this kind of patterns in fromPath with lid paths
 