### PR TITLE
Remove extraneous deprecation warnings

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -555,7 +555,6 @@ class TaskConfig extends LazyMap implements Cloneable {
         if( code == null )
             return defValue
 
-        log.warn1 "The `when` process section is deprecated -- use conditional logic in the calling workflow instead"
         String source = null
         try {
             if( code instanceof Closure ) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -308,8 +308,6 @@ class TaskProcessor {
         this.ownerScript = script
         this.config = config
         this.taskBody = taskBody
-        if( taskBody.isShell )
-            log.warn1 "The `shell` process section is deprecated -- use the `script` section instead"
         this.name = name
         this.maxForks = config.maxForks && config.maxForks>0 ? config.maxForks as int : 0
         this.forksCount = maxForks ? new LongAdder() : null

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/FeatureFlagDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/FeatureFlagDsl.java
@@ -17,7 +17,6 @@ package nextflow.script.dsl;
 
 public class FeatureFlagDsl {
 
-    @Deprecated
     @FeatureFlag("nextflow.enable.configProcessNamesValidation")
     @Description("""
         When `true`, prints a warning for every `withName:` process selector that doesn't match a process in the pipeline (default: `true`).

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -362,7 +362,6 @@ public interface ProcessDsl extends DslScope {
         """)
         void tuple(Object... args);
 
-        @Deprecated
         @Description("""
             Declare an `each` input.
         """)

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/WorkflowDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/WorkflowDsl.java
@@ -204,7 +204,6 @@ public interface WorkflowDsl extends DslScope {
     """)
     Channel max(Channel source, Closure comparator);
 
-    @Deprecated
     @Operator
     @Description("""
         The `merge` operator joins the values from two or more channels into a new channel.

--- a/modules/nf-lang/src/main/java/nextflow/script/types/Channel.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/Channel.java
@@ -306,7 +306,6 @@ public abstract class Channel<E> {
     """)
     public abstract Channel max(Closure comparator);
 
-    @Deprecated
     @Operator
     @Description("""
         The `merge` operator joins the values from two or more channels into a new channel.


### PR DESCRIPTION
Removes the runtime warnings for `shell` and `when` deprecations. This way, non-developer users won't be spooked by these warnings, while developers will receive this warning from the linter / language server.

Also removed some spurious deprecations that I added in the first iteration of the language server. Things like `each` and `merge` don't need to be called out specifically because we'll just introduce static types and v2 operators instead.