### PR TITLE
[POC] Configurable mounting point via config option  google.batch.mountRoot

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -878,6 +878,11 @@ The following settings are available for Google Cloud Batch:
 : Max number of execution attempts of a job interrupted by a Compute Engine Spot reclaim event (default: `0`).
 : See also: `google.batch.autoRetryExitCodes`
 
+`google.batch.mountRoot`
+: :::{versionadded} 25.05.0-edge
+  :::
+: The root directory for GCS mounting in the container (default: `/mnt/disks`).
+
 `google.batch.network`
 : The URL of an existing network resource to which the VM will be attached.
 

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -168,7 +168,10 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
     String getArrayWorkDir(TaskHandler handler) {
         return isFusionEnabled() || isWorkDirDefaultFS()
             ? TaskArrayExecutor.super.getArrayWorkDir(handler)
-            : containerMountPath(handler.task.workDir as CloudStoragePath)
+            : containerMountPath(
+                handler.task.workDir as CloudStoragePath, 
+                config.getMountRoot()
+            )
     }
 
     @Override

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -37,6 +37,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.cloud.google.batch.client.BatchClient
+import nextflow.cloud.google.batch.client.BatchConfig
 import nextflow.cloud.types.CloudMachineInfo
 import nextflow.cloud.types.PriceModel
 import nextflow.exception.ProcessException
@@ -148,8 +149,8 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         }
         else {
             final taskBean = task.toTaskBean()
-            return new GoogleBatchScriptLauncher(taskBean, executor.remoteBinDir)
-                .withConfig(executor.config)
+            final config = executor.config ?: new BatchConfig()
+            return new GoogleBatchScriptLauncher(taskBean, executor.remoteBinDir, config)
                 .withIsArray(task.isArray())
         }
     }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -37,6 +37,8 @@ class BatchConfig {
 
     static final private List<String> DEFAULT_GCSFUSE_OPTS = List.<String>of('-o rw', '-implicit-dirs')
 
+    static final private String DEFAULT_MOUNT_ROOT = '/mnt/disks'
+
     private GoogleOpts googleOpts
     private GoogleCredentials credentials
     private List<String> allowedLocations
@@ -55,6 +57,7 @@ class BatchConfig {
     private BatchRetryConfig retryConfig
     private List<Integer> autoRetryExitCodes
     private List<String> gcsfuseOptions
+    private String mountRoot
 
     GoogleOpts getGoogleOpts() { return googleOpts }
     GoogleCredentials getCredentials() { return credentials }
@@ -74,6 +77,7 @@ class BatchConfig {
     BatchRetryConfig getRetryConfig() { retryConfig }
     List<Integer> getAutoRetryExitCodes() { autoRetryExitCodes }
     List<String> getGcsfuseOptions() { gcsfuseOptions }
+    String getMountRoot() { mountRoot }
 
     static BatchConfig create(Session session) {
         final result = new BatchConfig()
@@ -95,6 +99,7 @@ class BatchConfig {
         result.retryConfig = new BatchRetryConfig( session.config.navigate('google.batch.retryPolicy') as Map ?: Map.of() )
         result.autoRetryExitCodes = session.config.navigate('google.batch.autoRetryExitCodes', DEFAULT_RETRY_LIST) as List<Integer>
         result.gcsfuseOptions = session.config.navigate('google.batch.gcsfuseOptions', DEFAULT_GCSFUSE_OPTS) as List<String>
+        result.mountRoot = session.config.navigate('google.batch.mountRoot', DEFAULT_MOUNT_ROOT) as String
         return result
     }
 


### PR DESCRIPTION
This commit adds the ability to configure the root of the mounting point for gcsfuse such that you could specify where the data is mounted. It is controlled by the config item google.batch.mountRoot with a default of /mnt/disks

Note: from some testing it appears it is not possible to actually change the root path, so I do not recommend working on this until we get confirmation from Google. However, I'm opening this PR so someone doesn't make my mistakes.

- `/mnt/disks` :white_check_mark:
- `/data` :x:
- `/mnt/disks2` :x:
- `/mnt/disks/hello`  :white_check_mark:
- `/mnt` :x:
