### PR TITLE
POC: Support pipeline archives instead of git repos or local paths

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -564,6 +564,61 @@ class CmdRun extends CmdBase implements HubOptions {
         }
 
         /*
+         * Handle archive URLs directly
+         */
+        if (pipelineName.startsWith('http://') || pipelineName.startsWith('https://')) {
+            def url = pipelineName.toLowerCase()
+            
+            if (url.endsWith('.zip') || url.endsWith('.tar.gz') || url.endsWith('.tgz')) {
+                log.info "Detected archive URL: $pipelineName"
+                
+                // Use AssetManager to handle the archive
+                try {
+                    // For direct invocation of archive URLs, we'll create a generic AssetManager
+                    // and manually invoke its archive handling methods
+                    def manager = new AssetManager()
+                    
+                    // Create path in .nextflow/assets/artefacts directory
+                    String pathPart = pipelineName.replaceFirst('^https?://', '')
+                    pathPart = pathPart.replaceAll("[<>:\"|?*]", "_")
+                    def artefactsRoot = new File(AssetManager.root, "artefacts")
+                    File artefactPath = new File(artefactsRoot, pathPart)
+                    artefactPath.parentFile.mkdirs()
+
+                    if (!artefactPath.exists()) {
+                        log.info "Downloading and extracting archive..."
+                        // Download and extract the archive
+                        manager.downloadAndExtractArchive(pipelineName, artefactPath)
+                        
+                        log.debug "Downloaded and extracted to: $artefactPath"
+                    }
+                    else {
+                        log.info "Using cached archive: $artefactPath"
+                    }
+                    
+                    // Check if the archive contains a single root directory (common for GitHub archives)
+                    File[] files = artefactPath.listFiles()
+                    if (files && files.length == 1 && files[0].isDirectory()) {
+                        // The archive has a subdirectory - use that as the root
+                        artefactPath = files[0]
+                        log.debug "Using subdirectory as project root: $artefactPath"
+                    }
+                    
+                    // Now find the main script file in the extracted directory
+                    File scriptFile = mainScript 
+                        ? new File(artefactPath, mainScript)
+                        : manager.setLocalPath(artefactPath).getMainScriptFile()
+                    
+                    // Return the script as a local file
+                    return new ScriptFile(scriptFile)
+                }
+                catch (Exception e) {
+                    throw new AbortOperationException("Cannot download or extract archive: $pipelineName", e)
+                }
+            }
+        }
+        
+        /*
          * look for a file with the specified pipeline name
          */
         def script = new File(pipelineName)
@@ -595,11 +650,16 @@ class CmdRun extends CmdBase implements HubOptions {
         }
         // checkout requested revision
         try {
-            manager.checkout(revision)
-            manager.updateModules()
+            // Only perform checkout if this is a Git repository (not archive-based)
+            if (!manager.isLocalArchiveRepo()) {
+                manager.checkout(revision)
+                manager.updateModules()
+            }
             final scriptFile = manager.getScriptFile(mainScript)
-            if( checkForUpdate && !offline )
+            // Only check remote status for Git repositories
+            if (checkForUpdate && !offline && !manager.isLocalArchiveRepo()) {
                 manager.checkRemoteStatus(scriptFile.revisionInfo)
+            }
             // return the script file
             return scriptFile
         }
@@ -609,7 +669,6 @@ class CmdRun extends CmdBase implements HubOptions {
         catch( Exception e ) {
             throw new AbortOperationException("Unknown error accessing project `$repo` -- Repository may be corrupted: ${manager.localPath}", e)
         }
-
     }
 
     static protected File tryReadFromStdin() {

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -651,4 +651,39 @@ class AssetManagerTest extends Specification {
         !AssetManager.isRemoteBranch(local_master)
     }
 
+    def 'should detect archive URLs' () {
+        given:
+        def manager = new AssetManager()
+        
+        expect:
+        manager.isArchiveUrl('https://github.com/nextflow-io/rnaseq/archive/refs/tags/3.18.0.zip') == true
+        manager.isArchiveUrl('https://github.com/nextflow-io/rnaseq/archive/refs/tags/3.18.0.tar.gz') == true
+        manager.isArchiveUrl('https://github.com/nextflow-io/rnaseq.git') == false
+        manager.isArchiveUrl('nextflow-io/rnaseq') == false
+    }
+    
+    def 'should extract project name from GitHub archive URL' () {
+        given:
+        def manager = new AssetManager()
+        
+        when:
+        def result = manager.resolveNameFromGitUrl('https://github.com/nextflow-io/rnaseq/archive/refs/tags/3.18.0.zip')
+        
+        then:
+        result == 'nextflow-io/rnaseq'
+        manager.hub == 'github'
+    }
+    
+    def 'should extract project name from generic archive URL' () {
+        given:
+        def manager = new AssetManager()
+        
+        when:
+        def result = manager.resolveNameFromGitUrl('https://example.com/downloads/my-pipeline-1.0.0.zip')
+        
+        then:
+        result == 'archive/my-pipeline-1.0.0'
+        manager.hub == 'example'
+    }
+
 }


### PR DESCRIPTION
This adds support for using archives of pipelines instead of git repos for remote use. This is useful because it bypasses remote git which can be problematic in secure environments or when hitting rate limits. To use, you can run `nextflow run https://url.com/path/to/archive.tar.gz` which will download the files to artefacts and run them. We could imagine something like Seqera Platform serving secure URLs to Git archives to allow users to use a repo without granting them access to the repo itself. The main downside of this is it might encourage bad practice, where users will use this in preference to a Git repo where they should do the majority of their work.

Signed-off-by: adamrtalbot <12817534+adamrtalbot@users.noreply.github.com>

Hi! Thanks for contributing to Nextflow.

When submitting a Pull Request, please sign-off the DCO [1] to certify that you are the author of the contribution and you adhere to Nextflow's open source license [2] by adding a `Signed-off-by` line to the contribution commit message. See [3] for more details.

1. https://developercertificate.org/
2. https://github.com/nextflow-io/nextflow/blob/master/COPYING
3. https://github.com/apps/dco
