### PR TITLE
Fix variable checking in v2 config parser

### DIFF
--- a/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
@@ -121,4 +121,40 @@ class ConfigResolveTest extends Specification {
         deleteDir(root)
     }
 
+    def 'should check variables in a closure' () {
+        when:
+        def errors = check(
+            '''\
+            process {
+                ext.args = {
+                    args_list = []
+                    args_list.join(' ')
+                }
+            }
+            '''
+        )
+        then:
+        errors.size() == 2
+        errors[0].getStartLine() == 3
+        errors[0].getStartColumn() == 9
+        errors[0].getOriginalMessage() == '`args_list` was assigned but not declared'
+        errors[1].getStartLine() == 4
+        errors[1].getStartColumn() == 9
+        errors[1].getOriginalMessage() == '`args_list` is not defined'
+
+        when:
+        errors = check(
+            '''\
+            process {
+                ext.args = {
+                    def args_list = []
+                    args_list.join(' ')
+                }
+            }
+            '''
+        )
+        then:
+        errors.size() == 0
+    }
+
 }

--- a/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
@@ -126,10 +126,10 @@ class ConfigResolveTest extends Specification {
         def errors = check(
             '''\
             process {
-                ext.args = {
+                clusterOptions = {
                     args_list = []
                     args_list.join(' ')
-                }
+                }()
             }
             '''
         )
@@ -146,15 +146,42 @@ class ConfigResolveTest extends Specification {
         errors = check(
             '''\
             process {
-                ext.args = {
+                clusterOptions = {
                     def args_list = []
                     args_list.join(' ')
-                }
+                }()
             }
             '''
         )
         then:
         errors.size() == 0
+    }
+
+    def 'should allow dynamic process directives to reference process inputs' () {
+        when:
+        def errors = check(
+            '''\
+            process {
+                ext.prefix = { "${meta.id}.filter1" }
+            }
+            '''
+        )
+        then:
+        errors.size() == 0
+
+        when:
+        errors = check(
+            '''\
+            process {
+                ext.prefix = { "${meta.id}.filter1" }()
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 2
+        errors[0].getStartColumn() == 23
+        errors[0].getOriginalMessage() == '`meta` is not defined'
     }
 
 }


### PR DESCRIPTION
This PR fixes two issues with variable checking in config files:

- Issue with variable declarations reported in Slack: https://nextflow.slack.com/archives/C02TPSL19UJ/p1747399972745699?thread_ts=1747318132.936939&cid=C02TPSL19UJ
- Issue with dynamic config directives -- they can reference process inputs, which are not known during config parsing