### PR TITLE
POC: Global Cache

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -118,6 +118,12 @@ The following environment variables control the configuration of the Nextflow ru
 : The file storage path against which relative file paths are resolved.
 : For example, with `NXF_FILE_ROOT=/some/root/path`, the use of `file('hello')` will be resolved to the absolute path `/some/root/path/hello`. A remote root path can be specified using the usual protocol prefix, e.g. `NXF_FILE_ROOT=s3://my-bucket/data`. Files defined using an absolute path are not affected by this setting.
 
+`NXF_GLOBALCACHE_PATH`
+: :::{versionadded} 26.04.0
+  :::
+: Enable global caching, using the given path as cache root.
+: This allows cached tasks to be re-used by different runs. Enabling global caching implicitly enables resume, and sets the work directory to `${NXF_GLOBALCACHE_PATH}/work`.
+
 `NXF_HOME`
 : Nextflow home directory (default: `$HOME/.nextflow`).
 

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -426,7 +426,7 @@ class Session implements ISession {
             return null
         final String path = cloudcache.path
         final result = path ? FileHelper.asPath(path) : workDir
-        if( result.scheme !in ['s3','az','gs'] ) {
+        if( result.scheme !in ['file','s3','az','gs'] ) {
             throw new IllegalArgumentException("Storage path not supported by Cloud-cache - offending value: '${result}'")
         }
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHasher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHasher.groovy
@@ -50,11 +50,11 @@ class TaskHasher {
 
         final keys = new ArrayList<Object>()
 
-        // add session UUID
-        keys << session.uniqueId
-
-        // add fully-qualified process name
-        keys << task.processor.name
+        // add session id and process name if global caching is not enabled
+        if( session.uniqueId != new UUID(0L, 0L) ) {
+            keys << session.uniqueId
+            keys << task.processor.name
+        }
 
         // add source code of `script:` or `exec:` block
         //

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
@@ -260,7 +260,7 @@ class ScriptRunner {
         }
 
         // -- when resume, make sure the session id exists in the executions history
-        if( session.resumeMode && !HistoryFile.DEFAULT.checkExistsById(session.uniqueId.toString()) ) {
+        if( session.resumeMode && session.uniqueId != new UUID(0L, 0L) && !HistoryFile.DEFAULT.checkExistsById(session.uniqueId.toString()) ) {
             throw new AbortOperationException("Can't find a run with the specified id: ${session.uniqueId} -- Execution can't be resumed")
         }
 


### PR DESCRIPTION
This PR is a test to validate the possibility of a global cache to share the task caching between executions. This is forcing to have the same cloud-cache, working dir and sessionId for a defined global-cache.It is able to detect when same task is executed by different workflows without using the resume option. 

`-with-globalcache=<cloud_path>` parameter overwrites cloud cache path with `<cloud_path>/.nf-global-cache` and the working dir with `<cloud_path>/work` and creates a `SessionId` hashing the global cache path. This option implies `-resume`. 

I tested the concurrent execution of tasks in two different workflow and it is detecting if it is the same and generating a new hash. When executing a third workflow with the same task after the execution of the task it detects that is cached and do not run the task again.