### PR TITLE
Force overwritting to trace file

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -135,7 +135,7 @@ nxf_write_trace() {
         "syscr=${io_stat1[2]}" \
         "syscw=${io_stat1[3]}" \
         "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+        "write_bytes=${io_stat1[5]}" >| "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
 }
 
 nxf_trace_mac() {
@@ -211,7 +211,7 @@ nxf_trace_linux() {
         "syscr=${io_stat1[2]}" \
         "syscw=${io_stat1[3]}" \
         "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+        "write_bytes=${io_stat1[5]}" >| "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
 
     ## join nxf_mem_watch
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -119,7 +119,7 @@ nxf_write_trace() {
         "syscr=${io_stat1[2]}" \
         "syscw=${io_stat1[3]}" \
         "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+        "write_bytes=${io_stat1[5]}" >| "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
 }
 
 nxf_trace_mac() {
@@ -185,7 +185,7 @@ nxf_trace_linux() {
         "syscr=${io_stat1[2]}" \
         "syscw=${io_stat1[3]}" \
         "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" > "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+        "write_bytes=${io_stat1[5]}" >| "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
 
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true
     wait $mem_proc 2>/dev/null || true


### PR DESCRIPTION
close #6090 

This PR forces the overwrite of .command.trace to avoid the error writting the trace file when `bash -C ` (noclobber) is set in `process.shell`