### PR TITLE
Fix hashing of asset directories

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
+++ b/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
@@ -353,21 +353,20 @@ public class HashBuilder {
                 @Override
                 public FileVisitResult preVisitDirectory(Path path, BasicFileAttributes attrs) {
                     log.trace("Hash sha-256 dir content [DIR] path={} - base={}", path, base);
-                    // the file relative base
+
+                    // The file path relative to the base directory
                     String entry = base != null ? base.relativize(path).toString() : path.toString();
-                    // ↓ wouldn't this cause a null pointer exception when base is null?
-                    String value = base.relativize(path).toString();
                     
-                    pathShas.put(entry, value);
+                    // Store the directory path
+                    pathShas.put(entry, null);
+
                     return FileVisitResult.CONTINUE;
                 }
             });
 
             // Hash the directory content. The map should be sorted by the natural ordering of the keys.
             for (Map.Entry<String, String> pair : pathShas.entrySet()) {
-                if (pair.getKey() != null) {
-                    hasher.putUnencodedChars(pair.getKey());
-                }
+                hasher.putUnencodedChars(pair.getKey());
                 if (pair.getValue() != null) {
                     hasher.putUnencodedChars(pair.getValue());
                 }

--- a/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
+++ b/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
@@ -352,7 +352,9 @@ public class HashBuilder {
                     // the file relative base
                     if( base!=null )
                         hasher.putUnencodedChars(base.relativize(path).toString());
+                    // ↓ wouldn't this cause a null pointer exception when base is null?
                     hasher.putUnencodedChars(base.relativize(path).toString());
+                    // it looks like this code block might not get triggered?
                     return FileVisitResult.CONTINUE;
                 }
             });

--- a/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
+++ b/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
@@ -324,14 +324,23 @@ public class HashBuilder {
 
     static protected Hasher hashDirSha256( Hasher hasher, Path dir, Path base ) {
         try {
-            var entries = new HashMap<String, Path>();
+            var entries = new HashMap<String, String>();
 
             Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
                     log.trace("Hash sha-256 dir content [FILE] path={} - base={}", path, base);
-                    entries.put(relativePath(path, base).toString(), path);
-                    return FileVisitResult.CONTINUE;
+                    try {
+                        // the file relative path
+                        var name = relativePath(path, base).toString();
+                        // the file content sha-256 checksum
+                        var value = sha256Cache.get(path);
+                        entries.put(name, value);
+                        return FileVisitResult.CONTINUE;
+                    }
+                    catch (ExecutionException t) {
+                        throw new IOException("Failed to get SHA-256 from cache for " + path, t);
+                    }
                 }
 
                 @Override

--- a/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
+++ b/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
@@ -25,14 +25,11 @@ import java.nio.file.ProviderMismatchException;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Comparator;
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.CacheBuilder;


### PR DESCRIPTION
`Files.walkFileTree` does not guarantee any specific order for iterating over files within a directory:

> Considerations When Creating a FileVisitor
>
> A file tree is walked depth first, but you cannot make any assumptions about the iteration order that subdirectories are visited.

-- [source](https://docs.oracle.com/javase/tutorial/essential/io/walk.html)

This causes the sha of `HashBuilder.hashDirSha256` to be different in certain situations (#6112).

This PR fixes the issue by storing all of the (path, sha256) in an array list, sorting by path, and then passing them to the hasher.

Notes:

* The code in `preVisitDirectory` seems like it would cause a null pointer exception if the condition (`base != null`) is false -- so maybe `base` is always not null? What should happen in this code chuck if base does happen to be null?
* It's hard to add a unit test for this, since the issue only arises in very specific situations.