### PR TITLE
Add warning that lock files must be TXT files

### DIFF
--- a/docs/conda.md
+++ b/docs/conda.md
@@ -125,7 +125,7 @@ bioconda::multiqc=1.4
 ```
 
 :::{note}
-Dependency files must be a TXT file with the `.txt` extension.
+Dependency files must be a text file with the `.txt` extension.
 :::
 
 ### Conda lock files


### PR DESCRIPTION
- Refresh text in the conda lock files section.
- Add warning that lock files must be TXT files with the .txt extension to address a community issue. 