### PR TITLE
Bump Groovy to version 4.0.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,8 @@ allprojects {
 
         // Documentation required libraries
         groovyDoc 'org.fusesource.jansi:jansi:2.4.0'
-        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.26"
-        groovyDoc "org.apache.groovy:groovy-ant:4.0.26"
+        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.27"
+        groovyDoc "org.apache.groovy:groovy-ant:4.0.27"
     }
 
     test {

--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -25,12 +25,12 @@ dependencies {
     api(project(':nf-commons'))
     api(project(':nf-httpfs'))
     api(project(':nf-lang'))
-    api "org.apache.groovy:groovy:4.0.26"
-    api "org.apache.groovy:groovy-nio:4.0.26"
-    api "org.apache.groovy:groovy-xml:4.0.26"
-    api "org.apache.groovy:groovy-json:4.0.26"
-    api "org.apache.groovy:groovy-templates:4.0.26"
-    api "org.apache.groovy:groovy-yaml:4.0.26"
+    api "org.apache.groovy:groovy:4.0.27"
+    api "org.apache.groovy:groovy-nio:4.0.27"
+    api "org.apache.groovy:groovy-xml:4.0.27"
+    api "org.apache.groovy:groovy-json:4.0.27"
+    api "org.apache.groovy:groovy-templates:4.0.27"
+    api "org.apache.groovy:groovy-yaml:4.0.27"
     api "org.slf4j:jcl-over-slf4j:2.0.16"
     api "org.slf4j:jul-to-slf4j:2.0.16"
     api "org.slf4j:log4j-over-slf4j:2.0.16"
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'org.subethamail:subethasmtp:3.1.7'
     testImplementation (project(':nf-lineage'))
     // test configuration
-    testFixturesApi ("org.apache.groovy:groovy-test:4.0.26") { exclude group: 'org.apache.groovy' }
+    testFixturesApi ("org.apache.groovy:groovy-test:4.0.27") { exclude group: 'org.apache.groovy' }
     testFixturesApi ("org.objenesis:objenesis:3.4")
     testFixturesApi ("net.bytebuddy:byte-buddy:1.14.17")
     testFixturesApi ("org.spockframework:spock-core:2.3-groovy-4.0") { exclude group: 'org.apache.groovy' }

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -26,8 +26,8 @@ sourceSets {
 
 dependencies {
     api "ch.qos.logback:logback-classic:1.5.16"
-    api "org.apache.groovy:groovy:4.0.26"
-    api "org.apache.groovy:groovy-nio:4.0.26"
+    api "org.apache.groovy:groovy:4.0.27"
+    api "org.apache.groovy:groovy-nio:4.0.27"
     api "commons-lang:commons-lang:2.6"
     api 'com.google.guava:guava:33.0.0-jre'
     api 'org.pf4j:pf4j:3.12.0'
@@ -40,7 +40,7 @@ dependencies {
     testImplementation(testFixtures(project(":nextflow")))
     testFixturesImplementation(project(":nextflow"))
 
-    testImplementation "org.apache.groovy:groovy-json:4.0.26" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.27" // needed by wiremock
     testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-1') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 }

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -30,12 +30,12 @@ sourceSets {
 dependencies {
     api project(':nf-commons')
     api "ch.qos.logback:logback-classic:1.5.16"
-    api "org.apache.groovy:groovy:4.0.26"
-    api "org.apache.groovy:groovy-nio:4.0.26"
+    api "org.apache.groovy:groovy:4.0.27"
+    api "org.apache.groovy:groovy-nio:4.0.27"
     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
 
     /* testImplementation inherited from top gradle build file */
-    testImplementation "org.apache.groovy:groovy-json:4.0.26" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.27" // needed by wiremock
     testImplementation ('com.github.tomakehurst:wiremock:1.57') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 

--- a/modules/nf-lang/build.gradle
+++ b/modules/nf-lang/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 dependencies {
   antlr 'me.sunlan:antlr4:4.13.2.6'
-  api 'org.apache.groovy:groovy:4.0.26'
+  api 'org.apache.groovy:groovy:4.0.27'
   api 'org.pf4j:pf4j:3.12.0'
 
   testFixturesApi 'com.google.jimfs:jimfs:1.2'

--- a/modules/nf-lineage/build.gradle
+++ b/modules/nf-lineage/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':nextflow')
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }
 

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -60,6 +60,6 @@ dependencies {
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }

--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -53,6 +53,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }

--- a/plugins/nf-cloudcache/build.gradle
+++ b/plugins/nf-cloudcache/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }
 

--- a/plugins/nf-codecommit/build.gradle
+++ b/plugins/nf-codecommit/build.gradle
@@ -42,6 +42,6 @@ dependencies {
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }

--- a/plugins/nf-console/build.gradle
+++ b/plugins/nf-console/build.gradle
@@ -38,13 +38,13 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
     api("org.apache.groovy:groovy-console:4.0.21-patch.2") { transitive=false }
-    api("org.apache.groovy:groovy-swing:4.0.26")  { transitive=false }
+    api("org.apache.groovy:groovy-swing:4.0.27")  { transitive=false }
     // this is required by 'groovy-console'  
     api("com.github.javaparser:javaparser-core:3.25.8")
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }
 

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     api 'com.google.code.gson:gson:2.10.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }
 
 test {

--- a/plugins/nf-k8s/build.gradle
+++ b/plugins/nf-k8s/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     api 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }
 
 test {

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.12.7.1"
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
-    testImplementation "org.apache.groovy:groovy-json:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy-json:4.0.27"
     // wiremock required by TowerFusionEnvTest
     testImplementation "org.wiremock:wiremock:3.5.4"
 }

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     api 'io.seqera:wave-utils:0.15.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.26"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.26"
+    testImplementation "org.apache.groovy:groovy:4.0.27"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
 }


### PR DESCRIPTION
This PR bumps groovy to version 4.0.27 