### PR TITLE
Fix documentation of task id

### DIFF
--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -17,17 +17,14 @@ The following task properties are defined in the process body:
 
 `task.hash`
 : *Available only in `exec:` blocks*
-: The task unique hash ID.
-
-`task.id`
-: The pipeline-level task index. Corresponds to `task_id` in the {ref}`execution trace <trace-report>`.
+: The task hash.
 
 `task.index`
 : The process-level task index.
 
 `task.name`
 : *Available only in `exec:` blocks*
-: The current task name.
+: The task name.
 
 `task.previousException`
 : :::{versionadded} 24.10.0
@@ -45,7 +42,7 @@ The following task properties are defined in the process body:
 : This is useful when retrying a task execution to access the previous task attempt runtime metrics e.g. used memory and CPUs.
 
 `task.process`
-: The current process name.
+: The process name.
 
 `task.workDir`
 : *Available only in `exec:` blocks*


### PR DESCRIPTION
Close #6099 

- Originally, `task.index` was documented as being equivalent to `task_id` in the execution trace
- At some point I fixed this note and added `task.id` to the docs, since `task.id` is the true equivalent
- However, `task.id` is not actually supported in Nextflow scripts, I guess I never tested it
- This PR removes `task.id` from the reference docs since it is not supported