### PR TITLE
Make RepositoryProvider readBytes public

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/LocalRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/LocalRepositoryProvider.groovy
@@ -69,7 +69,7 @@ class LocalRepositoryProvider extends RepositoryProvider {
 
 
     @Override
-    protected byte[] readBytes(String path) {
+    byte[] readBytes(String path) {
 
         final git = Git.open(new File(this.path, project))
         try {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -309,7 +309,7 @@ abstract class RepositoryProvider {
      * @param path The relative path of a file stored in the repository
      * @return The file content a
      */
-    abstract protected byte[] readBytes( String path )
+    abstract byte[] readBytes( String path )
 
     String readText( String path ) {
         def bytes = readBytes(path)

--- a/plugins/nf-codecommit/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitRepositoryProvider.groovy
+++ b/plugins/nf-codecommit/src/main/nextflow/cloud/aws/codecommit/AwsCodeCommitRepositoryProvider.groovy
@@ -134,7 +134,7 @@ class AwsCodeCommitRepositoryProvider extends RepositoryProvider {
     // called by AssetManager
     // called by RepositoryProvider.readText()
     @Override
-    protected byte[] readBytes( String path ) {
+    byte[] readBytes( String path ) {
 
         final request = new GetFileRequest()
             .withRepositoryName(repositoryName)


### PR DESCRIPTION
This PR changes the signature of `RepositoryProvider.readBytes` to public 
