### PR TITLE
Add Platform info to Fusion license

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerFusionToken.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerFusionToken.groovy
@@ -82,6 +82,9 @@ class TowerFusionToken implements FusionToken {
     // Platform access token to use for requests
     private String accessToken
 
+    // Platform client
+    private TowerClient client
+
     TowerFusionToken() {
         final config = PlatformHelper.config()
         final env = SysEnv.get()
@@ -96,7 +99,7 @@ class TowerFusionToken implements FusionToken {
             throw new IllegalArgumentException("Missing Seqera Platform endpoint")
         if( !accessToken )
             throw new IllegalArgumentException("Missing Seqera Platform access token")
-        final client = TowerFactory.client()
+        client = TowerFactory.client()
         if( !client )
             throw new IllegalArgumentException("Seqera Platform client is not enabled")
     }
@@ -138,7 +141,12 @@ class TowerFusionToken implements FusionToken {
      * @return The signed JWT token
      */
     protected String getLicenseToken(String product, String version) {
-        final req = new GetLicenseTokenRequest(product: product, version: version ?: 'unknown')
+        final req = new GetLicenseTokenRequest(
+            product: product,
+            version: version ?: 'unknown',
+            workspaceId: client.getWorkspaceId(),
+            workflowId: client.getWorkflowId()
+        )
         final key = '${product}-${version}'
         try {
             final now = Instant.now()

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/exchange/GetLicenseTokenRequest.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/exchange/GetLicenseTokenRequest.groovy
@@ -1,9 +1,9 @@
 package io.seqera.tower.plugin.exchange
 
+
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-
 /**
  * Models a REST request to obtain a license-scoped JWT token from Platform
  *
@@ -19,4 +19,14 @@ class GetLicenseTokenRequest {
 
     /** The product version */
     String version
+
+    /**
+     * The Platform workflow ID associated with this request
+     */
+    String workflowId
+
+    /**
+     * The Platform workspace ID associated with this request
+     */
+    String workspaceId
 }


### PR DESCRIPTION
This PR adds Platform `workspaceId` and `workflowId` to Fusion license http request 