### PR TITLE
Remove Az Fusion environment variable

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -50,7 +50,6 @@ import com.azure.compute.batch.models.ContainerConfiguration
 import com.azure.compute.batch.models.ContainerRegistryReference
 import com.azure.compute.batch.models.ContainerType
 import com.azure.compute.batch.models.ElevationLevel
-import com.azure.compute.batch.models.EnvironmentSetting
 import com.azure.compute.batch.models.MetadataItem
 import com.azure.compute.batch.models.MountConfiguration
 import com.azure.compute.batch.models.NetworkConfiguration
@@ -553,14 +552,6 @@ class AzBatchService implements Closeable {
                 .setOutputFiles(outputFileUrls(task, sas))
                 .setRequiredSlots(slots)
                 .setConstraints(constraints)
-                .setEnvironmentSettings(taskEnv(config.batch()))
-    }
-
-    protected List<EnvironmentSetting> taskEnv(AzBatchOpts opts) {
-        return opts.poolIdentityClientId
-            ? List.of(new EnvironmentSetting("FUSION_AZ_MSI_CLIENT_ID")
-                .setValue(opts.poolIdentityClientId))
-            : List.<EnvironmentSetting>of()
     }
 
     /**

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -1027,24 +1027,4 @@ class AzBatchServiceTest extends Specification {
         ]
     }
 
-    @Unroll
-    def 'should create task env' () {
-        given:
-        def exec = Mock(AzBatchExecutor)
-        def service = new AzBatchService(exec)
-        List<EnvironmentSetting> env
-
-        when:
-        env = service.taskEnv(new AzBatchOpts([:]))
-        then:
-        env == []
-
-        when:
-        env = service.taskEnv(new AzBatchOpts([poolIdentityClientId:'12345']))
-        then:
-        env.size() == 1
-        env.first.name == 'FUSION_AZ_MSI_CLIENT_ID'
-        env.first.value == '12345'
-    }
-
 }


### PR DESCRIPTION
Turns out this wasn't required, so we might as well remove it.

Signed-off-by: adamrtalbot <12817534+adamrtalbot@users.noreply.github.com>

Hi! Thanks for contributing to Nextflow.

When submitting a Pull Request, please sign-off the DCO [1] to certify that you are the author of the contribution and you adhere to Nextflow's open source license [2] by adding a `Signed-off-by` line to the contribution commit message. See [3] for more details.

1. https://developercertificate.org/
2. https://github.com/nextflow-io/nextflow/blob/master/COPYING
3. https://github.com/apps/dco
