### PR TITLE
Replace foo/bar with better names in docs

### DIFF
--- a/docs/cache-and-resume.md
+++ b/docs/cache-and-resume.md
@@ -144,19 +144,19 @@ Sometimes a process needs to merge inputs from different sources. Consider the f
 
 ```nextflow
 workflow {
-    ch_foo = channel.of( ['1', '1.foo'], ['2', '2.foo'] )
-    ch_bar = channel.of( ['2', '2.bar'], ['1', '1.bar'] )
-    gather(ch_foo, ch_bar)
+    ch_bam = channel.of( ['1', '1.bam'], ['2', '2.bam'] )
+    ch_bai = channel.of( ['2', '2.bai'], ['1', '1.bai'] )
+    check_bam_bai(ch_bam, ch_bai)
 }
 
-process gather {
+process check_bam_bai {
     input:
-    tuple val(id), file(foo)
-    tuple val(id), file(bar)
+    tuple val(id), file(bam)
+    tuple val(id), file(bai)
 
     script:
     """
-    merge_command $foo $bar
+    check_bam_bai $bam $bai
     """
 }
 ```
@@ -167,18 +167,18 @@ The solution is to explicitly join the two channels before the process invocatio
 
 ```nextflow
 workflow {
-    ch_foo = channel.of( ['1', '1.foo'], ['2', '2.foo'] )
-    ch_bar = channel.of( ['2', '2.bar'], ['1', '1.bar'] )
-    gather(ch_foo.join(ch_bar))
+    ch_bam = channel.of( ['1', '1.bam'], ['2', '2.bam'] )
+    ch_bai = channel.of( ['2', '2.bai'], ['1', '1.bai'] )
+    check_bam_bai(ch_bam.join(ch_bai))
 }
 
-process gather {
+process check_bam_bai {
     input:
-    tuple val(id), file(foo), file(bar)
+    tuple val(id), file(bam), file(bai)
 
     script:
     """
-    merge_command $foo $bar
+    check_bam_bai $bam $bai
     """
 }
 ```

--- a/docs/channel.md
+++ b/docs/channel.md
@@ -38,7 +38,7 @@ channels if it is invoked with all value channels, including simple values which
 For example:
 
 ```nextflow
-process foo {
+process echo {
   input:
   val x
 
@@ -52,12 +52,12 @@ process foo {
 }
 
 workflow {
-  result = foo(1)
+  result = echo(1)
   result.view { file -> "Result: ${file}" }
 }
 ```
 
-In the above example, since the `foo` process is invoked with a simple value instead of a channel, the input is implicitly
+In the above example, since the `echo` process is invoked with a simple value instead of a channel, the input is implicitly
 wrapped in a value channel, and the output is also emitted as a value channel.
 
 See also: {ref}`process-multiple-input-channels`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,7 +7,7 @@ Nextflow provides a robust command line interface (CLI) for the management and e
 Simply run `nextflow` with no options or `nextflow -h` to see the list of available top-level options and commands. See {ref}`cli-reference` for the full list of subcommands with examples.
 
 :::{note}
-Nextflow options use a single dash prefix, e.g. `-foo`. Do not confuse with double dash notation, e.g. `--foo`, which is instead used for {ref}`Pipeline parameters <cli-params>`.
+Nextflow options use a single dash prefix, e.g. `-resume`. Do not confuse with double dash notation, e.g. `--resume`, which is instead used for {ref}`Pipeline parameters <cli-params>`.
 :::
 
 ## Basic usage
@@ -166,22 +166,22 @@ The `-v` option prints out information about Nextflow, such as the version and b
 
 ## Running pipelines
 
-The main purpose of the Nextflow CLI is to run Nextflow pipelines with the `run` command. Nextflow can execute a local script (e.g. `./main.nf`) or a remote project (e.g. `github.com/foo/bar`).
+The main purpose of the Nextflow CLI is to run Nextflow pipelines with the `run` command. Nextflow can execute a local script (e.g. `./main.nf`) or a remote project (e.g. `github.com/nextflow-io/hello`).
 
 ### Launching a remote project
 
 To launch the execution of a pipeline project, hosted in a remote code repository, you simply need to specify its qualified name or the repository URL after the `run` command. The qualified name is formed by two parts: the `owner` name and the `repository` name separated by a `/` character.
 
-In other words if a Nextflow project is hosted, for example, in a GitHub repository at the address `http://github.com/foo/bar`, it can be executed by entering the following command in your shell terminal:
+If a Nextflow project is hosted on GitHub, for example `http://github.com/nextflow-io/hello`, it can be executed by entering the following command in your shell terminal:
 
 ```bash
-nextflow run foo/bar
+nextflow run nextflow-io/hello
 ```
 
 or using the project URL:
 
 ```bash
-nextflow run http://github.com/foo/bar
+nextflow run http://github.com/nextflow-io/hello
 ```
 
 If the project is found, it will be automatically downloaded to the Nextflow home directory (`$HOME/.nextflow` by default) and cached for subsequent runs.
@@ -189,14 +189,6 @@ If the project is found, it will be automatically downloaded to the Nextflow hom
 :::{note}
 You must use the `-hub` option to specify the hosting service if your project is hosted on a service other than GitHub, e.g. `-hub bitbucket`. However, the `-hub` option is not required if you use the project URL.
 :::
-
-Try this feature by running the following command:
-
-```bash
-nextflow run nextflow-io/hello
-```
-
-It will download a trivial example from the repository published at [http://github.com/nextflow-io/hello](http://github.com/nextflow-io/hello) and execute it on your computer.
 
 If the `owner` is omitted, Nextflow will search your cached pipelines for a pipeline that matches the name specified. If no pipeline is found, Nextflow will try to download it using the `organization` name defined by the `NXF_ORG` environment variable (`nextflow-io` by default).
 
@@ -255,7 +247,7 @@ Parameters that are specified on the command line without a value are set to `tr
 :::
 
 :::{note}
-Parameters that are specified on the command line in kebab case (e.g., `--foo-bar`) are automatically converted to camel case (e.g., `--fooBar`). Because of this, a parameter defined as `fooBar` in the pipeline script can be specified on the command line as `--fooBar` or `--foo-bar`.
+Parameters that are specified on the command line in kebab case (e.g., `--alpha-beta`) are automatically converted to camel case (e.g., `--alphaBeta`). Because of this, a parameter defined as `alphaBeta` in the pipeline script can be specified on the command line as `--alphaBeta` or `--alpha-beta`.
 :::
 
 :::{warning}
@@ -275,14 +267,14 @@ $ nextflow run main.nf -params-file pipeline_params.yml
 The `-params-file` option loads parameters for your Nextflow pipeline from a JSON or YAML file. Parameters defined in the file are equivalent to specifying them directly on the command line. For example, instead of specifying parameters on the command line:
 
 ```console
-$ nextflow run main.nf --alpha 1 --beta foo
+$ nextflow run main.nf --alpha 1 --beta two
 ```
 
 Parameters can be represented in YAML format:
 
 ```yaml
 alpha: 1
-beta: 'foo'
+beta: 'two'
 ```
 
 Or in JSON format:
@@ -290,7 +282,7 @@ Or in JSON format:
 ```json
 {
   "alpha": 1,
-  "beta": "foo"
+  "beta": "two"
 }
 ```
 

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -46,7 +46,7 @@ Alternatively, it can be specified by setting the variable `NXF_CONDA_ENABLED=tr
 Conda package names can specified using the `conda` directive. Multiple package names can be specified by separating them with a blank space. For example:
 
 ```nextflow
-process foo {
+process hello {
   conda 'bwa samtools multiqc'
 
   script:
@@ -82,7 +82,7 @@ Read the Conda documentation for more details about how to create [environment f
 The path of an environment file can be specified using the `conda` directive:
 
 ```nextflow
-process foo {
+process hello {
   conda '/some/path/my-env.yaml'
 
   script:
@@ -174,7 +174,7 @@ Conda lock files must be a text file with the `.txt` extension.
 If you already have a local Conda environment, you can use it in your workflow specifying the installation directory of such environment by using the `conda` directive:
 
 ```nextflow
-process foo {
+process hello {
   conda '/path/to/an/existing/env/directory'
 
   script:

--- a/docs/config.md
+++ b/docs/config.md
@@ -84,7 +84,7 @@ process.executor = 'sge'
 process.queue = 'long'
 process.memory = '10G'
 
-includeConfig 'path/foo.config'
+includeConfig 'path/extra.config'
 ```
 
 Relative paths are resolved against the location of the including file.
@@ -185,7 +185,7 @@ process {
 
 The `withName` selector applies both to processes defined with the same name and processes included under the same alias. For example, `withName: hello` will apply to any process originally defined as `hello`, as well as any process included under the alias `hello`.
 
-Furthermore, selectors for the alias of an included process take priority over selectors for the original name of the process. For example, given a process defined as `foo` and included as `bar`, the selectors `withName: foo` and `withName: bar` will both be applied to the process, with the second selector taking priority over the first.
+Furthermore, selectors for the alias of an included process take priority over selectors for the original name of the process. For example, given a process defined as `hello` and included as `sayHello`, the selectors `withName: hello` and `withName: sayHello` will both be applied to the process, with the second selector taking priority over the first.
 
 :::{tip}
 Label and process names do not need to be enclosed with quotes, provided the name does not include special characters (`-`, `!`, etc) and is not a keyword or a built-in type identifier. When in doubt, you can enclose the label name or process name with single or double quotes.
@@ -199,26 +199,26 @@ Both label and process name selectors allow the use of a regular expression in o
 
 ```groovy
 process {
-    withLabel: 'foo|bar' {
+    withLabel: 'hello|bye' {
         cpus = 2
         memory = 4.GB
     }
 }
 ```
 
-The above configuration snippet requests 2 cpus and 4 GB of memory for processes labeled as `foo` or `bar`.
+The above configuration snippet requests 2 cpus and 4 GB of memory for processes labeled as `hello` or `bye`.
 
 A process selector can be negated prefixing it with the special character `!`. For example:
 
 ```groovy
 process {
-    withLabel: 'foo' { cpus = 2 }
-    withLabel: '!foo' { cpus = 4 }
+    withLabel: 'hello' { cpus = 2 }
+    withLabel: '!hello' { cpus = 4 }
     withName: '!align.*' { queue = 'long' }
 }
 ```
 
-The above configuration snippet sets 2 cpus for the processes annotated with the `foo` label and 4 cpus to all processes *not* annotated with that label. Finally it sets the use of `long` queue to all process whose name does *not* start with `align`.
+The above configuration snippet sets 2 cpus for every process labeled as `hello` and 4 cpus to every process *not* label as `hello`. It also specifies the `long` queue for every process whose name does *not* start with `align`.
 
 (config-selector-priority)=
 
@@ -238,17 +238,17 @@ For example:
 ```groovy
 process {
     cpus = 4
-    withLabel: foo { cpus = 8 }
-    withName: bar { cpus = 16 }
-    withName: 'baz:bar' { cpus = 32 }
+    withLabel: hello { cpus = 8 }
+    withName: bye { cpus = 16 }
+    withName: 'mysub:bye' { cpus = 32 }
 }
 ```
 
 With the above configuration:
 - All processes will use 4 cpus (unless otherwise specified in their process definition).
-- Processes annotated with the `foo` label will use 8 cpus.
-- Any process named `bar` (or imported as `bar`) will use 16 cpus.
-- Any process named `bar` (or imported as `bar`) invoked by a workflow named `baz` with use 32 cpus.
+- Processes annotated with the `hello` label will use 8 cpus.
+- Any process named `bye` (or imported as `bye`) will use 16 cpus.
+- Any process named `bye` (or imported as `bye`) invoked by a workflow named `mysub` with use 32 cpus.
 
 (config-profiles)=
 
@@ -297,7 +297,7 @@ When defining a profile in the config file, avoid using both the dot and block s
 
 ```groovy
 profiles {
-    foo {
+    cluster {
         process.memory = '2 GB'
         process {
             cpus = 2
@@ -309,7 +309,7 @@ profiles {
 Due to a limitation of the legacy config parser, the first setting will be overwritten by the second:
 
 ```console
-$ nextflow config -profile foo
+$ nextflow config -profile cluster
 process {
    cpus = 2
 }

--- a/docs/container.md
+++ b/docs/container.md
@@ -47,7 +47,7 @@ Every time your script launches a process execution, Nextflow will run it into a
 A Apptainer image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
 :::
 
-If you want to avoid entering the Apptainer image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the `nextflow.config` file:
+If you want to avoid entering the Apptainer image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
 
 ```groovy
 process.container = '/path/to/apptainer.img'
@@ -56,7 +56,7 @@ apptainer.enabled = true
 
 In the above example replace `/path/to/apptainer.img` with any Apptainer image of your choice.
 
-Read the {ref}`config-page` page to learn more about the `nextflow.config` file and how to use it to configure your pipeline execution.
+Read the {ref}`config-page` page to learn more about the configuration file and how to use it to configure your pipeline execution.
 
 :::{note}
 Unlike Docker, Nextflow does not automatically mount host paths in the container when using Apptainer. It expects that the paths are configured and mounted system wide by the Apptainer runtime. If your Apptainer installation allows user defined bind points, read the {ref}`Apptainer configuration <config-apptainer>` section to learn how to enable Nextflow auto mounts.
@@ -72,14 +72,14 @@ Nextflow no longer mounts the home directory when launching an Apptainer contain
 
 ### Multiple containers
 
-It is possible to specify a different Apptainer image for each process definition in your pipeline script. For example, let's suppose you have two processes named `foo` and `bar`. You can specify two different Apptainer images specifying them in the `nextflow.config` file as shown below:
+It is possible to specify a different Apptainer image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Apptainer images in the configuration file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }
@@ -176,7 +176,7 @@ Every time your script launches a process execution, Nextflow will run it into a
 A container image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
 :::
 
-If you want to avoid entering the Container image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the `nextflow.config` file:
+If you want to avoid entering the Container image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
 
 ```groovy
 process.container = '/path/to/container'
@@ -187,7 +187,7 @@ charliecloud.enabled = true
 If an absolute path is provided, the container needs to be in the Charliecloud flat directory format. See the section below on compatibility with Docker registries.
 :::
 
-Read the {ref}`config-page` page to learn more about the `nextflow.config` file and how to use it to configure your pipeline execution.
+Read the {ref}`config-page` page to learn more about the configuration file and how to use it to configure your pipeline execution.
 
 :::{warning}
 Nextflow automatically manages the file system mounts whenever a container is launched depending on the process input files. However, when a process input is a *symbolic link*, the linked file **must** be stored in the same folder where the symlink is located, or a sub-folder of it. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
@@ -215,14 +215,14 @@ charliecloud.enabled = true
 
 ### Multiple containers
 
-It is possible to specify a different Docker image for each process definition in your pipeline script. However, this can't be done with `-with-docker` command line option, since it doesn't support process selectors in the `nextflow.config` file, and doesn't check for the `container` process directive in the pipeline script file. Let's suppose you have two processes named `foo` and `bar`. You can specify two different Docker images for them in the Nextflow script as shown below:
+It is possible to specify a different Docker image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Docker images for them in the config file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }
@@ -270,7 +270,7 @@ Every time your script launches a process execution, Nextflow will run it into a
 A Docker image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
 :::
 
-If you want to avoid entering the Docker image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the `nextflow.config` file:
+If you want to avoid entering the Docker image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
 
 ```groovy
 process.container = 'nextflow/examples:latest'
@@ -279,7 +279,7 @@ docker.enabled = true
 
 In the above example replace `nextflow/examples:latest` with any Docker image of your choice.
 
-Read the {ref}`config-page` page to learn more about the `nextflow.config` file and how to use it to configure your pipeline execution.
+Read the {ref}`config-page` page to learn more about the configuration file and how to use it to configure your pipeline execution.
 
 :::{warning}
 Nextflow automatically manages the file system mounts whenever a container is launched depending on the process input files. However, when a process input is a *symbolic link*, the linked file **must** be stored in the same folder where the symlink is located, or a sub-folder of it. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
@@ -287,10 +287,10 @@ Nextflow automatically manages the file system mounts whenever a container is la
 
 ### Multiple containers
 
-It is possible to specify a different Docker image for each process definition in your pipeline script. Let's suppose you have two processes named `foo` and `bar`. You can specify two different Docker images for them in the Nextflow script as shown below:
+It is possible to specify a different Docker image for each process definition in your pipeline script. Suppose you have two processes named `hello` and `bye`. You can specify two different Docker images for them in the Nextflow script as shown below:
 
-```groovy
-process foo {
+```nextflow
+process hello {
   container 'image_name_1'
 
   script:
@@ -299,7 +299,7 @@ process foo {
   """
 }
 
-process bar {
+process bye {
   container 'image_name_2'
 
   script:
@@ -309,14 +309,14 @@ process bar {
 }
 ```
 
-Alternatively, the same containers definitions can be provided by using the `nextflow.config` file as shown below:
+Alternatively, the same containers definitions can be provided by using the configuration file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }
@@ -359,7 +359,7 @@ Every time your script launches a process execution, Nextflow will run it into a
 An OCI container image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
 :::
 
-If you want to avoid entering the Podman image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the `nextflow.config` file:
+If you want to avoid entering the Podman image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
 
 ```groovy
 process.container = 'nextflow/examples:latest'
@@ -368,7 +368,7 @@ podman.enabled = true
 
 In the above example replace `nextflow/examples:latest` with any Podman image of your choice.
 
-Read the {ref}`config-page` page to learn more about the `nextflow.config` file and how to use it to configure your pipeline execution.
+Read the {ref}`config-page` page to learn more about the configuration file and how to use it to configure your pipeline execution.
 
 :::{warning}
 Nextflow automatically manages the file system mounts whenever a container is launched depending on the process input files. However, when a process input is a *symbolic link*, the linked file **must** be stored in the same folder where the symlink is located, or a sub-folder of it. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
@@ -376,10 +376,10 @@ Nextflow automatically manages the file system mounts whenever a container is la
 
 ### Multiple containers
 
-It is possible to specify a different container image for each process definition in your pipeline script. Let's suppose you have two processes named `foo` and `bar`. You can specify two different container images for them in the Nextflow script as shown below:
+It is possible to specify a different container image for each process definition in your pipeline script. Let's suppose you have two processes named `hello` and `bye`. You can specify two different container images for them in the Nextflow script as shown below:
 
-```groovy
-process foo {
+```nextflow
+process hello {
   container 'image_name_1'
 
   script:
@@ -388,7 +388,7 @@ process foo {
   """
 }
 
-process bar {
+process bye {
   container 'image_name_2'
 
   script:
@@ -398,14 +398,14 @@ process bar {
 }
 ```
 
-Alternatively, the same containers definitions can be provided by using the `nextflow.config` file as shown below:
+Alternatively, the same containers definitions can be provided by using the configuration file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }
@@ -456,14 +456,14 @@ if you do not specify an image tag, the `latest` tag will be fetched by default.
 
 ### Multiple containers
 
-It is possible to specify a different Sarus image for each process definition in your pipeline script. For example, let's suppose you have two processes named `foo` and `bar`. You can specify two different Sarus images specifying them in the `nextflow.config` file as shown below:
+It is possible to specify a different Sarus image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Sarus images specifying them in the configuration file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }
@@ -506,14 +506,14 @@ Shifter will search the Docker Hub registry for the images. If you do not specif
 
 ### Multiple containers
 
-It is possible to specify a different Shifter image for each process definition in your pipeline script. For example, let's suppose you have two processes named `foo` and `bar`. You can specify two different Shifter images specifying them in the `nextflow.config` file as shown below:
+It is possible to specify a different Shifter image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Shifter images specifying them in the configuration file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }
@@ -561,7 +561,7 @@ Every time your script launches a process execution, Nextflow will run it into a
 A Singularity image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
 :::
 
-If you want to avoid entering the Singularity image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the `nextflow.config` file:
+If you want to avoid entering the Singularity image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
 
 ```groovy
 process.container = '/path/to/singularity.img'
@@ -570,7 +570,7 @@ singularity.enabled = true
 
 In the above example replace `/path/to/singularity.img` with any Singularity image of your choice.
 
-Read the {ref}`config-page` page to learn more about the `nextflow.config` file and how to use it to configure your pipeline execution.
+Read the {ref}`config-page` page to learn more about the configuration file and how to use it to configure your pipeline execution.
 
 :::{note}
 Unlike Docker, Nextflow does not automatically mount host paths in the container when using Singularity. It expects that the paths are configure and mounted system wide by the Singularity runtime. If your Singularity installation allows user defined bind points, read the {ref}`Singularity configuration <config-singularity>` section to learn how to enable Nextflow auto mounts.
@@ -594,14 +594,14 @@ The execution command for Singularity/Apptainer containers can be set to `run` b
 
 ### Multiple containers
 
-It is possible to specify a different Singularity image for each process definition in your pipeline script. For example, let's suppose you have two processes named `foo` and `bar`. You can specify two different Singularity images specifying them in the `nextflow.config` file as shown below:
+It is possible to specify a different Singularity image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Singularity images specifying them in the configuration file as shown below:
 
 ```groovy
 process {
-    withName:foo {
+    withName:hello {
         container = 'image_name_1'
     }
-    withName:bar {
+    withName:bye {
         container = 'image_name_2'
     }
 }

--- a/docs/developer/nextflow.ast.md
+++ b/docs/developer/nextflow.ast.md
@@ -28,7 +28,7 @@ Here is the example from {ref}`your-first-script`:
 ```nextflow
 params.str = 'Hello world!'
 
-process splitLetters {
+process split_letters {
   output:
     path 'chunk_*'
 
@@ -38,7 +38,7 @@ process splitLetters {
   """
 }
 
-process convertToUpper {
+process convert_to_upper {
   input:
     path x
   output:
@@ -51,7 +51,7 @@ process convertToUpper {
 }
 
 workflow {
-  splitLetters | flatten | convertToUpper | view { it.trim() }
+  split_letters | flatten | convert_to_upper | view { it.trim() }
 }
 ```
 
@@ -60,7 +60,7 @@ Here it is after being parsed and de-sugared by Groovy:
 ```groovy
 params.str = 'Hello world!'
 
-process( splitLetters( {
+process( split_letters( {
   output:
     path('chunk_*')
 
@@ -70,7 +70,7 @@ process( splitLetters( {
   """
 } ))
 
-process( convertToUpper( {
+process( convert_to_upper( {
   input:
     path(x)
   output:
@@ -83,7 +83,7 @@ process( convertToUpper( {
 } ))
 
 workflow({
-  splitLetters | flatten | convertToUpper | view { it.trim() }
+  split_letters | flatten | convert_to_upper | view { it.trim() }
 })
 ```
 
@@ -105,12 +105,12 @@ import nextflow.Channel as channel
 public class script1677225313239 extends nextflow.script.BaseScript { 
 
     public script1677225313239() {
-        nextflow.script.ScriptMeta.get(this).setDsl1ProcessNames(['splitLetters', 'convertToUpper'])
+        nextflow.script.ScriptMeta.get(this).setDsl1ProcessNames(['split_letters', 'convert_to_upper'])
     }
 
     public script1677225313239(final groovy.lang.Binding context) {
         super.setBinding(context)
-        nextflow.script.ScriptMeta.get(this).setDsl1ProcessNames(['splitLetters', 'convertToUpper'])
+        nextflow.script.ScriptMeta.get(this).setDsl1ProcessNames(['split_letters', 'convert_to_upper'])
     }
 
     public static void main(final java.lang.String[] args) {
@@ -121,7 +121,7 @@ public class script1677225313239 extends nextflow.script.BaseScript {
     protected java.lang.Object runScript() {
         params.str = 'Hello world!'
 
-        this.process('splitLetters', { 
+        this.process('split_letters', { 
             this._out_path('chunk_*')
             new nextflow.script.BodyDef(
                 {
@@ -135,7 +135,7 @@ public class script1677225313239 extends nextflow.script.BaseScript {
             )
         })
 
-        this.process('convertToUpper', { 
+        this.process('convert_to_upper', { 
             this._in_path(new nextflow.script.TokenVar('x'))
             this._out_stdout()
             new nextflow.script.BodyDef(
@@ -153,16 +153,16 @@ public class script1677225313239 extends nextflow.script.BaseScript {
         this.workflow({ 
             new nextflow.script.BodyDef(
                 {
-                    splitLetters | flatten | convertToUpper | this.view({ 
+                    split_letters | flatten | convert_to_upper | this.view({ 
                         it.trim()
                     })
                 },
-                '  splitLetters | flatten | convertToUpper | view { it.trim() }\n',
+                '  split_letters | flatten | convert_to_upper | view { it.trim() }\n',
                 'workflow',
                 [
                     new nextflow.script.TokenValRef('flatten', 24, 18),
-                    new nextflow.script.TokenValRef('splitLetters', 24, 3),
-                    new nextflow.script.TokenValRef('convertToUpper', 24, 28)
+                    new nextflow.script.TokenValRef('split_letters', 24, 3),
+                    new nextflow.script.TokenValRef('convert_to_upper', 24, 28)
                 ]
             )
         })

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -79,7 +79,7 @@ class MyPlugin extends BasePlugin implements PluginAbstractExec {
 You can then execute this command using the `nextflow plugin` command:
 
 ```bash
-nextflow plugin my-plugin:hello --foo --bar
+nextflow plugin my-plugin:hello --alpha --beta
 ```
 
 See the {ref}`cli-plugin` CLI command for usage information.
@@ -167,7 +167,7 @@ class MyExecutor extends Executor implements ExtensionPoint {
 You can then use this executor in your pipeline:
 
 ```nextflow
-process foo {
+process hello {
     executor 'my-executor'
 
     // ...

--- a/docs/git.md
+++ b/docs/git.md
@@ -223,13 +223,13 @@ providers {
 Then you will be able to run/pull a project with Nextflow using the following command line:
 
 ```bash
-nextflow run foo/bar -hub mygit
+nextflow run acme/hello -hub mygit
 ```
 
 Or, alternatively, using the Git clone URL:
 
 ```bash
-nextflow run http://gitlab.acme.org/foo/bar.git
+nextflow run http://gitlab.acme.org/acme/hello.git
 ```
 
 :::{note}

--- a/docs/google.md
+++ b/docs/google.md
@@ -100,7 +100,7 @@ The `machineType` directive can be used to request a specific VM instance type. 
 Platform [machine type](https://cloud.google.com/compute/docs/machine-types) or [custom machine type](https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type).
 
 ```nextflow
-process myTask {
+process my_task {
     cpus 8
     memory '40 GB'
 
@@ -110,7 +110,7 @@ process myTask {
     """
 }
 
-process anotherTask {
+process other_task {
     machineType 'n1-highmem-8'
 
     script:
@@ -127,7 +127,7 @@ The `machineType` directive can also be a comma-separated list of patterns. The 
 number of characters and `?` to match any single character. Examples of valid patterns: `c2-*`, `m?-standard*`, `n*`.
 
 ```nextflow
-process myTask {
+process my_task {
     cpus 8
     memory '20 GB'
     machineType 'n2-*,c2-*,m3-*'
@@ -146,7 +146,7 @@ The `machineType` directive can also be an [Instance Template](https://cloud.goo
 specified as `template://<instance-template>`. For example:
 
 ```nextflow
-process myTask {
+process my_task {
     cpus 8
     memory '20 GB'
     machineType 'template://my-template'

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -99,7 +99,7 @@ $$
 
 The behavior of **Memory Usage** plots can be examined using two programs written in C. The first program allocates a variable of 1 GiB:
 
-```{code-block} c
+```c
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/resource.h>
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
 
 The second program allocates a variable of 1 GiB and fills it with data:
 
-```{code-block} c
+```c
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/resource.h>
@@ -224,10 +224,10 @@ int main(int argc, char **argv) {
 }
 ```
 
-The first and second programs are executed as `foo` and `bar`, respectively, in the following script:
+The first and second programs are executed as `malloc` and `malloc_fill`, respectively, in the following script:
 
 ```nextflow
-process foo {
+process malloc {
     memory '1.5 GB'
 
     script:
@@ -236,7 +236,7 @@ process foo {
     """
 }
 
-process bar {
+process malloc_fill {
     memory '1.5 GB'
 
     script:
@@ -246,22 +246,22 @@ process bar {
 }
 
 workflow{
-    foo() // Allocates a variable of 1 GiB
-    bar() // Allocates a variable of 1 GiB and fills it with data
+    malloc() // Allocates a variable of 1 GiB
+    malloc_fill() // Allocates a variable of 1 GiB and fills it with data
 }
 ```
 
-The **Virtual (RAM + Disk swap)** tab shows that both `foo` and `bar` use the same amount of virtual memory (~1 GiB):
+The **Virtual (RAM + Disk swap)** tab shows that both `malloc` and `malloc_fill` use the same amount of virtual memory (~1 GiB):
 
 ```{image} _static/report-resource-memory-vmem.png
 ```
 
-However, the **Physical (RAM)** tab shows that `bar` uses ~1 GiB of RAM while `foo` uses ~0 GiB of RAM:
+However, the **Physical (RAM)** tab shows that `malloc_fill` uses ~1 GiB of RAM while `malloc` uses ~0 GiB of RAM:
 
 ```{image} _static/report-resource-memory-ram.png
 ```
 
-The **% RAM Allocated** tab shows that `foo` and `bar` used 0% and 67% of resources set in the `memory` directive, respectively:
+The **% RAM Allocated** tab shows that `malloc` and `malloc_fill` used 0% and 67% of resources set in the `memory` directive, respectively:
 
 ```{image} _static/report-resource-memory-pctram.png
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -16,7 +16,7 @@ CPU Usage plots report how CPU resources are used by each process.
 For example, using the [stress](https://people.seas.harvard.edu/~apw/stress/) program, the following script would report 100% CPU usage in the **Raw Usage** tab and 50% CPU usage in the **% Allocated** tab as the process requested double the number of CPUs that are required:
 
 ```nextflow
-process cpuUsageEx1 {
+process cpu_usage_ex1 {
   cpus 2
 
   script:
@@ -26,7 +26,7 @@ process cpuUsageEx1 {
 }
 
 workflow{
-    cpuUsageEx1() // Stress using 1 CPU
+    cpu_usage_ex1() // Stress using 1 CPU
 }
 ```
 
@@ -37,7 +37,7 @@ See [Linux stress command with examples](https://www.geeksforgeeks.org/linux-str
 CPU usage decreases if processes spend some time performing pure computation and some time waiting for CPUs. For example, using the `stress` and `sleep` commands, the following script would report 75% CPU usage in the **Raw Usage** tab:
 
 ```nextflow
-process cpuUsageEx2 {
+process cpu_usage_ex2 {
   cpus 1
 
   script:
@@ -49,7 +49,7 @@ process cpuUsageEx2 {
 }
 
 workflow{
-    cpuUsageEx2() // Stress using 1 CPU and sleep
+    cpu_usage_ex2() // Stress using 1 CPU and sleep
 }
 ```
 
@@ -62,7 +62,7 @@ $$
 CPU usage increases if a single step is forked on multiple CPUs:
 
 ```nextflow
-process cpuUsageEx3 {
+process cpu_usage_ex3 {
   cpus 2
 
   script:
@@ -73,7 +73,7 @@ process cpuUsageEx3 {
 }
 
 workflow{
-    cpuUsageEx3() // Stress using 2 CPUs and sleep
+    cpu_usage_ex3() // Stress using 2 CPUs and sleep
 }
 ```
 

--- a/docs/migrations/24-04.md
+++ b/docs/migrations/24-04.md
@@ -50,11 +50,12 @@ nextflow.preview.output = true
 
 workflow {
   main:
-  ch_foo = foo(data)
-  bar(ch_foo)
+  ch_fastqc = fastqc(data)
+  multiqc(ch_fastqc.collect())
 
   publish:
-  ch_foo >> 'foo'
+  ch_fastqc >> 'qc'
+  multiqc.out >> 'summary'
 }
 
 output {

--- a/docs/migrations/dsl1.md
+++ b/docs/migrations/dsl1.md
@@ -119,7 +119,7 @@ DSL2 scripts cannot exceed 64 KB in size. Split large DSL1 scripts into modules 
 - Unqualified value and file elements in a tuple declaration are no longer allowed. Use an explicit `val` or `path` qualifier. For example:
 
   ```nextflow
-  process foo {
+  process sam2bam {
       input:
       tuple X, 'some-file.sam'
 
@@ -136,7 +136,7 @@ DSL2 scripts cannot exceed 64 KB in size. Split large DSL1 scripts into modules 
   Use:
 
   ```nextflow
-  process foo {
+  process sam2bam {
       input:
       tuple val(X), path('some-file.sam')
 
@@ -181,23 +181,23 @@ An early preview of DSL2 was available in 2020. Note that some of that early DSL
   For example:
 
   ```nextflow
-  include './some/library'
-  include bar from './other/library'
+  include './modules/hello'
+  include bye from './modules/bye'
 
   workflow {
-      foo()
-      bar()
+      hello()
+      bye()
   }
   ```
 
   Should be replaced with:
 
   ```nextflow
-  include { foo } from './some/library'
-  include { bar } from './other/library'
+  include { hello } from './modules/hello'
+  include { bye } from './modules/bye'
 
   workflow {
-      foo()
-      bar()
+      hello()
+      bye()
   }
   ```

--- a/docs/migrations/dsl1.md
+++ b/docs/migrations/dsl1.md
@@ -13,7 +13,7 @@ nextflow.enable.dsl=1
 
 params.str = 'Hello world!'
 
-process splitLetters {
+process split_letters {
     output:
     file 'chunk_*' into letters
 
@@ -23,7 +23,7 @@ process splitLetters {
     """
 }
 
-process convertToUpper {
+process convert_to_upper {
     input:
     file x from letters.flatten()
 
@@ -48,7 +48,7 @@ You can see the DSL1 Nextflow script from above written in DSL2 here:
 ```nextflow
 params.str = 'Hello world!'
 
-process splitLetters {
+process split_letters {
     output:
     path 'chunk_*'
 
@@ -58,7 +58,7 @@ process splitLetters {
     """
 }
 
-process convertToUpper {
+process convert_to_upper {
     input:
     path x
 
@@ -72,7 +72,7 @@ process convertToUpper {
 }
 
 workflow {
-    splitLetters | flatten | convertToUpper | view { v -> v.trim() }
+    split_letters | flatten | convert_to_upper | view { v -> v.trim() }
 }
 ```
 

--- a/docs/module.md
+++ b/docs/module.md
@@ -15,15 +15,15 @@ You can include any definition from a module into a Nextflow script using the `i
 For example:
 
 ```nextflow
-include { foo } from './some/module'
+include { cat } from './some/module'
 
 workflow {
     data = channel.fromPath('/some/data/*.txt')
-    foo(data)
+    cat(data)
 }
 ```
 
-The above snippet imports a process named `foo`, defined in the module, into the main execution context. This way, `foo` can be invoked in the `workflow` scope.
+The above snippet imports a process named `cat`, defined in the module, into the main execution context. This way, `cat` can be invoked in the `workflow` scope.
 
 Nextflow implicitly looks for the script file `./some/module.nf`, resolving the path against the *including* script location.
 
@@ -50,7 +50,7 @@ some
 When defined as a directory, the module must be included by specifying the module directory path:
 
 ```nextflow
-include { foo } from './some/module'
+include { hello } from './some/module'
 ```
 
 Module directories allow the use of module scoped binaries scripts. See [Module binaries] for details.
@@ -60,12 +60,12 @@ Module directories allow the use of module scoped binaries scripts. See [Module 
 A Nextflow script can include any number of modules, and an `include` statement can import any number of definitions from a module. Multiple definitions can be included from the same module by using the syntax shown below:
 
 ```nextflow
-include { foo; bar } from './some/module'
+include { cat; wc } from './some/module'
 
 workflow {
     data = channel.fromPath('/some/data/*.txt')
-    foo(data)
-    bar(data)
+    cat(data)
+    wc(data)
 }
 ```
 
@@ -76,23 +76,23 @@ workflow {
 When including definition from a module, it's possible to specify an *alias* with the `as` keyword. Aliasing allows you to avoid module name clashes, by assigning them different names in the including context. For example:
 
 ```nextflow
-include { foo } from './some/module'
-include { foo as bar } from './other/module'
+include { cat as cat_alpha } from './some/module'
+include { cat as cat_beta } from './other/module'
 
 workflow {
-    foo(some_data)
-    bar(other_data)
+    cat_alpha(some_data)
+    cat_beta(other_data)
 }
 ```
 
 You can also include the same definition multiple times under different names:
 
 ```nextflow
-include { foo; foo as bar } from './some/module'
+include { cat as cat_alpha; cat as cat_beta } from './some/module'
 
 workflow {
-    foo(some_data)
-    bar(other_data)
+    cat_alpha(some_data)
+    cat_beta(other_data)
 }
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,7 +25,7 @@ A Nextflow script looks like this:
 params.query = "/some/data/sample.fa"
 params.db = "/some/path/pdb"
 
-process blastSearch {
+process blast_search {
   input:
   path query
   path db
@@ -40,7 +40,7 @@ process blastSearch {
   """
 }
 
-process extractTopHits {
+process extract_top_hits {
   input:
   path top_hits
   path db
@@ -56,14 +56,14 @@ process extractTopHits {
 
 workflow {
   def query_ch = channel.fromPath(params.query)
-  blastSearch(query_ch, params.db)
-  extractTopHits(blastSearch.out, params.db).view()
+  blast_search(query_ch, params.db)
+  extract_top_hits(blast_search.out, params.db).view()
 }
 ```
 
-The above example defines two processes. Their execution order is not determined by the fact that the `blastSearch` process comes before `extractTopHits` in the script (it could also be written the other way around). Instead, execution order is determined by their _dependencies_ -- `extractTopHits` depends on the output of `blastSearch`, so `blastSearch` will be executed first, and then `extractTopHits`.
+The above example defines two processes. Their execution order is not determined by the fact that the `blast_search` process comes before `extract_top_hits` in the script (it could also be written the other way around). Instead, execution order is determined by their _dependencies_ -- `extract_top_hits` depends on the output of `blast_search`, so `blast_search` will be executed first, and then `extract_top_hits`.
 
-When the workflow is started, it will create two processes and one channel (`query_ch`) and it will link all of them. Both processes will be started at the same time and they will listen to their respective input channels. Whenever `blastSearch` emits a value, `extractTopHits` will receive it (i.e. `extractTopHits` consumes the channel in a *reactive* way).
+When the workflow is started, it will create two processes and one channel (`query_ch`) and it will link all of them. Both processes will be started at the same time and they will listen to their respective input channels. Whenever `blast_search` emits a value, `extract_top_hits` will receive it (i.e. `extract_top_hits` consumes the channel in a *reactive* way).
 
 Read the {ref}`Channel <channel-page>` and {ref}`Process <process-page>` sections to learn more about these features.
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -189,7 +189,7 @@ echo "process completed"
 Variables prefixed with the dollar character (`$`) are interpreted as Nextflow variables when the template script is executed by Nextflow and Bash variables when executed directly. For example, the above script can be executed from the command line by providing each input as an environment variable:
 
 ```bash
-STR='foo' bash templates/my_script.sh
+STR='Hello!' bash templates/my_script.sh
 ```
 
 The following caveats should be considered:
@@ -458,18 +458,18 @@ This feature allows you to execute the process command multiple times without wo
 Channel factories like `channel.fromPath` produce file objects, but a `path` input can also accept a string literal path. The string value should be an absolute path, i.e. it must be prefixed with a `/` character or a supported URI protocol (`file://`, `http://`, `s3://`, etc), and it cannot contain special characters (`\n`, etc).
 
 ```nextflow
-process foo {
+process cat {
   input:
   path x
 
   script:
   """
-  your_command --in $x
+  cat $x
   """
 }
 
 workflow {
-  foo('/some/data/file.txt')
+  cat('/some/data/file.txt')
 }
 ```
 
@@ -751,7 +751,7 @@ As a result, channel values are consumed sequentially and any empty channel will
 For example:
 
 ```nextflow
-process foo {
+process echo {
   input:
   val x
   val y
@@ -765,11 +765,11 @@ process foo {
 workflow {
   x = channel.of(1, 2)
   y = channel.of('a', 'b', 'c')
-  foo(x, y)
+  echo(x, y)
 }
 ```
 
-The process `foo` is executed two times because the `x` channel emits only two values, therefore the `c` element is discarded. It outputs:
+The process `echo` is executed two times because the `x` channel emits only two values, therefore the `c` element is discarded. It outputs:
 
 ```
 1 and a
@@ -781,7 +781,7 @@ A different semantic is applied when using a {ref}`value channel <channel-type-v
 To better understand this behavior, compare the previous example with the following one:
 
 ```nextflow
-process bar {
+process echo {
   input:
   val x
   val y
@@ -795,11 +795,11 @@ process bar {
 workflow {
   x = channel.value(1)
   y = channel.of('a', 'b', 'c')
-  foo(x, y)
+  echo(x, y)
 }
 ```
 
-The above example executes the `bar` process three times because `x` is a value channel, therefore its value can be read as many times as needed. The process termination is determined by the contents of `y`. It outputs:
+The above example executes the `echo` process three times because `x` is a value channel, therefore its value can be read as many times as needed. The process termination is determined by the contents of `y`. It outputs:
 
 ```
 1 and a
@@ -846,7 +846,7 @@ Refer to the {ref}`process reference <process-reference-outputs>` for the full l
 The `val` qualifier allows you to output any Nextflow variable defined in the process. A common use case is to output a variable that was defined in the `input` section, as shown in the following example:
 
 ```nextflow
-process foo {
+process echo {
   input:
   each x
 
@@ -862,15 +862,15 @@ process foo {
 workflow {
   methods = ['prot', 'dna', 'rna']
 
-  receiver = foo(methods)
-  receiver.view { method -> "Received: $method" }
+  received = echo(methods)
+  received.view { method -> "Received: $method" }
 }
 ```
 
 The output value can be a value literal, an input variable, any other Nextflow variable in the process scope, or a value expression. For example:
 
 ```nextflow
-process foo {
+process cat {
   input:
   path infile
 
@@ -888,7 +888,7 @@ process foo {
 
 workflow {
   ch_dummy = channel.fromPath('*').first()
-  (ch_var, ch_str, ch_exp) = foo(ch_dummy)
+  (ch_var, ch_str, ch_exp) = cat(ch_dummy)
 
   ch_var.view { var -> "ch_var: $var" }
   ch_str.view { str -> "ch_str: $str" }
@@ -901,7 +901,7 @@ workflow {
 The `path` qualifier allows you to output one or more files produced by the process. For example:
 
 ```nextflow
-process randomNum {
+process randomNumber {
   output:
   path 'result.txt'
 
@@ -912,12 +912,12 @@ process randomNum {
 }
 
 workflow {
-  numbers = randomNum()
+  numbers = randomNumber()
   numbers.view { file -> "Received: ${file.text}" }
 }
 ```
 
-In the above example, the `randomNum` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding output channel. A downstream process with a compatible input channel will be able to receive it.
+In the above example, the `randomNumber` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding output channel. A downstream process with a compatible input channel will be able to receive it.
 
 Refer to the {ref}`process reference <process-reference-outputs>` for the list of available options for `path` outputs.
 
@@ -1091,7 +1091,7 @@ While parentheses for input and output qualifiers are generally optional, they a
 Here's an example with a single path output (parentheses optional):
 
 ```nextflow
-process foo {
+process hello {
     output:
     path 'result.txt', hidden: true
 
@@ -1105,7 +1105,7 @@ process foo {
 And here's an example with a tuple output (parentheses required):
 
 ```nextflow
-process foo {
+process hello {
     output:
     tuple path('last_result.txt'), path('result.txt', hidden: true)
 
@@ -1125,7 +1125,7 @@ process foo {
 The `emit` option can be used on a process output to define a name for the corresponding output channel, which can be used to access the channel by name from the process output. For example:
 
 ```nextflow
-process FOO {
+process hello_bye {
     output:
     path 'hello.txt', emit: hello
     stdout emit: bye
@@ -1138,8 +1138,8 @@ process FOO {
 }
 
 workflow {
-    FOO()
-    FOO.out.hello.view()
+    hello_bye()
+    hello_bye.out.hello.view()
 }
 ```
 
@@ -1219,7 +1219,7 @@ Software dependencies:
 The `task` object also contains the values of all process directives for the given task, which allows you to access these settings at runtime. For examples:
 
 ```nextflow
-process foo {
+process hello {
   script:
   """
   some_tool --cpus $task.cpus --mem $task.memory
@@ -1238,7 +1238,7 @@ A directive can be assigned *dynamically*, during the process execution, so that
 To be defined dynamically, the directive's value needs to be expressed using a {ref}`closure <script-closure>`. For example:
 
 ```nextflow
-process foo {
+process hello {
   executor 'sge'
   queue { entries > 100 ? 'long' : 'short' }
 
@@ -1279,7 +1279,7 @@ It's a very common scenario that different instances of the same process may hav
 [Dynamic directives](#dynamic-directives) can be used to adjust the requested task resources when a task fails and is re-executed. For example:
 
 ```nextflow
-process foo {
+process hello {
     memory { 2.GB * task.attempt }
     time { 1.hour * task.attempt }
 
@@ -1314,11 +1314,16 @@ disk { [request: 375.GB * task.attempt, type: 'local-ssd'] }
 Task resources can also be defined in terms of task inputs. For example:
 
 ```nextflow
-process foo {
+process hello {
     memory { 8.GB + 1.GB * Math.ceil(input_file.size() / 1024 ** 3) }
 
     input:
     path input_file
+
+    script:
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -1334,7 +1339,7 @@ In this example, each task requests 8 GB of memory, plus the size of the input f
 Task resource requests can be updated relative to the {ref}`trace record <trace-report>` metrics of the previous task attempt. The metrics can be accessed through the `task.previousTrace` variable. For example:
 
 ```nextflow
-process foo {
+process hello {
     memory { task.attempt > 1 ? task.previousTrace.memory * 2 : (1.GB) }
     errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries 3
@@ -1353,7 +1358,7 @@ In the above example, the {ref}`process-memory` is set according to previous tra
 There are cases in which the required execution resources may be temporary unavailable e.g. network congestion. In these cases immediately re-executing the task will likely result in the identical error. A retry with an exponential backoff delay can better recover these error conditions:
 
 ```nextflow
-process foo {
+process hello {
   errorStrategy { sleep(Math.pow(2, task.attempt) * 200 as long); return 'retry' }
   maxRetries 5
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -7,7 +7,7 @@ In Nextflow, a **process** is a specialized function for executing scripts in a 
 Here is an example process definition:
 
 ```nextflow
-process sayHello {
+process hello {
     output:
     path 'hello.txt'
 
@@ -33,7 +33,7 @@ The script string is executed as a [Bash](<http://en.wikipedia.org/wiki/Bash_(Un
 The script section can be a simple string or a multi-line string. The latter approach makes it easier to write scripts with multiple commands spanning multiple lines. For example:
 
 ```nextflow
-process doMoreThings {
+process blast {
   """
   blastp -db $db -query query.fa -outfmt 6 > blast_result
   cat blast_result | head -n 10 | cut -f 2 > top_hits
@@ -57,9 +57,9 @@ When you need to access a system environment variable in your script, you have t
 If you don't need to access any Nextflow variables, you can define your script section with single-quotes:
 
 ```nextflow
-process printPath {
+process echo_path {
   '''
-  echo The path is: $PATH
+  echo "The path is: $PATH"
   '''
 }
 ```
@@ -67,7 +67,7 @@ process printPath {
 Otherwise, you can define your script with double-quotes and escape the system environment variables by prefixing them with a back-slash `\` character, as shown in the following example:
 
 ```nextflow
-process doOtherThings {
+process blast {
   """
   blastp -db \$DB -query query.fa -outfmt 6 > blast_result
   cat blast_result | head -n $MAX | cut -f 2 > top_hits
@@ -89,7 +89,7 @@ A pipeline may be composed of processes that execute very different tasks. With 
 To use a language other than Bash, simply start your process script with the corresponding [shebang](<http://en.wikipedia.org/wiki/Shebang_(Unix)>). For example:
 
 ```nextflow
-process perlTask {
+process perl_task {
     """
     #!/usr/bin/perl
 
@@ -97,7 +97,7 @@ process perlTask {
     """
 }
 
-process pythonTask {
+process python_task {
     """
     #!/usr/bin/python
 
@@ -108,8 +108,8 @@ process pythonTask {
 }
 
 workflow {
-    perlTask()
-    pythonTask()
+    perl_task()
+    python_task()
 }
 ```
 
@@ -162,16 +162,16 @@ Process scripts can be externalized to **template** files, which allows them to 
 A template can be used in place of an embedded script using the `template` function in the script section:
 
 ```nextflow
-process templateExample {
+process hello {
     input:
     val STR
 
     script:
-    template 'my_script.sh'
+    template 'hello.sh'
 }
 
 workflow {
-    channel.of('this', 'that') | templateExample
+    channel.of('this', 'that') | hello
 }
 ```
 
@@ -217,7 +217,7 @@ The `shell` section is a string expression that defines the script that is execu
 This way, it is possible to use both Nextflow and Bash variables in the same script without having to escape the latter, which makes process scripts easier to read and maintain. For example:
 
 ```nextflow
-process myTask {
+process hello {
     input:
     val str
 
@@ -228,7 +228,7 @@ process myTask {
 }
 
 workflow {
-    channel.of('Hello', 'Hola', 'Bonjour') | myTask
+    channel.of('Hello', 'Hola', 'Bonjour') | hello
 }
 ```
 
@@ -249,16 +249,16 @@ The `exec` section executes the given code without launching a job.
 For example:
 
 ```nextflow
-process simpleSum {
+process hello {
     input:
-    val x
+    val name
 
     exec:
-    println "Hello Mr. $x"
+    println "Hello Mr. $name"
 }
 
 workflow {
-    channel.of('a', 'b', 'c') | simpleSum
+    channel.of('a', 'b', 'c') | hello
 }
 ```
 
@@ -282,19 +282,19 @@ A native process is very similar to a {ref}`function <syntax-function>`. However
 You can define a command *stub*, which replaces the actual process command when the `-stub-run` or `-stub` command-line option is enabled:
 
 ```nextflow
-process INDEX {
-  input:
+process salmon_index {
+    input:
     path transcriptome
 
-  output:
+    output:
     path 'index'
 
-  script:
+    script:
     """
     salmon index --threads $task.cpus -t $transcriptome -i index
     """
 
-  stub:
+    stub:
     """
     mkdir index
     touch index/seq.bin
@@ -341,19 +341,19 @@ See {ref}`process reference <process-reference-inputs>` for the full list of inp
 The `val` qualifier accepts any data type. It can be accessed in the process script by using the specified input name, as shown in the following example:
 
 ```nextflow
-process basicExample {
+process echo {
   input:
   val x
 
   script:
   """
-  echo process job $x
+  echo "process job $x"
   """
 }
 
 workflow {
   def num = channel.of(1,2,3)
-  basicExample(num)
+  echo(num)
 }
 ```
 
@@ -373,18 +373,18 @@ While channels do emit items in the order that they are received, *processes* do
 When the process declares exactly one input, the pipe `|` operator can be used to provide inputs to the process, instead of passing it as a parameter. Both methods have identical semantics:
 
 ```nextflow
-process basicExample {
+process echo {
   input:
   val x
 
   script:
   """
-  echo process job $x
+  echo "process job $x"
   """
 }
 
 workflow {
-  channel.of(1,2,3) | basicExample
+  channel.of(1,2,3) | echo
 }
 ```
 :::
@@ -396,7 +396,7 @@ workflow {
 The `path` qualifier allows you to provide input files to the process execution context. Nextflow will stage the files into the process execution directory, and they can be accessed in the script by using the specified input name. For example:
 
 ```nextflow
-process blastThemAll {
+process blast {
   input:
   path query_file
 
@@ -408,7 +408,7 @@ process blastThemAll {
 
 workflow {
   def proteins = channel.fromPath( '/some/path/*.fa' )
-  blastThemAll(proteins)
+  blast(proteins)
 }
 ```
 
@@ -433,7 +433,7 @@ path 'query.fa'
 The previous example can be re-written as shown below:
 
 ```nextflow
-process blastThemAll {
+process blast {
   input:
   path 'query.fa'
 
@@ -445,7 +445,7 @@ process blastThemAll {
 
 workflow {
   def proteins = channel.fromPath( '/some/path/*.fa' )
-  blastThemAll(proteins)
+  blast(proteins)
 }
 ```
 
@@ -490,7 +490,7 @@ A `path` input can also accept a collection of files instead of a single value. 
 When the input has a fixed file name and a collection of files is received by the process, the file name will be appended with a numerical suffix representing its ordinal position in the list. For example:
 
 ```nextflow
-process blastThemAll {
+process blast {
     input:
     path 'seq'
 
@@ -502,7 +502,7 @@ process blastThemAll {
 
 workflow {
     def fasta = channel.fromPath( "/some/path/*.fa" ).buffer(size: 3)
-    blastThemAll(fasta)
+    blast(fasta)
 }
 ```
 
@@ -532,7 +532,7 @@ The target input file name may contain the `*` and `?` wildcards, which can be u
 The following example shows how a wildcard can be used in the input file definition:
 
 ```nextflow
-process blastThemAll {
+process blast {
     input:
     path 'seq?.fa'
 
@@ -544,7 +544,7 @@ process blastThemAll {
 
 workflow {
     def fasta = channel.fromPath( "/some/path/*.fa" ).buffer(size: 3)
-    blastThemAll(fasta)
+    blast(fasta)
 }
 ```
 
@@ -573,7 +573,7 @@ When a task is executed, Nextflow will check whether the received files for each
 When the input file name is specified by using the `name` option or a string literal, you can also use other input values as variables in the file name string. For example:
 
 ```nextflow
-process simpleCount {
+process grep {
   input:
   val x
   path "${x}.fa"
@@ -598,18 +598,18 @@ In most cases, you won't need to use dynamic file names, because each task is ex
 The `env` qualifier allows you to define an environment variable in the process execution context based on the input value. For example:
 
 ```nextflow
-process printEnv {
+process echo_env {
     input:
     env 'HELLO'
 
     script:
     '''
-    echo $HELLO world!
+    echo "$HELLO world!"
     '''
 }
 
 workflow {
-    channel.of('hello', 'hola', 'bonjour', 'ciao') | printEnv
+    channel.of('hello', 'hola', 'bonjour', 'ciao') | echo_env
 }
 ```
 
@@ -625,7 +625,7 @@ hola world!
 The `stdin` qualifier allows you to forward the input value to the [standard input](http://en.wikipedia.org/wiki/Standard_streams#Standard_input_.28stdin.29) of the process script. For example:
 
 ```nextflow
-process printAll {
+process cat {
   input:
   stdin
 
@@ -638,7 +638,7 @@ process printAll {
 workflow {
   channel.of('hello', 'hola', 'bonjour', 'ciao')
     | map { v -> v + '\n' }
-    | printAll
+    | cat
 }
 ```
 
@@ -658,7 +658,7 @@ hello
 The `tuple` qualifier allows you to group multiple values into a single input definition. It can be useful when a channel emits tuples of values that need to be handled separately. Each element in the tuple is associated with a corresponding element in the `tuple` definition. For example:
 
 ```nextflow
-process tupleExample {
+process cat {
     input:
     tuple val(x), path('input.txt')
 
@@ -670,7 +670,7 @@ process tupleExample {
 }
 
 workflow {
-  channel.of( [1, 'alpha.txt'], [2, 'beta.txt'], [3, 'delta.txt'] ) | tupleExample
+  channel.of( [1, 'alpha.txt'], [2, 'beta.txt'], [3, 'delta.txt'] ) | cat
 }
 ```
 
@@ -683,7 +683,7 @@ A `tuple` definition may contain any of the following qualifiers, as previously 
 The `each` qualifier allows you to repeat the execution of a process for each item in a collection, each time a new value is received. For example:
 
 ```nextflow
-process alignSequences {
+process align {
   input:
   path seq
   each mode
@@ -698,7 +698,7 @@ workflow {
   sequences = channel.fromPath('*.fa')
   methods = ['regular', 'espresso', 'psicoffee']
 
-  alignSequences(sequences, methods)
+  align(sequences, methods)
 }
 ```
 
@@ -707,7 +707,7 @@ In the above example, each time a file of sequences is emitted from the `sequenc
 Input repeaters can be applied to files as well. For example:
 
 ```nextflow
-process alignSequences {
+process align {
   input:
   path seq
   each mode
@@ -724,7 +724,7 @@ workflow {
   methods = ['regular', 'espresso']
   libraries = [ file('PQ001.lib'), file('PQ002.lib'), file('PQ003.lib') ]
 
-  alignSequences(sequences, methods, libraries)
+  align(sequences, methods, libraries)
 }
 ```
 
@@ -901,7 +901,7 @@ workflow {
 The `path` qualifier allows you to output one or more files produced by the process. For example:
 
 ```nextflow
-process randomNumber {
+process random_number {
   output:
   path 'result.txt'
 
@@ -912,12 +912,12 @@ process randomNumber {
 }
 
 workflow {
-  numbers = randomNumber()
+  numbers = random_number()
   numbers.view { file -> "Received: ${file.text}" }
 }
 ```
 
-In the above example, the `randomNumber` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding output channel. A downstream process with a compatible input channel will be able to receive it.
+In the above example, the `random_number` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding output channel. A downstream process with a compatible input channel will be able to receive it.
 
 Refer to the {ref}`process reference <process-reference-outputs>` for the list of available options for `path` outputs.
 
@@ -926,7 +926,7 @@ Refer to the {ref}`process reference <process-reference-outputs>` for the list o
 When an output file name contains a `*` or `?` wildcard character, it is interpreted as a [glob][glob] path matcher. This allows you to capture multiple files into a list and emit the list as a single value. For example:
 
 ```nextflow
-process splitLetters {
+process split_letters {
     output:
     path 'chunk_*'
 
@@ -937,7 +937,7 @@ process splitLetters {
 }
 
 workflow {
-    splitLetters
+    split_letters
         | flatten
         | view { chunk -> "File: ${chunk.name} => ${chunk.text}" }
 }
@@ -1173,7 +1173,7 @@ The `when` section allows you to define a condition that must be satisfied in or
 It can be useful to enable/disable the process execution depending on the state of various inputs and parameters. For example:
 
 ```nextflow
-process find {
+process blast_search {
   input:
   path proteins
   val dbtype

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -456,16 +456,16 @@ You can think of it as a channel that is shared across many different processes 
 A process output can be assigned to a topic using the `topic` option on an output, for example:
 
 ```nextflow
-process foo {
+process hello {
   output:
-  val('foo'), topic: my_topic
+  val('hello'), topic: my_topic
 
   // ...
 }
 
-process bar {
+process bye {
   output:
-  val('bar'), topic: my_topic
+  val('bye'), topic: my_topic
 
   // ...
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -937,15 +937,15 @@ Filter specific fields from the execution log of a process.
 ```console
 $ nextflow log tiny_leavitt -f 'process,exit,hash,duration'
 
-splitLetters        0       1f/f1ea91       112ms
-convertToUpper      0       bf/334115       144ms
-convertToUpper      0       a3/06521d       139ms
+split_letters       0       1f/f1ea91       112ms
+convert_to_upper    0       bf/334115       144ms
+convert_to_upper    0       a3/06521d       139ms
 ```
 
 Filter fields from the execution log of a process based on a criteria.
 
 ```console
-$ nextflow log tiny_leavitt -F 'process =~ /splitLetters/'
+$ nextflow log tiny_leavitt -F 'process =~ /split_letters/'
 
 work/1f/f1ea9158fb23b53d5083953121d6b6
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -582,7 +582,7 @@ $ nextflow inspect nextflow-io/hello
 Specify parameters as with the `run` command:
 
 ```console
-$ nextflow inspect main.nf --alpha 1 --beta foo
+$ nextflow inspect main.nf --alpha 1 --beta hello
 ```
 
 ### `kuberun`
@@ -850,7 +850,7 @@ The `log` command is used to query the execution metadata associated with pipeli
 : Comma-separated list of fields to include in the printed log. Use the `-l` option to see the list of available fields.
 
 `-F, -filter`
-: Filter log entries by a custom expression, e.g. `process =~ /foo.*/ && status == 'COMPLETED'`.
+: Filter log entries by a custom expression, e.g. `process =~ /hello.*/ && status == 'COMPLETED'`.
 
 `-h, -help`
 : Print the command usage.
@@ -1426,15 +1426,12 @@ List the folder structure of the downloaded pipeline:
 $ nextflow view -l nextflow-io/hello
 
 == content of path: .nextflow/assets/nextflow-io/hello
+.git
+.gitignore
 LICENSE
 README.md
-nextflow.config
-.gitignore
-circle.yml
-foo.nf
-.git
-.travis.yml
 main.nf
+nextflow.config
 ```
 
 View the contents of a downloaded pipeline without omitting the header:

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -106,7 +106,7 @@ The following environment variables control the configuration of the Nextflow ru
 : :::{versionadded} 23.05.0-edge
   :::
 : The file storage path against which relative file paths are resolved.
-: For example, with `NXF_FILE_ROOT=/some/root/path`, the use of `file('foo')` will be resolved to the absolute path `/some/root/path/foo`. A remote root path can be specified using the usual protocol prefix, e.g. `NXF_FILE_ROOT=s3://my-bucket/data`. Files defined using an absolute path are not affected by this setting.
+: For example, with `NXF_FILE_ROOT=/some/root/path`, the use of `file('hello')` will be resolved to the absolute path `/some/root/path/hello`. A remote root path can be specified using the usual protocol prefix, e.g. `NXF_FILE_ROOT=s3://my-bucket/data`. Files defined using an absolute path are not affected by this setting.
 
 `NXF_HOME`
 : Nextflow home directory (default: `$HOME/.nextflow`).

--- a/docs/reference/operator.md
+++ b/docs/reference/operator.md
@@ -512,7 +512,7 @@ The `tag` option can be used to select which channels to dump:
 :language: nextflow
 ```
 
-Then, you can run your pipeline with `-dump-channels foo` or `-dump-channels bar` to dump the content of either channel. Multiple tag names can be specified as a comma-separated list.
+Then, you can run your pipeline with `-dump-channels plus1` or `-dump-channels exp2` to dump the content of either channel. Multiple tag names can be specified as a comma-separated list.
 
 Available options:
 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -262,7 +262,7 @@ When combined with the {ref}`container directive <process-container>`, the `afte
 The `arch` directive allows you to define the CPU architecture to build the software in use by the process' task. For example:
 
 ```nextflow
-process cpu_task {
+process blast {
     spack 'blast-plus@2.13.0'
     arch 'linux/x86_64', target: 'cascadelake'
 
@@ -305,7 +305,7 @@ A job array is a collection of jobs with the same resource requirements and the 
 The directive should be specified with a given array size, along with an executor that supports job arrays. For example:
 
 ```nextflow
-process cpu_task {
+process hello {
     executor 'slurm'
     array 100
 
@@ -382,7 +382,7 @@ The `cache` directive allows you to store the process results to a local cache. 
 The cache is enabled by default, but you can disable it for a specific process by setting the `cache` directive to `false`. For example:
 
 ```nextflow
-process noCacheThis {
+process hello {
   cache false
   // ...
 }
@@ -475,7 +475,7 @@ It requires the Docker daemon to be running in machine where the pipeline is exe
 For example:
 
 ```nextflow
-process runThisInDocker {
+process hello_docker {
   container 'dockerbox:tag'
 
   script:
@@ -502,7 +502,7 @@ This directive is ignored for processes that are {ref}`executed natively <proces
 The `containerOptions` directive allows you to specify any container execution option supported by the underlying container engine (ie. Docker, Singularity, etc). This can be useful to provide container settings only for a specific process e.g. mount a custom path:
 
 ```nextflow
-process runThisWithDocker {
+process hello_docker {
     container 'busybox:latest'
     containerOptions '--volume /data/db:/db'
 
@@ -527,9 +527,8 @@ This feature is not supported by the {ref}`k8s-executor` executor.
 The `cpus` directive allows you to define the number of (logical) CPU required by the process' task. For example:
 
 ```nextflow
-process big_job {
+process blast {
   cpus 8
-  executor 'sge'
 
   script:
   """
@@ -551,7 +550,7 @@ By default the `stdout` produced by the commands executed in all processes is ig
 For example:
 
 ```nextflow
-process sayHello {
+process hello {
   debug true
 
   script:
@@ -574,9 +573,8 @@ Without specifying `debug true`, you won't see the `Hello` string printed out wh
 The `disk` directive allows you to define how much local disk storage the process is allowed to use. For example:
 
 ```nextflow
-process big_job {
+process hello {
     disk '2 GB'
-    executor 'cirrus'
 
     script:
     """
@@ -637,7 +635,7 @@ When setting the `errorStrategy` directive to `ignore` the process doesn't stop 
 For example:
 
 ```nextflow
-process ignoreAnyError {
+process hello {
   errorStrategy 'ignore'
 
   // ...
@@ -649,7 +647,7 @@ In this case, the workflow will complete successfully and return an exit status 
 The `retry` error strategy allows you to re-submit for execution a process returning an error condition. For example:
 
 ```nextflow
-process retryIfFail {
+process hello {
   errorStrategy 'retry'
 
   // ...
@@ -694,7 +692,7 @@ The following executors are available:
 The following example shows how to set the process's executor:
 
 ```nextflow
-process doSomething {
+process hello {
   executor 'sge'
 
   // ...
@@ -712,7 +710,7 @@ Each executor supports additional directives and `executor` configuration option
 The `ext` is a special directive used as *namespace* for user custom process directives. This can be useful for advanced configuration options. For example:
 
 ```nextflow
-process mapping {
+process star {
   container "biocontainers/star:${task.ext.version}"
 
   input:
@@ -731,7 +729,7 @@ In the above example, the process container version is controlled by `ext.versio
 The `ext` directive can be set in the process definition:
 
 ```nextflow
-process mapping {
+process hello {
   ext version: '2.5.3', args: '--alpha --beta'
 
   // ...
@@ -791,7 +789,7 @@ The above example produces:
 The `label` directive allows the annotation of processes with mnemonic identifier of your choice. For example:
 
 ```nextflow
-process bigTask {
+process hello {
   label 'big_mem'
 
   script:
@@ -870,7 +868,7 @@ queue named `on-demand-compute`.
 The `maxErrors` directive allows you to specify the maximum number of times a process can fail when using the `retry` error strategy. By default this directive is disabled, you can set it as shown in the example below:
 
 ```nextflow
-process retryIfFail {
+process hello {
   errorStrategy 'retry'
   maxErrors 5
 
@@ -896,7 +894,7 @@ The `maxForks` directive allows you to define the maximum number of process inst
 If you want to execute a process in a sequential manner, set this directive to one. For example:
 
 ```nextflow
-process doNotParallelizeIt {
+process hello {
   maxForks 1
 
   script:
@@ -913,7 +911,7 @@ process doNotParallelizeIt {
 The `maxRetries` directive allows you to define the maximum number of times a process instance can be re-submitted in case of failure. This value is applied only when using the `retry` error strategy. By default only one retry is allowed, you can increase this value as shown below:
 
 ```nextflow
-process retryIfFail {
+process hello {
     errorStrategy 'retry'
     maxRetries 3
 
@@ -937,9 +935,8 @@ See also: [errorStrategy](#errorstrategy) and [maxErrors](#maxerrors).
 The `memory` directive allows you to define how much memory the process is allowed to use. For example:
 
 ```nextflow
-process big_job {
+process hello {
     memory '2 GB'
-    executor 'sge'
 
     script:
     """
@@ -973,7 +970,7 @@ If it is available in your system you can use it with Nextflow in order to confi
 In a process definition you can use the `module` directive to load a specific module version to be used in the process execution environment. For example:
 
 ```nextflow
-process basicExample {
+process blast {
   module 'ncbi-blast/2.2.27'
 
   script:
@@ -986,7 +983,7 @@ process basicExample {
 You can repeat the `module` directive for each module you need to load. Alternatively multiple modules can be specified in a single `module` directive by separating all the module names by using a `:` (colon) character as shown below:
 
 ```nextflow
-process manyModules {
+process blast {
   module 'ncbi-blast/2.2.27:t_coffee/10.0:clustalw/2.1'
 
   script:
@@ -1003,7 +1000,7 @@ process manyModules {
 The `penv` directive allows you to define the parallel environment to be used when submitting a parallel task to the {ref}`SGE <sge-executor>` resource manager. For example:
 
 ```nextflow
-process big_job {
+process blast {
   cpus 4
   penv 'smp'
   executor 'sge'
@@ -1028,7 +1025,7 @@ The `pod` directive allows the definition of pod specific settings, such as envi
 For example:
 
 ```nextflow
-process your_task {
+process echo {
   pod env: 'MESSAGE', value: 'hello world'
 
   script:
@@ -1324,7 +1321,7 @@ Available options:
 The `queue` directive allows you to set the `queue` where jobs are scheduled when using a grid based executor in your pipeline. For example:
 
 ```nextflow
-process grid_job {
+process hello {
     queue 'long'
     executor 'sge'
 
@@ -1359,7 +1356,7 @@ This directive is only used by certain executors. Refer to the {ref}`executor-pa
 The `resourceLabels` directive allows you to specify custom name-value pairs that Nextflow applies to the computing resource used to carry out the process execution. Resource labels can be specified using the syntax shown below:
 
 ```nextflow
-process my_task {
+process hello {
     resourceLabels region: 'some-region', user: 'some-username'
 
     script:
@@ -1396,7 +1393,7 @@ See also: [label](#label)
 The `resourceLimits` directive allows you to specify environment-specific limits for task resource requests. Resource limits can be specified in a process as follows:
 
 ```nextflow
-process my_task {
+process hello {
   resourceLimits cpus: 24, memory: 768.GB, time: 72.h
 
   script:
@@ -1432,7 +1429,7 @@ The `secret` directive allows a process to access secrets.
 Secrets can be added to a process as follows:
 
 ```nextflow
-process someJob {
+process hello_secret {
     secret 'MY_ACCESS_KEY'
     secret 'MY_SECRET_KEY'
 
@@ -1462,7 +1459,7 @@ This is useful when your pipeline is launched by using a grid executor, because 
 In its basic form simply specify `true` at the directive value, as shown below:
 
 ```nextflow
-process simpleTask {
+process hello {
   scratch true
 
   output:
@@ -1505,7 +1502,7 @@ The following values are supported:
 The `shell` directive allows you to define a custom shell command for process scripts. By default, script blocks are executed with `/bin/bash -ue`.
 
 ```nextflow
-process doMoreThings {
+process hello {
     shell '/bin/bash', '-euo', 'pipefail'
 
     script:
@@ -1603,7 +1600,7 @@ In more detail, it affects the process execution in two main ways:
 The following example shows how to use the `storeDir` directive to create a directory containing a BLAST database for each species specified by an input parameter:
 
 ```nextflow
-process formatBlastDatabases {
+process make_blast_db {
   storeDir '/db/genomes'
 
   input:
@@ -1669,7 +1666,7 @@ See also {ref}`Trace execution report <trace-report>`
 The `time` directive allows you to define how long a process is allowed to run. For example:
 
 ```nextflow
-process big_job {
+process hello {
     time '1h'
 
     script:

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -216,7 +216,7 @@ The following options are available for all process outputs:
 The `accelerator` directive allows you to request hardware accelerators (e.g. GPUs) for the task execution. For example:
 
 ```nextflow
-process foo {
+process hello {
     accelerator 4, type: 'nvidia-tesla-k80'
 
     script:
@@ -361,12 +361,12 @@ The `beforeScript` directive allows you to execute a custom (Bash) snippet *befo
 For example:
 
 ```nextflow
-process foo {
+process hello {
   beforeScript 'source /cluster/bin/setup'
 
   script:
   """
-  echo bar
+  echo 'hello'
   """
 }
 ```
@@ -412,7 +412,7 @@ The `clusterOptions` directive allows the usage of any native configuration opti
 The cluster options can be a string:
 
 ```nextflow
-process foo {
+process hello {
   clusterOptions '-x 1 -y 2'
   // ...
 }
@@ -425,7 +425,7 @@ Prior to this version, grid executors that require each option to be on a separa
 The cluster options can also be a string list:
 
 ```nextflow
-process foo {
+process hello {
   clusterOptions '-x 1', '-y 2', '--flag'
   // ...
 }
@@ -450,7 +450,7 @@ The `conda` directive allows for the definition of the process dependencies usin
 Nextflow automatically sets up an environment for the given package names listed by in the `conda` directive. For example:
 
 ```nextflow
-process foo {
+process hello {
   conda 'bwa=0.7.15'
 
   script:
@@ -732,7 +732,7 @@ The `ext` directive can be set in the process definition:
 
 ```nextflow
 process mapping {
-  ext version: '2.5.3', args: '--foo --bar'
+  ext version: '2.5.3', args: '--alpha --beta'
 
   // ...
 }
@@ -742,7 +742,7 @@ Or in the Nextflow configuration:
 
 ```groovy
 process.ext.version = '2.5.3'
-process.ext.args = '--foo --bar'
+process.ext.args = '--alpha --beta'
 ```
 
 (process-fair)=
@@ -755,11 +755,12 @@ process.ext.args = '--foo --bar'
 The `fair` directive, when enabled, guarantees that process outputs will be emitted in the order in which they were received. For example:
 
 ```nextflow
-process foo {
+process hello {
     fair true
 
     input:
     val x
+
     output:
     tuple val(task.index), val(x)
 
@@ -770,7 +771,7 @@ process foo {
 }
 
 workflow {
-    channel.of('A','B','C','D') | foo | view
+    channel.of('A','B','C','D') | hello | view
 }
 ```
 
@@ -822,7 +823,7 @@ The `machineType` can be used to specify a predefined Google Compute Platform [m
 This directive is optional and if specified overrides the cpus and memory directives:
 
 ```nextflow
-process foo {
+process hello {
   machineType 'n1-highmem-8'
 
   script:
@@ -845,7 +846,7 @@ When used along with `retry` error strategy, it can be useful to re-schedule the
 resource requirement. For example:
 
 ```nextflow
-process foo {
+process hello {
   errorStrategy 'retry'
   maxSubmitAwait '10 mins'
   maxRetries 3
@@ -1028,22 +1029,22 @@ For example:
 
 ```nextflow
 process your_task {
-  pod env: 'FOO', value: 'bar'
+  pod env: 'MESSAGE', value: 'hello world'
 
   script:
   """
-  echo $FOO
+  echo $MESSAGE
   """
 }
 ```
 
-The above snippet defines an environment variable named `FOO` whose value is `bar`.
+The above snippet defines an environment variable named `MESSAGE` whose value is `'hello world'`.
 
 When defined in the Nextflow configuration file, a pod setting can be defined as a map:
 
 ```groovy
 process {
-  pod = [env: 'FOO', value: 'bar']
+  pod = [env: 'MESSAGE', value: 'hello world']
 }
 ```
 
@@ -1052,7 +1053,7 @@ Or as a list of maps:
 ```groovy
 process {
   pod = [
-    [env: 'FOO', value: 'bar'],
+    [env: 'MESSAGE', value: 'hello world'],
     [secret: 'my-secret/key1', mountPath: '/etc/file.txt']
   ]
 }
@@ -1222,7 +1223,7 @@ The following options are available:
 The `publishDir` directive allows you to publish the process output files to a specified folder. For example:
 
 ```nextflow
-process foo {
+process hello {
     publishDir '/data/chunks'
 
     output:
@@ -1248,7 +1249,7 @@ The `publishDir` directive can be specified more than once in order to publish o
 By default files are published to the target folder creating a *symbolic link* for each process output that links the file produced into the process working directory. This behavior can be modified using the `mode` option, for example:
 
 ```nextflow
-process foo {
+process hello {
     publishDir '/data/chunks', mode: 'copy', overwrite: false
 
     output:
@@ -1314,7 +1315,7 @@ Available options:
 : :::{versionadded} 21.12.0-edge
   :::
 : *Experimental: currently only supported for S3.*
-: Allow the association of arbitrary tags with the published file e.g. `tags: [FOO: 'Hello world']`.
+: Allow the association of arbitrary tags with the published file e.g. `tags: [MESSAGE: 'Hello world']`.
 
 (process-queue)=
 
@@ -1529,7 +1530,7 @@ The `spack` directive allows for the definition of the process dependencies usin
 Nextflow automatically sets up an environment for the given package names listed by in the `spack` directive. For example:
 
 ```nextflow
-process foo {
+process hello {
     spack 'bwa@0.7.15'
 
     script:
@@ -1634,7 +1635,7 @@ The `storeDir` directive should not be used to publish workflow outputs. Use the
 The `tag` directive allows you to associate each process execution with a custom label, so that it will be easier to identify them in the log file or in the trace execution report. For example:
 
 ```nextflow
-process foo {
+process hello {
   tag "$code"
 
   input:
@@ -1647,16 +1648,16 @@ process foo {
 }
 
 workflow {
-  channel.of('alpha', 'gamma', 'omega') | foo
+  channel.of('alpha', 'gamma', 'omega') | hello
 }
 ```
 
 The above snippet will print a log similar to the following one, where process names contain the tag value:
 
 ```
-[6e/28919b] Submitted process > foo (alpha)
-[d2/1c6175] Submitted process > foo (gamma)
-[1c/3ef220] Submitted process > foo (omega)
+[6e/28919b] Submitted process > hello (alpha)
+[d2/1c6175] Submitted process > hello (gamma)
+[1c/3ef220] Submitted process > hello (omega)
 ```
 
 See also {ref}`Trace execution report <trace-report>`

--- a/docs/reference/stdlib-types.md
+++ b/docs/reference/stdlib-types.md
@@ -477,7 +477,7 @@ The following methods are useful for getting attributes of a file:
 : Gets the file parent path, e.g. `/some/path/file.txt` -> `/some/path`.
 
 `getScheme() -> String`
-: Gets the file URI scheme, e.g. `s3://some-bucket/foo.txt` -> `s3`.
+: Gets the file URI scheme, e.g. `s3://some-bucket/hello.txt` -> `s3`.
 
 `isDirectory() -> boolean`
 : Returns `true` if the file is a directory.
@@ -503,11 +503,11 @@ The following methods are useful for getting attributes of a file:
 `toUriString() -> String`
 : Gets the file path along with the protocol scheme:
   ```nextflow
-  def ref = file('s3://some-bucket/foo.txt')
+  def ref = file('s3://some-bucket/hello.txt')
 
-  assert ref.toString() == '/some-bucket/foo.txt'
-  assert "$ref" == '/some-bucket/foo.txt'
-  assert ref.toUriString() == 's3://some-bucket/foo.txt'
+  assert ref.toString() == '/some-bucket/hello.txt'
+  assert "$ref" == '/some-bucket/hello.txt'
+  assert ref.toUriString() == 's3://some-bucket/hello.txt'
   ```
 
 <h3>Reading</h3>

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -76,29 +76,29 @@ nextflow.preview.recursion = true
 An include declaration consists of an *include source* and one or more *include clauses*:
 
 ```nextflow
-include { foo as bar } from './some/module'
+include { hallo as sayHello } from './some/module'
 ```
 
-The include source should be a string literal and should refer to either a local path (e.g. `./module.nf`) or a plugin (e.g. `plugin/nf-hello`). Each include clause should specify a name, and may also specify an *alias*. In the above example, `foo` is included under the alias `bar`.
+The include source should be a string literal and should refer to either a local path (e.g. `./module.nf`) or a plugin (e.g. `plugin/nf-hello`). Each include clause should specify a name, and may also specify an *alias*. In the above example, `hallo` is included under the alias `sayHello`.
 
 Include clauses can be separated by semi-colons or newlines:
 
 ```nextflow
 // semi-colons
-include { foo ; bar as baz } from './some/module'
+include { hallo ; bye as goodbye } from './some/module'
 
 // newlines
 include {
-    foo
-    bar as baz
+    hallo
+    bye as goodbye
 } from './some/module'
 ```
 
 Include clauses can also be specified as separate includes:
 
 ```nextflow
-include { foo } from './some/module'
-include { bar as baz } from './some/module'
+include { hallo } from './some/module'
+include { bye as goodbye } from './some/module'
 ```
 
 The following definitions can be included:
@@ -352,13 +352,13 @@ Variables declared in an if or else branch exist only within that branch:
 
 ```nextflow
 if( true )
-    def x = 'foo'
+    def x = 'hello'
 println x           // error: `x` is undefined
 
 // solution: declare `x` outside of if branch
 def x
 if( true )
-    x = 'foo'
+    x = 'hello'
 println x
 ```
 
@@ -525,10 +525,10 @@ A try/catch statement consists of a *try block* followed by any number of *catch
 ```nextflow
 def text = null
 try {
-    text = file('foo.txt').text
+    text = file('hello.txt').text
 }
 catch( IOException e ) {
-    log.warn "Could not load foo.txt"
+    log.warn "Could not load hello.txt"
 }
 ```
 
@@ -676,7 +676,7 @@ A list literal consists of a comma-separated list of zero or more expressions, e
 A map literal consists of a comma-separated list of one or more *map entries*, enclosed in square brackets. Each map entry consists of a *key expression* and *value expression* separated by a colon:
 
 ```nextflow
-[foo: 1, bar: 2, baz: 3]
+[alpha: 1, beta: 2, gamma: 3]
 ```
 
 An empty map is specified with a single colon to distinguish it from an empty list:
@@ -688,9 +688,9 @@ An empty map is specified with a single colon to distinguish it from an empty li
 Both the key and value can be any expression. Identifier keys are treated as string literals (i.e. the quotes can be omitted). A variable can be used as a key by enclosing it in parentheses:
 
 ```nextflow
-def x = 'foo'
+def x = 'alpha'
 [(x): 1]
-// -> ['foo': 1]
+// -> ['alpha': 1]
 ```
 
 ### Closure

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -180,7 +180,7 @@ Entry workflow definitions are ignored when a script is included as a module. Th
 A process consists of a name and a body. The process body consists of one or more [statements](#statements). A minimal process definition must return a string:
 
 ```nextflow
-process sayHello {
+process hello {
     """
     echo 'Hello world!'
     """
@@ -225,7 +225,7 @@ Each section may contain one or more statements. For directives, inputs, and out
 The script section can be substituted with an exec section:
 
 ```nextflow
-process greetExec {
+process greet {
     input: 
     val greeting
     val name

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -88,7 +88,7 @@ nextflow log goofy_kilby -t my-template.md > execution-report.md
 The `filter` option makes it possible to select which entries to include in the log report. Any valid groovy boolean expression on the log fields can be used to define the filter condition. For example:
 
 ```bash
-nextflow log goofy_kilby -filter 'name =~ /foo.*/ && status == "FAILED"'
+nextflow log goofy_kilby -filter 'name =~ /hello.*/ && status == "FAILED"'
 ```
 
 (execution-report)=

--- a/docs/script.md
+++ b/docs/script.md
@@ -136,9 +136,9 @@ The `assert` keyword simply tests a condition and raises an error if the conditi
 Comparison operators can be used to compare two values:
 
 ```nextflow
-assert 3 < 3.14         // numbers are compared as, well, numbers
+assert 3 < 3.14             // numbers are compared as numbers
 assert 3 <= 3
-assert 'foo' > 'bar'    // strings are compared alphabetically
+assert 'hello' < 'world'    // strings are compared alphabetically
 ```
 
 Logical operators can be used to perform Boolean logic:
@@ -297,15 +297,15 @@ Regular expressions are the Swiss Army knife of text processing. They provide th
 Use `=~` to check whether a given pattern occurs anywhere in a string:
 
 ```nextflow
-assert 'foo' =~ /foo/
-assert 'foobar' =~ /foo/
+assert 'hello' =~ /hello/
+assert 'hello world' =~ /hello/
 ```
 
 Use `==~` to check whether a string matches a given regular expression pattern exactly.
 
 ```nextflow
-assert 'foo' ==~ /foo/
-assert !('foobar' ==~ /foo/)
+assert 'hello' ==~ /hello/
+assert !('hello world' ==~ /hello/)
 ```
 
 ### String replacement

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -52,7 +52,7 @@ Secrets **cannot** be assigned to pipeline parameters.
 Secrets can be access by pipeline processes by using the `secret` directive. For example:
 
 ```nextflow
-process someJob {
+process my_task {
     secret 'MY_ACCESS_KEY'
     secret 'MY_SECRET_KEY'
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -16,10 +16,10 @@ You can configure your credentials for various Git providers in the Git configur
 
 Nextflow can work with repositories stored in a local or shared file system. The repository must be created as a [bare repository](https://craftquest.io/articles/what-is-a-bare-git-repository).
 
-For example, given a bare repository at `/shared/projects/foo.git`, Nextflow is able to run it using the following syntax:
+For example, given a bare repository at `/shared/projects/hello.git`, Nextflow is able to run it using the following syntax:
 
 ```bash
-nextflow run file:/shared/projects/foo.git
+nextflow run file:/shared/projects/hello.git
 ```
 
 See [Git documentation](https://git-scm.com/book/en/v2/Git-on-the-Server-Getting-Git-on-a-Server) for more details about how create and manage bare repositories.
@@ -38,16 +38,16 @@ To learn more about this and other project metadata information, that can be def
 
 Once you have uploaded your pipeline project to GitHub other people can execute it simply using the project name or the repository URL.
 
-For if your GitHub account name is `foo` and you have uploaded a project into a repository named `bar` the repository URL will be `http://github.com/foo/bar` and people will able to download and run it by using either the command:
+For if your GitHub account name is `acme` and you have uploaded a project into a repository named `hello` the repository URL will be `http://github.com/acme/hello` and people will able to download and run it by using either the command:
 
 ```bash
-nextflow run foo/bar
+nextflow run acme/hello
 ```
 
 or
 
 ```bash
-nextflow run http://github.com/foo/bar
+nextflow run http://github.com/acme/hello
 ```
 
 See the {ref}`CLI <cli-page>` page to learn how to use the Nextflow command line to run pipelines and manage pipeline projects.
@@ -215,8 +215,8 @@ Any environment variable that may be required by the tools in your pipeline can 
 
 ```groovy
 env {
-  DELTA = 'foo'
-  GAMMA = 'bar'
+  DELTA = 'hello'
+  GAMMA = 'world'
 }
 ```
 

--- a/docs/snippets/branch-with-mapper.nf
+++ b/docs/snippets/branch-with-mapper.nf
@@ -1,9 +1,9 @@
 channel.of(1, 2, 3, 40, 50)
     .branch { v ->
-        foo: v < 10
+        alpha: v < 10
             return v + 2
 
-        bar: v < 50
+        beta: v < 50
             return v - 2
 
         other: true
@@ -11,6 +11,6 @@ channel.of(1, 2, 3, 40, 50)
     }
     .set { result }
 
-result.foo.view { v -> "$v is foo" }
-result.bar.view { v -> "$v is bar" }
+result.alpha.view { v -> "$v is alpha" }
+result.beta.view { v -> "$v is beta" }
 result.other.view { v -> "$v is other" }

--- a/docs/snippets/branch-with-mapper.out
+++ b/docs/snippets/branch-with-mapper.out
@@ -1,5 +1,5 @@
-3 is foo
-4 is foo
-5 is foo
-38 is bar
+3 is alpha
+4 is alpha
+5 is alpha
+38 is beta
 0 is other

--- a/docs/snippets/dump.nf
+++ b/docs/snippets/dump.nf
@@ -1,7 +1,7 @@
 channel.of( 1, 2, 3 )
     .map { v -> v + 1 }
-    .dump(tag: 'foo')
+    .dump(tag: 'plus1')
 
 channel.of( 1, 2, 3 )
-    .map { v -> v ^ 2 }
-    .dump(tag: 'bar')
+    .map { v -> v ** 2 }
+    .dump(tag: 'exp2')

--- a/docs/snippets/multimap-shared.nf
+++ b/docs/snippets/multimap-shared.nf
@@ -1,6 +1,6 @@
 channel.of( 1, 2, 3 )
-    .multiMap { v -> foo: bar: v }
+    .multiMap { v -> alpha: beta: v }
     .set { result }
 
-result.foo.view { v -> "foo $v" }
-result.bar.view { v -> "bar $v" }
+result.alpha.view { v -> "alpha $v" }
+result.beta.view { v -> "beta $v" }

--- a/docs/snippets/multimap-shared.out
+++ b/docs/snippets/multimap-shared.out
@@ -1,6 +1,6 @@
-bar 1
-bar 2
-bar 3
-foo 1
-foo 2
-foo 3
+alpha 1
+alpha 2
+alpha 3
+beta 1
+beta 2
+beta 3

--- a/docs/snippets/multimap.nf
+++ b/docs/snippets/multimap.nf
@@ -1,9 +1,9 @@
 channel.of( 1, 2, 3, 4 )
     .multiMap { v ->
-        foo: v + 1
-        bar: v * v
+        inc: v + 1
+        squared: v * v
     }
     .set { result }
 
-result.foo.view { v -> "foo $v" }
-result.bar.view { v -> "bar $v" }
+result.inc.view { v -> "inc $v" }
+result.squared.view { v -> "squared $v" }

--- a/docs/snippets/multimap.out
+++ b/docs/snippets/multimap.out
@@ -1,8 +1,8 @@
-foo 2
-foo 3
-foo 4
-foo 5
-bar 1
-bar 4
-bar 9
-bar 16
+inc 2
+inc 3
+inc 4
+inc 5
+squared 1
+squared 4
+squared 9
+squared 16

--- a/docs/snippets/process-out-env.nf
+++ b/docs/snippets/process-out-env.nf
@@ -1,13 +1,13 @@
-process myTask {
+process seq {
     output:
-    env 'FOO'
+    env 'RESULT'
 
     script:
     '''
-    FOO=$(seq 5)
+    RESULT=$(seq 5)
     '''
 }
 
 workflow {
-    myTask | view
+    seq | view
 }

--- a/docs/snippets/process-out-eval.nf
+++ b/docs/snippets/process-out-eval.nf
@@ -1,4 +1,4 @@
-process sayHello {
+process hello {
     output:
     eval('echo Hello world!')
 
@@ -9,5 +9,5 @@ process sayHello {
 }
 
 workflow {
-    sayHello | view
+    hello | view
 }

--- a/docs/snippets/process-stdout.nf
+++ b/docs/snippets/process-stdout.nf
@@ -1,13 +1,13 @@
-process sayHello {
+process hello {
     output:
     stdout
 
     script:
     """
-    echo Hello world!
+    echo "Hello world!"
     """
 }
 
 workflow {
-    sayHello | view { message -> "I say... $message" }
+    hello | view { message -> "I say... $message" }
 }

--- a/docs/snippets/your-first-script.nf
+++ b/docs/snippets/your-first-script.nf
@@ -1,6 +1,6 @@
 params.str = 'Hello world!'
 
-process splitLetters {
+process split_letters {
     output:
     path 'chunk_*'
 
@@ -10,7 +10,7 @@ process splitLetters {
     """
 }
 
-process convertToUpper {
+process convert_to_upper {
     input:
     path x
 
@@ -24,5 +24,5 @@ process convertToUpper {
 }
 
 workflow {
-    splitLetters | flatten | convertToUpper | view { v -> v.trim() }
+    split_letters | flatten | convert_to_upper | view { v -> v.trim() }
 }

--- a/docs/spack.md
+++ b/docs/spack.md
@@ -46,7 +46,7 @@ Alternatively, it can be specified by setting the variable `NXF_SPACK_ENABLED=tr
 Spack package names can specified using the `spack` directive. Multiple package names can be specified by separating them with a blank space. For example:
 
 ```nextflow
-process foo {
+process hello {
   spack 'bwa samtools py-multiqc'
 
   script:
@@ -91,7 +91,7 @@ Read the Spack documentation for more details about how to create [environment f
 The path of an environment file can be specified using the `spack` directive:
 
 ```nextflow
-process foo {
+process hello {
   spack '/some/path/my-env.yaml'
 
   script:
@@ -110,7 +110,7 @@ The environment file name **must** have a `.yaml` extension or else it won't be 
 If you already have a local Spack environment, you can use it in your workflow specifying the installation directory of such environment by using the `spack` directive:
 
 ```nextflow
-process foo {
+process hello {
   spack '/path/to/an/existing/env/directory'
 
   script:

--- a/docs/strict-syntax.md
+++ b/docs/strict-syntax.md
@@ -79,7 +79,7 @@ workflow {
 Script declarations and statements cannot be mixed at the same level. All statements must reside within script declarations unless the script is a code snippet:
 
 ```nextflow
-process foo {
+process hello {
     // ...
 }
 
@@ -101,7 +101,7 @@ Mixing statements and script declarations was necessary in DSL1 and optional in 
 In Groovy, variables can be assigned in an expression:
 
 ```groovy
-foo(x = 1, y = 2)
+hello(x = 1, y = 2)
 ```
 
 In the strict syntax, assignments are allowed only as statements:
@@ -109,13 +109,13 @@ In the strict syntax, assignments are allowed only as statements:
 ```nextflow
 x = 1
 y = 2
-foo(x, y)
+hello(x, y)
 ```
 
 In Groovy, variables can be incremented and decremented in an expression:
 
 ```groovy
-foo(x++, y--)
+hello(x++, y--)
 ```
 
 In the strict syntax, use `+=` and `-=` instead:
@@ -123,7 +123,7 @@ In the strict syntax, use `+=` and `-=` instead:
 ```nextflow
 x += 1
 y -= 1
-foo(x, y)
+hello(x, y)
 ```
 
 ### For and while loops
@@ -284,7 +284,7 @@ def a = 1
 final b = 2
 def c = 3, d = 4
 def (e, f) = [5, 6]
-String str = 'foo'
+String str = 'hello'
 def Map meta = [:]
 ```
 
@@ -295,7 +295,7 @@ def a = 1
 def b = 2
 def (c, d) = [3, 4]
 def (e, f) = [5, 6]
-def str = 'foo'
+def str = 'hello'
 def meta = [:]
 ```
 
@@ -506,23 +506,23 @@ While params can be used anywhere in the pipeline code, they are only intended t
 As a best practice, processes and workflows should receive params as explicit inputs:
 
 ```nextflow
-process foo {
+process myproc {
     input:
-    val foo_args
+    val myproc_args
 
     // ...
 }
 
-workflow bar {
+workflow myflow {
     take:
-    bar_args
+    myflow_args
 
     // ...
 }
 
 workflow {
-    foo(params.foo_args)
-    bar(params.bar_args)
+    myproc(params.myproc_args)
+    myflow(params.myflow_args)
 }
 ```
 

--- a/docs/strict-syntax.md
+++ b/docs/strict-syntax.md
@@ -388,7 +388,7 @@ def x = '42'.toInteger()    // preferred
 In Nextflow DSL2, the name of a process `env` input/output can be specified with or without quotes:
 
 ```nextflow
-process PROC {
+process my_task {
     input:
     env FOO
     env 'BAR'
@@ -400,7 +400,7 @@ process PROC {
 In the strict syntax, the name must be specified with quotes:
 
 ```nextflow
-process PROC {
+process my_task {
     input:
     env 'FOO'
     env 'BAR'
@@ -427,7 +427,7 @@ process greet {
 In the strict syntax, the `script:` label can be omitted only if there are no other sections:
 
 ```nextflow
-process sayHello {
+process hello {
     """
     echo 'Hello world!'
     """

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -26,6 +26,19 @@ The language server parses scripts and config files according to the {ref}`Nextf
 
 When you hover over certain source code elements, such as variable names and function calls, the extension provides a tooltip with related information, such as the definition and/or documentation for the element.
 
+If a [Javadoc](https://en.wikipedia.org/wiki/Javadoc) comment is defined above a workflow, process, or function, the extension will include the contents of the comment in hover hints. The following is an example Javadoc comment:
+
+```nextflow
+/**
+ * Say hello to someone.
+ *
+ * @param name
+ */
+def sayHello(name) {
+    println "Hello, ${name}!"
+}
+```
+
 ### Code navigation
 
 The **Outline** section in the Explorer panel lists top-level definitions when you view a script. Include declarations in scripts and config files act as links, and ctrl-clicking them opens the corresponding script or config file.

--- a/docs/wave.md
+++ b/docs/wave.md
@@ -165,13 +165,13 @@ tower.accessToken = '<YOUR ACCESS TOKEN>'
 
 In the above snippet, replace `<YOUR REGISTRY>` with a container registry of your choice. For example, `quay.io` (no prefix or suffix is needed).
 The container will be copied with the same name, tag, and checksum in the specified registry. For example, if the source
-container is `quay.io/biocontainers/bwa:0.7.13--1` and the build repository setting is `foo.com`, the resulting container
-name is `foo.com/biocontainers/bwa:0.7.13--1`.
+container is `quay.io/biocontainers/bwa:0.7.13--1` and the build repository setting is `example.com`, the resulting container
+name is `example.com/biocontainers/bwa:0.7.13--1`.
 
 :::{tip}
 When using a path prefix in the target registry name, it will be prepended to the resulting container name. For example,
-having `quay.io/biocontainers/bwa:0.7.13--1` as source container and `foo.com/bar` as build repository, the resulting
-container will be named `foo.com/bar/biocontainers/bwa:0.7.13--1`.
+having `quay.io/biocontainers/bwa:0.7.13--1` as source container and `example.com/library` as build repository, the resulting
+container will be named `example.com/library/biocontainers/bwa:0.7.13--1`.
 :::
 
 The credentials to allow the push of  containers in the target repository need to be provided via the Seqera Platform
@@ -193,7 +193,7 @@ tower.accessToken = '<YOUR ACCESS TOKEN>'
 Nextflow will only allow the use of containers with no security
 vulnerabilities when using these settings. You can define the level of accepted vulnerabilities using `wave.scan.allowedLevels`. For example:
 
-```
+```groovy
 wave.scan.allowedLevels = 'low,medium'
 ```
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -340,7 +340,7 @@ process greet {
     result = "$data world"
 }
 
-process toUpper {
+process to_upper {
     input:
     val data
 
@@ -354,13 +354,13 @@ process toUpper {
 workflow {
     channel.of('Hello')
         | map { v -> v.reverse() }
-        | (greet & toUpper)
+        | (greet & to_upper)
         | mix
         | view
 }
 ```
 
-In the above snippet, the initial channel is piped to the {ref}`operator-map` operator, which reverses the string value. Then, the result is passed to the processes `greet` and `toUpper`, which are executed in parallel. Each process outputs a channel, and the two channels are combined using the {ref}`operator-mix` operator. Finally, the result is printed using the {ref}`operator-view` operator.
+In the above snippet, the initial channel is piped to the {ref}`operator-map` operator, which reverses the string value. Then, the result is passed to the processes `greet` and `to_upper`, which are executed in parallel. Each process outputs a channel, and the two channels are combined using the {ref}`operator-mix` operator. Finally, the result is printed using the {ref}`operator-view` operator.
 
 The same code can also be written as:
 
@@ -368,7 +368,7 @@ The same code can also be written as:
 workflow {
     ch = channel.of('Hello').map { v -> v.reverse() }
     ch_greet = greet(ch)
-    ch_upper = toUpper(ch)
+    ch_upper = to_upper(ch)
     ch_greet.mix(ch_upper).view()
 }
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -17,25 +17,32 @@ A script can define up to one *entry workflow*, which does not have a name and s
 ```nextflow
 workflow {
     channel.of('Bonjour', 'Ciao', 'Hello', 'Hola')
-        | map { v -> "$v world!" }
-        | view
+        .map { v -> "$v world!" }
+        .view()
 }
 ```
 
 ### Parameters
 
-Parameters can be defined in the script with a default value that can be overridden from the CLI, params file, or config file. Parameters should only be used by the entry workflow:
+Parameters can be declared by assigning a `params` property to a default value:
 
 ```nextflow
-params.data = '/some/data/file'
+params.input = '/some/data/file'
+params.save_intermeds = false
 
 workflow {
-    if( params.data )
-        bar(params.data)
+    if( params.input )
+        analyze(params.input, params.save_intermeds)
     else
-        bar(foo())
+        analyze(fake_input(), params.save_intermeds)
 }
 ```
+
+:::{note}
+As a best practice, params should be used only in the entry workflow and passed to workflows and processes as explicit inputs.
+:::
+
+The default value can be overridden by the command line, params file, or config file. Parameters from multiple sources are resolved in the order described in {ref}`cli-params`.
 
 ## Named workflows
 
@@ -43,8 +50,8 @@ A *named workflow* is a workflow that can be called by other workflows:
 
 ```nextflow
 workflow my_workflow {
-    foo()
-    bar( foo.out.collect() )
+    hello()
+    bye( hello.out.collect() )
 }
 
 workflow {
@@ -52,7 +59,7 @@ workflow {
 }
 ```
 
-The above example defines a workflow named `my_workflow` which is called from another workflow as `my_workflow()`. Both `foo` and `bar` could be any other process or workflow.
+The above example defines a workflow named `my_workflow` which is called by the entry workflow. Both `hello` and `bye` could be any other process or workflow.
 
 ### Takes and emits
 
@@ -65,8 +72,8 @@ workflow my_workflow {
     data2
 
     main:
-    foo(data1, data2)
-    bar(foo.out)
+    hello(data1, data2)
+    bye(hello.out)
 }
 ```
 
@@ -83,11 +90,11 @@ The `emit:` section is used to declare the outputs of a named workflow:
 ```nextflow
 workflow my_workflow {
     main:
-    foo(data)
-    bar(foo.out)
+    hello(data)
+    bye(hello.out)
 
     emit:
-    bar.out
+    bye.out
 }
 ```
 
@@ -98,11 +105,11 @@ If an output is assigned to a name, the name can be used to reference the output
 ```nextflow
 workflow my_workflow {
     main:
-    foo(data)
-    bar(foo.out)
+    hello(data)
+    bye(hello.out)
 
     emit:
-    my_data = bar.out
+    my_data = bye.out
 }
 ```
 
@@ -119,41 +126,41 @@ Every output must be assigned to a name when multiple outputs are declared.
 Processes and workflows are called like functions, passing their inputs as arguments:
 
 ```nextflow
-process foo {
+process hello {
     output:
-    path 'foo.txt', emit: txt
+    path 'hello.txt', emit: txt
 
     script:
     """
-    your_command > foo.txt
+    your_command > hello.txt
     """
 }
 
-process bar {
+process bye {
     input:
-    path x
+    path 'hello.txt'
 
     output:
-    path 'bar.txt', emit: txt
+    path 'bye.txt', emit: txt
 
     script:
     """
-    another_command $x > bar.txt
+    another_command hello.txt > bye.txt
     """
 }
 
-workflow flow {
+workflow hello_bye {
     take:
     data
 
     main:
-    foo()
-    bar(data)
+    hello()
+    bye(data)
 }
 
 workflow {
     data = channel.fromPath('/some/path/*.txt')
-    flow(data)
+    hello_bye(data)
 }
 ```
 
@@ -166,64 +173,64 @@ Processes and workflows have a few extra rules for how they can be called:
 The "return value" of a process or workflow call is the process outputs or workflow emits, respectively. The return value can be assigned to a variable or passed into another call:
 
 ```nextflow
-workflow flow {
+workflow hello_bye {
     take:
     data
 
     main:
-    bar_out = bar(foo(data))
+    bye_out = bye(hello(data))
 
     emit:
-    bar_out
+    bye_out
 }
 
 workflow {
     data = channel.fromPath('/some/path/*.txt')
-    flow_out = flow(data)
+    bye_out = hello_bye(data)
 }
 ```
 
 Named outputs can be accessed as properties of the return value:
 
 ```nextflow
-workflow flow {
+workflow hello_bye {
     take:
     data
 
     main:
-    foo_out = foo(data)
-    bar_out = bar(foo_out.txt)
+    hello_out = hello(data)
+    bye_out = bye(hello_out.txt)
 
     emit:
-    bar = bar_out.txt
+    bye = bye_out.txt
 }
 
 workflow {
     data = channel.fromPath('/some/path/*.txt')
-    flow_out = flow(data)
-    bar_out = flow_out.bar
+    flow_out = hello_bye(data)
+    bye_out = flow_out.bye
 }
 ```
 
 As a convenience, process and workflow outputs can also be accessed without first assigning to a variable, by using the `.out` property of the process or workflow name:
 
 ```nextflow
-workflow flow {
+workflow hello_bye {
     take:
     data
 
     main:
-    foo(data)
-    bar(foo.out)
+    hello(data)
+    bye(hello.out)
 
     emit:
-    bar = bar.out
+    bye = bye.out
 }
 
 workflow {
     data = channel.fromPath('/some/path/*.txt')
-    flow(data)
-    flow.out.bar.view()
+    hello_bye(data)
+    hello_bye.out.bye.view()
 }
 ```
 
@@ -232,7 +239,7 @@ Process named outputs are defined using the `emit` option on a process output. S
 :::
 
 :::{note}
-Process and workflow outputs can also be accessed by index (e.g., `foo.out[0]`, `foo.out[1]`, etc.). Multiple outputs should instead be accessed by name.
+Process and workflow outputs can also be accessed by index (e.g., `hello.out[0]`, `hello.out[1]`, etc.). As a best practice, multiple outputs should be accessed by name.
 :::
 
 Workflows can be composed in the same way:
@@ -243,11 +250,11 @@ workflow flow1 {
     data
 
     main:
-    foo(data)
-    bar(foo.out)
+    tick(data)
+    tack(tick.out)
 
     emit:
-    bar.out
+    tack.out
 }
 
 workflow flow2 {
@@ -255,11 +262,11 @@ workflow flow2 {
     data
 
     main:
-    foo(data)
-    baz(foo.out)
+    tick(data)
+    tock(tick.out)
 
     emit:
-    baz.out
+    tock.out
 }
 
 workflow {
@@ -270,7 +277,7 @@ workflow {
 ```
 
 :::{note}
-The same process can be called in different workflows without using an alias, like `foo` in the above example, which is used in both `flow1` and `flow2`. The workflow call stack determines the *fully qualified process name*, which is used to distinguish the different process calls, i.e. `flow1:foo` and `flow2:foo` in the above example.
+The same process can be called in different workflows without using an alias, like `tick` in the above example, which is used in both `flow1` and `flow2`. The workflow call stack determines the *fully qualified process name*, which is used to distinguish the different process calls, i.e. `flow1:tick` and `flow2:tick` in the above example.
 :::
 
 :::{tip}
@@ -286,7 +293,7 @@ The following operators have a special meaning when used in a workflow with proc
 The `|` *pipe* operator can be used to chain processes, operators, and workflows:
 
 ```nextflow
-process foo {
+process greet {
     input:
     val data
 
@@ -299,20 +306,20 @@ process foo {
 
 workflow {
     channel.of('Hello','Hola','Ciao')
-        | foo
+        | greet
         | map { v -> v.toUpperCase() }
         | view
 }
 ```
 
-The above snippet defines a process named `foo` and invokes it with the input channel. The result is then piped to the {ref}`operator-map` operator, which converts each string to uppercase, and finally to the {ref}`operator-view` operator which prints it.
+The above snippet defines a process named `greet` and invokes it with the input channel. The result is then piped to the {ref}`operator-map` operator, which converts each string to uppercase, and finally to the {ref}`operator-view` operator which prints it.
 
 The same code can also be written as:
 
 ```nextflow
 workflow {
     ch1 = channel.of('Hello','Hola','Ciao')
-    ch2 = foo( ch1 )
+    ch2 = greet( ch1 )
     ch2.map { v -> v.toUpperCase() }.view()
 }
 ```
@@ -322,7 +329,7 @@ workflow {
 The `&` *and* operator can be used to call multiple processes in parallel with the same channel(s):
 
 ```nextflow
-process foo {
+process greet {
     input:
     val data
 
@@ -333,7 +340,7 @@ process foo {
     result = "$data world"
 }
 
-process bar {
+process toUpper {
     input:
     val data
 
@@ -347,22 +354,22 @@ process bar {
 workflow {
     channel.of('Hello')
         | map { v -> v.reverse() }
-        | (foo & bar)
+        | (greet & toUpper)
         | mix
         | view
 }
 ```
 
-In the above snippet, the initial channel is piped to the {ref}`operator-map` operator, which reverses the string value. Then, the result is passed to the processes `foo` and `bar`, which are executed in parallel. Each process outputs a channel, and the two channels are combined using the {ref}`operator-mix` operator. Finally, the result is printed using the {ref}`operator-view` operator.
+In the above snippet, the initial channel is piped to the {ref}`operator-map` operator, which reverses the string value. Then, the result is passed to the processes `greet` and `toUpper`, which are executed in parallel. Each process outputs a channel, and the two channels are combined using the {ref}`operator-mix` operator. Finally, the result is printed using the {ref}`operator-view` operator.
 
 The same code can also be written as:
 
 ```nextflow
 workflow {
     ch = channel.of('Hello').map { v -> v.reverse() }
-    ch_foo = foo(ch)
-    ch_bar = bar(ch)
-    ch_foo.mix(ch_bar).view()
+    ch_greet = greet(ch)
+    ch_upper = toUpper(ch)
+    ch_greet.mix(ch_upper).view()
 }
 ```
 
@@ -486,20 +493,20 @@ By default, all output files are published to the output directory. Each output 
 ```nextflow
 workflow {
     main:
-    ch_foo = foo()
-    ch_bar = bar(ch_foo)
+    ch_step1 = step1()
+    ch_step2 = step2(ch_step1)
 
     publish:
-    foo = ch_foo
-    bar = ch_bar
+    step1 = ch_step1
+    step2 = ch_step2
 }
 
 output {
-    foo {
-        path 'foo'
+    step1 {
+        path 'step1'
     }
-    bar {
-        path 'bar'
+    step2 {
+        path 'step2'
     }
 }
 ```
@@ -508,9 +515,9 @@ The following directory structure will be created:
 
 ```
 results/
-└── foo/
+└── step1/
     └── ...
-└── bar/
+└── step2/
     └── ...
 ```
 

--- a/docs/your-first-script.md
+++ b/docs/your-first-script.md
@@ -23,8 +23,8 @@ You will run a basic Nextflow pipeline that splits a string of text into two fil
 // Default parameter input
 params.str = "Hello world!"
 
-// splitString process
-process splitString {
+// split process
+process split {
     publishDir "results/lower"
     
     input:
@@ -39,8 +39,8 @@ process splitString {
     """
 }
 
-// convertToUpper process
-process convertToUpper {
+// convert_to_upper process
+process convert_to_upper {
     publishDir "results/upper"
     tag "$y"
 
@@ -58,18 +58,18 @@ process convertToUpper {
 
 // Workflow block
 workflow {
-    ch_str = channel.of(params.str)     // Create a channel using parameter input
-    ch_chunks = splitString(ch_str)     // Split string into chunks and create a named channel
-    convertToUpper(ch_chunks.flatten()) // Convert lowercase letters to uppercase letters
+    ch_str = channel.of(params.str)       // Create a channel using parameter input
+    ch_chunks = split(ch_str)             // Split string into chunks and create a named channel
+    convert_to_upper(ch_chunks.flatten()) // Convert lowercase letters to uppercase letters
 }
 ```
 
 This script defines two processes:
 
-- `splitString`: takes a string input, splits it into 6-character chunks, and writes the chunks to files with the prefix `chunk_`
-- `convertToUpper`: takes files as input, transforms their contents to uppercase letters, and writes the uppercase strings to files with the prefix `upper_`
+- `split`: takes a string input, splits it into 6-character chunks, and writes the chunks to files with the prefix `chunk_`
+- `convert_to_upper`: takes files as input, transforms their contents to uppercase letters, and writes the uppercase strings to files with the prefix `upper_`
 
-The `splitString` output is emitted as a single element. The `flatten` operator splits this combined element so that each file is treated as a sole element.
+The `split` output is emitted as a single element. The `flatten` operator splits this combined element so that each file is treated as a sole element.
 
 The outputs from both processes are published in subdirectories, that is, `lower` and `upper`, in the `results` directory.
 
@@ -92,11 +92,11 @@ You will see output similar to the following:
 Launching `main.nf` [big_wegener] DSL2 - revision: 13a41a8946
 
 executor >  local (3)
-[82/457482] splitString (1)           | 1 of 1 ✔
-[2f/056a98] convertToUpper (chunk_aa) | 2 of 2 ✔
+[82/457482] split (1)                   | 1 of 1 ✔
+[2f/056a98] convert_to_upper (chunk_aa) | 2 of 2 ✔
 ```
 
-Nextflow creates a `work` directory to store files used during a pipeline run. Each execution of a process is run as a separate task. The `splitString` process is run as one task and the `convertToUpper` process is run as two tasks. The hexadecimal string, for example, `82/457482`, is the beginning of a unique hash. It is a prefix used to identify the task directory where the script was executed.
+Nextflow creates a `work` directory to store files used during a pipeline run. Each execution of a process is run as a separate task. The `split` process is run as one task and the `convert_to_upper` process is run as two tasks. The hexadecimal string, for example, `82/457482`, is the beginning of a unique hash. It is a prefix used to identify the task directory where the script was executed.
 
 :::{tip}
 Run your pipeline with `-ansi-log false` to see each task printed on a separate line:
@@ -111,9 +111,9 @@ You will see output similar to the following:
 ```console
 N E X T F L O W  ~  version 24.10.3
 Launching `main.nf` [peaceful_watson] DSL2 - revision: 13a41a8946
-[43/f1f8b5] Submitted process > splitString (1)
-[a2/5aa4b1] Submitted process > convertToUpper (chunk_ab)
-[30/ba7de0] Submitted process > convertToUpper (chunk_aa)
+[43/f1f8b5] Submitted process > split (1)
+[a2/5aa4b1] Submitted process > convert_to_upper (chunk_ab)
+[30/ba7de0] Submitted process > convert_to_upper (chunk_aa)
 ```
 
 ::: 
@@ -127,11 +127,11 @@ Nextflow tracks task executions in a task cache, a key-value store of previously
 You can enable resumability using the `-resume` flag when running a pipeline. To modify and resume your pipeline:
 
 1. Open `main.nf`
-2. Replace the `convertToUpper` process with the following:
+2. Replace the `convert_to_upper` process with the following:
 
     ```{code-block} groovy
     :class: copyable
-    process convertToUpper {
+    process convert_to_upper {
         publishDir "results/upper"
         tag "$y"
 
@@ -164,11 +164,11 @@ You will see output similar to the following:
 Launching `main.nf` [furious_curie] DSL2 - revision: 5490f13c43
 
 executor >  local (2)
-[82/457482] splitString (1)           | 1 of 1, cached: 1 ✔
-[02/9db40b] convertToUpper (chunk_aa) | 2 of 2 ✔
+[82/457482] split (1)                   | 1 of 1, cached: 1 ✔
+[02/9db40b] convert_to_upper (chunk_aa) | 2 of 2 ✔
 ```
 
-Nextflow skips the execution of the `splitString` process and retrieves the results from the cache. The `convertToUpper` process is executed twice.
+Nextflow skips the execution of the `split` process and retrieves the results from the cache. The `convert_to_upper` process is executed twice.
 
 See {ref}`cache-resume-page` for more information about Nextflow cache and resume functionality. 
 
@@ -195,11 +195,11 @@ You will see output similar to the following:
 Launching `main.nf` [distracted_kalam] DSL2 - revision: 082867d4d6
 
 executor >  local (4)
-[55/a3a700] process > splitString (1)           [100%] 1 of 1 ✔
-[f4/af5ddd] process > convertToUpper (chunk_ac) [100%] 3 of 3 ✔
+[55/a3a700] process > split (1)                   [100%] 1 of 1 ✔
+[f4/af5ddd] process > convert_to_upper (chunk_ac) [100%] 3 of 3 ✔
 ```
 
-The input string is now longer and the `splitString` process splits it into three chunks. The `convertToUpper` process is run three times.
+The input string is now longer and the `split` process splits it into three chunks. The `convert_to_upper` process is run three times.
 
 See {ref}`cli-params` for more information about modifying pipeline parameters.
 


### PR DESCRIPTION
This PR removes the use of `foo` and `bar` in the docs with better names, e.g. `hello` and `bye` for processes, `alpha` and `beta` for parameters, and so on.