### PR TITLE
fix: Cap azcopy memory usage at 80% of container memory

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
@@ -41,11 +41,13 @@ class AzFileCopyStrategy extends SimpleFileCopyStrategy {
     private Duration delayBetweenAttempts
     private String sasToken
     private Path remoteBinDir
+    private TaskBean task
 
     protected AzFileCopyStrategy() {}
 
     AzFileCopyStrategy(TaskBean bean, AzBatchExecutor executor) {
         super(bean)
+        this.task = bean
         this.config = executor.config
         this.remoteBinDir = executor.remoteBinDir
         this.sasToken = config.storage().sasToken
@@ -64,6 +66,7 @@ class AzFileCopyStrategy extends SimpleFileCopyStrategy {
         copy.remove('PATH')
         copy.put('PATH', '$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH')
         copy.put('AZCOPY_LOG_LOCATION', '$PWD/.azcopy_log')
+        copy.put('AZCOPY_BUFFER_GB', String.valueOf((task.containerMemory?.toGiga() ?: 2) * 0.8))
         copy.put('AZ_SAS', sasToken)
 
         // finally render the environment

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzFileCopyStrategy.groovy
@@ -68,6 +68,7 @@ class AzFileCopyStrategy extends SimpleFileCopyStrategy {
         copy.remove('PATH')
         copy.put('PATH', '$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH')
         copy.put('AZCOPY_LOG_LOCATION', '$PWD/.azcopy_log')
+        copy.put('AZCOPY_BUFFER_GB', String.valueOf((task.containerMemory?.toGiga()?: 1) * 0.8))
         copy.put('AZ_SAS', sasToken)
 
         // finally render the environment

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -392,7 +392,7 @@ class AzFileCopyStrategyTest extends Specification {
         binding.task_env == '''\
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
-                    export AZCOPY_BUFFER_GB="1.6"
+                    export AZCOPY_BUFFER_GB="0.8"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -230,6 +230,7 @@ class AzFileCopyStrategyTest extends Specification {
                     export BAR="any"
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
+                    export AZCOPY_BUFFER_GB="1.6"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 
@@ -391,6 +392,7 @@ class AzFileCopyStrategyTest extends Specification {
         binding.task_env == '''\
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
+                    export AZCOPY_BUFFER_GB="1.6"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -85,7 +85,9 @@ class AzFileCopyStrategyTest extends Specification {
                 # stage input files
                 downloads=(true)
                 
-                nxf_parallel "${downloads[@]}"
+                for cmd in "${downloads[@]}"; do
+                    $cmd
+                done
                 '''.stripIndent()
 
         binding.unstage_controls == '''\
@@ -222,7 +224,9 @@ class AzFileCopyStrategyTest extends Specification {
                 chmod +x $PWD/.nextflow-bin/* || true
                 downloads=(true)
                 
-                nxf_parallel "${downloads[@]}"
+                for cmd in "${downloads[@]}"; do
+                    $cmd
+                done
                 '''.stripIndent()
 
         binding.task_env == '''\
@@ -230,7 +234,6 @@ class AzFileCopyStrategyTest extends Specification {
                     export BAR="any"
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
-                    export AZCOPY_BUFFER_GB="1.6"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 
@@ -372,19 +375,23 @@ class AzFileCopyStrategyTest extends Specification {
                 downloads=(true)
                 rm -f file1.txt
                 rm -f file2.txt
-                downloads+=("nxf_az_download 'http://account.blob.core.windows.net/my-data/work/dir/file1.txt' file1.txt")
-                downloads+=("nxf_az_download 'http://account.blob.core.windows.net/my-data/work/dir/file2.txt' file2.txt")
-                nxf_parallel "${downloads[@]}"
+                downloads+=("nxf_az_download http://account.blob.core.windows.net/my-data/work/dir/file1.txt file1.txt")
+                downloads+=("nxf_az_download http://account.blob.core.windows.net/my-data/work/dir/file2.txt file2.txt")
+                for cmd in "${downloads[@]}"; do
+                    $cmd
+                done
                 '''.stripIndent()
 
         binding.unstage_outputs == '''
                     uploads=()
                     IFS=$'\\n'
                     for name in $(eval "ls -1d foo.txt bar.fastq" | sort | uniq); do
-                        uploads+=("nxf_az_upload '$name' 'http://account.blob.core.windows.net/my-data/work/dir'")
+                        uploads+=("nxf_az_upload '$name' http://account.blob.core.windows.net/my-data/work/dir")
                     done
                     unset IFS
-                    nxf_parallel "${uploads[@]}"
+                    for cmd in "${uploads[@]}"; do
+                        $cmd
+                    done
                     '''.stripIndent().leftTrim()
 
         binding.launch_cmd == '/bin/bash .command.run nxf_trace'
@@ -392,7 +399,6 @@ class AzFileCopyStrategyTest extends Specification {
         binding.task_env == '''\
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
-                    export AZCOPY_BUFFER_GB="0.8"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -234,6 +234,7 @@ class AzFileCopyStrategyTest extends Specification {
                     export BAR="any"
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
+                    export AZCOPY_BUFFER_GB="0.8"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 
@@ -399,6 +400,7 @@ class AzFileCopyStrategyTest extends Specification {
         binding.task_env == '''\
                     export PATH="$PWD/.nextflow-bin:$AZ_BATCH_NODE_SHARED_DIR/bin/:$PATH"
                     export AZCOPY_LOG_LOCATION="$PWD/.azcopy_log"
+                    export AZCOPY_BUFFER_GB="0.8"
                     export AZ_SAS="12345"
                     '''.stripIndent()
 


### PR DESCRIPTION
azcopy was consuming more memory than the hard cap of the container memory. This PR does two things:

- Downloads the files in linear, since azcopy is super fast anyway
- Caps it to 80% of the container memory, which should be sufficient for most cases while preventing excessive memory usage.

Fixes #6161 