### PR TITLE
Upgrade AWS instructions to AL2023

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -355,8 +355,6 @@ The following snippet shows how to install Docker on an Amazon EC2 instance:
 ```bash
 # install Docker
 sudo yum update -y
-# For Amazon Linux 2, run the following: 
-# sudo amazon-linux-extras install docker
 sudo yum install docker
 
 # start the Docker service
@@ -379,9 +377,6 @@ The ECS agent is included in the **Amazon ECS-optimized Amazon Linux 2023 AMI** 
 To install the agent, follow these steps:
 
 ```bash
-# For Amazon Linux 2, run the following: 
-# sudo amazon-linux-extras disable docker
-# sudo amazon-linux-extras install -y ecs
 sudo yum install ecs-init
 sudo systemctl enable --now ecs
 ```

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -348,14 +348,15 @@ The grandparent directory of the `aws` tool will be mounted into the container a
 
 ### Docker installation
 
-Docker is required by Nextflow to execute tasks on AWS Batch. The **Amazon ECS-Optimized Amazon Linux 2 (AL2) x86_64 AMI** has Docker installed, however, if you create your AMI from a different AMI that does not have Docker installed, you will need to install it manually.
+Docker is required by Nextflow to execute tasks on AWS Batch. The **Amazon ECS-optimized Amazon Linux 2023 AMI** has Docker installed, however, if you create your AMI from a different AMI that does not have Docker installed, you will need to install it manually.
 
 The following snippet shows how to install Docker on an Amazon EC2 instance:
 
 ```bash
 # install Docker
 sudo yum update -y
-sudo amazon-linux-extras install docker
+# For Amazon Linux 2, run the following: 
+# sudo amazon-linux-extras install docker
 sudo yum install docker
 
 # start the Docker service
@@ -365,7 +366,7 @@ sudo service docker start
 sudo usermod -a -G docker ec2-user
 ```
 
-You may have to reboot your instance for the changes to `ec2-user` to take effect.
+You must logging out and logging back in again to use the new `ec2-user` permissions.
 
 These steps must be done *before* creating the AMI from the current EC2 instance.
 
@@ -373,13 +374,15 @@ These steps must be done *before* creating the AMI from the current EC2 instance
 
 The [ECS container agent](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_agent.html) is a component of Amazon Elastic Container Service (Amazon ECS) and is responsible for managing containers on behalf of ECS. AWS Batch uses ECS to execute containerized jobs, therefore it requires the agent to be installed on EC2 instances within your Compute Environments.
 
-The ECS agent is included in the **Amazon ECS-Optimized Amazon Linux 2 (AL2) x86_64 AMI** . If you use a different base AMI, you can also install the agent on any EC2 instance that supports the Amazon ECS specification.
+The ECS agent is included in the **Amazon ECS-optimized Amazon Linux 2023 AMI** . If you use a different base AMI, you can also install the agent on any EC2 instance that supports the Amazon ECS specification.
 
 To install the agent, follow these steps:
 
 ```bash
-sudo amazon-linux-extras disable docker
-sudo amazon-linux-extras install -y ecs
+# For Amazon Linux 2, run the following: 
+# sudo amazon-linux-extras disable docker
+# sudo amazon-linux-extras install -y ecs
+sudo yum install ecs-init
 sudo systemctl enable --now ecs
 ```
 


### PR DESCRIPTION
The recommended AWS AMI (AL2023) no longer contains `amazon-linux-extras`

See:

https://docs.aws.amazon.com/linux/al2/ug/prepare-for-al2023.html
https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-docker.html
https://docs.aws.amazon.com/batch/latest/userguide/create-batch-ami.html
