### PR TITLE
Replace URLConnection with HttpClient

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.scm
 
+import java.net.http.HttpResponse
 import java.util.regex.Pattern
 
 import groovy.transform.CompileDynamic
@@ -162,14 +163,11 @@ final class AzureRepositoryProvider extends RepositoryProvider {
      *
      * @param connection A {@link HttpURLConnection} connection instance
      */
-    protected checkResponse( HttpURLConnection connection ) {
-
-        if (connection.getHeaderFields().containsKey("x-ms-continuationtoken")) {
-            this.continuationToken = connection.getHeaderField("x-ms-continuationtoken");
-        } else {
-            this.continuationToken = null
-        }
-
+    protected checkResponse( HttpResponse<String> connection ) {
+        this.continuationToken = connection
+                .headers()
+                .firstValue("x-ms-continuationtoken")
+                .orElse(null)
         super.checkResponse(connection)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
@@ -43,7 +43,7 @@ final class GiteaRepositoryProvider extends RepositoryProvider {
     }
 
     @Override
-    protected String[] auth() {
+    protected String[] getAuth() {
         if( config.token ) {
             // set the token in the request header
             // https://docs.gitea.io/en-us/api-usage/#authentication

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
@@ -16,9 +16,9 @@
 
 package nextflow.scm
 
+
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-
 /**
  * Implements a repository provider for Gitea service
  *
@@ -43,14 +43,14 @@ final class GiteaRepositoryProvider extends RepositoryProvider {
     }
 
     @Override
-    protected void auth( URLConnection connection ) {
+    protected String[] auth() {
         if( config.token ) {
             // set the token in the request header
             // https://docs.gitea.io/en-us/api-usage/#authentication
-            connection.setRequestProperty("Authorization", "token $config.token")
+            return new String[] { "Authorization", "token $config.token" as String }
         }
         else {
-            super.auth(connection)
+            return EMPTY_ARRAY
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -39,7 +39,7 @@ class GitlabRepositoryProvider extends RepositoryProvider {
     }
 
     @Override
-    protected String[] auth() {
+    protected String[] getAuth() {
         if( config.token ) {
             // set the token in the request header
             return new String[] { "PRIVATE-TOKEN", config.token }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -39,13 +39,15 @@ class GitlabRepositoryProvider extends RepositoryProvider {
     }
 
     @Override
-    protected void auth( URLConnection connection ) {
+    protected String[] auth() {
         if( config.token ) {
             // set the token in the request header
-            connection.setRequestProperty("PRIVATE-TOKEN", config.token)
-        } else if( config.password ) {
-            connection.setRequestProperty("PRIVATE-TOKEN", config.password)
+            return new String[] { "PRIVATE-TOKEN", config.token }
         }
+        if( config.password ) {
+            return new String[] { "PRIVATE-TOKEN", config.password }
+        }
+        return EMPTY_ARRAY
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -201,7 +201,7 @@ abstract class RepositoryProvider {
         final request = HttpRequest
             .newBuilder()
             .uri(new URI(api))
-            .headers(auth())
+            .headers(getAuth())
             .GET()
         // submit the request
         final resp = httpClient.send(request.build(), HttpResponse.BodyHandlers.ofString())
@@ -226,7 +226,7 @@ abstract class RepositoryProvider {
      *      array when the credentials are not available or provided.
      *      Note: {@code null} is not a valid return value for this method.
      */
-    protected String[] auth() {
+    protected String[] getAuth() {
         if( hasCredentials() ) {
             String authString = "${getUser()}:${getPassword()}".bytes.encodeBase64().toString()
             return new String[] { "Authorization", "Basic " + authString }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GithubRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GithubRepositoryProviderTest.groovy
@@ -128,7 +128,7 @@ class GithubRepositoryProviderTest extends Specification {
         def provider = Spy(new GithubRepositoryProvider('foo',Mock(ProviderConfig)))
 
         when:
-        final result = provider.auth()
+        final result = provider.getAuth()
         then:
         _ * provider.getUser() 
         _ * provider.getPassword()

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GithubRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GithubRepositoryProviderTest.groovy
@@ -126,17 +126,15 @@ class GithubRepositoryProviderTest extends Specification {
         SysEnv.push(['GITHUB_TOKEN': '1234567890'])
         and:
         def provider = Spy(new GithubRepositoryProvider('foo',Mock(ProviderConfig)))
-        and:
-        def conn = Mock(HttpURLConnection)
 
         when:
-        provider.auth(conn)
+        final result = provider.auth()
         then:
         _ * provider.getUser() 
         _ * provider.getPassword()
         1 * provider.hasCredentials()
         and:
-        1 * conn.setRequestProperty('Authorization', "Basic ${'1234567890:x-oauth-basic'.bytes.encodeBase64()}".toString())
+        result == new String[] { 'Authorization', "Basic ${'1234567890:x-oauth-basic'.bytes.encodeBase64()}".toString() }
 
         cleanup:
         SysEnv.pop()

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -93,7 +93,7 @@ class RepositoryProviderTest extends Specification {
         def conn = Mock(HttpURLConnection)
 
         when:
-        def headers = provider.auth()
+        def headers = provider.getAuth()
         then:
         1 * provider.getUser() >> null
         1 * provider.hasCredentials()
@@ -102,7 +102,7 @@ class RepositoryProviderTest extends Specification {
         headers == [] as String[]
 
         when:
-        headers = provider.auth()
+        headers = provider.getAuth()
         then:
         _ * provider.getUser() >> 'foo'
         _ * provider.getPassword() >> 'bar'

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -93,19 +93,21 @@ class RepositoryProviderTest extends Specification {
         def conn = Mock(HttpURLConnection)
 
         when:
-        provider.auth(conn)
+        def headers = provider.auth()
         then:
         1 * provider.getUser() >> null
         1 * provider.hasCredentials()
         0 * conn.setRequestProperty('Authorization', _)
+        and:
+        headers == [] as String[]
 
         when:
-        provider.auth(conn)
+        headers = provider.auth()
         then:
         _ * provider.getUser() >> 'foo'
         _ * provider.getPassword() >> 'bar'
         1 * provider.hasCredentials()
         and:
-        1 * conn.setRequestProperty('Authorization', "Basic ${'foo:bar'.bytes.encodeBase64()}")
+        headers == new String[] { 'Authorization', "Basic ${'foo:bar'.bytes.encodeBase64()}" }
     }
 }


### PR DESCRIPTION
This PR replaces the HttpURLConnection with HttpClient provided by Java 11 and later. 

This allows a more final control on HTTP settings (e.g. virtual threads pool) and response error status (and retries)