### PR TITLE
Fix class not found exception GoogleLifeScienceExecutor

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -211,7 +211,7 @@ class BatchClient {
         final now = System.currentTimeMillis()
         TaskStatusRecord record = arrayTaskStatus.get(taskName)
         if( !record || now - record.timestamp > TASK_STATE_INVALID_TIME ){
-            log.debug("[GOOGLE BATCH] Updating tasks status for job $jobId")
+            log.trace("[GOOGLE BATCH] Updating tasks status for job $jobId")
             updateArrayTasks(jobId, now)
             record = arrayTaskStatus.get(taskName)
         }

--- a/plugins/nf-google/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-google/src/resources/META-INF/extensions.idx
@@ -15,6 +15,5 @@
 #
 
 nextflow.cloud.google.batch.GoogleBatchExecutor
-nextflow.cloud.google.lifesciences.GoogleLifeSciencesExecutor
 nextflow.cloud.google.util.GsPathSerializer
 nextflow.cloud.google.util.GsPathFactory


### PR DESCRIPTION
close #6192 
Fix a logging issue. It is trying to load the GoogleLifeScienceExecutor despite it is removed. It was not removed in the extension file.

I have also changed the level of a log that was periodically printed when using arrays.