### PR TITLE
typo correction for ternary operator

### DIFF
--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -848,7 +848,7 @@ process hello {
   errorStrategy 'retry'
   maxSubmitAwait '10 mins'
   maxRetries 3
-  queue "${task.submitAttempt==1 : 'spot-compute' : 'on-demand-compute'}"
+  queue "${task.submitAttempt==1 ? 'spot-compute' : 'on-demand-compute'}"
 
   script:
   """


### PR DESCRIPTION
In the `### maxSubmitAwait` subsection, it originally read:

`queue "${task.submitAttempt==1 : 'spot-compute' : 'on-demand-compute'}"`

I believe this should be a standard ternary operator:

`queue "${task.submitAttempt==1 ? 'spot-compute' : 'on-demand-compute'}"`

(Note a colon has changed to a question mark)