### PR TITLE
Implement retry strategy for Git repository provider

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1182,9 +1182,25 @@ Read the {ref}`sharing-page` page to learn how to publish your pipeline to GitHu
 
 ## `nextflow`
 
-:::{deprecated} 24.10.0
-The `nextflow.publish` scope has been renamed to `workflow.output`. See {ref}`config-workflow` for more information.
+:::{versionchanged} 24.10.0
+The `nextflow.publish.retryPolicy` settings were moved to `workflow.output.retryPolicy`.
 :::
+
+:::{versionchanged} 25.06.0-edge
+The `workflow.output.retryPolicy` settings were moved to `nextflow.retryPolicy`.
+:::
+
+`retryPolicy.delay`
+: Delay used for retryable operations (default: `350ms`).
+
+`retryPolicy.jitter`
+: Jitter value used for retryable operations (default: `0.25`).
+
+`retryPolicy.maxAttempts`
+: Max attempts used for retryable operations (default: `5`).
+
+`retryPolicy.maxDelay`
+: Max delay used for retryable operations (default: `90s`).
 
 (config-notification)=
 
@@ -1640,18 +1656,6 @@ The `workflow` scope provides workflow execution options.
 
   `'standard'`
   : Overwrite existing files when the file size or last modified timestamp is different.
-
-`workflow.output.retryPolicy.delay`
-: Delay when retrying a failed publish operation (default: `350ms`).
-
-`workflow.output.retryPolicy.jitter`
-: Jitter value when retrying a failed publish operation (default: `0.25`).
-
-`workflow.output.retryPolicy.maxAttempt`
-: Max attempts when retrying a failed publish operation (default: `5`).
-
-`workflow.output.retryPolicy.maxDelay`
-: Max delay when retrying a failed publish operation (default: `90s`).
 
 `workflow.output.storageClass`
 : *Currently only supported for S3.*

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -166,6 +166,26 @@ The following environment variables control the configuration of the Nextflow ru
   :::
 : Defines the default behavior of `publishDir.failOnError` setting. See {ref}`publishDir<process-publishdir>` directive for more information.
 
+`NXF_RETRY_POLICY_DELAY`
+: :::{versionadded} 25.06.0-edge
+  :::
+: Delay used for HTTP retryable operations (default: `350ms`).
+
+`NXF_RETRY_POLICY_JITTER`
+: :::{versionadded} 25.06.0-edge
+  :::
+: Jitter value used for HTTP retryable operations (default: `0.25`).
+
+`NXF_RETRY_POLICY_MAX_ATTEMPTS`
+: :::{versionadded} 25.06.0-edge
+  :::
+: Max number of attempts used for HTTP retryable operations (default: `5`).
+
+`NXF_RETRY_POLICY_MAX_DELAY`
+: :::{versionadded} 25.06.0-edge
+  :::
+: Max delay used for HTTP retryable operations (default: `90s`).
+
 `NXF_SCM_FILE`
 : :::{versionadded} 20.10.0
   :::

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -52,6 +52,7 @@ import nextflow.file.TagAwareFile
 import nextflow.trace.event.FilePublishEvent
 import nextflow.util.HashBuilder
 import nextflow.util.PathTrie
+import nextflow.util.RetryConfig
 /**
  * Implements the {@code publishDir} directory. It create links or copies the output
  * files of a given task to a user specified directory.
@@ -127,7 +128,7 @@ class PublishDir {
      */
     private String storageClass
 
-    private PublishRetryConfig retryConfig
+    private RetryConfig retryConfig
 
     private PathMatcher matcher
 
@@ -231,19 +232,10 @@ class PublishDir {
         return result
     }
 
-    protected Map getRetryOpts() {
-        def result = session.config.navigate('nextflow.publish.retryPolicy') as Map
-        if( result != null )
-            log.warn 'The `nextflow.publish` config scope has been renamed to `workflow.output`'
-        else
-            result = session.config.navigate('workflow.output.retryPolicy') as Map ?: Collections.emptyMap()
-        return result
-    }
-
     protected void apply0(Set<Path> files) {
         assert path
         // setup the retry policy config to be used
-        this.retryConfig = new PublishRetryConfig(getRetryOpts())
+        this.retryConfig = RetryConfig.config(session)
 
         createPublishDir()
         validatePublishMode()

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -34,7 +34,6 @@ import nextflow.exception.AbortOperationException
 import nextflow.exception.AmbiguousPipelineNameException
 import nextflow.script.ScriptFile
 import nextflow.util.IniFile
-import nextflow.util.RetryConfig
 import org.eclipse.jgit.api.CreateBranchCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ListBranchCommand
@@ -87,8 +86,6 @@ class AssetManager {
 
     private List<ProviderConfig> providerConfigs
 
-    private RetryConfig retryConfig
-
     /**
      * Create a new asset manager object with default parameters
      */
@@ -127,7 +124,7 @@ class AssetManager {
     AssetManager build( String pipelineName, Map config = null, HubOptions cliOpts = null ) {
 
         this.providerConfigs = ProviderConfig.createFromMap(config)
-        this.retryConfig = new RetryConfig(config?.retryPolicy as Map ?: Collections.emptyMap())
+
         this.project = resolveName(pipelineName)
         this.localPath = checkProjectDir(project)
         this.hub = checkHubProvider(cliOpts)
@@ -360,9 +357,7 @@ class AssetManager {
         if( !config )
             throw new AbortOperationException("Unknown repository configuration provider: $providerName")
 
-        return RepositoryFactory
-                    .newRepositoryProvider(config, project)
-                    .setRetryConfig(retryConfig)
+        return RepositoryFactory.newRepositoryProvider(config, project)
     }
 
     AssetManager setLocalPath(File path) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -127,7 +127,7 @@ class AssetManager {
     AssetManager build( String pipelineName, Map config = null, HubOptions cliOpts = null ) {
 
         this.providerConfigs = ProviderConfig.createFromMap(config)
-        this.retryConfig = new RetryConfig(config.retryPolicy as Map ?: Collections.emptyMap())
+        this.retryConfig = new RetryConfig(config?.retryPolicy as Map ?: Collections.emptyMap())
         this.project = resolveName(pipelineName)
         this.localPath = checkProjectDir(project)
         this.hub = checkHubProvider(cliOpts)

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -161,14 +161,14 @@ final class AzureRepositoryProvider extends RepositoryProvider {
      * Check for response error status. Throws a {@link nextflow.exception.AbortOperationException} exception
      * when a 401 or 403 error status is returned.
      *
-     * @param connection A {@link HttpURLConnection} connection instance
+     * @param response A {@link HttpURLConnection} connection instance
      */
-    protected checkResponse( HttpResponse<String> connection ) {
-        this.continuationToken = connection
+    protected checkResponse( HttpResponse<String> response) {
+        this.continuationToken = response
                 .headers()
                 .firstValue("x-ms-continuationtoken")
                 .orElse(null)
-        super.checkResponse(connection)
+        super.checkResponse(response)
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/main/groovy/nextflow/util/RetryConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/RetryConfig.groovy
@@ -17,13 +17,14 @@
 
 package nextflow.util
 
+import static nextflow.util.ConfigHelper.*
+
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import groovy.util.logging.Slf4j
 import nextflow.Global
 import nextflow.Session
-
 /**
  * Models retry policy configuration
  *
@@ -35,24 +36,31 @@ import nextflow.Session
 @CompileStatic
 class RetryConfig {
 
-    private Duration delay = Duration.of('350ms')
-    private Duration maxDelay = Duration.of('90s')
-    private int maxAttempts = 5
-    private double jitter = 0.25
+    private final static Duration DEFAULT_DELAY = Duration.of('350ms')
+    private final static Duration DEFAULT_MAX_DELAY = Duration.of('90s')
+    private final static Integer DEFAULT_MAX_ATTEMPTS = 5
+    private final static Double DEFAULT_JITTER = 0.25
+
+    private final static String ENV_PREFIX = 'NXF_RETRY_POLICY_'
+
+    final private Duration delay
+    final private Duration maxDelay
+    final private int maxAttempts
+    final private double jitter
 
     RetryConfig() {
         this(Collections.emptyMap())
     }
 
     RetryConfig(Map config) {
-        if( config.delay )
-            delay = config.delay as Duration
-        if( config.maxDelay )
-            maxDelay = config.maxDelay as Duration
-        if( config.maxAttempts )
-            maxAttempts = config.maxAttempts as int
-        if( config.jitter )
-            jitter = config.jitter as double
+        delay =
+            valueOf(config, 'delay', ENV_PREFIX, DEFAULT_DELAY, Duration)
+        maxDelay =
+            valueOf(config, 'maxDelay', ENV_PREFIX, DEFAULT_MAX_DELAY, Duration)
+        maxAttempts =
+            valueOf(config, 'maxAttempts', ENV_PREFIX, DEFAULT_MAX_ATTEMPTS, Integer)
+        jitter =
+            valueOf(config, 'jitter', ENV_PREFIX, DEFAULT_JITTER, Double)
     }
 
     Duration getDelay() { delay }
@@ -74,4 +82,6 @@ class RetryConfig {
         log.warn "Missing nextflow session - using default retry config"
         return new RetryConfig()
     }
+
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -16,8 +16,11 @@
 
 package nextflow.scm
 
-import spock.lang.Specification
+import java.net.http.HttpClient
+import java.net.http.HttpResponse
 
+import nextflow.util.RetryConfig
+import spock.lang.Specification
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -109,5 +112,44 @@ class RepositoryProviderTest extends Specification {
         1 * provider.hasCredentials()
         and:
         headers == new String[] { 'Authorization', "Basic ${'foo:bar'.bytes.encodeBase64()}" }
+    }
+
+    def 'should test retry with exception' () {
+        given:
+        def client = Mock(HttpClient)
+        and:
+        def provider = Spy(RepositoryProvider)
+        provider.@httpClient = client
+        provider.@config = new ProviderConfig('github', [server: 'https://github.com'] as ConfigObject)
+        provider.setRetryConfig(new RetryConfig(maxAttempts: 3))
+
+        when:
+        provider.invoke('https://api.github.com/repos/project/x')
+        then:
+        3 * client.send(_,_) >> { throw new SocketException("Something failed") }
+        and:
+        def e = thrown(IOException)
+        e.message == "Something failed"
+    }
+
+    def 'should test retry with http response code' () {
+        given:
+        def client = Mock(HttpClient)
+        and:
+        def provider = Spy(RepositoryProvider)
+        provider.@httpClient = client
+        provider.@config = new ProviderConfig('github', [server: 'https://github.com'] as ConfigObject)
+        provider.setRetryConfig(new RetryConfig())
+
+        when:
+        def result = provider.invoke('https://api.github.com/repos/project/x')
+        then:
+        1 * client.send(_,_) >> Mock(HttpResponse) {statusCode()>>500 }
+        then:
+        1 * client.send(_,_) >> Mock(HttpResponse) {statusCode()>>502 }
+        then:
+        1 * client.send(_,_) >> Mock(HttpResponse) {statusCode()>>200; body()>>'OK' }
+        and:
+        result == 'OK'
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -18,6 +18,7 @@ package nextflow.scm
 
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
+import java.nio.channels.UnresolvedAddressException
 
 import nextflow.util.RetryConfig
 import spock.lang.Specification
@@ -152,4 +153,20 @@ class RepositoryProviderTest extends Specification {
         and:
         result == 'OK'
     }
+
+    def 'should validate is retryable' () {
+        given:
+        def provider = Spy(RepositoryProvider)
+        expect:
+        provider.isRetryable(ERR) == EXPECTED
+
+        where:
+        EXPECTED    | ERR
+        false       | new RuntimeException()
+        false       | new IOException()
+        true        | new SocketException()
+        false       | new SocketException(new UnresolvedAddressException())
+        false       | new SocketTimeoutException()
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/ConfigHelperTest.groovy
@@ -19,6 +19,7 @@ package nextflow.util
 import java.nio.file.Files
 import java.nio.file.Paths
 
+import nextflow.SysEnv
 import nextflow.config.ConfigClosurePlaceholder
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -368,6 +369,71 @@ class ConfigHelperTest extends Specification {
         "withName:2foo"     | "'withName:2foo'"     | "withName:'2foo'"
     }
 
+    @Unroll
+    def 'should get config from map' () {
+        given:
+        def NAME = 'foo'
+        def PREFIX = 'P_'
+        and:
+        SysEnv.push(ENV)
 
+        expect:
+        ConfigHelper.valueOf(CONFIG, NAME, PREFIX, DEF_VAL, DEF_TYPE) == EXPECTED
 
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        CONFIG          | ENV           | DEF_VAL       | DEF_TYPE      | EXPECTED
+        null            | [:]           | null          | String        | null
+        [:]             | [:]           | null          | String        | null
+        [:]             | [:]           | 'one'         | String        | 'one'
+        [foo:'two']     | [:]           | 'one'         | String        | 'two'
+        [foo:'']        | [:]           | 'one'         | String        | ''
+        [foo:'two']     | [P_FOO:'bar'] | 'one'         | String        | 'two'
+        [:]             | [P_FOO:'bar'] | 'one'         | String        | 'bar'
+
+        and:
+        null            | [:]           | null          | Integer       | null
+        [:]             | [:]           | null          | Integer       | null
+        [:]             | [:]           | 1             | Integer       | 1
+        [foo:2]         | [:]           | 1             | Integer       | 2
+        [foo:'2']       | [:]           | 1             | Integer       | 2
+        [foo:'2']       | [P_FOO:'3']   | 1             | Integer       | 2
+        [:]             | [P_FOO:'3']   | 1             | Integer       | 3
+
+        and:
+        null            | [:]           | null          | Boolean       | null
+        [:]             | [:]           | true          | Boolean       | true
+        [foo:false]     | [:]           | true          | Boolean       | false
+        [foo:'false']   | [:]           | true          | Boolean       | false
+        [foo:true]      | [:]           | false         | Boolean       | true
+        [foo:'true']    | [:]           | false         | Boolean       | true
+        [foo:'true']    | [P_FOO:'false']| null         | Boolean       | true
+        [:]             | [P_FOO:'false']| null         | Boolean       | false
+        [:]             | [P_FOO:'true'] | null         | Boolean       | true
+
+        and:
+        [:]             | [:]           | Duration.of('1s') | Duration  | Duration.of('1s')
+        [foo:'10ms']    | [:]           | null              | Duration  | Duration.of('10ms')
+        [:]             | [P_FOO:'1s']  | null              | Duration  | Duration.of('1s')
+    }
+
+    def 'should map camelCase to snake uppercase' () {
+        given:
+        SysEnv.push(ENV)
+
+        expect:
+        ConfigHelper.valueOf([:], NAME, PREFIX, null, String) == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        EXPECTED    | PREFIX    | NAME              | ENV
+        null        | 'foo'     | 'bar'             | [:]
+        'one'       | 'foo'     | 'bar'             | [FOO_BAR: 'one']
+        'one'       | 'foo_'    | 'bar'             | [FOO_BAR: 'one']
+        'one'       | 'foo_'    | 'thisAndThat'     | [FOO_THIS_AND_THAT: 'one']
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/util/RetryConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/RetryConfigTest.groovy
@@ -15,7 +15,7 @@
  *
  */
 
-package nextflow.processor
+package nextflow.util
 
 import nextflow.util.Duration
 import spock.lang.Specification
@@ -24,21 +24,21 @@ import spock.lang.Specification
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
-class PublishRetryConfigTest extends Specification {
+class RetryConfigTest extends Specification {
 
     def 'should create retry config' () {
 
         expect:
-        new PublishRetryConfig().delay == Duration.of('350ms')
-        new PublishRetryConfig().maxDelay == Duration.of('90s')
-        new PublishRetryConfig().maxAttempts == 5
-        new PublishRetryConfig().jitter == 0.25d
+        new RetryConfig().delay == Duration.of('350ms')
+        new RetryConfig().maxDelay == Duration.of('90s')
+        new RetryConfig().maxAttempts == 5
+        new RetryConfig().jitter == 0.25d
 
         and:
-        new PublishRetryConfig([maxAttempts: 20]).maxAttempts == 20
-        new PublishRetryConfig([delay: '1s']).delay == Duration.of('1s')
-        new PublishRetryConfig([maxDelay: '1m']).maxDelay == Duration.of('1m')
-        new PublishRetryConfig([jitter: '0.5']).jitter == 0.5d
+        new RetryConfig([maxAttempts: 20]).maxAttempts == 20
+        new RetryConfig([delay: '1s']).delay == Duration.of('1s')
+        new RetryConfig([maxDelay: '1m']).maxDelay == Duration.of('1m')
+        new RetryConfig([jitter: '0.5']).jitter == 0.5d
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/util/RetryConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/RetryConfigTest.groovy
@@ -17,9 +17,8 @@
 
 package nextflow.util
 
-import nextflow.util.Duration
+import nextflow.SysEnv
 import spock.lang.Specification
-
 /**
  *
  * @author Ben Sherman <bentshermann@gmail.com>
@@ -40,6 +39,25 @@ class RetryConfigTest extends Specification {
         new RetryConfig([maxDelay: '1m']).maxDelay == Duration.of('1m')
         new RetryConfig([jitter: '0.5']).jitter == 0.5d
 
+    }
+
+    def 'should get the setting from the system env' () {
+        given:
+        SysEnv.push([
+            NXF_RETRY_POLICY_DELAY: '10s',
+            NXF_RETRY_POLICY_MAX_DELAY: '100s',
+            NXF_RETRY_POLICY_MAX_ATTEMPTS: '1000',
+            NXF_RETRY_POLICY_JITTER: '10000'
+        ])
+
+        expect:
+        new RetryConfig().getDelay() == Duration.of('10s')
+        new RetryConfig().getMaxDelay() == Duration.of('100s')
+        new RetryConfig().getMaxAttempts() == 1000
+        new RetryConfig().getJitter() == 10_000
+
+        cleanup:
+        SysEnv.pop()
     }
 
 }


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement of the retry policy mechanism across the codebase, aiming to standardize and centralize its configuration and usage. The changes include the migration of retry policy settings to a new `RetryConfig` class, updates to the documentation, and modifications to several classes to adopt the new retry mechanism.

### Retry Policy Refactor and Centralization:
* Migrated retry policy settings from `workflow.output.retryPolicy` to `nextflow.retryPolicy` in the configuration, and updated relevant documentation in `docs/reference/config.md`. Added details about new retry policy parameters like `delay`, `jitter`, `maxAttempts`, and `maxDelay`. [[1]](diffhunk://#diff-9ae244d0598c1cc7efc9875baf25a5f8b4bc13aabad4fbe17dd4bc5cfe856909L1185-R1204) [[2]](diffhunk://#diff-9ae244d0598c1cc7efc9875baf25a5f8b4bc13aabad4fbe17dd4bc5cfe856909L1644-L1655)
* Renamed `PublishRetryConfig` to `RetryConfig` and moved it to the `nextflow.util` package. Added getter methods and a static factory method for creating instances based on the session configuration. [[1]](diffhunk://#diff-2879bd3c6ba111849164cc79813f974b253b36f488bb829ac0835520d8d07d11L18-R47) [[2]](diffhunk://#diff-2879bd3c6ba111849164cc79813f974b253b36f488bb829ac0835520d8d07d11R57-R76)

### Codebase Updates for Retry Policy:
* Updated the `PublishDir` class to use the new `RetryConfig` class for retry policy configuration, replacing the older `PublishRetryConfig`. [[1]](diffhunk://#diff-eeace5fe1e124ffdd862d54674b34fbd3390751994c6f9bec6cacae3a8e5913dR55) [[2]](diffhunk://#diff-eeace5fe1e124ffdd862d54674b34fbd3390751994c6f9bec6cacae3a8e5913dL130-R131) [[3]](diffhunk://#diff-eeace5fe1e124ffdd862d54674b34fbd3390751994c6f9bec6cacae3a8e5913dL234-R238)
* Modified the `AssetManager` class to include a `RetryConfig` instance and integrate it into repository provider creation. [[1]](diffhunk://#diff-7d4ab6ce00ff586a8192fc059ed67326b0aaf80cb0459a01ec0e00acc49ae762R37) [[2]](diffhunk://#diff-7d4ab6ce00ff586a8192fc059ed67326b0aaf80cb0459a01ec0e00acc49ae762R90-R91) [[3]](diffhunk://#diff-7d4ab6ce00ff586a8192fc059ed67326b0aaf80cb0459a01ec0e00acc49ae762L127-R130) [[4]](diffhunk://#diff-7d4ab6ce00ff586a8192fc059ed67326b0aaf80cb0459a01ec0e00acc49ae762L360-R365)
* Use `retryPolicy` setting defined in the `scm` config for Git repository providers 

### Enhancements to Repository Providers:
* Introduced a retry mechanism for HTTP requests in `RepositoryProvider` using the `Failsafe` library. Added methods to create retry policies, handle retryable HTTP status codes, and apply retry logic to HTTP requests. [[1]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331R19-R30) [[2]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331R392-R465)
* Refactored the `RepositoryProvider` class to use the new `RetryConfig` for HTTP request retries and updated methods to improve readability and error handling. [[1]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331L67-R83) [[2]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331R212-R221) [[3]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331L199-R233) [[4]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331L241-R277) [[5]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331L262-R301) [[6]](diffhunk://#diff-bca858810859bb18fbb796b959de9fc818664f36c072656396ec2f05eb656331L312-L315)
* Rewrite `checkResponse` logic due the use of HttpClient` over `HttpURLConnection`  
