### PR TITLE
Add additional test for hasher

### DIFF
--- a/modules/nf-commons/src/test/nextflow/util/HashBuilderTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/HashBuilderTest.groovy
@@ -131,4 +131,26 @@ class HashBuilderTest extends Specification {
         then:
         hash1.hash() == hash2.hash()
     }
+
+    def 'directories with same content but different structure should yield different hashes'() {
+        given:
+        def folder = TestHelper.createInMemTempDir()
+        folder.resolve('dir1').mkdir()
+        folder.resolve('dir2').mkdir()
+        and:
+        folder.resolve('dir1/foo').text = "I'm foo"
+        folder.resolve('dir1/bar').text = "I'm bar"
+        and:
+        // the content of these files is intentionally swapped
+        folder.resolve('dir2/foo').text = "I'm bar"
+        folder.resolve('dir2/bar').text = "I'm foo"
+
+        when:
+        def hash1 = HashBuilder.hashDirSha256(HashBuilder.defaultHasher(), folder.resolve('dir1'), folder.resolve('dir1'))
+        and:
+        def hash2 = HashBuilder.hashDirSha256(HashBuilder.defaultHasher(), folder.resolve('dir2'), folder.resolve('dir2'))
+
+        then:
+        hash1.hash() != hash2.hash()
+    }
 }


### PR DESCRIPTION
This PR is related to a bug that was introduced by merging #6197 in order to fix #6112.

By making the order of `hashDirSha256` invariant to the order in which data is processed, the link between the file path and its hash is lost.

This PR adds a unit test where the filename of two files are swapped, resulting in hashDirSha256 returning the same hash (while it shouldn't).

Credits go to @DriesSchaumont for noticing the issue.

----------

Running the tests added by this PR yields:

```bash
$ ./gradlew :nf-commons:test

> Task :nf-commons:test

HashBuilderTest > directories with same content but different structure should yield different hashes FAILED
    org.spockframework.runtime.ConditionNotSatisfiedError at HashBuilderTest.groovy:154

806 tests completed, 1 failed

> Task :nf-commons:test FAILED

[Incubating] Problems report is available at: file:///home/rcannood/workspace/rcannood/nextflow/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':nf-commons:test'.
> There were failing tests. See the report at: file:///home/rcannood/workspace/rcannood/nextflow/modules/nf-commons/build/reports/tests/test/index.html

* Try:
> Run with --scan to get full insights.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 9s
24 actionable tasks: 2 executed, 6 from cache, 16 up-to-date
```

I tried going over the different versions of HashBuilder.java in the commits in #6113 but for all of these commits, the tests are passing:

* Commit 18f3fc5e07bb79d2d6918ca1bebf7127927ed183: test passes
* Commit 1e5dd8729e8dc57e95ff0b164b7a6b6a0071bd62: test passes
* Commit 31e1a8a81cd2fe9cd2d0c8e3a96a77ef480c8b91: test passes
* Commit 415f16264f7f22fc8c394e776fcd37ee232124b3: test passes

