### PR TITLE
Resolve auth for Git providers that use tokens

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -126,12 +126,14 @@ abstract class RepositoryProvider {
     }
 
     boolean hasCredentials() {
-        getUser() && getPassword()
+        return (getUser() && getPassword()) || getToken()
     }
 
     String getUser() { config?.user }
 
     String getPassword() { config?.password }
+
+    String getToken() { config?.token }
 
     /**
      * @return The name of the source hub service e.g. github or bitbucket


### PR DESCRIPTION
Those Git providers that rely on tokens for authentication ([GitLab](https://github.com/nextflow-io/nextflow/blob/d1e6836ea8bf85c26c0279a74e590593ce9849b2/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy#L43-L46), [Gitea](https://github.com/nextflow-io/nextflow/blob/d1e6836ea8bf85c26c0279a74e590593ce9849b2/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy#L47-L51), [Bitbucket](https://github.com/nextflow-io/nextflow/pull/6209)) do not need username and password to be defined too.

This PR tweaks the logic that determines whether a Git provider has authentication properties configured or not to take into account the sole presence of the `token` field.