### PR TITLE
Upgrade to Groovy 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,8 @@ allprojects {
     tasks.withType(Test) {
         jvmArgs ([
             '--enable-preview',
+            // preserve Groovy 4 file/path truthiness (a non-null File/Path is truthy regardless of existence) -- see GROOVY-11996
+            '-Dgroovy.truth.file.exists.enabled=false',
             '--add-opens=java.base/java.lang=ALL-UNNAMED',
             '--add-opens=java.base/java.io=ALL-UNNAMED',
             '--add-opens=java.base/java.nio=ALL-UNNAMED',

--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ allprojects {
 
         // Documentation required libraries
         groovyDoc 'org.fusesource.jansi:jansi:2.4.0'
-        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.31"
-        groovyDoc "org.apache.groovy:groovy-ant:4.0.31"
+        groovyDoc "org.apache.groovy:groovy-groovydoc:5.0.7"
+        groovyDoc "org.apache.groovy:groovy-ant:5.0.7"
     }
 
     test {

--- a/launch.sh
+++ b/launch.sh
@@ -73,6 +73,8 @@ if [[ ! $JAVA_VER =~ $version_check ]]; then
     exit 1
 fi
 JVM_ARGS+=" -Dfile.encoding=UTF-8 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+# preserve Groovy 4 file/path truthiness (a non-null File/Path is truthy regardless of existence) -- see GROOVY-11996
+JVM_ARGS+=" -Dgroovy.truth.file.exists.enabled=false"
 JVM_ARGS+=" --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio.file.spi=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED"
 [[ "$JAVA_VER" =~ ^(24|25|26) ]]&& JVM_ARGS+=" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 [[ $NXF_ENABLE_VIRTUAL_THREADS == 'true' ]] && [[ "$JAVA_VER" =~ ^(19|20) ]] && JVM_ARGS+=" --enable-preview"

--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -41,12 +41,12 @@ dependencies {
     api(project(':nf-commons'))
     api(project(':nf-httpfs'))
     api(project(':nf-lang'))
-    api "org.apache.groovy:groovy:4.0.31"
-    api "org.apache.groovy:groovy-nio:4.0.31"
-    api "org.apache.groovy:groovy-xml:4.0.31"
-    api "org.apache.groovy:groovy-json:4.0.31"
-    api "org.apache.groovy:groovy-templates:4.0.31"
-    api "org.apache.groovy:groovy-yaml:4.0.31"
+    api "org.apache.groovy:groovy:5.0.7"
+    api "org.apache.groovy:groovy-nio:5.0.7"
+    api "org.apache.groovy:groovy-xml:5.0.7"
+    api "org.apache.groovy:groovy-json:5.0.7"
+    api "org.apache.groovy:groovy-templates:5.0.7"
+    api "org.apache.groovy:groovy-yaml:5.0.7"
     api "org.slf4j:jcl-over-slf4j:2.0.17"
     api "org.slf4j:jul-to-slf4j:2.0.17"
     api "org.slf4j:log4j-over-slf4j:2.0.17"
@@ -79,11 +79,11 @@ dependencies {
     testImplementation (project(':nf-lineage'))
     testImplementation 'org.wiremock:wiremock-standalone:3.13.2'
     // test configuration
-    testFixturesApi ("org.apache.groovy:groovy-test:4.0.31") { exclude group: 'org.apache.groovy' }
+    testFixturesApi ("org.apache.groovy:groovy-test:5.0.7") { exclude group: 'org.apache.groovy' }
     testFixturesApi ("org.objenesis:objenesis:3.4")
     testFixturesApi ("net.bytebuddy:byte-buddy:1.14.17")
-    testFixturesApi ("org.spockframework:spock-core:2.4-groovy-4.0") { exclude group: 'org.apache.groovy' }
-    testFixturesApi ('org.spockframework:spock-junit4:2.4-groovy-4.0') { exclude group: 'org.apache.groovy' }
+    testFixturesApi ("org.spockframework:spock-core:2.4-groovy-5.0") { exclude group: 'org.apache.groovy' }
+    testFixturesApi ('org.spockframework:spock-junit4:2.4-groovy-5.0') { exclude group: 'org.apache.groovy' }
     testFixturesApi 'com.google.jimfs:jimfs:1.2'
     // note: declare as separate dependency to avoid a circular dependency
     lineageImplementation (project(':nf-lineage'))

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1239,7 +1239,7 @@ class Session implements ISession {
     def fetchContainers() {
 
         def result = [:]
-        if( config.process instanceof Map<String,?> ) {
+        if( config.process instanceof Map ) {
 
             /*
              * look for `container` definition at process level

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLog.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLog.groovy
@@ -220,6 +220,7 @@ class CmdLog extends CmdBase implements CacheBase {
     /**
      * Wrap a {@link TraceRecord} instance as a {@link Map} or a {@link Binding} object
      */
+    @Slf4j
     private static class TraceAdaptor extends Binding {
 
         static private int MAX_LINES = 100
@@ -299,13 +300,14 @@ class CmdLog extends CmdBase implements CacheBase {
                 def result = new StringBuilder()
                 path.withReader { reader ->
                     String line
-                    while( (line=reader.readLine()) && c++<MAX_LINES ) {
+                    // MAX_LINES must be cast to `int` in order to satisfy type checker
+                    // seems to be caused by the delegate
+                    while( (line=reader.readLine()) && c++ < (int)MAX_LINES ) {
                         result << line << '\n'
                     }
                 }
 
                 result.toString() ?: TraceRecord.NA
-
             }
             catch( IOError e ) {
                 log.debug "Failed to fetch content for file: $path -- Cause: ${e.message ?: e}"

--- a/modules/nextflow/src/main/groovy/nextflow/dataflow/ChannelImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dataflow/ChannelImpl.groovy
@@ -143,7 +143,7 @@ class ChannelImpl {
         return new ChannelImpl(target)
     }
 
-    ChannelImpl flatMap(Function<?,Iterable> transform = null) {
+    ChannelImpl flatMap(Function<Object,Iterable> transform = null) {
         final source = getReadChannel()
         final target = CH.create()
         final onNext = { value ->
@@ -218,7 +218,7 @@ class ChannelImpl {
         return new ChannelImpl(target)
     }
 
-    ValueImpl reduce(BiFunction<?,?,?> accumulator) {
+    ValueImpl reduce(BiFunction<Object,Object,Object> accumulator) {
         final source = getReadChannel()
         final target = CH.value()
 
@@ -246,7 +246,7 @@ class ChannelImpl {
         return new ValueImpl(target)
     }
 
-    ValueImpl reduce(Object seed, BiFunction<?,?,?> accumulator) {
+    ValueImpl reduce(Object seed, BiFunction<Object,Object,Object> accumulator) {
         final source = getReadChannel()
         final target = CH.value()
 

--- a/modules/nextflow/src/main/groovy/nextflow/dataflow/ValueImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dataflow/ValueImpl.groovy
@@ -85,7 +85,7 @@ class ValueImpl {
         return new ValueImpl(target)
     }
 
-    ChannelImpl flatMap(Function<?,Iterable> transform = null) {
+    ChannelImpl flatMap(Function<Object,Iterable> transform = null) {
         final target = CH.create()
         final onNext = { value ->
             final iterable = transform != null ? transform.apply(value) : value

--- a/modules/nextflow/src/main/groovy/nextflow/dataflow/ops/CombineOpV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dataflow/ops/CombineOpV2.groovy
@@ -102,8 +102,8 @@ class CombineOpV2 {
         return result
     }
 
-    private Collection<?> leftValues = []
-    private Collection<?> rightValues = []
+    private Collection<Object> leftValues = []
+    private Collection<Object> rightValues = []
     private int count = 2
 
     private synchronized void onNext(DataflowWriteChannel target, Object value, int index) {

--- a/modules/nextflow/src/main/groovy/nextflow/dataflow/ops/JoinOpV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dataflow/ops/JoinOpV2.groovy
@@ -76,9 +76,9 @@ class JoinOpV2 {
         return result
     }
 
-    private Map<?,Collection<RecordMap>> mappingsLeft = [:]
-    private Map<?,Collection<RecordMap>> mappingsRight = [:]
-    private Set<?> emitted = []
+    private Map<Object,Collection<RecordMap>> mappingsLeft = [:]
+    private Map<Object,Collection<RecordMap>> mappingsRight = [:]
+    private Set<Object> emitted = []
     private volatile int count = 2
     private volatile boolean failed
 

--- a/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorFactory.groovy
@@ -65,9 +65,9 @@ class ExecutorFactory {
 
     @PackageScope Map<String, Class<? extends Executor>> executorsMap
 
-    private Map<Class<? extends Executor>,? extends Executor> executors = new HashMap<>()
+    private Map<Class<? extends Executor>,Executor> executors = new HashMap<>()
 
-    @PackageScope Map<Class<? extends Executor>,? extends Executor> getExecutors() { executors }
+    @PackageScope Map<Class<? extends Executor>,Executor> getExecutors() { executors }
 
     ExecutorFactory() {
         init0(Collections.<Class<Executor>>emptyList())

--- a/modules/nextflow/src/main/groovy/nextflow/extension/CombineOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/CombineOp.groovy
@@ -75,7 +75,7 @@ class CombineOp {
     }
 
     CombineOp setPivot( pivot ) {
-        this.pivot = (List<Integer>)(pivot instanceof List<Integer> ? pivot : [pivot])
+        this.pivot = (List<Integer>)(pivot instanceof List ? pivot : [pivot])
         return this
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/extension/DumpOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/DumpOp.groovy
@@ -51,7 +51,6 @@ class DumpOp {
 
     DumpOp(Map opts, Closure<String> renderer) {
         checkParams('dump', opts, PARAMS_DUMP)
-        this.source = source
         this.tag = opts.tag
         this.pretty = opts.pretty ?: false
         this.renderer = renderer
@@ -75,11 +74,8 @@ class DumpOp {
 
     DataflowWriteChannel apply() {
 
-        if( !isEnabled() ) {
-            if( source instanceof DataflowWriteChannel )
-                return (DataflowWriteChannel)source
+        if( !isEnabled() )
             throw new IllegalArgumentException("Illegal dump operator source channel")
-        }
 
         final target = CH.createBy(source)
         final events = new HashMap(2)

--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -62,8 +62,8 @@ class PublishOp {
         this.source = source
         this.publishOpts = opts
         this.path = opts.path as String
-        if( opts.pathResolver instanceof Closure )
-            this.pathResolver = opts.pathResolver as Closure
+        if( opts.pathResolver instanceof Closure cl )
+            this.pathResolver = cl
         if( opts.index )
             this.indexOpts = new IndexOpts(opts.index as Map)
     }
@@ -161,7 +161,7 @@ class PublishOp {
         // if the closure contained publish statements, use
         // the resulting mapping to create a saveAs closure
         final mapping = dsl.build()
-        if( mapping instanceof Map<String,String> )
+        if( mapping instanceof Map )
             return { filename -> filename in mapping ? outputDir.resolve(mapping[filename]) : null }
 
         // if the resolved publish path is a string, resolve it
@@ -182,11 +182,11 @@ class PublishOp {
             if( source instanceof Path ) {
                 publish0(source, target)
             }
-            else if( source instanceof Collection<Path> ) {
+            else if( source instanceof Collection ) {
                 if( !target.endsWith('/') )
                     throw new ScriptRuntimeException("Invalid publish target '${target}' for workflow output '${name}' -- should be a directory (end with a `/`) when publishing a collection of files")
                 for( final path : source )
-                    publish0(path, target)
+                    publish0((Path) path, target)
             }
             else {
                 throw new ScriptRuntimeException("Invalid publish source for workflow output '${name}' -- expected a file or collection of files, but received: ${source} [${source.class.simpleName}]")
@@ -314,7 +314,7 @@ class PublishOp {
 
         // if the target resolver is a closure, use it to transform
         // the source filename to the target path
-        if( targetResolver instanceof Closure<Path> ) {
+        if( targetResolver instanceof Closure ) {
             // note: the closure can return null to e.g. not
             // publish specific files
             final relPath = sourceDir.relativize(path).toString()

--- a/modules/nextflow/src/main/groovy/nextflow/extension/SplitOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/SplitOp.groovy
@@ -94,7 +94,7 @@ class SplitOp {
             multiSplit = true
             pairedEnd = true
         }
-        if( params.elem instanceof List<Integer> ) {
+        if( params.elem instanceof List ) {
             indexes = params.elem as List<Integer>
             multiSplit = true
         }

--- a/modules/nextflow/src/main/groovy/nextflow/file/DirListener.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/DirListener.groovy
@@ -48,7 +48,7 @@ interface DirListener {
      * @param events the list of events to watch
      * @return
      */
-    default WatchEvent.Kind<Path>[] stringToWatchEvents(String events = null){
+    default WatchEvent.Kind<Path>[] stringToWatchEvents(String events) {
         def result = []
         if( !events )
             result << ENTRY_CREATE

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -151,7 +151,7 @@ class PublishDir {
 
     void setPath( def value ) {
         final resolved = value instanceof Closure ? value.call() : value
-        if( resolved instanceof String || resolved instanceof GString )
+        if( resolved instanceof CharSequence )
             nullPathWarn = checkNull(resolved.toString())
         this.path = FileHelper.toCanonicalPath(resolved)
     }
@@ -169,7 +169,7 @@ class PublishDir {
                 ? tags.call()
                 : tags
 
-        if( result instanceof Map<String,String> )
+        if( result instanceof Map )
             return result
 
         throw new IllegalArgumentException("Invalid publishDir tags attribute: $tags")

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -83,9 +83,11 @@ class TaskConfig extends LazyMap implements Cloneable {
         // clear cache to force re-compute dynamic entries
         this.cache.clear()
 
-        // set the binding context for 'ext' map
+        // set the binding context for 'ext' map -- call the setter explicitly:
+        // a bare `ext.binding = context` is not routed to the protected
+        // `setBinding` under Groovy 5 and would be stored as a map entry
         if( getTarget().ext instanceof LazyMap ext )
-            ext.binding = context
+            ext.setBinding(context)
 
         // set the this object in the task context in order to allow task properties to be resolved in process script
         context.put(TASK_CONTEXT_PROPERTY_NAME, this)

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -73,8 +73,12 @@ class TaskConfig extends LazyMap implements Cloneable {
     TaskConfig setContext( Map context ) {
         assert context != null
 
-        // set the binding context for this map
-        this.binding = context
+        // set the binding context for this map -- call the setter explicitly
+        // rather than assigning `this.binding` (a private field of the LazyMap
+        // super-class): a bare property assignment would be routed through the
+        // overridden `setProperty` and stored as a directive instead of setting
+        // the binding.
+        setBinding(context)
 
         // clear cache to force re-compute dynamic entries
         this.cache.clear()
@@ -133,10 +137,16 @@ class TaskConfig extends LazyMap implements Cloneable {
     }
 
     void setProperty(String name, Object value) {
-        // task directives are stored as map entries; route property
-        // assignment to `put` so read-only getters (e.g. `getShell`) do
-        // not cause a ReadOnlyPropertyException under Groovy 5
-        put(name, value)
+        // if the class defines a real setter for this property (e.g.
+        // `setContext`, `setTarget`), use it; otherwise store the value as a
+        // task directive in the underlying map. Without the map fallback, a
+        // bare assignment to a read-only directive (getter but no setter, e.g.
+        // `shell`) would throw ReadOnlyPropertyException under Groovy 5.
+        final setter = 'set' + name.capitalize()
+        if( metaClass.respondsTo(this, setter, [value] as Object[]) )
+            metaClass.invokeMethod(this, setter, value)
+        else
+            put(name, value)
     }
 
     final getRawValue(String key) {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -80,8 +80,8 @@ class TaskConfig extends LazyMap implements Cloneable {
         this.cache.clear()
 
         // set the binding context for 'ext' map
-        if( target.ext instanceof LazyMap )
-            (target.ext as LazyMap).binding = context
+        if( getTarget().ext instanceof LazyMap ext )
+            ext.binding = context
 
         // set the this object in the task context in order to allow task properties to be resolved in process script
         context.put(TASK_CONTEXT_PROPERTY_NAME, this)
@@ -133,7 +133,7 @@ class TaskConfig extends LazyMap implements Cloneable {
     }
 
     final getRawValue(String key) {
-        return target.get(key)
+        return getTarget().get(key)
     }
 
     def get( String key ) {
@@ -142,11 +142,11 @@ class TaskConfig extends LazyMap implements Cloneable {
 
         def result
         if( key == 'ext' ) {
-            if( target.containsKey(key) )
-                result = target.get(key)
+            if( getTarget().containsKey(key) )
+                result = getTarget().get(key)
             else {
                 result = new LazyMap()
-                target.put(key, result)
+                getTarget().put(key, result)
             }
         }
         else
@@ -167,7 +167,7 @@ class TaskConfig extends LazyMap implements Cloneable {
                     super.setDynamic(flag)
                 }
             }
-            target.put(key, value)
+            getTarget().put(key, value)
         }
         else if( key == 'ext' && value instanceof Map ) {
             super.put( key, new LazyMap(value) )
@@ -181,8 +181,8 @@ class TaskConfig extends LazyMap implements Cloneable {
         if( super.isDynamic() )
             return true
 
-        if( target.ext instanceof LazyMap )
-            return (target.ext as LazyMap).isDynamic()
+        if( getTarget().ext instanceof LazyMap ext )
+            return ext.isDynamic()
 
         return false
     }
@@ -553,7 +553,7 @@ class TaskConfig extends LazyMap implements Cloneable {
      */
     protected boolean getWhenGuard(boolean defValue=true) throws FailedGuardException {
 
-        final code = target.get(NextflowDSLImpl.PROCESS_WHEN)
+        final code = getTarget().get(NextflowDSLImpl.PROCESS_WHEN)
         if( code == null )
             return defValue
 
@@ -573,7 +573,7 @@ class TaskConfig extends LazyMap implements Cloneable {
 
 
     protected TaskClosure getStubBlock() {
-        final code = target.get(NextflowDSLImpl.PROCESS_STUB)
+        final code = getTarget().get(NextflowDSLImpl.PROCESS_STUB)
         if( !code )
             return null
         if( code instanceof TaskClosure )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -132,6 +132,13 @@ class TaskConfig extends LazyMap implements Cloneable {
         return get(name)
     }
 
+    void setProperty(String name, Object value) {
+        // task directives are stored as map entries; route property
+        // assignment to `put` so read-only getters (e.g. `getShell`) do
+        // not cause a ReadOnlyPropertyException under Groovy 5
+        put(name, value)
+    }
+
     final getRawValue(String key) {
         return getTarget().get(key)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1276,7 +1276,7 @@ class TaskProcessor {
             if( value instanceof Path ) {
                 files.add((Path)value)
             }
-            else if( value instanceof Collection<Path> ) {
+            else if( value instanceof Collection ) {
                 files.addAll(value)
             }
             else if( value != null ) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -659,7 +659,13 @@ class AssetManager implements Closeable {
      * @return {@code true} when the SCM source points to a local file-system repository.
      */
     boolean isLocalScmSource() {
-        return provider instanceof LocalRepositoryProvider
+        // assign to a local before the `instanceof` check: under Groovy 5 the
+        // static compiler otherwise narrows the `provider` *field* type to
+        // LocalRepositoryProvider class-wide, inserting bogus casts in other
+        // methods (e.g. clone/getRemoteRevisions/updateModules) that fail with
+        // ClassCastException for non-local providers.
+        final p = provider
+        return p instanceof LocalRepositoryProvider
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -1005,8 +1005,8 @@ class AssetManager implements Closeable {
             return
 
         List<String> filter = []
-        if( modules instanceof List<String> ) {
-            filter.addAll(modules)
+        if( modules instanceof List ) {
+            filter.addAll(modules as List<String>)
         }
         else if( modules instanceof String ) {
             filter.addAll( modules.tokenize(', ') )

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -139,8 +139,8 @@ final class AzureRepositoryProvider extends RepositoryProvider {
     }
 
     @Memoized
-    protected <T> List<T> invokeAndResponseWithPaging(String url, Closure<T> parse) {
-        final result = new ArrayList<T>(50)
+    protected List invokeAndResponseWithPaging(String url, Closure parse) {
+        final result = new ArrayList(50)
         do {
             final resp = invokeAndParseResponse(url)
             final tags = resp.value as List<Map>

--- a/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
@@ -118,8 +118,8 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
     }
 
     @Memoized
-    protected <T> List<T> invokeAndResponseWithPaging(String url, Closure<T> parse) {
-        final result = new ArrayList<T>(50)
+    protected List invokeAndResponseWithPaging(String url, Closure parse) {
+        final result = new ArrayList(50)
         do {
             final resp = invokeAndParseResponse(url)
             final tags = resp.values as List<Map>

--- a/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketServerRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketServerRepositoryProvider.groovy
@@ -167,7 +167,7 @@ final class BitbucketServerRepositoryProvider extends RepositoryProvider {
     }
 
     @Memoized
-    protected <T> List<T> invokeAndResponseWithPaging(String request, Closure<T> parse) {
+    protected List invokeAndResponseWithPaging(String request, Closure parse) {
         int start = 0
         final limit = 100
         final result = new ArrayList()

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
@@ -78,7 +78,7 @@ final class GiteaRepositoryProvider extends RepositoryProvider {
     List<BranchInfo> getBranches() {
         // https://try.gitea.io/api/swagger#/repository/repoListBranches
         final url = "${config.endpoint}/repos/${project}/branches"
-        this.<BranchInfo>invokeAndResponseWithPaging(url, { Map branch -> new BranchInfo(branch.name as String, branch.commit?.id as String) })
+        invokeAndResponseWithPaging(url, { Map branch -> new BranchInfo(branch.name as String, branch.commit?.id as String) })
     }
 
     @Override
@@ -86,7 +86,7 @@ final class GiteaRepositoryProvider extends RepositoryProvider {
     List<TagInfo> getTags() {
         // https://try.gitea.io/api/swagger#/repository/repoListTags
         final url = "${config.endpoint}/repos/${project}/tags"
-        this.<TagInfo>invokeAndResponseWithPaging(url, { Map tag -> new TagInfo(tag.name as String, tag.commit?.sha as String) })
+        invokeAndResponseWithPaging(url, { Map tag -> new TagInfo(tag.name as String, tag.commit?.sha as String) })
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -91,14 +91,14 @@ class GitlabRepositoryProvider extends RepositoryProvider {
     List<BranchInfo> getBranches() {
         // https://docs.gitlab.com/ee/api/branches.html
         final url = "${config.endpoint}/api/v4/projects/${getProjectName()}/repository/branches"
-        this.<BranchInfo>invokeAndResponseWithPaging(url, { Map branch -> new BranchInfo(branch.name as String, branch.commit?.id as String) })
+        invokeAndResponseWithPaging(url, { Map branch -> new BranchInfo(branch.name as String, branch.commit?.id as String) })
     }
 
     @Override
     List<TagInfo> getTags() {
         // https://docs.gitlab.com/ee/api/tags.html
         final url = "${config.endpoint}/api/v4/projects/${getProjectName()}/repository/tags"
-        this.<TagInfo>invokeAndResponseWithPaging(url, { Map tag -> new TagInfo(tag.name as String, tag.commit?.id as String) })
+        invokeAndResponseWithPaging(url, { Map tag -> new TagInfo(tag.name as String, tag.commit?.id as String) })
     }
 
     /** {@inheritDoc} */

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -333,10 +333,13 @@ abstract class RepositoryProvider {
             throw new HttpResponseLengthExceedException("HTTP response '${response.uri()}' is too big - response length: ${length}; max allowed length: ${max}")
     }
 
-    protected <T> List<T> invokeAndResponseWithPaging(String request, Closure<T> parse) {
+    protected List invokeAndResponseWithPaging(String request, Closure parse) {
         // this is needed because apparently bytebuddy used by testing framework is not able
         // to handle properly this method signature using both generics and `@Memoized` annotation.
-        // therefore the `@Memoized` has been moved to the inner method invocation
+        // therefore the `@Memoized` has been moved to the inner method invocation.
+        // note: a method-level generic signature (`<T>`) must be avoided here because Groovy 5
+        // eagerly introspects the class via `java.beans.Introspector` on construction, which
+        // throws a NPE in the JDK `TypeResolver` for methods with method-level type variables.
         return invokeAndResponseWithPaging0(request, parse)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/IterableDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IterableDef.groovy
@@ -181,7 +181,11 @@ trait IterableDef {
     }
 
     private DataflowWriteChannel accumulator(DataflowReadChannel source, int i) {
-        final mapper = { value -> accumulators[i].add(value); return accumulators[i].clone() }
+        final mapper = { value ->
+            final next = new ArrayList<>(accumulators[i])
+            next.add(value)
+            return next
+        }
         return new MapOp(source, mapper).apply()
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/IterableDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IterableDef.groovy
@@ -182,9 +182,11 @@ trait IterableDef {
 
     private DataflowWriteChannel accumulator(DataflowReadChannel source, int i) {
         final mapper = { value ->
-            final next = new ArrayList<>(accumulators[i])
-            next.add(value)
-            return next
+            // accumulate the value into the i-th accumulator and feed back a
+            // snapshot copy (the accumulator must be mutated so that each
+            // iteration sees all previously emitted values)
+            accumulators[i].add(value)
+            return new ArrayList<>(accumulators[i])
         }
         return new MapOp(source, mapper).apply()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessConfig.groovy
@@ -147,6 +147,14 @@ class ProcessConfig implements Map<String,Object>, Cloneable {
 
     }
 
+    @Override
+    void setProperty( String name, Object value ) {
+        // process directives are stored as map entries; route property
+        // assignment to `put` so read-only getters (e.g. `getFair`) do not
+        // cause a ReadOnlyPropertyException under Groovy 5
+        put(name, value)
+    }
+
     BaseScript getOwnerScript() { ownerScript }
 
     String getProcessName() { processName }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -107,7 +107,7 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
         def result = clone()
         result.@processName = name
         result.@simpleName = stripScope(name)
-        result.@processConfig.processName = name
+        result.@processConfig.setProcessName(name)
         return result
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptBinding.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptBinding.groovy
@@ -71,7 +71,8 @@ class ScriptBinding extends WorkflowBinding {
         // create and populate args
         args = new ArrayList<>()
         if( vars.args ) {
-            if( !(vars.args instanceof List<String>) ) throw new IllegalArgumentException("ScriptBinding 'args' must be a List value")
+            if( vars.args !instanceof List )
+                throw new IllegalArgumentException("ScriptBinding 'args' must be a List value")
             args.addAll((List<String>)vars.args)
         }
         vars.put('args', args)
@@ -79,7 +80,8 @@ class ScriptBinding extends WorkflowBinding {
         // create and populate params
         params = new ParamsMap()
         if( vars.params ) {
-            if( !(vars.params instanceof Map) ) throw new IllegalArgumentException("ScriptBinding 'params' must be a Map value")
+            if( vars.params !instanceof Map )
+                throw new IllegalArgumentException("ScriptBinding 'params' must be a Map value")
             params.putAll((Map)vars.params)
         }
         vars.params = params
@@ -211,6 +213,7 @@ class ScriptBinding extends WorkflowBinding {
     /**
      * Implements immutable params map
      */
+    @Slf4j
     @CompileStatic
     static class ParamsMap implements Record, Map<String,Object> {
 
@@ -245,7 +248,7 @@ class ScriptBinding extends WorkflowBinding {
                 final msg = "Access to undefined parameter `$key` -- Initialise it to a default value eg. `params.$key = some_value`"
                 if( NF.isStrictMode() )
                     throw new AbortOperationException(msg)
-                log.warn1(msg, firstOnly: true)
+                log.warn1(msg)
                 return null
             }
             return target.get(key)

--- a/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessConfigBuilder.groovy
@@ -196,10 +196,10 @@ class ProcessConfigBuilder extends ProcessBuilder {
                 continue
 
             if( entry.key == 'ext' ) {
-                if( config.getProperty('ext') instanceof Map ) {
+                final ext = config.getProperty('ext')
+                if( ext instanceof Map ) {
                     // update missing 'ext' properties found in 'process' scope
-                    final ext = config.getProperty('ext') as Map
-                    entry.value.each { String k, v -> ext[k] = v }
+                    ext.putAll(entry.value as Map)
                 }
                 continue
             }

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/InParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/InParam.groovy
@@ -31,9 +31,15 @@ interface InParam extends Cloneable {
 
     Object getRawChannel()
 
-    short index
+    // NOTE: declared as explicit getters (rather than `short index` /
+    // `short mapIndex`) because Groovy 5 compiles a bare typed field in an
+    // interface as a `static final` constant (value 0) instead of an abstract
+    // property. That constant shadowed the real instance value during dynamic
+    // property access (e.g. in `BaseInParam.decodeInputs`), breaking input
+    // resolution.
+    short getIndex()
 
-    short mapIndex
+    short getMapIndex()
 
     def decodeInputs( List values )
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessInput.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessInput.groovy
@@ -87,6 +87,16 @@ class ProcessInput implements InParam {
     }
 
     @Override
+    short getIndex() {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    short getMapIndex() {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
     def decodeInputs( List values ) {
         throw new UnsupportedOperationException()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessInputsDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessInputsDef.groovy
@@ -36,7 +36,7 @@ class ProcessInputsDef implements Cloneable {
      * task against the task context and added to the task
      * environment.
      */
-    private Map<String,?> env = [:]
+    private Map<String,Object> env = [:]
 
     /**
      * Input files which will be evaluated for each task
@@ -80,7 +80,7 @@ class ProcessInputsDef implements Cloneable {
         return params.get(i)
     }
 
-    Map<String,?> getEnv() {
+    Map<String,Object> getEnv() {
         return env
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptCompiler.java
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptCompiler.java
@@ -305,7 +305,7 @@ public class ScriptCompiler {
             // convert to Groovy
             var sn = (ScriptNode) source.getAST();
             for ( var type : DEFAULT_IMPORTS )
-                sn.addImport(null, type);
+                sn.addImport(type.getNameWithoutPackage(), type);
             sn.addStaticStarImport(null, ClassHelper.makeWithoutCaching("nextflow.Nextflow"));
 
             var channelNamespace = sn.isTypingEnabled()

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ResourcesAggregator.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ResourcesAggregator.groovy
@@ -71,7 +71,7 @@ class ResourcesAggregator {
             final summary = summaries[process]
             summary.names.each { String series ->
                 // the task execution turn a triple
-                tasks << { return [ process, series, summary.compute(series)] } as Callable<List>
+                tasks.add({ -> [process, series, summary.compute(series)] } as Callable<List>)
             }
             // initialise the result entry
             result.put(process, new HashMap(10))

--- a/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
@@ -97,7 +97,7 @@ class KryoHelper {
             if( v instanceof Class )
                 kryo.register(k,(Serializer)v.newInstance())
 
-            else if( v instanceof Closure<Serializer> )
+            else if( v instanceof Closure )
                 kryo.register(k, v.call(kryo))
 
             else

--- a/modules/nextflow/src/main/groovy/nextflow/util/ServiceName.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/ServiceName.groovy
@@ -50,6 +50,6 @@ import java.lang.annotation.Target
      * @return {@code true} when the executor should have priority over non-important ones
      */
     @Deprecated
-    boolean important() default Boolean.FALSE
+    boolean important() default false
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/util/SimpleAgent.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/SimpleAgent.groovy
@@ -106,6 +106,7 @@ class SimpleAgent<T> {
         }
     }
 
+    @Slf4j
     @CompileStatic
     private static class RetrieveValueClosure<T> extends Closure {
 

--- a/modules/nextflow/src/main/groovy/nextflow/util/ThreadPoolHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/ThreadPoolHelper.groovy
@@ -60,13 +60,12 @@ class ThreadPoolHelper {
         }
     }
 
-    static protected int pending(ExecutorService pool) {
-        if( pool instanceof ThreadPoolExecutor) {
-            final p1 = ((ThreadPoolExecutor)pool)
-            return p1.getTaskCount() - p1.getCompletedTaskCount()
+    static protected long pending(ExecutorService pool) {
+        if( pool instanceof ThreadPoolExecutor tpe ) {
+            return tpe.getTaskCount() - tpe.getCompletedTaskCount()
         }
-        else if( pool instanceof ThreadContainer ) {
-            return pool.threadCount()
+        else if( pool instanceof ThreadContainer tc ) {
+            return tc.threadCount()
         }
         return -1
     }

--- a/modules/nextflow/src/test/groovy/nextflow/ast/OpXformTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/ast/OpXformTest.groovy
@@ -76,7 +76,7 @@ class OpXformTest extends Specification {
 
         then:
         result instanceof TokenBranchDef
-        result.closure instanceof Closure<TokenBranchChoice>
+        result.closure instanceof Closure
         result.branches == ['x','y']
         and:
         result.closure.call(0).value == 'hello'

--- a/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/conda/CondaCacheTest.groovy
@@ -245,7 +245,7 @@ class CondaCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand( "conda create --yes --quiet --prefix $PREFIX $ENV" ) >> null
+        1 * cache.runCommand( "conda create --yes --quiet --prefix $PREFIX $ENV" ) >> 0
         result == PREFIX
     }
 
@@ -269,7 +269,7 @@ class CondaCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("mamba create --yes --quiet --prefix $PREFIX $ENV") >> null
+        1 * cache.runCommand("mamba create --yes --quiet --prefix $PREFIX $ENV") >> 0
         result == PREFIX
     }
 
@@ -293,7 +293,7 @@ class CondaCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("micromamba create --yes --quiet --prefix $PREFIX $ENV") >> null
+        1 * cache.runCommand("micromamba create --yes --quiet --prefix $PREFIX $ENV") >> 0
         result == PREFIX
     }
 
@@ -317,7 +317,7 @@ class CondaCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("mamba env create --yes --prefix $PREFIX --file $ENV") >> null
+        1 * cache.runCommand("mamba env create --yes --prefix $PREFIX --file $ENV") >> 0
         result == PREFIX
     }
 
@@ -341,7 +341,7 @@ class CondaCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("micromamba env create --yes --prefix $PREFIX --file $ENV") >> null
+        1 * cache.runCommand("micromamba env create --yes --prefix $PREFIX --file $ENV") >> 0
         result == PREFIX
     }
 
@@ -358,7 +358,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isExplicitFile(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand( "conda create --this --that --yes --quiet --prefix $PREFIX $ENV" ) >> null
+        1 * cache.runCommand( "conda create --this --that --yes --quiet --prefix $PREFIX $ENV" ) >> 0
         result == PREFIX
     }
 
@@ -375,7 +375,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isExplicitFile(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("mamba create --this --that --yes --quiet --prefix $PREFIX $ENV") >> null
+        1 * cache.runCommand("mamba create --this --that --yes --quiet --prefix $PREFIX $ENV") >> 0
         result == PREFIX
     }
 
@@ -392,7 +392,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isExplicitFile(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("micromamba create --this --that --yes --quiet --prefix $PREFIX $ENV") >> null
+        1 * cache.runCommand("micromamba create --this --that --yes --quiet --prefix $PREFIX $ENV") >> 0
         result == PREFIX
     }
 
@@ -409,7 +409,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isExplicitFile(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand("conda create --yes --quiet --prefix /foo/bar -c bioconda -c defaults bwa=1.1.1") >> null
+        1 * cache.runCommand("conda create --yes --quiet --prefix /foo/bar -c bioconda -c defaults bwa=1.1.1") >> 0
         result == PREFIX
     }
 
@@ -426,7 +426,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         0 * cache.isExplicitFile(ENV)
         1 * cache.makeAbsolute(ENV) >> Paths.get('/usr/base').resolve(ENV)
-        1 * cache.runCommand( "conda env create --prefix $PREFIX --file /usr/base/foo.yml" ) >> null
+        1 * cache.runCommand( "conda env create --prefix $PREFIX --file /usr/base/foo.yml" ) >> 0
         result == PREFIX
 
     }
@@ -444,7 +444,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         0 * cache.isExplicitFile(ENV)
         1 * cache.makeAbsolute(ENV) >> Paths.get('/usr/base').resolve(ENV)
-        1 * cache.runCommand( "micromamba env create --yes --prefix $PREFIX --file /usr/base/foo.yml" ) >> null
+        1 * cache.runCommand( "micromamba env create --yes --prefix $PREFIX --file /usr/base/foo.yml" ) >> 0
         result == PREFIX
 
     }
@@ -475,7 +475,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isExplicitFile(ENV)
         1 * cache.makeAbsolute(ENV) >> envFile.toAbsolutePath()
-        1 * cache.runCommand( "conda create --this --that --yes --quiet --prefix $PREFIX --file ${envFile.toAbsolutePath()}" ) >> null
+        1 * cache.runCommand( "conda create --this --that --yes --quiet --prefix $PREFIX --file ${envFile.toAbsolutePath()}" ) >> 0
         result == PREFIX
 
         cleanup:
@@ -507,7 +507,7 @@ class CondaCacheTest extends Specification {
         1 * cache.isYamlFilePath(ENV)
         1 * cache.isExplicitFile(ENV)
         1 * cache.makeAbsolute(ENV) >> envFile.toAbsolutePath()
-        1 * cache.runCommand( "micromamba create --this --that --yes --quiet --prefix $PREFIX --file ${envFile.toAbsolutePath()}" ) >> null
+        1 * cache.runCommand( "micromamba create --this --that --yes --quiet --prefix $PREFIX --file ${envFile.toAbsolutePath()}" ) >> 0
         result == PREFIX
 
         cleanup:

--- a/modules/nextflow/src/test/groovy/nextflow/extension/SplitOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/SplitOpTest.groovy
@@ -145,15 +145,15 @@ class SplitOpTest extends Specification {
         1 * op.createSplitter(METHOD, [elem:-1, autoClose: false, into:out1] ) >> splitter1
         1 * op.createSplitter(METHOD, [elem:-2, autoClose: false, into:out2] ) >> splitter2
 
-        1 * op.applySplittingOperator(copy1, out1, splitter1) >> null
-        1 * op.applySplittingOperator(copy2, out2, splitter2) >> null
+        1 * op.applySplittingOperator(copy1, out1, splitter1) >> { }
+        1 * op.applySplittingOperator(copy2, out2, splitter2) >> { }
 
         1 * splitter1.setEmitSplitIndex(true)
         1 * splitter2.setEmitSplitIndex(true)
 
         1 * splitter1.setMultiSplit(true)
         1 * splitter2.setMultiSplit(true)
-        1 * op.applyMergingOperator([out1, out2], _ as DataflowBroadcast, [-1,-2]) >> null
+        1 * op.applyMergingOperator([out1, out2], _ as DataflowBroadcast, [-1,-2]) >> { }
         then:
         result instanceof DataflowBroadcast
     }

--- a/modules/nextflow/src/test/groovy/nextflow/mail/MailerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/mail/MailerTest.groovy
@@ -168,7 +168,7 @@ class MailerTest extends Specification {
         0 * mailer.getSysMailer() >> null
         1 * mailer.provider() >> provider
         1 * mailer.createMimeMessage(mail) >> MSG
-        1 * provider.send(MSG, mailer) >> null
+        1 * provider.send(MSG, mailer) >> { }
 
     }
 
@@ -185,7 +185,7 @@ class MailerTest extends Specification {
         then:
         1 * mailer.provider() >> provider
         1 * mailer.createMimeMessage(mail) >> MSG
-        1 * provider.send(MSG, mailer) >> null
+        1 * provider.send(MSG, mailer) >> { }
     }
 
     def 'should throw an exception' () {
@@ -211,7 +211,7 @@ class MailerTest extends Specification {
         then:
         1 * mailer.provider() >> provider
         1 * mailer.createTextMessage(mail) >> MSG
-        1 * provider.send(MSG, mailer) >> null
+        1 * provider.send(MSG, mailer) >> { }
     }
 
 
@@ -358,7 +358,7 @@ class MailerTest extends Specification {
         }
 
         then:
-        1 * mailer.send(Mail.of([to: 'paolo@dot.com', from:'yo@dot.com', subject: 'This is a test', body: 'Hello there'])) >> null
+        1 * mailer.send(Mail.of([to: 'paolo@dot.com', from:'yo@dot.com', subject: 'This is a test', body: 'Hello there'])) >> { }
 
     }
 
@@ -394,7 +394,7 @@ class MailerTest extends Specification {
         }
 
         then:
-        1 * mailer.send(Mail.of([to: 'you@dot.com', subject: 'foo', body: BODY])) >> null
+        1 * mailer.send(Mail.of([to: 'you@dot.com', subject: 'foo', body: BODY])) >> { }
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/processor/LocalPollingMonitorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/LocalPollingMonitorTest.groovy
@@ -60,7 +60,7 @@ class LocalPollingMonitorTest extends Specification {
         when:
         monitor.submit(handler)
         then:
-        session.notifyTaskSubmit(handler) >> null
+        session.notifyTaskSubmit(handler) >> { }
         monitor.getRunningQueue().size()==1
         monitor.availCpus == 7
         monitor.availMemory == MemoryUnit.of('18GB').toBytes()
@@ -106,8 +106,8 @@ class LocalPollingMonitorTest extends Specification {
         when:
         monitor.submit(handler)
         then:
-        1 * handler.submit() >> null
-        1 * session.notifyTaskSubmit(handler) >> null
+        1 * handler.submit() >> { }
+        1 * session.notifyTaskSubmit(handler) >> { }
         and:
         monitor.canSubmit(handler) == true
         monitor.availCpus == 6
@@ -116,8 +116,8 @@ class LocalPollingMonitorTest extends Specification {
         when:
         monitor.submit(handler)
         then:
-        1 * handler.submit() >> null
-        1 * session.notifyTaskSubmit(handler) >> null
+        1 * handler.submit() >> { }
+        1 * session.notifyTaskSubmit(handler) >> { }
         and:
         monitor.canSubmit(handler) == false
         monitor.availCpus == 2
@@ -153,8 +153,8 @@ class LocalPollingMonitorTest extends Specification {
         when:
         monitor.submit(handler)
         then:
-        1 * handler.submit() >> null
-        1 * session.notifyTaskSubmit(handler) >> null
+        1 * handler.submit() >> { }
+        1 * session.notifyTaskSubmit(handler) >> { }
         and:
         monitor.canSubmit(handler) == false
         monitor.availCpus == 0

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskHandlerTest.groovy
@@ -156,7 +156,9 @@ class TaskHandlerTest extends Specification {
         def handler = Spy(TaskHandler)
         handler.task = Mock(TaskRun) {
             getProcessor() >> Mock(TaskProcessor) {
-                getMaxForks() >> MAX
+                // getMaxForks() returns a primitive int; a null stub cannot be
+                // cast to int under Groovy 5, so map the `null` (unset) case to 0
+                getMaxForks() >> (MAX ?: 0)
                 getForksCount() >> { COUNT ? _adder(COUNT) : null }
             }
         }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy
@@ -104,8 +104,8 @@ class TaskPollingMonitorTest extends Specification {
         then:
         1 * session.disableJobsCancellation >> false
         and:
-        1 * handler.kill() >> null
-        1 * session.notifyTaskComplete(handler) >> null
+        1 * handler.kill()
+        1 * session.notifyTaskComplete(handler)
     }
 
     def 'should not cancel running jobs' () {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
@@ -896,8 +896,8 @@ class TaskRunTest extends Specification {
         when:
         task.resolve(body)
         then:
-        1 * task.resolveBody(body) >> null
-        0 * task.resolveStub(_) >> null
+        1 * task.resolveBody(body) >> { }
+        0 * task.resolveStub(_)
     }
 
     def 'should resolve task body when no stub' () {
@@ -913,8 +913,8 @@ class TaskRunTest extends Specification {
         when:
         task.resolve(body)
         then:
-        1 * task.resolveBody(body) >> null
-        0 * task.resolveStub(_) >> null
+        1 * task.resolveBody(body) >> { }
+        0 * task.resolveStub(_)
     }
 
     def 'should resolve task stub' () {
@@ -931,8 +931,8 @@ class TaskRunTest extends Specification {
         when:
         task.resolve(body)
         then:
-        1 * task.resolveStub(stub) >> null
-        0 * task.resolveBody(_) >> null
+        1 * task.resolveStub(stub) >> { }
+        0 * task.resolveBody(_)
     }
 
     def 'should get stub source via method access' () {

--- a/modules/nextflow/src/test/groovy/nextflow/scm/MultiRevisionRepositoryStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/MultiRevisionRepositoryStrategyTest.groovy
@@ -295,7 +295,7 @@ class MultiRevisionRepositoryStrategyTest extends Specification {
         def work = Git.init().setDirectory(workDir).setInitialBranch('main').call()
         new File(workDir, 'a.txt').text = 'A'
         work.add().addFilepattern('a.txt').call()
-        def commitA = work.commit().setMessage('A').call()
+        def commitA = work.commit().setSign(false).setMessage('A').call()
         work.push().setRemote(upstreamDir.absolutePath).setRefSpecs(new RefSpec('refs/heads/main:refs/heads/main')).call()
         work.close()
 
@@ -323,7 +323,7 @@ class MultiRevisionRepositoryStrategyTest extends Specification {
         work = Git.open(workDir)
         new File(workDir, 'a.txt').text = 'B'
         work.add().addFilepattern('a.txt').call()
-        def commitB = work.commit().setAmend(true).setMessage('B').call()
+        def commitB = work.commit().setSign(false).setAmend(true).setMessage('B').call()
         work.push().setRemote(upstreamDir.absolutePath).setForce(true).setRefSpecs(new RefSpec('refs/heads/main:refs/heads/main')).call()
         work.close()
 

--- a/modules/nextflow/src/test/groovy/nextflow/spack/SpackCacheTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/spack/SpackCacheTest.groovy
@@ -116,7 +116,7 @@ class SpackCacheTest extends Specification {
         then:
         1 * cache.spackPrefixPath(ENV,null) >> PREFIX
         0 * cache.isYamlFilePath(ENV)
-        1 * cache.runCommand( "spack env activate $PREFIX ; spack install -y ; spack env deactivate" ) >> null
+        1 * cache.runCommand( "spack env activate $PREFIX ; spack install -y ; spack env deactivate" ) >> { }
         result == PREFIX
 
         when:
@@ -125,7 +125,7 @@ class SpackCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand( "spack env create -d $PREFIX ; spack env activate $PREFIX ; spack add $ENV ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack concretize -f ; spack install -y ; spack env deactivate" ) >> null
+        1 * cache.runCommand( "spack env create -d $PREFIX ; spack env activate $PREFIX ; spack add $ENV ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack concretize -f ; spack install -y ; spack env deactivate" ) >> { }
         result == PREFIX
 
     }
@@ -144,7 +144,7 @@ class SpackCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand( "spack env create -d $PREFIX ; spack env activate $PREFIX ; spack add $ENV ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack config add packages:all:target:[$ARCH] ; spack concretize -f ; spack install -n -j 2 -y ; spack env deactivate" ) >> null
+        1 * cache.runCommand( "spack env create -d $PREFIX ; spack env activate $PREFIX ; spack add $ENV ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack config add packages:all:target:[$ARCH] ; spack concretize -f ; spack install -n -j 2 -y ; spack env deactivate" ) >> { }
         result == PREFIX
     }
 
@@ -162,7 +162,7 @@ class SpackCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         0 * cache.makeAbsolute(_)
-        1 * cache.runCommand( "spack env create -d $PREFIX ; spack env activate $PREFIX ; spack add $ENV ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack config add packages:all:target:[$ARCH] ; spack concretize -f ; spack install -j 2 -y ; spack env deactivate" ) >> null
+        1 * cache.runCommand( "spack env create -d $PREFIX ; spack env activate $PREFIX ; spack add $ENV ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack config add packages:all:target:[$ARCH] ; spack concretize -f ; spack install -j 2 -y ; spack env deactivate" ) >> { }
         result == PREFIX
     }
 
@@ -179,7 +179,7 @@ class SpackCacheTest extends Specification {
         then:
         1 * cache.isYamlFilePath(ENV)
         1 * cache.makeAbsolute(ENV) >> Paths.get('/usr/base').resolve(ENV)
-        1 * cache.runCommand( "spack env create -d $PREFIX /usr/base/$ENV ; spack env activate $PREFIX ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack concretize -f ; spack install -y ; spack env deactivate" ) >> null
+        1 * cache.runCommand( "spack env create -d $PREFIX /usr/base/$ENV ; spack env activate $PREFIX ; spack env view enable ; spack config add concretizer:unify:true ; spack config add concretizer:reuse:false ; spack concretize -f ; spack install -y ; spack env deactivate" ) >> { }
         result == PREFIX
 
     }

--- a/modules/nextflow/src/test/groovy/nextflow/splitter/AbstractSplitterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/splitter/AbstractSplitterTest.groovy
@@ -26,13 +26,22 @@ import spock.lang.Specification
  */
 class AbstractSplitterTest extends Specification {
 
+    // concrete subclass used to exercise AbstractSplitter's non-abstract
+    // methods. Note: `[:] as AbstractSplitter` no longer works under Groovy 5
+    // — the generated proxy does not delegate the concrete methods.
+    static class TestSplitter extends AbstractSplitter {
+        protected process(Object targetObject) { }
+        protected normalizeSource(object) { object }
+        protected CollectorStrategy createCollector() { null }
+    }
+
     private Path file(String name) { Paths.get(name) }
 
     def 'test invokeEachClosure method'() {
 
 
         when:
-        def splitter = [:] as AbstractSplitter
+        def splitter = new TestSplitter()
         then:
         splitter.invokeEachClosure(null, 'hola') == 'hola'
         splitter.invokeEachClosure({ x -> x.reverse() }, 'hola') == 'aloh'
@@ -63,56 +72,56 @@ class AbstractSplitterTest extends Specification {
         def splitter
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         then:
         splitter.elem == null
         splitter.findSource([ 10, 20 ]) == 10
         splitter.elem == 0
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         then:
         splitter.elem == null
         splitter.findSource([ 10, file('/hello') ]) == file('/hello')
         splitter.elem == 1
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         splitter.elem = -2  // <-- find the second file
         then:
         splitter.findSource([ 10, 20, file('/hello'), 30, 40, file('/second'), file('/third') ]) == file('/second')
         splitter.elem == 5
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         splitter.elem = -3  // <-- find the third file
         then:
         splitter.findSource([ 10, 20, file('/hello'), 30, 40, file('/second'), file('/third') ]) == file('/third')
         splitter.elem == 6
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         splitter.elem = 1
         then:
         splitter.findSource([ 10, 20, file('/hello') ]) == 20
         splitter.elem == 1
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         splitter.elem = 0
         then:
         splitter.findSource([ 10, 20, Paths.get('/hello') ]) == 10
         splitter.elem == 0
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         splitter.elem = -1
         splitter.findSource([ 10, 20 ])
         then:
         thrown(IllegalArgumentException)
 
         when:
-        splitter = [:] as AbstractSplitter
+        splitter = new TestSplitter()
         splitter.elem = -2
         splitter.findSource([ 10, 20, Paths.get('/hello') ])
         then:

--- a/modules/nextflow/src/test/groovy/nextflow/splitter/AbstractTextSplitterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/splitter/AbstractTextSplitterTest.groovy
@@ -27,6 +27,13 @@ import test.TestHelper
  */
 class AbstractTextSplitterTest extends Specification {
 
+    // concrete subclass used to exercise AbstractTextSplitter's non-abstract
+    // methods. Note: `[:] as AbstractTextSplitter` no longer works under
+    // Groovy 5 — the generated proxy does not delegate the concrete methods.
+    static class TestTextSplitter extends AbstractTextSplitter {
+        protected fetchRecord(BufferedReader reader) { null }
+    }
+
     def testGetCollectorBaseFile() {
 
         given:
@@ -37,7 +44,7 @@ class AbstractTextSplitterTest extends Specification {
         def splitter
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.options(file: folder, by: 2)
         result = splitter.getCollectorBaseFile()
         then:
@@ -45,7 +52,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash != null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.options(file: folder, by: 2, elem:2)
         splitter.multiSplit = true
         result = splitter.getCollectorBaseFile()
@@ -54,7 +61,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash != null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.options(file: Paths.get('/some/file.txt'), by: 2)
         result = splitter.getCollectorBaseFile()
         then:
@@ -62,7 +69,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash != null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.options(file: true, by: 2)
         result = splitter.getCollectorBaseFile()
         then:
@@ -71,7 +78,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash == null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.options(file: 'chunk_name', by:2)
         result = splitter.getCollectorBaseFile()
         then:
@@ -80,7 +87,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash == null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.options(file: 'chunk_name', by:2, elem:3)
         splitter.multiSplit = true
         result = splitter.getCollectorBaseFile()
@@ -90,7 +97,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash == null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.sourceFile = Paths.get('/some/file.txt')
         splitter.options(file: true, by: 2)
         result = splitter.getCollectorBaseFile()
@@ -100,7 +107,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash == null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.sourceFile = Paths.get('/some/file.fasta.gz')
         splitter.options(file: true, by: 2)
         result = splitter.getCollectorBaseFile()
@@ -110,7 +117,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash == null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.sourceFile = Paths.get('/some/file.fa.gz')
         splitter.options(file: 'my_file_name', by: 2)
         result = splitter.getCollectorBaseFile()
@@ -120,7 +127,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash == null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.sourceFile = Paths.get('/some/file.fa.gz')
         splitter.options(file: folder, by: 2)
         result = splitter.getCollectorBaseFile()
@@ -130,7 +137,7 @@ class AbstractTextSplitterTest extends Specification {
         result.hash != null
 
         when:
-        splitter = [:] as AbstractTextSplitter
+        splitter = new TestTextSplitter()
         splitter.sourceFile = Paths.get('/some/file.fasta.gz')
         splitter.options(file: true)
         result = splitter.createCollector()
@@ -143,7 +150,7 @@ class AbstractTextSplitterTest extends Specification {
         given:
         def folder = TestHelper.createInMemTempDir()
         def result
-        def splitter = [:] as AbstractTextSplitter
+        def splitter = new TestTextSplitter()
         splitter.options(file: folder, by: 2)
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ReportObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ReportObserverTest.groovy
@@ -181,12 +181,12 @@ class ReportObserverTest extends Specification {
         when:
         observer.onTaskComplete(EVENT1)
         then:
-        1 * observer.aggregate(RECORD1) >> null
+        1 * observer.aggregate(RECORD1) >> { }
 
         when:
         observer.onTaskCached(EVENT2)
         then:
-        1 * observer.aggregate(RECORD2) >> null
+        1 * observer.aggregate(RECORD2) >> { }
         observer.records[TASKID2] == RECORD2
 
         when:

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -27,8 +27,8 @@ sourceSets {
 dependencies {
     api(project(':nf-lang'))
     api "ch.qos.logback:logback-classic:1.5.37"
-    api "org.apache.groovy:groovy:4.0.31"
-    api "org.apache.groovy:groovy-nio:4.0.31"
+    api "org.apache.groovy:groovy:5.0.7"
+    api "org.apache.groovy:groovy-nio:5.0.7"
     api "org.apache.commons:commons-lang3:3.18.0"
     api 'com.google.guava:guava:33.0.0-jre'
     api 'org.pf4j:pf4j:3.14.1'
@@ -48,7 +48,7 @@ dependencies {
     testImplementation(testFixtures(project(":nextflow")))
     testFixturesImplementation(project(":nextflow"))
 
-    testImplementation "org.apache.groovy:groovy-json:4.0.31" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:5.0.7" // needed by wiremock
     testImplementation ('org.wiremock:wiremock-standalone:3.13.2') { exclude module: 'groovy-all' }
 }
 

--- a/modules/nf-commons/src/main/nextflow/config/RegistryConfig.groovy
+++ b/modules/nf-commons/src/main/nextflow/config/RegistryConfig.groovy
@@ -54,7 +54,7 @@ class RegistryConfig implements ConfigScope {
 
     RegistryConfig(Map opts) {
         final urlObject = opts.url ?: [DEFAULT_REGISTRY_URL]
-        if (urlObject instanceof Collection<String>)
+        if (urlObject instanceof Collection)
             this.url = (urlObject as Collection<String>).collect { it.replaceAll(/\/+$/, '') }
         else
             this.url = [urlObject.toString().replaceAll(/\/+$/, '')]

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginRef.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginRef.groovy
@@ -18,15 +18,15 @@ package nextflow.plugin
 
 import com.google.common.hash.Hasher
 import groovy.transform.Canonical
-import nextflow.util.CacheFunnel
-import nextflow.util.CacheHelper
+import groovy.transform.CompileStatic
 /**
  * Model a plugin Id and version
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Canonical
-class PluginRef implements CacheFunnel, Comparable<PluginRef> {
+@CompileStatic
+class PluginRef implements Comparable<PluginRef> {
 
     /**
      * Plugin unique ID
@@ -53,14 +53,6 @@ class PluginRef implements CacheFunnel, Comparable<PluginRef> {
         if( defaultPlugins.hasPlugin(id) )
             return defaultPlugins.getPlugin(id)
         return new PluginRef(id)
-    }
-
-    @Override
-    Hasher funnel(Hasher hasher, CacheHelper.HashMode mode) {
-        hasher.putUnencodedChars(id)
-        if( version )
-            hasher.putUnencodedChars(version)
-        return hasher
     }
 
     @Override

--- a/modules/nf-commons/src/main/nextflow/util/CacheFunnel.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheFunnel.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package nextflow.util
+package nextflow.util;
 
-import com.google.common.hash.Hasher
-import groovy.transform.CompileStatic
+import com.google.common.hash.Hasher;
 /**
  * Interface to delegate cache hashing to
  * a the implementing object
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-@CompileStatic
-interface CacheFunnel {
+public interface CacheFunnel {
 
-    Hasher funnel(Hasher hasher, CacheHelper.HashMode mode)
+    Hasher funnel(Hasher hasher, CacheHelper.HashMode mode);
 
 }

--- a/modules/nf-commons/src/main/nextflow/util/CmdLineOptionMap.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/CmdLineOptionMap.groovy
@@ -30,7 +30,7 @@ import groovy.transform.ToString
 @CompileStatic
 @ToString(includes = 'options', includeFields = true)
 @EqualsAndHashCode(includes = 'options', includeFields = true)
-class CmdLineOptionMap implements CacheFunnel {
+class CmdLineOptionMap {
 
     final private Map<String, List<String>> options = new LinkedHashMap<String, List<String>>()
     final private static CmdLineOptionMap EMPTY = new CmdLineOptionMap()
@@ -89,10 +89,5 @@ class CmdLineOptionMap implements CacheFunnel {
             serialized << "option{${it.key}: ${it.value.each {it}}}"
         }
         return "[${serialized.join(', ')}]"
-    }
-
-    @Override
-    Hasher funnel(Hasher hasher, CacheHelper.HashMode mode) {
-        return CacheHelper.hasher(hasher, options, mode)
     }
 }

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginUpdaterTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginUpdaterTest.groovy
@@ -600,7 +600,7 @@ class PluginUpdaterTest extends Specification {
 
         and:
         // Mock pullPlugin0 to prevent real implementation calls
-        2 * updater.pullPlugin0(_, _) >> null
+        2 * updater.pullPlugin0(_, _) >> { }
 
         cleanup:
         folder?.deleteDir()

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -30,12 +30,12 @@ sourceSets {
 dependencies {
     api project(':nf-commons')
     api "ch.qos.logback:logback-classic:1.5.37"
-    api "org.apache.groovy:groovy:4.0.31"
-    api "org.apache.groovy:groovy-nio:4.0.31"
+    api "org.apache.groovy:groovy:5.0.7"
+    api "org.apache.groovy:groovy-nio:5.0.7"
     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
 
     /* testImplementation inherited from top gradle build file */
-    testImplementation "org.apache.groovy:groovy-json:4.0.31" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:5.0.7" // needed by wiremock
     testImplementation ('org.wiremock:wiremock-standalone:3.13.2') { exclude module: 'groovy-all' }
 
     testImplementation(testFixtures(project(":nextflow")))

--- a/modules/nf-lang/build.gradle
+++ b/modules/nf-lang/build.gradle
@@ -23,7 +23,7 @@ compileJava {
 
 dependencies {
   antlr 'me.sunlan:antlr4:4.13.2.6'
-  api 'org.apache.groovy:groovy:4.0.31'
+  api 'org.apache.groovy:groovy:5.0.7'
   api 'org.pf4j:pf4j:3.14.1'
 
   testFixturesApi 'com.google.jimfs:jimfs:1.2'

--- a/modules/nf-lineage/build.gradle
+++ b/modules/nf-lineage/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':nextflow')
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }
 

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinExtensionImpl.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinExtensionImpl.groovy
@@ -49,7 +49,8 @@ class LinExtensionImpl implements LinExtension {
     }
 
     private static Map<String, List<String>> buildQueryParams(Map<String,?> opts) {
-        final queryParams = [type: [FileOutput.class.simpleName] ]
+        final Map<String, List<String>> queryParams = [:]
+        queryParams['type'] = [FileOutput.class.simpleName]
         if( opts.workflowRun )
             queryParams['workflowRun'] = [opts.workflowRun as String]
         if( opts.taskRun )

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -246,9 +246,9 @@ class LinObserver implements TraceObserverV2 {
         if (value instanceof Path) {
             return asUriString(storeTaskOutput(task, (Path) value))
         }
-        if (value instanceof Collection<Path>) {
+        if (value instanceof Collection) {
             final files = new LinkedList<String>()
-            for (Path it : value) {
+            for (final it : value) {
                 files.add( asUriString(storeTaskOutput(task, (Path)it)) )
             }
             return files

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinUtilsTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinUtilsTest.groovy
@@ -86,13 +86,13 @@ class LinUtilsTest extends Specification{
         when:
         def params = LinUtils.getMetadataObject(lidStore, new URI('lid://testKey#params'))
         then:
-        params instanceof List<Parameter>
+        params instanceof List
         (params as List<Parameter>).size() == 2
 
         when:
         def outputs = LinUtils.getMetadataObject(lidStore, new URI('lid://testKey#output'))
         then:
-        outputs instanceof List<Parameter>
+        outputs instanceof List
         def param = (outputs as List)[0] as Parameter
         param.name == "output"
 

--- a/nextflow
+++ b/nextflow
@@ -470,6 +470,8 @@ else
     launcher+=(--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED)
     launcher+=(--add-opens=java.base/jdk.internal.vm=ALL-UNNAMED)
     launcher+=(--add-opens=java.base/java.util.regex=ALL-UNNAMED)
+    # preserve Groovy 4 file/path truthiness (a non-null File/Path is truthy regardless of existence) -- see GROOVY-11996
+    launcher+=(-Dgroovy.truth.file.exists.enabled=false)
     if [[ "$JAVA_VER" =~ ^(24|25|26) ]]; then
         launcher+=(--enable-native-access=ALL-UNNAMED)
         launcher+=(--sun-misc-unsafe-memory-access=allow)

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -74,6 +74,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -361,7 +361,9 @@ class AwsBatchTaskHandlerTest extends Specification {
             fusionEnabled() >> false
             getAwsOptions() >> Mock(AwsOptions) {
                 getRetryMode() >> RETRY_MODE
-                getMaxTransferAttempts() >> MAX_ATTEMPTS
+                // getMaxTransferAttempts() returns a primitive int; a null stub
+                // cannot be cast to int under Groovy 5, so map null (unset) to 0
+                getMaxTransferAttempts() >> (MAX_ATTEMPTS ?: 0)
             }
         }
 
@@ -951,7 +953,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         then:
         1 * executor.shouldDeleteJob('job1') >> true
         and:
-        1 * handler.terminateJob('job1') >> null
+        1 * handler.terminateJob('job1') >> { }
 
         when:
         handler.@jobId = 'job1:task2'
@@ -959,7 +961,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         then:
         1 * executor.shouldDeleteJob('job1') >> true
         and:
-        1 * handler.terminateJob('job1') >> null
+        1 * handler.terminateJob('job1') >> { }
 
         when:
         handler.@jobId = 'job1:task2'
@@ -967,7 +969,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         then:
         1 * executor.shouldDeleteJob('job1') >> false
         and:
-        0 * handler.terminateJob('job1') >> null
+        0 * handler.terminateJob('job1')
     }
 
     def 'should create the trace record' () {

--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -77,6 +77,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -533,7 +533,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        1 * svc.terminateJobs() >> null
+        1 * svc.terminateJobs() >> { }
     }
 
     def 'should not cleanup jobs by default' () {
@@ -544,7 +544,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        0 * svc.cleanupJobs() >> null
+        0 * svc.cleanupJobs() >> { }
     }
 
     def 'should cleanup jobs if specified' () {
@@ -555,7 +555,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        1 * svc.cleanupJobs() >> null
+        1 * svc.cleanupJobs() >> { }
     }
 
     def 'should not cleanup pools by default' () {
@@ -566,7 +566,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        0 * svc.cleanupPools() >> null
+        0 * svc.cleanupPools() >> { }
     }
 
     def 'should cleanup pools with autoPoolMode' () {
@@ -577,7 +577,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        1 * svc.cleanupPools() >> null
+        1 * svc.cleanupPools() >> { }
     }
 
     def 'should cleanup pools with allowPoolCreation' () {
@@ -588,7 +588,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        1 * svc.cleanupPools() >> null
+        1 * svc.cleanupPools() >> { }
     }
 
 
@@ -600,7 +600,7 @@ class AzBatchServiceTest extends Specification {
         when:
         svc.close()
         then:
-        0 * svc.cleanupPools() >> null
+        0 * svc.cleanupPools() >> { }
     }
 
     def 'should get spec from pool config' () {
@@ -943,7 +943,7 @@ class AzBatchServiceTest extends Specification {
         service.safeCreatePool(spec)
 
         then: 'createPool is called once'
-        1 * service.createPool(spec) >> null
+        1 * service.createPool(spec) >> { }
         and:
         noExceptionThrown()
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchTaskHandlerTest.groovy
@@ -138,7 +138,7 @@ class AzBatchTaskHandlerTest extends Specification {
             getBatchService() >> batchService
         }
         def handler = Spy(new AzBatchTaskHandler(task, executor)){
-            deleteTask(_,_) >> null
+            deleteTask(_,_) >> { }
         }
         handler.status = TaskStatus.RUNNING
         handler.taskKey = taskKey
@@ -171,7 +171,7 @@ class AzBatchTaskHandlerTest extends Specification {
             getBatchService() >> batchService
         }
         def handler = Spy(new AzBatchTaskHandler(task, executor)){
-            deleteTask(_,_) >> null
+            deleteTask(_,_) >> { }
         }
         handler.status = TaskStatus.RUNNING
         handler.taskKey = taskKey
@@ -205,7 +205,7 @@ class AzBatchTaskHandlerTest extends Specification {
             getBatchService() >> batchService
         }
         def handler = Spy(new AzBatchTaskHandler(task, executor)){
-            deleteTask(_,_) >> null
+            deleteTask(_,_) >> { }
         }
         handler.status = TaskStatus.RUNNING
         handler.taskKey = taskKey
@@ -238,7 +238,7 @@ class AzBatchTaskHandlerTest extends Specification {
             getBatchService() >> batchService
         }
         def handler = Spy(new AzBatchTaskHandler(task, executor)){
-            deleteTask(_,_) >> null
+            deleteTask(_,_) >> { }
         }
         handler.status = TaskStatus.RUNNING
         handler.taskKey = taskKey

--- a/plugins/nf-cloudcache/build.gradle
+++ b/plugins/nf-cloudcache/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }
 

--- a/plugins/nf-codecommit/build.gradle
+++ b/plugins/nf-codecommit/build.gradle
@@ -58,6 +58,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }

--- a/plugins/nf-console/build.gradle
+++ b/plugins/nf-console/build.gradle
@@ -51,13 +51,13 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     api("org.apache.groovy:groovy-console:4.0.21-patch.2") { transitive=false }
-    api("org.apache.groovy:groovy-swing:4.0.31")  { transitive=false }
+    api("org.apache.groovy:groovy-swing:5.0.7")  { transitive=false }
     // this is required by 'groovy-console'
     api("com.github.javaparser:javaparser-core:3.25.8")
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }
 

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -72,8 +72,8 @@ dependencies {
     runtimeOnly 'com.fasterxml.jackson.core:jackson-databind:2.18.9'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }
 
 test {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchMachineTypeSelector.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchMachineTypeSelector.groovy
@@ -181,7 +181,7 @@ class GoogleBatchMachineTypeSelector {
 
         products.collect {
             new MachineType(
-                    type: it.type,
+                    type: it.type as String,
                     family: it.type.toString().split('-')[0],
                     spotPrice: averageSpotPrice(it.spotPrice as List<CloudPrice>),
                     onDemandPrice: it.onDemandPrice as float,

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -634,7 +634,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         handler.isActive() >> false
         0 * executor.shouldDeleteJob('job1') >> true
         and:
-        0 * client.deleteJob('job1') >> null
+        0 * client.deleteJob('job1')
 
         when:
         handler.@jobId = 'job1'
@@ -643,7 +643,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         handler.isActive() >> true
         1 * executor.shouldDeleteJob('job1') >> true
         and:
-        1 * client.deleteJob('job1') >> null
+        1 * client.deleteJob('job1')
 
         when:
         handler.@jobId = 'job1'
@@ -652,7 +652,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         handler.isActive() >> true
         1 * executor.shouldDeleteJob('job1') >> false
         and:
-        0 * client.deleteJob('job1') >> null
+        0 * client.deleteJob('job1')
     }
 
     JobStatus makeJobStatus(JobStatus.State state, String desc = null) {

--- a/plugins/nf-k8s/build.gradle
+++ b/plugins/nf-k8s/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     api 'org.bouncycastle:bcpkix-jdk18on:1.84'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }
 
 test {

--- a/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -449,10 +449,10 @@ class PodSpecBuilder {
             container.securityContext = secContext
         }
 
-        final spec = [
-                restartPolicy: restart,
-                containers: [ container ],
-        ]
+        final Map<String,?> spec = [:]
+
+        spec.restartPolicy = restart
+        spec.containers = [ container ]
 
         if( nodeSelector )
             spec.nodeSelector = nodeSelector.toSpec()

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sDriverLauncherTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sDriverLauncherTest.groovy
@@ -54,10 +54,10 @@ class K8sDriverLauncherTest extends Specification {
         1 * driver.makeK8sConfig(NF_CONFIG) >> K8S_CONFIG
         1 * driver.makeK8sClient(K8S_CONFIG) >> K8S_CLIENT
         1 * K8S_CONFIG.checkStorageAndPaths(K8S_CLIENT)
-        1 * driver.createK8sConfigMap() >> null
+        1 * driver.createK8sConfigMap() >> { }
         1 * driver.createK8sLauncherPod() >> null
-        1 * driver.waitPodStart() >> null
-        1 * driver.printK8sPodOutput() >> null
+        1 * driver.waitPodStart() >> { }
+        1 * driver.printK8sPodOutput() >> { }
 
         driver.pipelineName == NAME
         driver.interactive == false
@@ -650,7 +650,7 @@ class K8sDriverLauncherTest extends Specification {
         1 * driver.waitPodTermination() >> 0
         then:
         1 * config.getCleanup(true) >> true
-        1 * driver.deleteConfigMap() >> null
+        1 * driver.deleteConfigMap() >> { }
 
         when:
         driver.shutdown()
@@ -658,7 +658,7 @@ class K8sDriverLauncherTest extends Specification {
         1 * driver.waitPodTermination() >> 1
         then:
         1 * config.getCleanup(false) >> true
-        1 * driver.deleteConfigMap() >> null
+        1 * driver.deleteConfigMap() >> { }
 
         when:
         driver.shutdown()
@@ -666,7 +666,7 @@ class K8sDriverLauncherTest extends Specification {
         1 * driver.waitPodTermination() >> 1
         then:
         1 * config.getCleanup(false) >> false
-        0 * driver.deleteConfigMap() >> null
+        0 * driver.deleteConfigMap() >> { }
 
     }
 }

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -509,8 +509,8 @@ class K8sTaskHandlerTest extends Specification {
         then:
         1 * handler.getState() >> fullState
         1 * handler.updateTimestamps(termState)
-        1 * handler.deleteJobIfSuccessful(task) >> null
-        1 * handler.saveJobLogOnError(task) >> null
+        1 * handler.deleteJobIfSuccessful(task) >> { }
+        1 * handler.saveJobLogOnError(task) >> { }
         handler.task.exitStatus == 0
         handler.task.@stdout == OUT_FILE
         handler.task.@stderr == ERR_FILE
@@ -525,8 +525,8 @@ class K8sTaskHandlerTest extends Specification {
         1 * handler.getState() >> noExitCodeState
         1 * handler.updateTimestamps(noExitCodeTermState)
         1 * handler.readExitFile() >> EXIT_STATUS
-        1 * handler.deleteJobIfSuccessful(task) >> null
-        1 * handler.saveJobLogOnError(task) >> null
+        1 * handler.deleteJobIfSuccessful(task) >> { }
+        1 * handler.saveJobLogOnError(task) >> { }
         handler.task.exitStatus == EXIT_STATUS
         handler.task.@stdout == OUT_FILE
         handler.task.@stderr == ERR_FILE
@@ -557,8 +557,8 @@ class K8sTaskHandlerTest extends Specification {
         1 * handler.getState() >> [terminated: termState]
         1 * handler.updateTimestamps(termState)
         0 * handler.readExitFile()
-        1 * handler.deleteJobIfSuccessful(task) >> null
-        1 * handler.saveJobLogOnError(task) >> null
+        1 * handler.deleteJobIfSuccessful(task) >> { }
+        1 * handler.saveJobLogOnError(task) >> { }
         handler.task.exitStatus == 137
         handler.status == TaskStatus.COMPLETED
         result == true

--- a/plugins/nf-k8s/src/test/nextflow/k8s/client/K8sClientTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/client/K8sClientTest.groovy
@@ -46,8 +46,8 @@ class K8sClientTest extends Specification {
         def resp = client.makeRequest('GET', '/foo/bar')
         then:
         1 * client.createConnection0("https://host.com:443/foo/bar") >> HTTPS_CONN
-        1 * client.setupHttpsConn(HTTPS_CONN) >> null
-        1 * HTTPS_CONN.setRequestMethod('GET') >> null
+        1 * client.setupHttpsConn(HTTPS_CONN) >> { }
+        1 * HTTPS_CONN.setRequestMethod('GET') >> { }
         1 * HTTPS_CONN.setRequestProperty("Authorization", "Bearer $TOKEN")
         1 * HTTPS_CONN.setRequestProperty("Content-Type", "application/json")
         1 * HTTPS_CONN.getResponseCode() >> 200
@@ -61,8 +61,8 @@ class K8sClientTest extends Specification {
         client.makeRequest('POST', '/foo/bar')
         then:
         1 * client.createConnection0("http://my-server.com/foo/bar") >> HTTP_CONN
-        0 * client.setupHttpsConn(_) >> null
-        1 * HTTP_CONN.setRequestMethod('POST') >> null
+        0 * client.setupHttpsConn(_) >> { }
+        1 * HTTP_CONN.setRequestMethod('POST') >> { }
         1 * HTTP_CONN.getResponseCode() >> 401
         1 * HTTP_CONN.getErrorStream() >> { new ByteArrayInputStream('{"field_x":"oops.."}'.bytes) }
         def e = thrown(K8sResponseException)
@@ -1129,7 +1129,7 @@ class K8sClientTest extends Specification {
         then:
         // first attempt: stale token, 401
         2 * client.createConnection0("https://host.com:443/api/v1/pods/foo/status") >>> [CONN_401, CONN_200]
-        2 * client.setupHttpsConn(_) >> null
+        2 * client.setupHttpsConn(_) >> { }
         1 * CONN_401.setRequestProperty("Authorization", "Bearer stale-token")
         1 * CONN_401.setRequestMethod('GET')
         1 * CONN_401.setRequestProperty("Content-Type", "application/json")
@@ -1168,7 +1168,7 @@ class K8sClientTest extends Specification {
         then:
         // exactly one attempt — no retry because there's no file to re-read
         1 * client.createConnection0(_) >> CONN
-        1 * client.setupHttpsConn(_) >> null
+        1 * client.setupHttpsConn(_) >> { }
         1 * CONN.setRequestMethod('GET')
         1 * CONN.setRequestProperty("Authorization", "Bearer inline-token")
         1 * CONN.setRequestProperty("Content-Type", "application/json")

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -61,6 +61,13 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.21.5"
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
+    testImplementation "org.apache.groovy:groovy-json:5.0.7"
+    // wiremock required by TowerFusionEnvTest; use the self-contained
+    // distribution which shades its dependencies (incl. handlebars) to
+    // avoid pulling vulnerable transitive deps (GHSA-r4gv-qr8j-p3pg)
+    testImplementation "org.wiremock:wiremock-standalone:3.13.2"
+    // Address security vulnerabilities CVE-2022-45688 and CVE-2023-5072
+    testImplementation 'org.json:json:20240303'
 }

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -67,9 +67,9 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.21.5"
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
-    testImplementation "org.apache.groovy:groovy-json:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
+    testImplementation "org.apache.groovy:groovy-json:5.0.7"
     // wiremock required by TowerFusionEnvTest
     testImplementation "org.wiremock:wiremock:3.13.2"
     // Address security vulnerabilities CVE-2022-45688 and CVE-2023-5072

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -66,6 +66,6 @@ dependencies {
     api 'io.seqera:wave-utils:1.31.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:5.0.7"
+    testImplementation "org.apache.groovy:groovy-nio:5.0.7"
 }

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveFactoryTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveFactoryTest.groovy
@@ -39,7 +39,7 @@ class WaveFactoryTest extends Specification {
         then:
         CONFIG == EXPECTED
         and:
-        DISABLED * session.setDisableRemoteBinDir(true) >> null
+        DISABLED * session.setDisableRemoteBinDir(true)
 
         where:
         CONFIG                      | EXPECTED                  | DISABLED
@@ -113,7 +113,7 @@ class WaveFactoryTest extends Specification {
         then:
         noExceptionThrown()
         and:
-        0 * session.setDisableRemoteBinDir(true) >> null
+        0 * session.setDisableRemoteBinDir(true)
         and:
         CONFIG == [wave:[:], fusion:[enabled:true]]
 


### PR DESCRIPTION
Initial attempt to upgrade to [Groovy 5](https://groovy-lang.org/releasenotes/groovy-5.0.html).

Benefits:
- new collection functions like `zip` (can be added to Nextflow standard library)
- pattern matching for `instanceof` (can be added to Nextflow language)
- use `_` for placeholder variables (can be added to Nextflow language)

Changes:

- Had to remove generic type arguments from `instanceof` checks as the Groovy parser doesn't allow it anymore

- Had to add `@Slf4j` to some inner classes to make `log` work in that class. not sure if this is a bug or just a breaking change 

Current issues:

- Groovy complained about a few implementers of `CacheFunnel`, even though I didn't see anything wrong. Converting CacheFunnel to Java fixed the issue for one but not the other

- Multiple issues with the type checker that I'm pretty sure are just Groovy bugs, particularly `CmdLog` and `DumpOp`

- The type checker does not recognize `target` in `TaskConfig` as a Map, seems like a bug. I wonder if it's an edge case since `target` is defined in super class as private and a Delegate

Overall it looks like Groovy 5 beta still has a few compiler bugs to sort out. But I'm excited to get it working so that I can bring the new pattern matching features into the Nextflow language.