### PR TITLE
Upload Google Batch log on task exit

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -204,7 +204,7 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
     }
 
     static String launchCommand( String workDir ) {
-        "trap \"{ cp ${TaskRun.CMD_LOG} ${workDir}/${TaskRun.CMD_LOG}; }\" ERR; /bin/bash ${workDir}/${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}"
+        "trap \"{ cp ${TaskRun.CMD_LOG} ${workDir}/${TaskRun.CMD_LOG}; }\" EXIT; /bin/bash ${workDir}/${TaskRun.CMD_RUN} 2>&1 | tee ${TaskRun.CMD_LOG}"
     }
 
     static String containerMountPath(CloudStoragePath path) {

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
@@ -126,7 +126,7 @@ class GoogleBatchExecutorTest extends Specification {
 
         where:
         FUSION  | DEFAULT_FS  | TASK_DIR            | EXPECTED
-        false   | false       | 'gs://foo/work/dir' | '/bin/bash -o pipefail -c \'trap "{ cp .command.log gs://foo/work/dir/.command.log; }" ERR; /bin/bash gs://foo/work/dir/.command.run 2>&1 | tee .command.log\''
+        false   | false       | 'gs://foo/work/dir' | '/bin/bash -o pipefail -c \'trap "{ cp .command.log gs://foo/work/dir/.command.log; }" EXIT; /bin/bash gs://foo/work/dir/.command.run 2>&1 | tee .command.log\''
         true    | false       | '/fusion/work/dir'  | 'bash /fusion/work/dir/.command.run'
         false   | true        | '/nfs/work/dir'     | 'bash /nfs/work/dir/.command.run 2>&1 > /nfs/work/dir/.command.log'
     }


### PR DESCRIPTION
This pull request updates the behavior of the trap command in the Google Batch Script Launcher and its corresponding test case. The trap now triggers on `EXIT` instead of `ERR` to ensure cleanup actions are performed regardless of whether the script exits successfully or with an error.

Updates to trap command behavior:

* [`plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy`](diffhunk://#diff-5a492f3bd48a2f68ae819fa4efb2b7fb874732c0b8e720a09bbadfecbc547d00L207-R207): Changed the trap command in the `launchCommand` method to trigger on `EXIT` instead of `ERR`, ensuring log copying occurs on any script termination.
* [`plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy`](diffhunk://#diff-1d010711c5150855d148651e42268e45ab5ec739504e16541f9ea4938b84e8cbL129-R129): Updated the expected trap command in the test case to reflect the change from `ERR` to `EXIT`.