### PR TITLE
Fix docs rendering on config page

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -185,7 +185,7 @@ The following settings are available:
 
 `aws.batch.terminateUnschedulableJobs`
 : :::{versionadded} 25.03.0-edge
-:::
+  :::
 : When `true`, jobs that cannot be scheduled for lack of resources or misconfiguration are terminated automatically (default: `false`). The pipeline may complete with an error status depending on the error strategy defined for the corresponding jobs.
 
 `aws.batch.volumes`


### PR DESCRIPTION
Minor formatting bug when rendering the [AWS config reference](https://www.nextflow.io/docs/latest/reference/config.html#aws):

![CleanShot 2025-06-30 at 15 49 05@2x](https://github.com/user-attachments/assets/c0bf2154-2525-4368-b2ee-3b9682880b84)
