### PR TITLE
fix mamba env create stalls at prompt

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/conda/CondaCache.groovy
@@ -281,7 +281,7 @@ class CondaCache {
         def cmd
         if( isYamlFilePath(condaEnv) ) {
             final target = isYamlUriPath(condaEnv) ? condaEnv : Escape.path(makeAbsolute(condaEnv))
-            final yesOpt = binaryName == 'micromamba' ? '--yes ' : ''
+            final yesOpt = ['micromamba', 'mamba'].contains(binaryName) ? '--yes ' : ''
             cmd = "${binaryName} env create ${yesOpt}--prefix ${Escape.path(prefixPath)} --file ${target}"
         }
         else if( isTextFilePath(condaEnv) ) {


### PR DESCRIPTION
To fix #5625
the error is due to mamba hangs at Confirm changes: [Y/n], it cannot proceed without user confirm changes.
Nextflow use `--yes` and `--quiet` for `isTextFilePath`, 
when it is using yaml file, it only do the `--yes` for micromamba.
I added mamba.