### PR TITLE
Fix bugs with workflow output and lineage

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -269,6 +269,8 @@ class PublishOp {
                     return normalizePath(el, targetResolver)
                 if( el instanceof Collection<Path> )
                     return normalizePaths(el, targetResolver)
+                if( el instanceof Map )
+                    return normalizePaths(el, targetResolver)
                 return el
             }
         }
@@ -280,6 +282,8 @@ class PublishOp {
                     if( v instanceof Path )
                         return Map.entry(k, normalizePath(v, targetResolver))
                     if( v instanceof Collection<Path> )
+                        return Map.entry(k, normalizePaths(v, targetResolver))
+                    if( v instanceof Map )
                         return Map.entry(k, normalizePaths(v, targetResolver))
                     return Map.entry(k, v)
                 }

--- a/modules/nf-lineage/src/test/nextflow/lineage/serde/LinEncoderTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/serde/LinEncoderTest.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.lineage.serde
 
+import java.nio.file.Path
 import java.time.OffsetDateTime
 
 import nextflow.lineage.model.v1beta1.Checksum
@@ -83,16 +84,19 @@ class LinEncoderTest extends Specification{
         result.params.get(0).name == "param1"
     }
 
-    def 'should encode and decode WorkflowResults'(){
+    def 'should encode and decode WorkflowOutputs'(){
         given:
         def encoder = new LinEncoder()
         and:
         def time = OffsetDateTime.now()
-        def wfResults = new WorkflowOutput(time, "lid://1234", [new Parameter("String", "a", "A"), new Parameter("String", "b", "B")])
+        def wfResults = new WorkflowOutput(time, "lid://1234", [
+            new Parameter("Collection", "a", [id: 'id', file: 'sample.txt' as Path]),
+            new Parameter("String", "b", "B")
+        ])
+
         when:
         def encoded = encoder.encode(wfResults)
         def object = encoder.decode(encoded)
-
         then:
         object instanceof WorkflowOutput
         def result = object as WorkflowOutput
@@ -133,7 +137,7 @@ class LinEncoderTest extends Specification{
         result.binEntries.get(0).checksum.value == "78910"
     }
 
-    def 'should encode and decode TaskResults'(){
+    def 'should encode and decode TaskOutputs'(){
         given:
         def encoder = new LinEncoder()
         and:


### PR DESCRIPTION
This PR fixes two bugs related to workflow outputs and lineage:

1. Nested maps in published outputs were not properly normalized for the lineage / index file.
2. Publishing a workflow output with a typical structure (list of maps containing files) causes a stack overflow error

@jorgee I have added a unit test demonstrating the stack overflow error with the LinEncoder. Can you recommend a fix?

TODO:
- [ ] fix stack overflow error
- [ ] document how non-task output files are handled