### PR TITLE
Update nf-build-plugin gradle plugin to AWS SDK V2

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,12 +7,14 @@ repositories {
     mavenCentral()
 }
 
-version = "1.0.1"
+version = "2.0.0"
 group = "io.nextflow"
 
 dependencies {
-    implementation ('com.amazonaws:aws-java-sdk-s3:1.12.777')
     implementation 'com.google.code.gson:gson:2.13.1'
+    implementation 'software.amazon.awssdk:s3:2.31.64'
+    implementation 'software.amazon.awssdk:s3-transfer-manager:2.31.64'
+    implementation 'commons-codec:commons-codec:1.18.0'
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/groovy/io/nextflow/gradle/tasks/S3Download.groovy
+++ b/buildSrc/src/main/groovy/io/nextflow/gradle/tasks/S3Download.groovy
@@ -1,16 +1,19 @@
 package io.nextflow.gradle.tasks
 
-import java.text.DecimalFormat
+import org.gradle.api.GradleException
 
-import com.amazonaws.event.ProgressEvent
-import com.amazonaws.event.ProgressListener
-import com.amazonaws.services.s3.transfer.Transfer
-import com.amazonaws.services.s3.transfer.TransferManager
+import java.text.DecimalFormat
 import groovy.transform.CompileStatic
 import io.nextflow.gradle.tasks.AbstractS3Task
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import software.amazon.awssdk.transfer.s3.S3TransferManager
+import software.amazon.awssdk.transfer.s3.model.DownloadDirectoryRequest
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest
+import software.amazon.awssdk.transfer.s3.progress.TransferListener
+
+import java.util.concurrent.ExecutionException
 
 /**
  * Download files from a S3 bucket
@@ -41,35 +44,70 @@ class S3Download extends AbstractS3Task {
 
     @TaskAction
     def task() {
-        TransferManager tm = new TransferManager(getS3Client())
-        Transfer transfer
+        def transferManager = S3TransferManager.builder()
+            .s3Client(getS3AsyncClient()) // ensure this returns an `S3AsyncClient`
+            .build()
+
+        def listener = new S3Listener()
 
         // directory download
         if (keyPrefix != null) {
             logger.quiet("S3 Download recursive s3://${bucket}/${keyPrefix} → ${project.file(destDir)}/")
-            transfer = (Transfer) tm.downloadDirectory(bucket, keyPrefix, project.file(destDir))
-        }
+            def request = DownloadDirectoryRequest.builder()
+                .bucket(bucket)
+                .listObjectsV2RequestTransformer(builder -> builder.prefix(keyPrefix))
+                .destination(project.file(destDir).toPath())
+                .downloadFileRequestTransformer(builder-> builder.addTransferListener(listener))
+                .build()
+
+            def download = transferManager.downloadDirectory(request)
+            try{
+			    def completed = download.completionFuture().get()
+                if (!completed.failedTransfers().isEmpty()){
+                    throw new GradleException("Some transfers in S3 download directory: s3://"+ bucket +"/"+ keyPrefix +" has failed - Transfers: " +  completed.failedTransfers() );
+			    }
+		    } catch (InterruptedException e){
+			    logger.debug("S3 download directory: s3://{}/{} interrupted", bucket, keyPrefix);
+			    Thread.currentThread().interrupt();
+		    } catch ( ExecutionException e) {
+                String msg = String.format("Exception thrown downloading S3 object s3://{}/{}", bucket, keyPrefix);
+                throw new GradleException(msg, e.getCause());
+            }
 
         // single file download
-        else {
+        } else {
             logger.quiet("S3 Download s3://${bucket}/${key} → ${file}")
             File f = new File(file)
             f.parentFile.mkdirs()
-            transfer = (Transfer) tm.download(bucket, key, f)
+            def request = DownloadFileRequest.builder()
+                .getObjectRequest { it.bucket(bucket).key(key) }
+                .destination(f.toPath())
+                .addTransferListener(listener)
+                .build()
+
+            def download = transferManager.downloadFile(request)
+            try{
+                download.completionFuture().get()
+            } catch (InterruptedException e){
+			    logger.debug("S3 download file: s3://{}/{} interrupted", bucket, key);
+			    Thread.currentThread().interrupt();
+		    } catch ( ExecutionException e) {
+                String msg = String.format("Exception thrown downloading S3 object s3://{}/{}", bucket, key);
+                throw new GradleException(msg, e.getCause());
+            }
         }
 
-        S3Listener listener = new S3Listener()
-        listener.transfer = transfer
-        transfer.addProgressListener(listener)
-        transfer.waitForCompletion()
+        transferManager.close()
     }
 
-    class S3Listener implements ProgressListener {
-        Transfer transfer
-
+    class S3Listener implements TransferListener {
         DecimalFormat df = new DecimalFormat("#0.0")
-        public void progressChanged(ProgressEvent e) {
-            logger.info("${df.format(transfer.progress.percentTransferred)}%")
+
+        @Override
+        void bytesTransferred(Context.BytesTransferred context) {
+            def request = context.request() as DownloadFileRequest
+            if (!context.progressSnapshot().ratioTransferred().empty)
+                logger.info("${request.destination()}: ${df.format(context.progressSnapshot().ratioTransferred().asDouble)}%")
         }
     }
 }


### PR DESCRIPTION
This PR updates the gradle plugin `nf-build-plugin` to use AWS SDK v2. 
- Migrated `AbstractS3Task` and `S3Upload `and `S3Download` tasks to SDK v2.

