### PR TITLE
Fix silent failure when downloading a directory with AWS SDK v2

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
@@ -506,7 +506,11 @@ public class S3Client {
 
 		DirectoryDownload downloadDirectory = transferManager().downloadDirectory(downloadDirRequest);
 		try{
-			downloadDirectory.completionFuture().get();
+			CompletedDirectoryDownload completed = downloadDirectory.completionFuture().get();
+            if (!completed.failedTransfers().isEmpty()){
+				log.debug("S3 download directory: s3://{}/{} failed transfers", source.getBucket(), source.getKey());
+				throw new IOException("Some transfers in S3 download directory: s3://"+ source.getBucket() +"/"+ source.getKey() +" has failed - Transfers: " +  completed.failedTransfers() );
+			}
 		} catch (InterruptedException e){
 			log.debug("S3 download directory: s3://{}/{} interrupted", source.getBucket(), source.getKey());
 			Thread.currentThread().interrupt();


### PR DESCRIPTION
Porting the nf-build-plugin, I have noted the download directory method implemented in the nf-amazon plugin is not checking if there are failed transfers. It could silently ignore failures in the transfers generated by the download directory in the S3 Transfer Manager. This check is already done when uploading a directory.

In this PR, the same mechanism is added for the download case. The CompleatedDirectoryDownload.failedTransfers() is inspected to check if there have been errors in the generated transfers. 