### PR TITLE
Prevent using Azure Low Priority VMs when using Batch Managed mode

### DIFF
--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     api('com.azure:azure-identity:1.15.1') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+    api('com.azure.resourcemanager:azure-resourcemanager-batch:1.1.0-beta.4') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 
     // address security vulnerabilities
     runtimeOnly 'io.netty:netty-handler:4.1.118.Final'

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchExecutor.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchExecutor.groovy
@@ -100,20 +100,18 @@ class AzBatchExecutor extends Executor implements ExtensionPoint {
             log.debug "[AZURE BATCH] Pool allocation mode determined as: ${poolAllocationMode}"
             
             if( poolAllocationMode == 'BATCH_SERVICE' || poolAllocationMode == 'BatchService' ) {
-                throw new AbortOperationException("Azure Low Priority VMs are deprecated and no longer supported for Batch Managed pool allocation mode. " +
-                    "Please update your configuration to use standard VMs instead, or migrate to User Subscription pool allocation mode. " +
-                    "Affected pools: ${poolNames}. " +
-                    "Remove 'lowPriority: true' from your pool configuration or set 'lowPriority: false'.")
+                throw new AbortOperationException(
+                    "Low Priority VMs are not supported with Batch Managed pool allocation mode. " +
+                    "Update your configuration to use standard VMs or switch to User Subscription mode. " +
+                    "Pools: ${poolNames}."
+                )
             } else if( poolAllocationMode == 'USER_SUBSCRIPTION' || poolAllocationMode == 'UserSubscription' ) {
                 // Low Priority VMs are still supported in User Subscription mode, proceed without warning
                 log.debug "[AZURE BATCH] User Subscription mode detected, allowing low priority VMs in pools: ${poolNames}"
             } else {
                 // If we can't determine the pool allocation mode, show a warning but allow execution
-                log.warn "[AZURE BATCH] Unable to determine pool allocation mode (got: ${poolAllocationMode}). " +
-                    "Low Priority VMs are configured in pools: ${poolNames}. " +
-                    "Please note that Low Priority VMs are deprecated in Batch Managed accounts. " +
-                    "If you're using a Batch Managed account, please update your configuration to use standard VMs. " +
-                    "To enable automatic detection, set azure.batch.subscriptionId in your config or AZURE_SUBSCRIPTION_ID environment variable."
+                log.warn "[AZURE BATCH] Unable to determine pool allocation mode. Low Priority VMs are configured in pools: ${poolNames}. " +
+                    "Low Priority VMs may not be supported. Set 'azure.batch.subscriptionId' in your config or 'AZURE_SUBSCRIPTION_ID' environment variable for automatic detection."
             }
         }
     }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -453,9 +453,10 @@ class AzBatchService implements Closeable {
      * Create and configure BatchManager
      */
     private com.azure.resourcemanager.batch.BatchManager createBatchManager(TokenCredential credential, String subscriptionId) {
-        // AzureProfile constructor: (tenantId, subscriptionId, environment)
+        // AzureProfile requires: (tenantId, subscriptionId, environment)
+        // We pass null for tenantId to use the default from the credential
         final profile = new com.azure.core.management.profile.AzureProfile(
-            null, // tenantId - null to use default
+            null, 
             subscriptionId,
             com.azure.core.management.AzureEnvironment.AZURE
         )

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzBatchOpts.groovy
@@ -48,6 +48,7 @@ class AzBatchOpts implements CloudTransferOptions {
     String accountKey
     String endpoint
     String location
+    String subscriptionId
     Boolean autoPoolMode
     Boolean allowPoolCreation
     Boolean terminateJobsOnCompletion
@@ -67,6 +68,7 @@ class AzBatchOpts implements CloudTransferOptions {
         accountKey = config.accountKey ?: sysEnv.get('AZURE_BATCH_ACCOUNT_KEY')
         endpoint = config.endpoint
         location = config.location
+        subscriptionId = config.subscriptionId ?: sysEnv.get('AZURE_SUBSCRIPTION_ID')
         autoPoolMode = config.autoPoolMode
         allowPoolCreation = config.allowPoolCreation
         terminateJobsOnCompletion = config.terminateJobsOnCompletion != Boolean.FALSE

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchExecutorTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchExecutorTest.groovy
@@ -1,0 +1,134 @@
+package nextflow.cloud.azure.batch
+
+import nextflow.Session
+import nextflow.cloud.azure.config.AzConfig
+import nextflow.cloud.azure.config.AzBatchOpts
+import nextflow.cloud.azure.config.AzPoolOpts
+import nextflow.exception.AbortOperationException
+import spock.lang.Specification
+
+/**
+ * Test for AzBatchExecutor validation logic
+ */
+class AzBatchExecutorTest extends Specification {
+
+    def 'should validate low priority VMs for BatchService allocation mode'() {
+        given:
+        def CONFIG = [
+            batch: [
+                endpoint: 'https://testaccount.eastus.batch.azure.com',
+                pools: [
+                    'pool1': [vmType: 'Standard_D2_v2', lowPriority: true],
+                    'pool2': [vmType: 'Standard_D2_v2', lowPriority: false]
+                ]
+            ]
+        ]
+        
+        and:
+        def config = new AzConfig(CONFIG)
+        def batchService = Mock(AzBatchService) {
+            getPoolAllocationMode() >> 'BATCH_SERVICE'
+        }
+        
+        and:
+        def executor = new AzBatchExecutor()
+        executor.config = config
+        executor.batchService = batchService
+
+        when:
+        executor.validateLowPriorityVMs()
+
+        then:
+        def e = thrown(AbortOperationException)
+        e.message.contains('Azure Low Priority VMs are deprecated and no longer supported for Batch Managed pool allocation mode')
+        e.message.contains('pool1')
+    }
+
+    def 'should allow low priority VMs for UserSubscription allocation mode'() {
+        given:
+        def CONFIG = [
+            batch: [
+                endpoint: 'https://testaccount.eastus.batch.azure.com',
+                pools: [
+                    'pool1': [vmType: 'Standard_D2_v2', lowPriority: true]
+                ]
+            ]
+        ]
+        
+        and:
+        def config = new AzConfig(CONFIG)
+        def batchService = Mock(AzBatchService) {
+            getPoolAllocationMode() >> 'USER_SUBSCRIPTION'
+        }
+        
+        and:
+        def executor = new AzBatchExecutor()
+        executor.config = config
+        executor.batchService = batchService
+
+        when:
+        executor.validateLowPriorityVMs()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should handle unknown allocation mode gracefully'() {
+        given:
+        def CONFIG = [
+            batch: [
+                endpoint: 'https://testaccount.eastus.batch.azure.com',
+                pools: [
+                    'pool1': [vmType: 'Standard_D2_v2', lowPriority: true]
+                ]
+            ]
+        ]
+        
+        and:
+        def config = new AzConfig(CONFIG)
+        def batchService = Mock(AzBatchService) {
+            getPoolAllocationMode() >> null
+        }
+        
+        and:
+        def executor = new AzBatchExecutor()
+        executor.config = config
+        executor.batchService = batchService
+
+        when:
+        executor.validateLowPriorityVMs()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should not validate when no low priority VMs configured'() {
+        given:
+        def CONFIG = [
+            batch: [
+                endpoint: 'https://testaccount.eastus.batch.azure.com',
+                pools: [
+                    'pool1': [vmType: 'Standard_D2_v2', lowPriority: false],
+                    'pool2': [vmType: 'Standard_D2_v2']
+                ]
+            ]
+        ]
+        
+        and:
+        def config = new AzConfig(CONFIG)
+        def batchService = Mock(AzBatchService) {
+            getPoolAllocationMode() >> 'BATCH_SERVICE'
+        }
+        
+        and:
+        def executor = new AzBatchExecutor()
+        executor.config = config
+        executor.batchService = batchService
+
+        when:
+        executor.validateLowPriorityVMs()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchExecutorTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchExecutorTest.groovy
@@ -27,7 +27,7 @@ class AzBatchExecutorTest extends Specification {
         and:
         def config = new AzConfig(CONFIG)
         def batchService = Mock(AzBatchService) {
-            getPoolAllocationMode() >> 'BATCH_SERVICE'
+            getPoolAllocationMode() >> 'BatchService'
         }
         
         and:
@@ -40,7 +40,8 @@ class AzBatchExecutorTest extends Specification {
 
         then:
         def e = thrown(AbortOperationException)
-        e.message.contains('Azure Low Priority VMs are deprecated and no longer supported for Batch Managed pool allocation mode')
+        e.message.contains('Low Priority VMs are not supported with Batch Managed pool allocation mode')
+        e.message.contains('Update your configuration to use standard VMs or switch to User Subscription mode')
         e.message.contains('pool1')
     }
 
@@ -58,7 +59,7 @@ class AzBatchExecutorTest extends Specification {
         and:
         def config = new AzConfig(CONFIG)
         def batchService = Mock(AzBatchService) {
-            getPoolAllocationMode() >> 'USER_SUBSCRIPTION'
+            getPoolAllocationMode() >> 'UserSubscription'
         }
         
         and:
@@ -117,7 +118,7 @@ class AzBatchExecutorTest extends Specification {
         and:
         def config = new AzConfig(CONFIG)
         def batchService = Mock(AzBatchService) {
-            getPoolAllocationMode() >> 'BATCH_SERVICE'
+            getPoolAllocationMode() >> 'BatchService'
         }
         
         and:

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzBatchOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzBatchOptsTest.groovy
@@ -105,4 +105,26 @@ class AzBatchOptsTest extends Specification {
         then:
         opts3.jobMaxWallClockTime.toString() == '12h'
     }
+
+    def 'should set subscription ID from config or environment' () {
+        when:
+        def opts1 = new AzBatchOpts([:], [:])
+        then:
+        opts1.subscriptionId == null
+
+        when:
+        def opts2 = new AzBatchOpts([subscriptionId: 'config-sub-id'], [:])
+        then:
+        opts2.subscriptionId == 'config-sub-id'
+
+        when:
+        def opts3 = new AzBatchOpts([:], [AZURE_SUBSCRIPTION_ID: 'env-sub-id'])
+        then:
+        opts3.subscriptionId == 'env-sub-id'
+
+        when:
+        def opts4 = new AzBatchOpts([subscriptionId: 'config-sub-id'], [AZURE_SUBSCRIPTION_ID: 'env-sub-id'])
+        then:
+        opts4.subscriptionId == 'config-sub-id'  // config takes precedence over environment
+    }
 }


### PR DESCRIPTION
Azure Low Priority VMs are deprecated in Batch Managed pool allocation mode but still supported in User Subscription mode. This adds validation to:
- Block low priority VMs for Batch Managed accounts with clear error message
- Allow low priority VMs for User Subscription accounts
- Gracefully handle unknown allocation modes with warnings

This required adding a `subscriptionId` to the `azure.batch` config to enable creation of the management client. If not supplied Nextflow will raise a warning and continue. This does open us up to being able to do more with Azure Batch because we have access to the management API.

Fix Azure Low Priority VM deprecation for Batch Managed accounts (#6258)
