### PR TITLE
Fail if splitFastq receives incomplete record

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/splitter/FastqSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/FastqSplitter.groovy
@@ -134,13 +134,16 @@ class FastqSplitter extends AbstractTextSplitter {
     @Override
     protected fetchRecord(BufferedReader reader) {
 
-        def l1 = reader.readLine()
-        def l2 = reader.readLine()
-        def l3 = reader.readLine()
-        def l4 = reader.readLine()
+        final l1 = reader.readLine()
+        final l2 = reader.readLine()
+        final l3 = reader.readLine()
+        final l4 = reader.readLine()
+
+        if( !l1 && !l2 && !l3 && !l4 )
+            return null
 
         if( !l1 || !l2 || !l3 || !l4 )
-            return null
+            throw new IllegalStateException(errorMessage)
 
         if( !l1.startsWith('@') || !l3.startsWith('+') )
             throw new IllegalStateException(errorMessage)


### PR DESCRIPTION
This PR improves the error handling of `splitFastq`. When reading a FASTQ record, if only some lines are present, that is an incomplete record and should raise an error. When all lines are missing, there are no more records and we can safely exit.

Related to #3216 