### PR TITLE
Workflow onComplete and onError sections

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -329,7 +329,7 @@ This limitation can be avoided by using the {ref}`strict config syntax <updating
 Use a {ref}`trace observer <plugins-trace-observers>` in a plugin to add custom workflow handlers to a pipeline via configuration.
 :::
 
-Workflow event handlers can be defined in the config file:
+You can define workflow event handlers in the config file:
 
 ```groovy
 workflow.onComplete = {
@@ -343,4 +343,4 @@ workflow.onError = {
 }
 ```
 
-While these handlers can also be defined in the pipeline code, this approach is useful for handling workflow events without modifying the pipeline code. See {ref}`workflow-handlers` for more information.
+This approach is useful for handling workflow events without modifying the pipeline code. See {ref}`workflow-handlers` for more information.

--- a/docs/config.md
+++ b/docs/config.md
@@ -321,9 +321,15 @@ process {
 This limitation can be avoided by using the {ref}`strict config syntax <updating-config-syntax>`.
 :::
 
+(config-workflow-handlers)=
+
 ## Workflow handlers
 
-Workflow event handlers can be defined in the config file, which is useful for handling pipeline events without having to modify the pipeline code:
+:::{deprecated} 25.10.0
+Use a {ref}`trace observer <plugins-trace-observers>` in a plugin to add custom workflow handlers to a pipeline via configuration.
+:::
+
+Workflow event handlers can be defined in the config file:
 
 ```groovy
 workflow.onComplete = {
@@ -337,4 +343,4 @@ workflow.onError = {
 }
 ```
 
-See {ref}`workflow-handlers` for more information.
+While these handlers can also be defined in the pipeline code, this approach is useful for handling workflow events without modifying the pipeline code. See {ref}`workflow-handlers` for more information.

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -327,6 +327,8 @@ class MyExecutor extends Executor {
 }
 ```
 
+(plugins-trace-observers)=
+
 ### Trace observers
 
 :::{versionchanged} 25.04

--- a/docs/migrations/25-10.md
+++ b/docs/migrations/25-10.md
@@ -12,7 +12,7 @@ This page is a work in progress and will be updated as features are finalized. I
 
 <h3>New syntax for workflow handlers</h3>
 
-The workflow `onComplete` and `onError` handlers were previously defined by calling `workflow.onComplete` and `workflow.onError` in the pipeline script. These handlers can now be defined as `onComplete` and `onError` sections in an entry workflow:
+The workflow `onComplete` and `onError` handlers were previously defined by calling `workflow.onComplete` and `workflow.onError` in the pipeline script. You can now define handlers as `onComplete` and `onError` sections in an entry workflow:
 
 ```nextflow
 workflow {
@@ -35,4 +35,4 @@ This syntax is simpler and easier to use with the {ref}`strict syntax <strict-sy
 
 ## Deprecations
 
-- The use of workflow handlers in the configuration file has been deprecated. These workflow handlers should be defined in the pipeline script or a plugin instead. See {ref}`config-workflow-handlers` for details.
+- The use of workflow handlers in the configuration file has been deprecated. You should define workflow handlers in the pipeline script or a plugin instead. See {ref}`config-workflow-handlers` for details.

--- a/docs/migrations/25-10.md
+++ b/docs/migrations/25-10.md
@@ -8,6 +8,31 @@ This page summarizes the upcoming changes in Nextflow 25.10, which will be relea
 This page is a work in progress and will be updated as features are finalized. It should not be considered complete until the 25.10 release.
 :::
 
+## Enhancements
+
+<h3>New syntax for workflow handlers</h3>
+
+The workflow `onComplete` and `onError` handlers were previously defined by calling `workflow.onComplete` and `workflow.onError` in the pipeline script. These handlers can now be defined as `onComplete` and `onError` sections in an entry workflow:
+
+```nextflow
+workflow {
+    main:
+    // ...
+
+    onComplete:
+    println "workflow complete"
+
+    onError:
+    println "error: ${workflow.errorMessage}"
+}
+```
+
+This syntax is simpler and easier to use with the {ref}`strict syntax <strict-syntax-page>`. See {ref}`workflow-handlers` for details.
+
 ## Breaking changes
 
 - The AWS Java SDK used by Nextflow was upgraded from v1 to v2, which introduced some breaking changes to the `aws.client` config options. See {ref}`the guide <aws-java-sdk-v2-page>` for details.
+
+## Deprecations
+
+- The use of workflow handlers in the configuration file has been deprecated. These workflow handlers should be defined in the pipeline script or a plugin instead. See {ref}`config-workflow-handlers` for details.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -23,6 +23,22 @@ workflow.onComplete {
 }
 ```
 
+:::{versionadded} 25.10.0
+:::
+
+Entry workflows can define an `onComplete` section instead of using `workflow.onComplete`:
+
+```nextflow
+workflow {
+    main:
+    // ...
+
+    onComplete:
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+}
+```
+
 (metadata-error-handler)=
 
 ### Error handler
@@ -38,6 +54,21 @@ workflow.onError {
 :::{note}
 Both the `onError` and `onComplete` handlers are invoked when an error condition is encountered. The first is called as soon as the error is raised, while the second is called just before the pipeline execution is about to terminate. When using the `finish` {ref}`process-error-strategy`, there may be a significant gap between the two, depending on the time required to complete any pending job.
 :::
+
+:::{versionadded} 25.10.0
+:::
+
+Entry workflows can define an `onError` section instead of using `workflow.onError`:
+
+```nextflow
+workflow {
+    main:
+    // ...
+
+    onError:
+    println "Error: Pipeline execution stopped with the following message: ${workflow.errorMessage}"
+}
+```
 
 ## Mail
 

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -169,7 +169,7 @@ workflow {
 
 - Only one entry workflow may be defined in a script.
 
-- The `main:` section label can be omitted if the other sections not specified.
+- The `main:` section label can be omitted if the other sections are not specified.
 
 - The publish section consists of one or more *publish statements*. A publish statement is an [assignment](#assignment), where the assignment target is the name of a workflow output.
 

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -173,7 +173,7 @@ workflow {
 
 - The publish section consists of one or more *publish statements*. A publish statement is an [assignment](#assignment), where the assignment target is the name of a workflow output.
 
-- The onComplete and onError sections consist of one or more [statements](#statements).
+- The `onComplete` and `onError` sections consist of one or more [statements](#statements).
 
 In order for a script to be executable, it must either define an entry workflow or be a code snippet as described [above](#script-declarations).
 

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -123,7 +123,7 @@ Parameters supplied via command line options, params files, and config files tak
 
 A workflow can be a *named workflow* or an *entry workflow*.
 
-A *named workflow* consists of a name and a body, and may consist of a *take*, *main*, *emit*, and *publish* section:
+A *named workflow* consists of a name and a body, and may consist of a *take*, *main*, and *emit* section:
 
 ```nextflow
 workflow greet {
@@ -146,28 +146,34 @@ workflow greet {
 
 - The emit section consists of one or more *emit statements*. An emit statement can be a [variable name](#variable), an [assignment](#assignment), or an [expression statement](#expression-statement). If an emit statement is an expression statement, it must be the only emit.
 
-- The publish section can be specified but is intended to be used in the entry workflow (see below).
 
-
-An *entry workflow* has no name and may consist of a *main* and *publish* section:
+An *entry workflow* has no name and may consist of a *main*, *publish*, *onComplete*, and *onError* section:
 
 ```nextflow
 workflow {
     main:
     greetings = channel.of('Bonjour', 'Ciao', 'Hello', 'Hola')
     messages = greetings.map { v -> "$v world!" }
-    greetings.view { it -> '$it world!' }
+    greetings.view { v -> "$v world!" }
 
     publish:
-    messages >> 'messages'
+    messages = messages
+
+    onComplete:
+    log.info 'Workflow completed successfully!'
+
+    onError:
+    log.error 'Workflow failed.'
 }
 ```
 
 - Only one entry workflow may be defined in a script.
 
-- The `main:` section label can be omitted if the publish section is not specified.
+- The `main:` section label can be omitted if the other sections not specified.
 
-- The publish section consists of one or more *publish statements*. A publish statement is a [right-shift expression](#binary-expressions), where the left-hand side is an expression that refers to a value in the workflow body, and the right-hand side is an expression that returns a string.
+- The publish section consists of one or more *publish statements*. A publish statement is an [assignment](#assignment), where the assignment target is the name of a workflow output.
+
+- The onComplete and onError sections consist of one or more [statements](#statements).
 
 In order for a script to be executable, it must either define an entry workflow or be a code snippet as described [above](#script-declarations).
 

--- a/modules/nf-lang/src/main/antlr/ScriptLexer.g4
+++ b/modules/nf-lang/src/main/antlr/ScriptLexer.g4
@@ -355,6 +355,8 @@ WHEN            : 'when';
 WORKFLOW        : 'workflow';
 EMIT            : 'emit';
 MAIN            : 'main';
+ONCOMPLETE      : 'onComplete';
+ONERROR         : 'onError';
 PUBLISH         : 'publish';
 TAKE            : 'take';
 

--- a/modules/nf-lang/src/main/antlr/ScriptParser.g4
+++ b/modules/nf-lang/src/main/antlr/ScriptParser.g4
@@ -227,27 +227,25 @@ workflowDef
 
 workflowBody
     // explicit main block with optional take/emit blocks
-    :   (sep TAKE COLON nls workflowTakes)?
-        sep MAIN COLON nls workflowMain
-        (sep EMIT COLON nls workflowEmits)?
-        (sep PUBLISH COLON nls workflowPublishers)?
+    :   (sep TAKE COLON nls take=workflowTakes)?
+        sep MAIN COLON nls main=blockStatements
+        (sep EMIT COLON nls emit=workflowEmits)?
+        (sep PUBLISH COLON nls publish=workflowPublishers)?
+        (sep ONCOMPLETE COLON nls onComplete=blockStatements)?
+        (sep ONERROR COLON nls onError=blockStatements)?
 
     // explicit emit block with optional take/main blocks
-    |   (sep TAKE COLON nls workflowTakes)?
-        (sep MAIN COLON nls workflowMain)?
-        sep EMIT COLON nls workflowEmits
-        (sep PUBLISH COLON nls workflowPublishers)?
+    |   (sep TAKE COLON nls take=workflowTakes)?
+        (sep MAIN COLON nls main=blockStatements)?
+        sep EMIT COLON nls emit=workflowEmits
+        (sep PUBLISH COLON nls publish=workflowPublishers)?
 
     // implicit main block
-    |   sep? workflowMain
+    |   sep? main=blockStatements
     ;
 
 workflowTakes
     :   identifier (sep identifier)*
-    ;
-
-workflowMain
-    :   blockStatements
     ;
 
 workflowEmits
@@ -517,6 +515,8 @@ identifier
     |   WORKFLOW
     |   EMIT
     |   MAIN
+    |   ONCOMPLETE
+    |   ONERROR
     |   PUBLISH
     |   TAKE
     ;
@@ -709,6 +709,8 @@ keywords
     |   WORKFLOW
     |   EMIT
     |   MAIN
+    |   ONCOMPLETE
+    |   ONERROR
     |   PUBLISH
     |   TAKE
     |   NullLiteral

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ScriptVisitorSupport.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ScriptVisitorSupport.java
@@ -66,6 +66,8 @@ public abstract class ScriptVisitorSupport extends ClassCodeVisitorSupport imple
         visit(node.main);
         visit(node.emits);
         visit(node.publishers);
+        visit(node.onComplete);
+        visit(node.onError);
     }
 
     @Override

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/WorkflowNode.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/WorkflowNode.java
@@ -43,13 +43,21 @@ public class WorkflowNode extends MethodNode {
     public final Statement main;
     public final Statement emits;
     public final Statement publishers;
+    public final Statement onComplete;
+    public final Statement onError;
 
-    public WorkflowNode(String name, Statement takes, Statement main, Statement emits, Statement publishers) {
+    public WorkflowNode(String name, Statement takes, Statement main, Statement emits, Statement publishers, Statement onComplete, Statement onError) {
         super(name, 0, dummyReturnType(emits), dummyParams(takes), ClassNode.EMPTY_ARRAY, EmptyStatement.INSTANCE);
         this.takes = takes;
         this.main = main;
         this.emits = emits;
         this.publishers = publishers;
+        this.onComplete = onComplete;
+        this.onError = onError;
+    }
+
+    public WorkflowNode(String name, Statement main) {
+        this(name, EmptyStatement.INSTANCE, main, EmptyStatement.INSTANCE, EmptyStatement.INSTANCE, EmptyStatement.INSTANCE, EmptyStatement.INSTANCE);
     }
 
     public boolean isEntry() {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
@@ -88,6 +88,8 @@ public class ScriptResolveVisitor extends ScriptVisitorSupport {
         resolver.visit(node.main);
         resolver.visit(node.emits);
         resolver.visit(node.publishers);
+        resolver.visit(node.onComplete);
+        resolver.visit(node.onError);
     }
 
     @Override

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -185,6 +185,9 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         visitWorkflowOutputs(node.emits, "emit");
         visitWorkflowOutputs(node.publishers, "output");
 
+        visit(node.onComplete);
+        visit(node.onError);
+
         currentDefinition = null;
         vsc.popScope();
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -221,9 +221,11 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             fmt.appendIndent();
             fmt.append("take:\n");
             visitWorkflowTakes(asBlockStatements(node.takes));
-            fmt.appendNewLine();
         }
         if( node.main instanceof BlockStatement ) {
+            if( node.takes instanceof BlockStatement ) {
+                fmt.appendNewLine();
+            }
             if( node.takes instanceof BlockStatement || node.emits instanceof BlockStatement || node.publishers instanceof BlockStatement ) {
                 fmt.appendIndent();
                 fmt.append("main:\n");
@@ -241,6 +243,18 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             fmt.appendIndent();
             fmt.append("publish:\n");
             fmt.visit(node.publishers);
+        }
+        if( node.onComplete instanceof BlockStatement ) {
+            fmt.appendNewLine();
+            fmt.appendIndent();
+            fmt.append("onComplete:\n");
+            fmt.visit(node.onComplete);
+        }
+        if( node.onError instanceof BlockStatement ) {
+            fmt.appendNewLine();
+            fmt.appendIndent();
+            fmt.append("onError:\n");
+            fmt.visit(node.onError);
         }
         fmt.decIndent();
         fmt.append("}\n");

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -507,41 +507,40 @@ public class ScriptAstBuilder {
         var name = ctx.name != null ? ctx.name.getText() : null;
 
         if( ctx.body == null ) {
-            var result = ast( new WorkflowNode(name, null, null, null, null), ctx );
+            var result = ast( new WorkflowNode(name, EmptyStatement.INSTANCE), ctx );
             groovydocManager.handle(result, ctx);
             return result;
         }
 
-        var takes = workflowTakes(ctx.body.workflowTakes());
-        var emits = workflowEmits(ctx.body.workflowEmits());
-        var publishers = workflowPublishers(ctx.body.workflowPublishers());
-        var main = blockStatements(
-            ctx.body.workflowMain() != null
-                ? ctx.body.workflowMain().blockStatements()
-                : null
-        );
+        var takes = workflowTakes(ctx.body.take);
+        var main = blockSection(ctx.body.main);
+        var emits = workflowEmits(ctx.body.emit);
+        var publishers = workflowPublishers(ctx.body.publish);
+        var onComplete = blockSection(ctx.body.onComplete);
+        var onError = blockSection(ctx.body.onError);
 
         if( name == null ) {
-            if( takes instanceof BlockStatement )
+            if( ctx.body.take != null )
                 collectSyntaxError(new SyntaxException("Entry workflow cannot have a take section", takes));
-            if( emits instanceof BlockStatement )
+            if( ctx.body.emit != null )
                 collectSyntaxError(new SyntaxException("Entry workflow cannot have an emit section", emits));
         }
         if( name != null ) {
-            if( publishers instanceof BlockStatement )
+            if( ctx.body.publish != null )
                 collectSyntaxError(new SyntaxException("Named workflow cannot have a publish section", publishers));
+            if( ctx.body.onComplete != null )
+                collectSyntaxError(new SyntaxException("Named workflow cannot have an onComplete section", onComplete));
+            if( ctx.body.onError != null )
+                collectSyntaxError(new SyntaxException("Named workflow cannot have an onError section", onComplete));
         }
 
-        var result = ast( new WorkflowNode(name, takes, main, emits, publishers), ctx );
+        var result = ast( new WorkflowNode(name, takes, main, emits, publishers, onComplete, onError), ctx );
         groovydocManager.handle(result, ctx);
         return result;
     }
 
     private WorkflowNode workflowDef(BlockStatement main) {
-        var takes = EmptyStatement.INSTANCE;
-        var emits = EmptyStatement.INSTANCE;
-        var publishers = EmptyStatement.INSTANCE;
-        return new WorkflowNode(null, takes, main, emits, publishers);
+        return new WorkflowNode(null, main);
     }
 
     private Statement workflowTakes(WorkflowTakesContext ctx) {
@@ -558,6 +557,12 @@ public class ScriptAstBuilder {
         var result = ast( stmt(variableName(ctx)), ctx );
         saveTrailingComment(result, ctx);
         return result;
+    }
+
+    private Statement blockSection(BlockStatementsContext ctx) {
+        if( ctx == null )
+            return EmptyStatement.INSTANCE;
+        return blockStatements(ctx);
     }
 
     private Statement workflowEmits(WorkflowEmitsContext ctx) {

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -132,6 +132,24 @@ class ScriptFormatterTest extends Specification {
             }
             '''
         )
+
+        checkFormat(
+            '''\
+            workflow hello{
+            take: x ; y ; emit: result = x * y
+            }
+            ''',
+            '''\
+            workflow hello {
+                take:
+                x
+                y
+
+                emit:
+                result = x * y
+            }
+            '''
+        )
     }
 
     def 'should format a process definition' () {

--- a/tests/checks/.IGNORE-PARSER-V2
+++ b/tests/checks/.IGNORE-PARSER-V2
@@ -1,1 +1,2 @@
 # TESTS THAT SHOULD ONLY BE RUN BY THE V2 PARSER
+workflow-oncomplete-v2.nf

--- a/tests/workflow-oncomplete-v2.nf
+++ b/tests/workflow-oncomplete-v2.nf
@@ -1,0 +1,48 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  * This test verify the `workflow.onComplete` defined in the config file
+  * works OK.
+  *
+  * See file `$PWD/checks/workflow-oncomplete.nf/.config` for details
+  */
+
+params.command = 'echo'
+
+process sayHello {
+  debug true
+
+  input:
+  val x
+
+  script:
+  """
+  ${params.command} '${x} world!'
+  """
+}
+
+workflow {
+  main:
+  channel.of('Bojour', 'Ciao', 'Hello', 'Hola', 'Γεια σου') | sayHello
+
+  onComplete:
+  log.info('Workflow completed successfully!')
+
+  onError:
+  log.error('Workflow failed.')
+}

--- a/validation/test.sh
+++ b/validation/test.sh
@@ -49,6 +49,7 @@ test_e2e() {
 # Integration tests
 #
 if [[ $TEST_MODE == 'test_integration' ]]; then
+  export NXF_SYNTAX_PARSER=v1
   test_integration ../tests/
   test_integration ../tests-v1/
   test_e2e


### PR DESCRIPTION
This PR adds new syntax for workflow onComplete and onError as sections in the entry workflow instead of closure calls.

It also deprecates config workflow handlers, as this kind of code should be implemented in a plugin trace observer. This is better anyway since a plugin is easier to re-use across multiple pipelines.