### PR TITLE
Fix explicit `it` closure parameter

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
@@ -119,4 +119,24 @@ class ScriptLoaderV2Test extends Specification {
         meta.getWorkflow('hello').declaredOutputs == ['result']
     }
 
+    def 'should allow explicit `it` closure parameter' () {
+
+        given:
+        def session = new Session()
+        def parser = new ScriptLoaderV2(session)
+
+        def TEXT = '''
+            workflow { 
+                channel.of(1, 2, 3).view { it -> "${it}" }
+            }
+            '''
+
+        when:
+        parser.parse(TEXT)
+        parser.runScript()
+
+        then:
+        noExceptionThrown()
+    }
+
 }

--- a/modules/nf-lang/src/main/java/nextflow/config/control/ConfigToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/control/ConfigToGroovyVisitor.java
@@ -74,7 +74,7 @@ public class ConfigToGroovyVisitor extends ConfigVisitorSupport {
         for( var call : node.statements )
             statements.add(stmt(call));
         var code = block(new VariableScope(), statements);
-        return stmt(callThisX("block", args(constX(node.name), closureX(code))));
+        return stmt(callThisX("block", args(constX(node.name), closureX(null, code))));
     }
 
     @Override
@@ -108,7 +108,7 @@ public class ConfigToGroovyVisitor extends ConfigVisitorSupport {
         }
         var code = block(new VariableScope(), statements);
         var kind = node.kind != null ? node.kind : "block";
-        return stmt(callThisX(kind, args(constX(node.name), closureX(code))));
+        return stmt(callThisX(kind, args(constX(node.name), closureX(null, code))));
     }
 
     @Override

--- a/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
@@ -1173,24 +1173,12 @@ public class ConfigAstBuilder {
     /// MISCELLANEOUS
 
     private Parameter[] formalParameterList(FormalParameterListContext ctx) {
-        // NOTE: implicit `it` parameter is deprecated, but allow it for now
         if( ctx == null )
             return Parameter.EMPTY_ARRAY;
 
-        var params = ctx.formalParameter().stream()
+        return ctx.formalParameter().stream()
             .map(this::formalParameter)
-            .toList();
-        for( int n = params.size(), i = n - 1; i >= 0; i -= 1 ) {
-            var param = params.get(i);
-            for( var other : params ) {
-                if( other == param )
-                    continue;
-                if( other.getName().equals(param.getName()) )
-                    throw createParsingFailedException("Duplicated parameter '" + param.getName() + "' found", param);
-            }
-        }
-
-        return params.toArray(Parameter.EMPTY_ARRAY);
+            .toArray(Parameter[]::new);
     }
 
     private Parameter formalParameter(FormalParameterContext ctx) {

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ImplicitClosureParameter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ImplicitClosureParameter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.ast;
+
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.Parameter;
+
+/**
+ * An implicit closure parameter (`it`). Used to discourage
+ * the use of implicit parameters.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class ImplicitClosureParameter extends Parameter {
+
+    public ImplicitClosureParameter() {
+        super(ClassHelper.dynamicType(), "it");
+    }
+}

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -132,12 +132,12 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
         var bodyDef = stmt(createX(
             "nextflow.script.BodyDef",
             args(
-                closureX(node.main),
+                closureX(null, node.main),
                 constX(getSourceText(node)),
                 constX("workflow")
             )
         ));
-        var closure = closureX(block(new VariableScope(), List.of(
+        var closure = closureX(null, block(new VariableScope(), List.of(
             node.takes,
             node.emits,
             bodyDef
@@ -207,13 +207,13 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
         var bodyDef = stmt(createX(
             "nextflow.script.BodyDef",
             args(
-                closureX(node.exec),
+                closureX(null, node.exec),
                 constX(getSourceText(node.exec)),
                 constX(node.type)
             )
         ));
         var stub = processStub(node.stub);
-        var closure = closureX(block(new VariableScope(), List.of(
+        var closure = closureX(null, block(new VariableScope(), List.of(
             node.directives,
             node.inputs,
             node.outputs,
@@ -350,7 +350,7 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
     }
 
     protected ClosureExpression wrapExpressionInClosure(Expression node)  {
-        return closureX(block(stmt(node)));
+        return closureX(null, block(stmt(node)));
     }
 
     private Statement processWhen(Expression when) {
@@ -371,7 +371,7 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
         return stmt(callThisX("stub", createX(
             "nextflow.script.TaskClosure",
             args(
-                closureX(stub),
+                closureX(null, stub),
                 constX(getSourceText(stub))
             )
         )));
@@ -392,11 +392,11 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
             .map((output) -> {
                 new PublishDslVisitor().visit(output.body);
                 var name = constX(output.name);
-                var body = closureX(output.body);
+                var body = closureX(null, output.body);
                 return stmt(callThisX("declare", args(name, body)));
             })
             .toList();
-        var closure = closureX(block(new VariableScope(), statements));
+        var closure = closureX(null, block(new VariableScope(), statements));
         var result = stmt(callThisX("output", args(closure)));
         moduleNode.addStatement(result);
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -22,6 +22,7 @@ import nextflow.script.ast.ASTNodeMarker;
 import nextflow.script.ast.AssignmentExpression;
 import nextflow.script.ast.FeatureFlagNode;
 import nextflow.script.ast.FunctionNode;
+import nextflow.script.ast.ImplicitClosureParameter;
 import nextflow.script.ast.IncludeNode;
 import nextflow.script.ast.OutputNode;
 import nextflow.script.ast.ProcessNode;
@@ -621,18 +622,18 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
 
         vsc.pushScope();
         node.setVariableScope(currentScope());
-        if( node.getParameters() != null ) {
+        if( node.isParameterSpecified() ) {
             for( var parameter : node.getParameters() ) {
                 vsc.declare(parameter, parameter);
                 if( parameter.hasInitialExpression() )
-                    visit(parameter.getInitialExpression());
+                    parameter.getInitialExpression().visit(this);
             }
         }
-        super.visitClosureExpression(node);
-        for( var it = currentScope().getReferencedLocalVariablesIterator(); it.hasNext(); ) {
-            var variable = it.next();
-            variable.setClosureSharedVariable(true);
+        else if( node.getParameters() != null ) {
+            var implicit = new ImplicitClosureParameter();
+            currentScope().putDeclaredVariable(implicit);
         }
+        super.visitClosureExpression(node);
         vsc.popScope();
 
         currentClosure = cl;
@@ -643,10 +644,7 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         var name = node.getName();
         Variable variable = vsc.findVariableDeclaration(name, node);
         if( variable == null ) {
-            if( "it".equals(name) ) {
-                vsc.addParanoidWarning("Implicit closure parameter `it` will not be supported in a future version", node);
-            }
-            else if( "args".equals(name) ) {
+            if( "args".equals(name) ) {
                 vsc.addParanoidWarning("The use of `args` outside the entry workflow will not be supported in a future version", node);
             }
             else if( "params".equals(name) ) {
@@ -658,6 +656,9 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
             else {
                 variable = new DynamicVariable(name, false);
             }
+        }
+        if( variable instanceof ImplicitClosureParameter ) {
+            vsc.addWarning("Implicit closure parameter is deprecated, declare an explicit parameter instead", variable.getName(), node);
         }
         if( variable != null ) {
             checkGlobalVariableInProcess(variable, node);

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -1545,24 +1545,12 @@ public class ScriptAstBuilder {
     /// MISCELLANEOUS
 
     private Parameter[] formalParameterList(FormalParameterListContext ctx) {
-        // NOTE: implicit `it` parameter is deprecated, but allow it for now
         if( ctx == null )
             return Parameter.EMPTY_ARRAY;
 
-        var params = ctx.formalParameter().stream()
+        return ctx.formalParameter().stream()
             .map(this::formalParameter)
-            .toList();
-        for( int n = params.size(), i = n - 1; i >= 0; i -= 1 ) {
-            var param = params.get(i);
-            for( var other : params ) {
-                if( other == param )
-                    continue;
-                if( other.getName().equals(param.getName()) )
-                    throw createParsingFailedException("Duplicated parameter '" + param.getName() + "' found", param);
-            }
-        }
-
-        return params.toArray(Parameter.EMPTY_ARRAY);
+            .toArray(Parameter[]::new);
     }
 
     private Parameter formalParameter(FormalParameterContext ctx) {


### PR DESCRIPTION
Fix #6237 

Fixes an issue with explicit `it` params. Also makes the detection of implicit `it` more precise.