### PR TITLE
GitlabRepositoryProvider now handles leading slashes for content URLs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -88,8 +88,7 @@ class GitlabRepositoryProvider extends RepositoryProvider {
         //  https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
         //
         final ref = revision ?: getDefaultBranch()
-        path = path.replaceAll("^/+", "")  // leading slashes cause 400s with GitLab
-        final encodedPath = URLEncoder.encode(path,'utf-8')
+        final encodedPath = URLEncoder.encode(path.stripStart('/'),'utf-8')
         return "${config.endpoint}/api/v4/projects/${getProjectName()}/repository/files/${encodedPath}?ref=${ref}"
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
@@ -19,7 +19,6 @@ package nextflow.scm
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Specification
-import spock.lang.Unroll
 
 /**
  *
@@ -51,20 +50,16 @@ class GitlabRepositoryProviderTest extends Specification {
     }
 
     @Requires({System.getenv('NXF_GITLAB_ACCESS_TOKEN')})
-    @Unroll
-    def 'should read file content: #contentURL'() {
+    def 'should read file content'() {
         given:
         def token = System.getenv('NXF_GITLAB_ACCESS_TOKEN')
         def config = new ProviderConfig('gitlab').setAuth(token)
 
         when:
         def repo = new GitlabRepositoryProvider('pditommaso/hello', config)
-        def result = repo.readText(contentURL)
+        def result = repo.readText('main.nf')
         then:
         result.trim().startsWith('#!/usr/bin/env nextflow')
-        where:
-        contentURL << ['main.nf', '/main.nf']
-
     }
 
     @Requires({System.getenv('NXF_GITLAB_ACCESS_TOKEN')})
@@ -125,6 +120,16 @@ class GitlabRepositoryProviderTest extends Specification {
         and:
         new GitlabRepositoryProvider('pditommaso/hello', obj)
                 .getContentUrl('conf/extra.conf') == 'https://gitlab.com/api/v4/projects/pditommaso%2Fhello/repository/files/conf%2Fextra.conf?ref=master'
+
+
+        and: // should strip leading slashes
+        new GitlabRepositoryProvider('pditommaso/hello', obj)
+            .getContentUrl('/main.nf') == 'https://gitlab.com/api/v4/projects/pditommaso%2Fhello/repository/files/main.nf?ref=master'
+
+        and:
+        new GitlabRepositoryProvider('pditommaso/hello', obj)
+            .getContentUrl('//conf/extra.conf') == 'https://gitlab.com/api/v4/projects/pditommaso%2Fhello/repository/files/conf%2Fextra.conf?ref=master'
+
 
     }
 }


### PR DESCRIPTION
A tiny change to handle leading slashes for GitLab content URLs. Leading forward slashes in relative content URLs are generally handles well by the repo providers, but GitLab does things a little differently. Instead of handling the entire URL path as an endpoint URL, it encodes the content URL as a single portion of the URL:

`"${config.endpoint}/api/v4/projects/${getProjectName()}/repository/files/${encodedPath}?ref=${ref}"`

Any leading slash in the `encodedPath` part results in a 400. This is currently uncaught by  nextflow.scm.RepositoryProvider#checkResponse, and results in a null value being returned.

This PR simply strips leading slashes from content URLs for gitlab, resolving the problem.
