### PR TITLE
feat: Updated Gitea ProviderConfig server default

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/ProviderConfig.groovy
@@ -77,7 +77,7 @@ class ProviderConfig {
 
             case 'gitea':
                 attr.platform = name
-                if( !attr.server ) attr.server = 'https://try.gitea.io'
+                if( !attr.server ) attr.server = 'https://gitea.com' // default to free tier
                 if( !attr.endpoint ) attr.endpoint = attr.server.toString().stripEnd('/') + '/api/v1'
                 break
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
@@ -25,20 +25,9 @@ import spock.lang.Specification
  */
 class GiteaRepositoryProviderTest extends Specification {
 
-    static final String CONFIG = '''
-        providers {
-            mygitea {
-                server = 'https://gitea.com'
-                endpoint = 'https://gitea.com/api/v1'
-                platform = 'gitea'
-            }
-        }
-        '''
-
     def 'should return repo url' () {
         given:
-        def config = new ConfigSlurper().parse(CONFIG)
-        def obj = new ProviderConfig('gitea', config.providers.mygitea as ConfigObject)
+        def obj = new ProviderConfig('gitea')
 
         expect:
         new GiteaRepositoryProvider('pditommaso/hello', obj).getEndpointUrl() == 'https://gitea.com/api/v1/repos/pditommaso/hello'
@@ -46,8 +35,7 @@ class GiteaRepositoryProviderTest extends Specification {
 
     def 'should return project URL' () {
         given:
-        def config = new ConfigSlurper().parse(CONFIG)
-        def obj = new ProviderConfig('gitea', config.providers.mygitea as ConfigObject)
+        def obj = new ProviderConfig('gitea')
 
         expect:
         new GiteaRepositoryProvider('pditommaso/hello', obj).getRepositoryUrl() == 'https://gitea.com/pditommaso/hello'
@@ -55,8 +43,7 @@ class GiteaRepositoryProviderTest extends Specification {
 
     def 'should return content URL' () {
         given:
-        def config = new ConfigSlurper().parse(CONFIG)
-        def obj = new ProviderConfig('gitea', config.providers.mygitea as ConfigObject)
+        def obj = new ProviderConfig('gitea')
 
         expect:
         new GiteaRepositoryProvider('pditommaso/hello', obj)
@@ -73,7 +60,7 @@ class GiteaRepositoryProviderTest extends Specification {
     def 'should read file content'() {
         given:
         def token =  System.getenv('NXF_GITEA_ACCESS_TOKEN')
-        def config = new ProviderConfig('gitea', new ConfigSlurper().parse(CONFIG).providers.mygitea as ConfigObject) .setAuth(token)
+        def config = new ProviderConfig('gitea') .setAuth(token)
 
         when:
         def repo = new GiteaRepositoryProvider('pditommaso/test-hello', config)
@@ -94,7 +81,7 @@ class GiteaRepositoryProviderTest extends Specification {
     def 'should read bytes gitea content'() {
         given:
         def token =  System.getenv('NXF_GITEA_ACCESS_TOKEN')
-        def config = new ProviderConfig('gitea', new ConfigSlurper().parse(CONFIG).providers.mygitea as ConfigObject) .setAuth(token)
+        def config = new ProviderConfig('gitea') .setAuth(token)
         def repo = new GiteaRepositoryProvider('pditommaso/test-hello', config)
         and:
         def DATA = this.class.getResourceAsStream('/test-asset.bin').bytes
@@ -111,7 +98,7 @@ class GiteaRepositoryProviderTest extends Specification {
     def 'should read bytes file content'() {
         given:
         def token =  System.getenv('NXF_GITEA_ACCESS_TOKEN')
-        def config = new ProviderConfig('gitea', new ConfigSlurper().parse(CONFIG).providers.mygitea as ConfigObject).setAuth(token)
+        def config = new ProviderConfig('gitea').setAuth(token)
 
         when:
         def repo = new GiteaRepositoryProvider('pditommaso/test-hello', config)

--- a/modules/nextflow/src/test/groovy/nextflow/scm/ProviderConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/ProviderConfigTest.groovy
@@ -189,6 +189,16 @@ class ProviderConfigTest extends Specification {
         config.user == null
         config.password == null
         config.token == 'xyz'
+
+        when:
+        config = new ProviderConfig('gitea', [auth: 'xyz'])
+        then:
+        config.auth == null
+        config.user == null
+        config.password == null
+        config.token == 'xyz'
+        config.server == 'https://gitea.com'
+        config.endpoint == 'https://gitea.com/api/v1'
     }
 
     def 'should ending slash and add protocol prefix' () {


### PR DESCRIPTION
The old try.gitea.io free tier url has been superseded by gitea.com. This PR simply updates that default in the ProviderConfig.