### PR TITLE
AzureRepositoryProvider readBytes corrupt 

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AzureRepositoryProvider.groovy
@@ -183,12 +183,35 @@ final class AzureRepositoryProvider extends RepositoryProvider {
         "${config.server}/${urlPath}"
     }
 
+    @Override
+    String readText( String path ) {
+        final url = getContentUrl(path)
+        final response = invokeAndParseResponse(url)
+        return response.get('content')?.toString()
+    }
+
     /** {@inheritDoc} */
     @Override
     byte[] readBytes(String path) {
-        final url = getContentUrl(path)
-        final response = invokeAndParseResponse(url)
-        return response.get('content')?.toString()?.getBytes()
+        // For binary content, use direct download instead of JSON embedding
+        final queryParams = [
+                'download': true,
+                'includeContent': false,
+                'includeContentMetadata': false,
+                "api-version": 6.0,
+                'path': path
+        ] as Map<String,Object>
+        
+        if( revision ) {
+            queryParams['versionDescriptor.version'] = revision
+            if( COMMIT_REGEX.matcher(revision).matches() )
+                queryParams['versionDescriptor.versionType'] = 'commit'
+        }
+        
+        final queryString = queryParams.collect({ "$it.key=$it.value"}).join('&')
+        final url = "$endpointUrl/items?$queryString"
+        // Use invokeBytes for direct binary content download
+        return invokeBytes(url)
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdConfigTest.groovy
@@ -24,6 +24,7 @@ import nextflow.extension.FilesEx
 import nextflow.plugin.Plugins
 import nextflow.secret.SecretsLoader
 import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Specification
 /**
  *
@@ -384,10 +385,12 @@ class CmdConfigTest extends Specification {
 
     }
 
-
     @IgnoreIf({System.getenv('NXF_SMOKE')})
+    @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})
     def 'should resolve remote config' () {
         given:
+        SysEnv.push(GITHUB_TOKEN: System.getenv('NXF_GITHUB_ACCESS_TOKEN'))
+        and:
         def buffer = new ByteArrayOutputStream()
         def cmd = new CmdConfig(
                 args: ['https://github.com/nextflow-io/hello'],
@@ -404,6 +407,9 @@ class CmdConfigTest extends Specification {
             }
             '''
             .stripIndent()
+
+        cleanup:
+        SysEnv.pop()
     }
 
     @IgnoreIf({System.getenv('NXF_SMOKE')})

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -20,6 +20,10 @@ import nextflow.exception.AbortOperationException
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Specification
+
+import javax.imageio.ImageIO
+import javax.imageio.stream.MemoryCacheImageInputStream
+
 /**
  *
  * @author Tobias Neumann <tobias.neumann.at@gmail.com>
@@ -134,6 +138,26 @@ class AzureRepositoryProviderTest extends Specification {
         then:
         result == 'println "Hello from Azure repos!"'
     }
+
+    @IgnoreIf({System.getenv('NXF_SMOKE')})
+    @Requires({System.getenv('NXF_AZURE_REPOS_TOKEN')})
+    def 'should read bytes file content'() {
+        given:
+        def token = System.getenv('NXF_AZURE_REPOS_TOKEN')
+        def config = new ProviderConfig('azurerepos').setAuth(token)
+
+        when:
+        // uses repo at https://dev.azure.com/seqera-pipelines-dev/_git/rnaseq
+        def repo = new AzureRepositoryProvider('seqera-pipelines-dev/rnaseq', config)
+        def result = repo.readBytes('/docs/images/nf-core-rnaseq_logo_light.png')
+
+        then:
+        def inputStream = new ByteArrayInputStream(result)
+        def imageInput = new MemoryCacheImageInputStream(inputStream)
+        final readers = ImageIO.getImageReaders(imageInput)
+        readers.hasNext()
+    }
+
 
     @IgnoreIf({System.getenv('NXF_SMOKE')})
     @Requires({System.getenv('NXF_AZURE_REPOS_TOKEN')})

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -147,11 +147,13 @@ class AzureRepositoryProviderTest extends Specification {
         def config = new ProviderConfig('azurerepos').setAuth(token)
 
         when:
-        // uses repo at https://dev.azure.com/seqera-pipelines-dev/_git/rnaseq
-        def repo = new AzureRepositoryProvider('seqera-pipelines-dev/rnaseq', config)
+        // uses repo at https://pditommaso.visualstudio.com/nf-azure-repo/_git/nf-azure-repo
+        def repo = new AzureRepositoryProvider('pditommaso/nf-azure-repo', config)
         def result = repo.readBytes('/docs/images/nf-core-rnaseq_logo_light.png')
 
         then:
+        result.length == 22915
+        and:
         def inputStream = new ByteArrayInputStream(result)
         def imageInput = new MemoryCacheImageInputStream(inputStream)
         final readers = ImageIO.getImageReaders(imageInput)
@@ -194,7 +196,7 @@ class AzureRepositoryProviderTest extends Specification {
         result == [
                 new RepositoryProvider.BranchInfo('dev', 'cc0ca18640a5c995231e22d91f1527d5155d024b'),
                 new RepositoryProvider.BranchInfo('feature-x', '13456a001ba5a27d643755614ab8e814d94ef888'),
-                new RepositoryProvider.BranchInfo('master', 'f84130388714582e20f0e2ff9a44b41978ec8929'),
+                new RepositoryProvider.BranchInfo('master', 'a207636e419f18c4b8c8586b00e329ab4788a7f5'),
         ]
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AzureRepositoryProviderTest.groovy
@@ -20,10 +20,6 @@ import nextflow.exception.AbortOperationException
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Specification
-
-import javax.imageio.ImageIO
-import javax.imageio.stream.MemoryCacheImageInputStream
-
 /**
  *
  * @author Tobias Neumann <tobias.neumann.at@gmail.com>
@@ -153,11 +149,7 @@ class AzureRepositoryProviderTest extends Specification {
 
         then:
         result.length == 22915
-        and:
-        def inputStream = new ByteArrayInputStream(result)
-        def imageInput = new MemoryCacheImageInputStream(inputStream)
-        final readers = ImageIO.getImageReaders(imageInput)
-        readers.hasNext()
+        result.sha256() == '7a396344498750f614155f6e4f38b7d6ca98ced45daf0921b64acf73b18efaf4'
     }
 
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
@@ -106,7 +106,6 @@ class GiteaRepositoryProviderTest extends Specification {
         result == DATA
     }
 
-
     @IgnoreIf({System.getenv('NXF_SMOKE')})
     @Requires({System.getenv('NXF_GITEA_ACCESS_TOKEN')})
     def 'should read bytes file content'() {

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
@@ -19,10 +19,6 @@ package nextflow.scm
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Specification
-
-import javax.imageio.ImageIO
-import javax.imageio.stream.MemoryCacheImageInputStream
-
 /**
  *
  * @author Akira Sekiguchi <pachiras.yokohama@gmail.com>
@@ -112,20 +108,18 @@ class GiteaRepositoryProviderTest extends Specification {
 
 
     @IgnoreIf({System.getenv('NXF_SMOKE')})
-    @Requires({System.getenv('NXF_AZURE_REPOS_TOKEN')})
+    @Requires({System.getenv('NXF_GITEA_ACCESS_TOKEN')})
     def 'should read bytes file content'() {
         given:
         def token =  System.getenv('NXF_GITEA_ACCESS_TOKEN')
         def config = new ProviderConfig('gitea', new ConfigSlurper().parse(CONFIG).providers.mygitea as ConfigObject).setAuth(token)
 
         when:
-        def repo = new GiteaRepositoryProvider('swingingsimiangitea/rnaseq', config)
+        def repo = new GiteaRepositoryProvider('pditommaso/test-hello', config)
         def result = repo.readBytes('docs/images/nf-core-rnaseq_logo_light.png')
 
         then:
-        def inputStream = new ByteArrayInputStream(result)
-        def imageInput = new MemoryCacheImageInputStream(inputStream)
-        final readers = ImageIO.getImageReaders(imageInput)
-        readers.hasNext()
+        result.length == 22915
+        result.sha256() == '7a396344498750f614155f6e4f38b7d6ca98ced45daf0921b64acf73b18efaf4'
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
@@ -19,6 +19,10 @@ package nextflow.scm
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Specification
+
+import javax.imageio.ImageIO
+import javax.imageio.stream.MemoryCacheImageInputStream
+
 /**
  *
  * @author Akira Sekiguchi <pachiras.yokohama@gmail.com>
@@ -106,4 +110,22 @@ class GiteaRepositoryProviderTest extends Specification {
         result == DATA
     }
 
+
+    @IgnoreIf({System.getenv('NXF_SMOKE')})
+    @Requires({System.getenv('NXF_AZURE_REPOS_TOKEN')})
+    def 'should read bytes file content'() {
+        given:
+        def token =  System.getenv('NXF_GITEA_ACCESS_TOKEN')
+        def config = new ProviderConfig('gitea', new ConfigSlurper().parse(CONFIG).providers.mygitea as ConfigObject).setAuth(token)
+
+        when:
+        def repo = new GiteaRepositoryProvider('swingingsimiangitea/rnaseq', config)
+        def result = repo.readBytes('docs/images/nf-core-rnaseq_logo_light.png')
+
+        then:
+        def inputStream = new ByteArrayInputStream(result)
+        def imageInput = new MemoryCacheImageInputStream(inputStream)
+        final readers = ImageIO.getImageReaders(imageInput)
+        readers.hasNext()
+    }
 }


### PR DESCRIPTION
The AzureRepositoryProvider readBytes method appears to corrupt data for image files.

This PR contains 2 identical tests for a Gitea and Azure repo, both of which simple readBytes for an image in each and check whether the bytes returned are a valid image. The Gitea test passes whilst the Azure test fails.

The tests are currently set up with a public Gitea repo, so the existing auth should work for that. The azure repo is private, so will need changing to a repo which the current CI env has access to.
