### PR TITLE
Fix AWS transfer manager anonymous fallback

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
@@ -103,7 +103,7 @@ public class S3Client {
 				return null;
 			return getBucketAcl(buckets.get(0).name()).owner().id();
 		}catch (Throwable e){
-			log.debug("Exception fetching caller account", e);
+			log.debug("Unable to fetch caller account - {} ", e.getMessage());
 			return null;
 		}
 	}


### PR DESCRIPTION
close #6295

The CrtAsyncClient produces a NPE when receiving AnonymousCredentials from a provider (https://github.com/aws/aws-sdk-java-v2/issues/5810) This is what produces failures when downloading with the S3 Transfer Manager and credentials are not set. The only working way to use anonymous credentials in the AWS S3 CRT client is is passing an AnonymousCredentialsProvider.

This PR implements a workaround to fix the fallback to anonymous credentials when no credentials are provided.

When using anynimous credentials, it is normal that the fetch for the caller account also fails. I have also changed the log message to print just the message instead of the full stack trace.