### PR TITLE
Fix new plugins registry download when OCI repository requires tokens

### DIFF
--- a/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
@@ -102,7 +102,7 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
 
     @Override
     FileDownloader getFileDownloader() {
-        return new SimpleFileDownloader()
+        return new OciAwareFileDownloader()
     }
 
     @Override

--- a/modules/nf-commons/src/main/nextflow/plugin/OciAwareFileDownloader.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/OciAwareFileDownloader.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nextflow.plugin
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.pf4j.update.SimpleFileDownloader
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Pattern
+
+/**
+ * FileDownloader extension that enables the download of OCI compliant artifact that require a token authorization.
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+@Slf4j
+@CompileStatic
+class OciAwareFileDownloader extends SimpleFileDownloader {
+
+    private static final Pattern WWW_AUTH_PATTERN = ~/Bearer realm="([^"]+)",\s*service="([^"]+)",\s*scope="([^"]+)"/
+
+    /**
+     * OCI aware download with token authorization. Tries to download the artifact and if it fails checks the headers to get the
+     * @param fileUrl source file
+     * @return
+     */
+    @Override
+    protected Path downloadFileHttp(URL fileUrl) {
+
+        Path destination = Files.createTempDirectory("pf4j-update-downloader");
+        destination.toFile().deleteOnExit();
+
+        String path = fileUrl.getPath();
+        String fileName = path.substring(path.lastIndexOf('/') + 1);
+        Path file = destination.resolve(fileName);
+        HttpURLConnection conn = (HttpURLConnection) fileUrl.openConnection()
+        conn.instanceFollowRedirects = true
+
+        if (conn.responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            def wwwAuth = conn.getHeaderField("WWW-Authenticate")
+            if (wwwAuth?.contains("Bearer")) {
+                log.debug("Received 401 — attempting OCI token auth")
+
+                def matcher = WWW_AUTH_PATTERN.matcher(wwwAuth)
+                if (!matcher.find()) {
+                    throw new IOException("Invalid WWW-Authenticate header: $wwwAuth")
+                }
+
+                def (realm, service, scope) = [matcher.group(1), matcher.group(2), matcher.group(3)]
+                def tokenUrl = "${realm}?service=${URLEncoder.encode(service, 'UTF-8')}&scope=${URLEncoder.encode(scope, 'UTF-8')}"
+                def token = fetchToken(tokenUrl)
+
+                // Retry download with Bearer token
+                def authConn = (HttpURLConnection) fileUrl.openConnection()
+                authConn.setRequestProperty("Authorization", "Bearer $token")
+                authConn.instanceFollowRedirects = true
+
+                authConn.inputStream.withStream { input ->
+                    file.withOutputStream { out -> out << input }
+                }
+
+                return file
+            }
+        }
+
+        // Fallback to default behavior
+        conn.inputStream.withStream { input ->
+            file.withOutputStream { out -> out << input }
+        }
+        return file
+    }
+
+    private String fetchToken(String tokenUrl) {
+        def conn = (HttpURLConnection) URI.create(tokenUrl).toURL().openConnection()
+        conn.setRequestProperty("Accept", "application/json")
+
+        def json = conn.inputStream.getText("UTF-8")
+        def matcher = json =~ /"token"\s*:\s*"([^"]+)"/
+        if (matcher.find()) {
+            return matcher.group(1)
+        }
+        throw new IOException("Token not found in response: $json")
+    }
+}
+
+

--- a/modules/nf-commons/src/test/nextflow/plugin/OciAwareFileDownloaderTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/OciAwareFileDownloaderTest.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.plugin
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+class OciAwareFileDownloaderTest extends Specification {
+
+    @Rule
+    WireMockRule wiremock = new WireMockRule(0)
+
+    OciAwareFileDownloader downloader
+
+    def setup() {
+        downloader = new OciAwareFileDownloader()
+    }
+
+    def 'should download file successfully without authentication'() {
+        given:
+        def fileContent = "test plugin archive content"
+        wiremock.stubFor(get(urlPathEqualTo("/plugin.zip"))
+            .willReturn(ok().withBody(fileContent))
+        )
+
+        when:
+        def downloadedFile = downloader.downloadFileHttp(new URL("${wiremock.baseUrl()}/plugin.zip"))
+
+        then:
+        downloadedFile != null
+        Files.exists(downloadedFile)
+        downloadedFile.text == fileContent
+        downloadedFile.fileName.toString() == "plugin.zip"
+
+        cleanup:
+        if (downloadedFile) Files.deleteIfExists(downloadedFile)
+    }
+
+    def 'should handle OCI token authentication when receiving 401 unauthorized'() {
+        given:
+        def fileContent = "authenticated plugin archive content"
+        def tokenResponse = '{"token": "test-bearer-token-12345"}'
+        def authServerUrl = "${wiremock.baseUrl()}/token"
+        def wwwAuthHeader = "Bearer realm=\"${authServerUrl}\",service=\"registry.example.com\",scope=\"repository:plugins/nf-test:pull\""
+
+        // Token endpoint returns authentication token
+
+        wiremock.stubFor( get(urlPathEqualTo("/token"))
+                .withQueryParam('service', equalTo('registry.example.com'))
+                .withQueryParam('scope', equalTo('repository:plugins/nf-test:pull'))
+                .willReturn( okJson(tokenResponse))
+        )
+        wiremock.stubFor(get(urlPathEqualTo("/plugin.zip"))
+            .willReturn(unauthorized().withHeader("WWW-Authenticate", wwwAuthHeader))
+        )
+
+        wiremock.stubFor(get(urlPathEqualTo("/plugin.zip"))
+            .withHeader("Authorization", equalTo("Bearer test-bearer-token-12345") )
+            .willReturn(ok().withBody(fileContent))
+        )
+
+        when:
+        def downloadedFile = downloader.downloadFileHttp(new URL("${wiremock.baseUrl()}/plugin.zip"))
+
+        then:
+        downloadedFile != null
+        Files.exists(downloadedFile)
+        downloadedFile.text == fileContent
+
+        cleanup:
+        Files.deleteIfExists(downloadedFile)
+    }
+
+    def 'should throw IOException when WWW-Authenticate header is malformed'() {
+        given:
+        wiremock.stubFor(get(urlPathEqualTo("/plugin.zip"))
+            .willReturn(unauthorized().withHeader("WWW-Authenticate", "Bearer invalid-header-format"))
+        )
+
+        when:
+        downloader.downloadFileHttp(new URL("${wiremock.baseUrl()}/plugin.zip"))
+
+        then:
+        def ex = thrown(IOException)
+        ex.message.contains("Invalid WWW-Authenticate header")
+    }
+
+    def 'should throw IOException when token is not found in response'() {
+        given:
+        def invalidTokenResponse = '{"access_token": "wrong-field-name"}'
+        def authServerUrl = "${wiremock.baseUrl()}/token"
+        def wwwAuthHeader = "Bearer realm=\"${authServerUrl}\",service=\"registry.example.com\",scope=\"repository:plugins/nf-test:pull\""
+
+        wiremock.stubFor( get(urlPathEqualTo("/token"))
+                .withQueryParam('service', equalTo('registry.example.com'))
+                .withQueryParam('scope', equalTo('repository:plugins/nf-test:pull'))
+                .willReturn( okJson(invalidTokenResponse))
+        )
+        wiremock.stubFor(get(urlPathEqualTo("/plugin.zip"))
+            .willReturn(unauthorized().withHeader("WWW-Authenticate", wwwAuthHeader))
+        )
+
+        when:
+        downloader.downloadFileHttp(new URL("${wiremock.baseUrl()}/plugin.zip"))
+
+        then:
+        def ex = thrown(IOException)
+        ex.message.contains("Token not found in response")
+    }
+}


### PR DESCRIPTION
Some OCI repositories despite artifact are public they do not allow direct HTTP downloads. They require to acquire a temporal token to preform the download.

This PR extends the pf4j simple file download to allow this type of downloads