### PR TITLE
Bump groovy 4.0.28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,8 @@ allprojects {
 
         // Documentation required libraries
         groovyDoc 'org.fusesource.jansi:jansi:2.4.0'
-        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.27"
-        groovyDoc "org.apache.groovy:groovy-ant:4.0.27"
+        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.28"
+        groovyDoc "org.apache.groovy:groovy-ant:4.0.28"
     }
 
     test {

--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -25,12 +25,12 @@ dependencies {
     api(project(':nf-commons'))
     api(project(':nf-httpfs'))
     api(project(':nf-lang'))
-    api "org.apache.groovy:groovy:4.0.27"
-    api "org.apache.groovy:groovy-nio:4.0.27"
-    api "org.apache.groovy:groovy-xml:4.0.27"
-    api "org.apache.groovy:groovy-json:4.0.27"
-    api "org.apache.groovy:groovy-templates:4.0.27"
-    api "org.apache.groovy:groovy-yaml:4.0.27"
+    api "org.apache.groovy:groovy:4.0.28"
+    api "org.apache.groovy:groovy-nio:4.0.28"
+    api "org.apache.groovy:groovy-xml:4.0.28"
+    api "org.apache.groovy:groovy-json:4.0.28"
+    api "org.apache.groovy:groovy-templates:4.0.28"
+    api "org.apache.groovy:groovy-yaml:4.0.28"
     api "org.slf4j:jcl-over-slf4j:2.0.17"
     api "org.slf4j:jul-to-slf4j:2.0.17"
     api "org.slf4j:log4j-over-slf4j:2.0.17"
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'org.subethamail:subethasmtp:3.1.7'
     testImplementation (project(':nf-lineage'))
     // test configuration
-    testFixturesApi ("org.apache.groovy:groovy-test:4.0.27") { exclude group: 'org.apache.groovy' }
+    testFixturesApi ("org.apache.groovy:groovy-test:4.0.28") { exclude group: 'org.apache.groovy' }
     testFixturesApi ("org.objenesis:objenesis:3.4")
     testFixturesApi ("net.bytebuddy:byte-buddy:1.14.17")
     testFixturesApi ("org.spockframework:spock-core:2.3-groovy-4.0") { exclude group: 'org.apache.groovy' }

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -26,8 +26,8 @@ sourceSets {
 
 dependencies {
     api "ch.qos.logback:logback-classic:1.5.18"
-    api "org.apache.groovy:groovy:4.0.27"
-    api "org.apache.groovy:groovy-nio:4.0.27"
+    api "org.apache.groovy:groovy:4.0.28"
+    api "org.apache.groovy:groovy-nio:4.0.28"
     api "commons-lang:commons-lang:2.6"
     api 'com.google.guava:guava:33.0.0-jre'
     api 'org.pf4j:pf4j:3.12.0'
@@ -40,7 +40,7 @@ dependencies {
     testImplementation(testFixtures(project(":nextflow")))
     testFixturesImplementation(project(":nextflow"))
 
-    testImplementation "org.apache.groovy:groovy-json:4.0.27" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.28" // needed by wiremock
     testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-1') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 }

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -30,12 +30,12 @@ sourceSets {
 dependencies {
     api project(':nf-commons')
     api "ch.qos.logback:logback-classic:1.5.18"
-    api "org.apache.groovy:groovy:4.0.27"
-    api "org.apache.groovy:groovy-nio:4.0.27"
+    api "org.apache.groovy:groovy:4.0.28"
+    api "org.apache.groovy:groovy-nio:4.0.28"
     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
 
     /* testImplementation inherited from top gradle build file */
-    testImplementation "org.apache.groovy:groovy-json:4.0.27" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.28" // needed by wiremock
     testImplementation ('com.github.tomakehurst:wiremock:1.57') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 

--- a/modules/nf-lang/build.gradle
+++ b/modules/nf-lang/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 dependencies {
   antlr 'me.sunlan:antlr4:4.13.2.6'
-  api 'org.apache.groovy:groovy:4.0.27'
+  api 'org.apache.groovy:groovy:4.0.28'
   api 'org.pf4j:pf4j:3.12.0'
 
   testFixturesApi 'com.google.jimfs:jimfs:1.2'

--- a/modules/nf-lineage/build.gradle
+++ b/modules/nf-lineage/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':nextflow')
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }
 

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -63,6 +63,6 @@ dependencies {
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }

--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -53,6 +53,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }

--- a/plugins/nf-cloudcache/build.gradle
+++ b/plugins/nf-cloudcache/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }
 

--- a/plugins/nf-codecommit/build.gradle
+++ b/plugins/nf-codecommit/build.gradle
@@ -42,6 +42,6 @@ dependencies {
         
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }

--- a/plugins/nf-console/build.gradle
+++ b/plugins/nf-console/build.gradle
@@ -38,13 +38,13 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
     api("org.apache.groovy:groovy-console:4.0.21-patch.2") { transitive=false }
-    api("org.apache.groovy:groovy-swing:4.0.27")  { transitive=false }
+    api("org.apache.groovy:groovy-swing:4.0.28")  { transitive=false }
     // this is required by 'groovy-console'  
     api("com.github.javaparser:javaparser-core:3.25.8")
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }
 

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -44,8 +44,8 @@ dependencies {
     api 'com.google.cloud:google-cloud-storage:2.53.2'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }
 
 test {

--- a/plugins/nf-k8s/build.gradle
+++ b/plugins/nf-k8s/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     api 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }
 
 test {

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.12.7.1"
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
-    testImplementation "org.apache.groovy:groovy-json:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
+    testImplementation "org.apache.groovy:groovy-json:4.0.28"
     // wiremock required by TowerFusionEnvTest
     testImplementation "org.wiremock:wiremock:3.5.4"
 }

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     api 'io.seqera:wave-utils:0.15.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.27"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.27"
+    testImplementation "org.apache.groovy:groovy:4.0.28"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.28"
 }


### PR DESCRIPTION
This pull request updates the Groovy library dependencies across multiple modules to version 4.0.28. The changes ensure consistency and compatibility with the latest Groovy release.

### Dependency Updates

* Updated Groovy dependencies from version `4.0.27` to `4.0.28` in `modules/nextflow/build.gradle`, including `groovy`, `groovy-nio`, `groovy-xml`, `groovy-json`, `groovy-templates`, and `groovy-yaml`. This also includes the `groovy-test` dependency for test fixtures. [[1]](diffhunk://#diff-2babbef7001c3511a463d7ac44f9bbf3910120367574c754f59c9617689fc43dL28-R33) [[2]](diffhunk://#diff-2babbef7001c3511a463d7ac44f9bbf3910120367574c754f59c9617689fc43dL60-R60)
* Updated Groovy dependencies in `modules/nf-commons/build.gradle` to version `4.0.28`, including `groovy`, `groovy-nio`, and `groovy-json`. [[1]](diffhunk://#diff-852c6469d85cf3a9326e10b1c29793ec7a771e869f47937effc635afd97353e0L29-R30) [[2]](diffhunk://#diff-852c6469d85cf3a9326e10b1c29793ec7a771e869f47937effc635afd97353e0L43-R43)
* Updated Groovy dependencies in `modules/nf-httpfs/build.gradle` to version `4.0.28`, including `groovy`, `groovy-nio`, and `groovy-json`.
* Updated `groovy` dependency to version `4.0.28` in `modules/nf-lang/build.gradle`.

### Plugin-Specific Updates

* Updated Groovy test dependencies to version `4.0.28` in the following plugin modules:
  - `nf-amazon`
  - `nf-azure`
  - `nf-cloudcache`
  - `nf-codecommit`
  - `nf-console` (including `groovy-swing`)
  - `nf-google`
  - `nf-k8s`
  - `nf-tower` (including `groovy-json`)
  - `nf-wave`