### PR TITLE
Register fully-qualified process names at compile-time

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -243,7 +243,7 @@ process {
     cpus = 4
     withLabel: hello { cpus = 8 }
     withName: bye { cpus = 16 }
-    withName: 'mysub:bye' { cpus = 32 }
+    withName: 'aloha:bye' { cpus = 32 }
 }
 ```
 
@@ -251,7 +251,7 @@ With the above configuration:
 - All processes will use 4 cpus (unless otherwise specified in their process definition).
 - Processes annotated with the `hello` label will use 8 cpus.
 - Any process named `bye` (or imported as `bye`) will use 16 cpus.
-- Any process named `bye` (or imported as `bye`) invoked by a workflow named `mysub` will use 32 cpus.
+- Any process named `bye` (or imported as `bye`) invoked by a workflow named `aloha` will use 32 cpus.
 
 (config-profiles)=
 

--- a/docs/reference/feature-flags.md
+++ b/docs/reference/feature-flags.md
@@ -2,26 +2,23 @@
 
 # Feature flags
 
-Feature flags are used to introduce experimental or other opt-in features. They can be specified in the pipeline script or the configuration file.
+Feature flags are used to introduce experimental or other opt-in features. They must be specified in the pipeline script.
 
 `nextflow.enable.configProcessNamesValidation`
+: :::{deprecated} 25.10.0
+  Use the {ref}`strict syntax <strict-syntax-page>` instead. It validates process selectors without producing false warnings.
+  :::
 : When `true`, prints a warning for every `withName:` process selector that doesn't match a process in the pipeline (default: `true`).
 
 `nextflow.enable.dsl`
+: :::{deprecated} 25.04.0
+  :::
 : Defines the DSL version to use (`1` or `2`).
-: :::{versionchanged} 22.03.0-edge
-  DSL2 was made the default DSL version.
-  :::
-: :::{versionchanged} 22.12.0-edge
-  DSL1 was removed.
-  :::
 
 `nextflow.enable.moduleBinaries`
 : When `true`, enables the use of modules with binary scripts. See {ref}`module-binaries` for more information.
 
 `nextflow.enable.strict`
-: :::{versionadded} 22.05.0-edge
-  :::
 : When `true`, the pipeline is executed in "strict" mode, which introduces the following rules:
 
   - When reading a params file, Nextflow will fail if a dynamic param value references an undefined variable
@@ -53,15 +50,13 @@ Feature flags are used to introduce experimental or other opt-in features. They 
 : When `true`, enables the use of the {ref}`workflow output definition <workflow-output-def>`.
 
 `nextflow.preview.recursion`
-: :::{versionadded} 21.11.0-edge
-  :::
 : *Experimental: may change in a future release.*
 : When `true`, enables {ref}`process and workflow recursion <workflow-recursion>`.
 
 `nextflow.preview.topic`
-: :::{versionadded} 23.11.0-edge
+: :::{versionadded} 24.04.0
   :::
-: :::{versionchanged} 25.04.0
+: :::{deprecated} 25.04.0
   This feature flag is no longer required to use topic channels.
   :::
 : When `true`, enables {ref}`topic channels <channel-topic>` feature.

--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
@@ -113,6 +113,9 @@ class ScriptLoaderV2 implements ScriptLoader {
             result.modules().forEach((path, clazz) -> {
                 createScript(clazz, new ScriptBinding(), path, true)
             })
+
+            for( final name : result.processNames() )
+                ScriptMeta.addResolvedName(name)
         }
         catch( CompilationFailedException e ) {
             if( scriptPath )

--- a/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
@@ -7,12 +7,13 @@ import nextflow.exception.ScriptCompilationException
 import nextflow.script.BaseScript
 import nextflow.script.ScriptMeta
 import nextflow.script.WorkflowDef
-import spock.lang.Specification
+import test.Dsl2Spec
+import test.MockExecutorFactory
 /**
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
-class ScriptLoaderV2Test extends Specification {
+class ScriptLoaderV2Test extends Dsl2Spec {
 
     def 'should run a file script' () {
 
@@ -117,6 +118,43 @@ class ScriptLoaderV2Test extends Specification {
         meta.definitions.size() == 2
         meta.getWorkflow('hello').declaredInputs == ['foo', 'bar']
         meta.getWorkflow('hello').declaredOutputs == ['result']
+    }
+
+    def 'should register fully-qualified process names' () {
+
+        given:
+        def session = new Session()
+        session.executorFactory = new MockExecutorFactory()
+        def parser = new ScriptLoaderV2(session)
+
+        def TEXT = '''
+
+            process hello {
+                'echo hello'
+            }
+
+            process bye {
+                'echo bye'
+            }
+
+            workflow aloha {
+                if( params.mode == 'hello' )
+                    hello()
+                if( params.mode == 'bye' )
+                    bye()
+            }
+
+            workflow {
+                aloha()
+            }
+            '''
+
+        when:
+        parser.parse(TEXT)
+        parser.runScript()
+
+        then:
+        ScriptMeta.allProcessNames() == [ 'hello', 'bye', 'aloha:hello', 'aloha:bye' ] as Set
     }
 
     def 'should allow explicit `it` closure parameter' () {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/CallSiteCollector.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/CallSiteCollector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.control;
+
+import java.util.IdentityHashMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import nextflow.script.ast.ASTNodeMarker;
+import nextflow.script.ast.ProcessNode;
+import nextflow.script.ast.ScriptNode;
+import nextflow.script.ast.WorkflowNode;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ * Collect call sites for each workflow in a script.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class CallSiteCollector {
+
+    public Map<WorkflowNode, Map<String, MethodNode>> apply(SourceUnit source) {
+        var callSites = new IdentityHashMap<WorkflowNode, Map<String, MethodNode>>();
+        if( source.getAST() instanceof ScriptNode sn ) {
+            for ( var wn : sn.getWorkflows() )
+                callSites.put(wn, new WorkflowVisitor().apply(wn));
+        }
+        return callSites;
+    }
+
+    public class WorkflowVisitor extends CodeVisitorSupport {
+
+        private Map<String, MethodNode> calls;
+
+        public Map<String, MethodNode> apply(WorkflowNode node) {
+            calls = new HashMap<>();
+            visit(node.main);
+            visit(node.emits);
+            visit(node.publishers);
+            return calls;
+        }
+
+        @Override
+        public void visitMethodCallExpression(MethodCallExpression node) {
+            visit(node.getObjectExpression());
+            visit(node.getArguments());
+
+            if( node.isImplicitThis() ) {
+                var mn = (MethodNode) node.getNodeMetaData(ASTNodeMarker.METHOD_TARGET);
+                if( mn instanceof WorkflowNode || mn instanceof ProcessNode )
+                    calls.put(node.getMethodAsString(), mn);
+            }
+        }
+    }
+}

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ProcessNameResolver.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ProcessNameResolver.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.control;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import nextflow.script.ast.ProcessNode;
+import nextflow.script.ast.ScriptNode;
+import nextflow.script.ast.WorkflowNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ * Resolve all fully-qualified process names invoked
+ * (directly or indirectly) by an entry workflow.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class ProcessNameResolver {
+
+    private Map<WorkflowNode, Map<String, MethodNode>> callSites;
+
+    public ProcessNameResolver(Map<WorkflowNode, Map<String, MethodNode>> callSites) {
+        this.callSites = callSites;
+    }
+
+    public Set<String> resolve(SourceUnit main) {
+        var result = new HashSet<String>();
+        var queue = new LinkedList<CallScope>();
+
+        if( main.getAST() instanceof ScriptNode sn && sn.getEntry() != null )
+            queue.add(new CallScope("", sn.getEntry()));
+
+        while( !queue.isEmpty() ) {
+            var scope = queue.remove();
+            var calls = callSites.get(scope.node());
+            calls.forEach((name, mn) -> {
+                if( mn instanceof WorkflowNode wn ) {
+                    var workflowName = fullyQualifiedName(scope.name(), name);
+                    queue.add(new CallScope(workflowName, wn));
+                }
+                else if( mn instanceof ProcessNode pn ) {
+                    var processName = fullyQualifiedName(scope.name(), name);
+                    result.add(processName);
+                }
+            });
+        }
+
+        return result;
+    }
+
+    private String fullyQualifiedName(String scope, String name) {
+        return scope.isEmpty()
+            ? name
+            : scope + ":" + name;
+    }
+
+    private static record CallScope(
+        String name,
+        WorkflowNode node
+    ) {}
+}

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/FeatureFlagDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/FeatureFlagDsl.java
@@ -17,6 +17,7 @@ package nextflow.script.dsl;
 
 public class FeatureFlagDsl {
 
+    @Deprecated
     @FeatureFlag("nextflow.enable.configProcessNamesValidation")
     @Description("""
         When `true`, prints a warning for every `withName:` process selector that doesn't match a process in the pipeline (default: `true`).


### PR DESCRIPTION
This PR extends the strict parser to resolve fully-qualified process names via static analysis -- including conditional processes.

This should eliminate any false warnings when validating process selectors. Thus we can deprecate the `nextflow.enable.configProcessNamesValidation` feature flag and move towards requiring all feature flags to be defined in the script.