### PR TITLE
Improve Fusion license error message

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerFusionToken.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerFusionToken.groovy
@@ -107,7 +107,7 @@ class TowerFusionToken implements FusionToken {
         if( !endpoint )
             throw new IllegalArgumentException("Missing Seqera Platform endpoint")
         if( !accessToken )
-            throw new IllegalArgumentException("Missing Seqera Platform access token")
+            throw new IllegalArgumentException("A Seqera Platform access token is required to use Fusion -- see https://docs.seqera.io/fusion/licensing for more information")
     }
 
     /**


### PR DESCRIPTION
This PR clarifies the error message when a platform access token is not provided, that it is required when using Fusion, with a link to the licensing docs.

Consider also lowering this error to a warning, if not for `master`, at least for previous releases that were backported.