### PR TITLE
Reset terminal color after lint success/failure message

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ErrorListener.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ErrorListener.groovy
@@ -237,13 +237,13 @@ class StandardErrorListener implements ErrorListener {
             term.newline()
         term.bold().a("Nextflow linting complete!").reset().newline()
         if( summary.filesWithErrors > 0 ) {
-            term.fg(Ansi.Color.RED).a(" ❌ ${summary.filesWithErrors} file${summary.filesWithErrors==1 ? '' : 's'} had ${summary.errors} error${summary.errors==1 ? '' : 's'}").newline()
+            term.fg(Ansi.Color.RED).a(" ❌ ${summary.filesWithErrors} file${summary.filesWithErrors==1 ? '' : 's'} had ${summary.errors} error${summary.errors==1 ? '' : 's'}").reset().newline()
         }
         if( summary.filesWithoutErrors > 0 ) {
             term.fg(Ansi.Color.GREEN).a(" ✅ ${summary.filesWithoutErrors} file${summary.filesWithoutErrors==1 ? '' : 's'} had no errors")
             if( summary.filesFormatted > 0 )
                 term.fg(Ansi.Color.BLUE).a(" (${summary.filesFormatted} formatted)")
-            term.newline()
+            term.reset().newline()
         }
         if( summary.filesWithErrors == 0 && summary.filesWithoutErrors == 0 ) {
             term.a(" No files found to process").newline()


### PR DESCRIPTION
This is a suggested fix for #6127 

I have not managed to build and test this with Gradle just yet, but seems it should work based on surrounding code, which does append the `.reset()` after changing color.