### PR TITLE
Check for duplicate process/workflow calls in strict syntax

### DIFF
--- a/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
@@ -256,6 +256,28 @@ class ScriptResolveTest extends Specification {
         errors[0].getStartLine() == 10
         errors[0].getStartColumn() == 9
         errors[0].getOriginalMessage() == 'Processes cannot be called from within a closure'
+
+        when:
+        errors = check(
+            '''\
+            process hello {
+                script:
+                """
+                echo hello
+                """
+            }
+
+            workflow {
+                hello()
+                hello()
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 10
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == 'Process `hello` cannot be called more than once in the same workflow -- use an alias instead'
     }
 
     def 'should report an error for an invalid workflow invocation' () {
@@ -294,6 +316,24 @@ class ScriptResolveTest extends Specification {
         errors[0].getStartLine() == 6
         errors[0].getStartColumn() == 9
         errors[0].getOriginalMessage() == 'Workflows cannot be called from within a closure'
+
+        when:
+        errors = check(
+            '''\
+            workflow hello {
+            }
+
+            workflow {
+                hello()
+                hello()
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 6
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == 'Workflow `hello` cannot be called more than once in the same workflow -- use an alias instead'
     }
 
 }


### PR DESCRIPTION
This PR adds the check for duplicate process/workflow calls to the strict syntax.

Currently the check is performed at runtime:

https://github.com/nextflow-io/nextflow/blob/6f6a4cd22a275ddfba062090aaf9401e96d313da/modules/nextflow/src/main/groovy/nextflow/script/BindableDef.groovy#L43-L47

With the strict syntax, we can now catch this error much earlier at compile-time.

It looks like the runtime check only applies to duplicate process calls. There is no equivalent check for duplicate workflow calls, but I believe there should be, since duplicate workflows would lead to processes with the same fully-qualified name.