### PR TITLE
Fix CSV writer with empty list

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/util/CsvWriterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/CsvWriterTest.groovy
@@ -38,4 +38,21 @@ class CsvWriterTest extends Specification {
             '''.stripIndent()
     }
 
+    def 'should write empty csv file'() {
+        given:
+        def file = TestHelper.createInMemTempFile()
+        and:
+        def records = []
+
+        when:
+        new CsvWriter([:]).apply(records, file)
+        then:
+        file.text == ''
+
+        when:
+        new CsvWriter([header: true]).apply(records, file)
+        then:
+        file.text == ''
+    }
+
 }


### PR DESCRIPTION
This PR fixes a bug with the CSV writer which happens when the list of records is empty.

In this case, it should simply write an empty index file.