### PR TITLE
Add -template option to plugin create command

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
@@ -48,6 +48,9 @@ class CmdPlugin extends CmdBase {
 
     @Parameter(hidden = true)
     List<String> args
+    
+    @Parameter(names = ['-template'], description = 'Plugin template version to use', hidden = true)
+    String templateVersion = 'v0.3.0'
 
     @Override
     void run() {
@@ -64,7 +67,7 @@ class CmdPlugin extends CmdBase {
             Plugins.pull(args[1].tokenize(','))
         }
         else if( args[0] == 'create' ) {
-            createPlugin(args)
+            createPlugin(args, templateVersion)
         }
         // plugin run command
         else if( args[0].contains(CMD_SEP) ) {
@@ -98,14 +101,14 @@ class CmdPlugin extends CmdBase {
         }
     }
 
-    static createPlugin(List<String> args) {
+    static createPlugin(List<String> args, String templateVersion) {
         if( args != ['create'] && (args[0] != 'create' || !(args.size() in [3, 4])) )
-            throw new AbortOperationException("Invalid create parameters - usage: nextflow plugin create <Plugin name> <Organization name>")
+            throw new AbortOperationException("Invalid create parameters - usage: nextflow plugin create <Plugin name> <Provider name>")
 
         final refactor = new PluginRefactor()
         if( args.size()>1 ) {
             refactor.withPluginName(args[1])
-            refactor.withOrgName(args[2])
+            refactor.withProviderName(args[2])
             refactor.withPluginDir(Path.of(args[3] ?: refactor.pluginName).toFile())
         }
         else {
@@ -113,11 +116,11 @@ class CmdPlugin extends CmdBase {
             print "Enter plugin name: "
             refactor.withPluginName(readLine())
 
-            // Prompt for maintainer organization
-            print "Enter organization: "
+            // Prompt for provider name
+            print "Enter provider name: "
+            refactor.withProviderName(readLine())
 
-            // Prompt for plugin path (default to the normalised plugin name)
-            refactor.withOrgName(readLine())
+            // Prompt for project path (default to the normalised plugin name)
             print "Enter project path [${refactor.pluginName}]: "
             refactor.withPluginDir(Path.of(readLine() ?: refactor.pluginName).toFile())
 
@@ -132,7 +135,7 @@ class CmdPlugin extends CmdBase {
         final File targetDir = refactor.getPluginDir()
 
         // clone the template repo
-        clonePluginTemplate(targetDir)
+        clonePluginTemplate(targetDir, templateVersion)
         // now refactor the template code
         refactor.apply()
         // remove git plat
@@ -148,15 +151,25 @@ class CmdPlugin extends CmdBase {
             : new BufferedReader(new InputStreamReader(System.in)).readLine()
     }
 
-    static private void clonePluginTemplate(File targetDir) {
+    static private void clonePluginTemplate(File targetDir, String templateVersion) {
         final templateUri = "https://github.com/nextflow-io/nf-plugin-template.git"
+        final isTag = templateVersion.startsWith('v')
+        final refSpec = isTag ? "refs/tags/$templateVersion".toString() : templateVersion
+        
         try {
-            Git.cloneRepository()
+            final gitCmd = Git.cloneRepository()
                 .setURI(templateUri)
                 .setDirectory(targetDir)
-                .setBranchesToClone(["refs/tags/v0.2.0"])
-                .setBranch("refs/tags/v0.2.0")
-                .call()
+            
+            if (isTag) {
+                gitCmd.setBranchesToClone([refSpec])
+                gitCmd.setBranch(refSpec)
+            } else {
+                // For branches, let Git handle the default behavior
+                gitCmd.setBranch(templateVersion)
+            }
+            
+            gitCmd.call()
         }
         catch (Exception e) {
             throw new AbortOperationException("Unable to clone pluging template repository - cause: ${e.message}")

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdPluginCreateTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdPluginCreateTest.groovy
@@ -40,7 +40,7 @@ class CmdPluginCreateTest extends Specification {
         def args = [
             'create',
             'hello world plugin',
-            'foo',
+            'Foo',
             folder.toAbsolutePath().toString() + '/hello']
 
         when:
@@ -58,7 +58,7 @@ class CmdPluginCreateTest extends Specification {
         Files.exists(folder.resolve('hello/src/test/groovy/foo/plugin/HelloWorldObserverTest.groovy'))
         and:
         Path.of(folder.resolve('hello/settings.gradle').toUri()).text.contains("rootProject.name = 'hello-world-plugin'")
-        Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("provider = 'foo'")
+        Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("provider = 'Foo'")
         Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("className = 'foo.plugin.HelloWorldPlugin'")
         Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("'foo.plugin.HelloWorldExtension'")
         Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("'foo.plugin.HelloWorldFactory'")

--- a/modules/nf-commons/src/test/nextflow/plugin/util/PluginRefactorTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/util/PluginRefactorTest.groovy
@@ -40,6 +40,10 @@ class PluginRefactorTest extends Specification {
         "   mixed---separators___"      || "MixedSeparators"
         "alreadyPascalCase"             || "AlreadyPascalCase"
         "foo-plugin"                    || "Foo"
+        "nf-hello"                      || "Hello"
+        "nf-my-plugin"                  || "My"
+        "NfHelloWorld"                  || "HelloWorld"
+        "my-nf-plugin"                  || "MyNf"
     }
 
     def "should normalize strings into kebab-case names"() {


### PR DESCRIPTION
## Summary
- Add hidden `-template` CLI option to `nextflow plugin create` command for specifying template version
- Support both Git tags (starting with 'v') and branches for template selection  
- Default template version set to `v0.3.0`
- Improve `PluginRefactor.normalizeToClassName()` to remove 'Nf' prefix from class names
- Add comprehensive test coverage for the new functionality

## Changes Made
1. **CmdPlugin.groovy**: Added `-template` parameter with logic to handle tags vs branches
2. **PluginRefactor.groovy**: Updated `normalizeToClassName()` to remove 'Nf' prefix only (not anywhere in string)
3. **Test Coverage**: Added test cases validating prefix removal behavior

## Test plan
- [x] Existing tests pass
- [x] New test cases validate 'Nf' prefix removal logic
- [x] Code compiles successfully
- [x] Git clone logic handles both tags and branches appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)