### PR TITLE
Add support for Bitbucket API tokens instead of access tokens

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/BitbucketRepositoryProvider.groovy
@@ -19,6 +19,9 @@ package nextflow.scm
 import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
 import nextflow.exception.AbortOperationException
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+
 /**
  * Implements a repository provider for the BitBucket service
  *
@@ -41,19 +44,28 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
 
     @Override
     protected String[] getAuth() {
-        return config.token
-            ? new String[] { "Authorization", "Bearer ${config.token}" }
-            : super.getAuth()
+        if (!hasCredentials()) {
+            return null
+        }
+
+        String secret = getPassword() ?: getToken()
+        String authString = "${getUser()}:${secret}".bytes.encodeBase64().toString()
+
+        return new String[] { "Authorization", "Basic " + authString }
     }
 
     @Override
     boolean hasCredentials() {
-        return getToken()
-            ? true
-            : super.hasCredentials()
+        return getUser() && (getPassword() || getToken())
     }
 
-   /** {@inheritDoc} */
+    /** {@inheritDoc} */
+    @Override
+    CredentialsProvider getGitCredentials() {
+        return new UsernamePasswordCredentialsProvider(getUser(), getPassword() ?: getToken())
+    }
+
+    /** {@inheritDoc} */
     @Override
     String getName() { "BitBucket" }
 
@@ -163,7 +175,12 @@ final class BitbucketRepositoryProvider extends RepositoryProvider {
         if( !result )
             throw new IllegalStateException("Missing clone URL for: $project")
 
-        return result.href
+        /**
+         * The clone URL when an API token is used is of the form: https://{bitbucket_username}:{api_token}@bitbucket.org/{workspace}/{repository}.git
+         * @see <a href="https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/">Using API tokens</a>
+         */
+        String cloneUrl = result.href
+        return getToken() ? cloneUrl.replace('@', ":${getToken()}@") : cloneUrl
     }
 
     @Override

--- a/modules/nextflow/src/test/groovy/nextflow/scm/BitbucketRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/BitbucketRepositoryProviderTest.groovy
@@ -36,7 +36,7 @@ class BitbucketRepositoryProviderTest extends Specification {
         when:
         def url = new BitbucketRepositoryProvider('pditommaso/tutorial',config).getCloneUrl()
         then:
-        url ==~ /https:\/\/\w+@bitbucket.org\/pditommaso\/tutorial.git/
+        url ==~ /https:\/\/.+@bitbucket.org\/pditommaso\/tutorial.git/
     }
 
     def testGetHomePage() {
@@ -182,11 +182,13 @@ class BitbucketRepositoryProviderTest extends Specification {
         provider.hasCredentials() == EXPECTED
 
         where:
-        EXPECTED    | CONFIG
-        false       | new ProviderConfig('bitbucket')
-        false       | new ProviderConfig('bitbucket').setUser('foo')
-        true        | new ProviderConfig('bitbucket').setUser('foo').setPassword('bar')
-        true        | new ProviderConfig('bitbucket').setToken('xyz')
+        EXPECTED | CONFIG
+        false    | new ProviderConfig('bitbucket')
+        false    | new ProviderConfig('bitbucket').setUser('foo')
+        false    | new ProviderConfig('bitbucket').setToken('xyz')
+        true     | new ProviderConfig('bitbucket').setUser('foo').setPassword('bar')
+        true     | new ProviderConfig('bitbucket').setUser('foo').setToken('xyz')
+        true     | new ProviderConfig('bitbucket').setUser('foo').setPassword('bar').setToken('xyz')
     }
 
     @Unroll
@@ -198,9 +200,9 @@ class BitbucketRepositoryProviderTest extends Specification {
         provider.getAuth() == EXPECTED as String[]
 
         where:
-        EXPECTED                                                        | CONFIG
-        null                                                            | new ProviderConfig('bitbucket')
-        ["Authorization", "Bearer xyz"]                                 | new ProviderConfig('bitbucket').setToken('xyz')
-        ["Authorization", "Basic ${"foo:bar".bytes.encodeBase64()}"]    | new ProviderConfig('bitbucket').setUser('foo').setPassword('bar')
+        EXPECTED                                                                 | CONFIG
+        null                                                                     | new ProviderConfig('bitbucket')
+        ["Authorization", "Basic ${"foo:bar".bytes.encodeBase64()}"]             | new ProviderConfig('bitbucket').setUser('foo').setPassword('bar')
+        ["Authorization", "Basic ${"foo@nextflow.io:xyz".bytes.encodeBase64()}"] | new ProviderConfig('bitbucket').setUser('foo@nextflow.io').setToken('xyz')
     }
 }


### PR DESCRIPTION
## Description

In https://github.com/nextflow-io/nextflow/pull/6209, it turns out I mixed up Bitbucket [access tokens](https://support.atlassian.com/bitbucket-cloud/docs/access-tokens/) with Bitbucket [API tokens](https://support.atlassian.com/bitbucket-cloud/docs/api-tokens/). API tokens are the chosen replacement for [app passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/), which cannot longer be created starting from [2025-09-09](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation).

This PR adds actual support for API tokens instead of access tokens. Using access tokens, operations such as contacting the REST API were working correctly, but others such as cloning a repository weren't.

### Guidelines for testing

- In bitbucket.org, create a private Nextflow pipeline repository.
- Create an API token ("Atlassian Account settings > Security tab > Create and manage API Tokens") and an app password ("Personal Bitbucket settings > App passwords > Create app password").
- In your local computer, create a SCM config file (`scm_token.config`) with the following contents for API token authentication:
```
providers {
    bitbucket {
        user = '<email>'
        token = '<API token>'
    }
}
```
- Run the pipeline; the repository is cloned correctly:
```
export NXF_SCM_FILE="$HOME/scm_token.config"
nextflow run https://bitbucket.org/<workspace>/<repo>
```
- In your local computer, create a SCM config file (`scm_pass.config`) with the following contents for app password authentication:
```
providers {
    bitbucket {
        user = '<username>'
        password = '<app password>'
    }
}
```
- Run the pipeline, the app password method keeps working correctly:
```
rm -rf ~/.nextflow/assets # Remove directory to make sure the repo is not fetched from local assets
export NXF_SCM_FILE="$HOME/scm_pass.config"
nextflow run https://bitbucket.org/<workspace>/<repo>
```