### PR TITLE
Update Azure and AWS deps

### DIFF
--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -58,9 +58,9 @@ dependencies {
     }
 
     // address security vulnerabilities
-    runtimeOnly 'io.netty:netty-common:4.1.124.Final'
-    runtimeOnly 'io.netty:netty-handler:4.1.124.Final'
-    runtimeOnly 'io.netty:netty-codec-http2:4.1.124.Final'
+    implementation 'io.netty:netty-common:4.1.124.Final'
+    implementation 'io.netty:netty-handler:4.1.124.Final'
+    implementation 'io.netty:netty-codec-http2:4.1.124.Final'
     
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')

--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -36,21 +36,21 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.12.0'
-    api('com.azure:azure-storage-blob:12.29.0') {
+    api('com.azure:azure-storage-blob:12.31.1') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     api('com.azure:azure-compute-batch:1.0.0-beta.3') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'com.google.guava', module: 'guava'
     }
-    api('com.azure:azure-identity:1.15.1') {
+    api('com.azure:azure-identity:1.17.0') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
 
     // address security vulnerabilities
-    runtimeOnly 'io.netty:netty-handler:4.1.124.Final'
-    runtimeOnly 'io.netty:netty-codec-http2:4.1.124.Final'
-    runtimeOnly 'net.minidev:json-smart:2.5.2'
+    implementation 'io.netty:netty-handler:4.1.124.Final'
+    implementation 'io.netty:netty-codec-http2:4.1.124.Final'
+    implementation 'net.minidev:json-smart:2.5.2'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')


### PR DESCRIPTION
This pull request updates dependency management for the Amazon and Azure plugins to address security vulnerabilities and ensure compatibility with newer library versions. The most important changes are grouped below:

**Dependency Updates for Azure Plugin:**

* Upgraded `com.azure:azure-storage-blob` from version 12.29.0 to 12.31.1 to include bug fixes and improvements.
* Upgraded `com.azure:azure-identity` from version 1.15.1 to 1.17.0 for enhanced authentication features and security patches.

**Security and Dependency Configuration:**

* Changed `io.netty` and `json-smart` dependencies from `runtimeOnly` to `implementation` in both `nf-amazon` and `nf-azure` plugins to ensure they are available at both compile and runtime, addressing security vulnerabilities. [[1]](diffhunk://#diff-5d1f75e6481b45584e9d20603122c206926aa56081a91b44fb7b5d8ba4f34f49L61-R63) [[2]](diffhunk://#diff-95b2798f38789220a95e2ab92e514dc2c67bed6336710bc0f511a9c48f18eac7L39-R53)