### PR TITLE
Use Managed Identities with Azure to download and upload files

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -35,8 +35,10 @@ import com.azure.compute.batch.models.BatchJobCreateContent
 import com.azure.compute.batch.models.BatchJobConstraints
 import com.azure.compute.batch.models.BatchJobUpdateContent
 import com.azure.compute.batch.models.BatchNodeFillType
+import com.azure.compute.batch.models.BatchNodeIdentityReference
 import com.azure.compute.batch.models.BatchPool
 import com.azure.compute.batch.models.BatchPoolCreateContent
+import com.azure.compute.batch.models.BatchPoolIdentity
 import com.azure.compute.batch.models.BatchPoolInfo
 import com.azure.compute.batch.models.BatchPoolState
 import com.azure.compute.batch.models.BatchStartTask
@@ -60,6 +62,7 @@ import com.azure.compute.batch.models.OutputFileDestination
 import com.azure.compute.batch.models.OutputFileUploadCondition
 import com.azure.compute.batch.models.OutputFileUploadConfig
 import com.azure.compute.batch.models.ResourceFile
+import com.azure.compute.batch.models.UserAssignedIdentity
 import com.azure.compute.batch.models.UserIdentity
 import com.azure.compute.batch.models.VirtualMachineConfiguration
 import com.azure.core.credential.AzureNamedKeyCredential
@@ -113,6 +116,8 @@ class AzBatchService implements Closeable {
     static private final long _1GB = 1 << 30
 
     static final private Map<String,AzVmPoolSpec> allPools = new HashMap<>(50)
+    
+    static final private Map<String,String> poolManagedIdentityIds = new HashMap<>(50)
 
     AzConfig config
 
@@ -474,6 +479,7 @@ class AzBatchService implements Closeable {
         assert jobId, 'Missing Azure Batch jobId argument'
         assert task, 'Missing Azure Batch task argument'
 
+        // SAS token is always required for output file uploads via azcopy
         final sas = config.storage().sasToken
         if( !sas )
             throw new IllegalArgumentException("Missing Azure Blob storage SAS token")
@@ -545,10 +551,19 @@ class AzBatchService implements Closeable {
         final constraints = taskConstraints(task)
 
         log.trace "[AZURE BATCH] Submitting task: $taskId, cpus=${task.config.getCpus()}, mem=${task.config.getMemory()?:'-'}, slots: $slots"
+        
+        // Check if we should use managed identity and identify the resource ID (ARM)
+        final poolIdentityClientId = config.batch().poolIdentityClientId
+        final poolManagedIdentityResourceId = poolIdentityClientId ? getPoolManagedIdentityResourceId(poolId, poolIdentityClientId) : null
+        if( poolIdentityClientId && !poolManagedIdentityResourceId ) {
+            // Throw a warning if we are trying to use managed identity and can't locate it on the pool
+            log.warn "[AZURE BATCH] No managed identity found for pool '$poolId' with client ID '${poolIdentityClientId}'. Falling back to SAS token authentication."
+        }
+        
         return new BatchTaskCreateContent(taskId, cmd)
                 .setUserIdentity(userIdentity(pool.opts.privileged, pool.opts.runAs, AutoUserScope.TASK))
                 .setContainerSettings(containerOpts)
-                .setResourceFiles(resourceFileUrls(task, sas))
+                .setResourceFiles(resourceFileUrls(task, poolManagedIdentityResourceId, sas))
                 .setOutputFiles(outputFileUrls(task, sas))
                 .setRequiredSlots(slots)
                 .setConstraints(constraints)
@@ -591,7 +606,7 @@ class AzBatchService implements Closeable {
         return result
     }
 
-    protected List<ResourceFile> resourceFileUrls(TaskRun task, String sas) {
+    protected List<ResourceFile> resourceFileUrls(TaskRun task, String poolManagedIdentityResourceId, String sas) {
         final cmdRun = (AzPath) task.workDir.resolve(TaskRun.CMD_RUN)
         final cmdScript = (AzPath) task.workDir.resolve(TaskRun.CMD_SCRIPT)
 
@@ -604,18 +619,49 @@ class AzBatchService implements Closeable {
                     .setFilePath('.nextflow-bin/azcopy')
         }
 
-        resFiles << new ResourceFile()
-                .setHttpUrl(AzHelper.toHttpUrl(cmdRun, sas))
-                .setFilePath(TaskRun.CMD_RUN)
+        // Create resource files with or without managed identity
+        if( poolManagedIdentityResourceId ) {
+            // When using managed identity, create BatchNodeIdentityReference
+            // For pool-level managed identity, we create an empty reference which will use the pool's identity
+            // The poolIdentityClientId configuration ensures the pool has been configured with a managed identity
+            // Azure Batch will automatically use that identity when downloading these resource files
+            // Create identity reference with the resource ID from the pool
+            final identityRef = new BatchNodeIdentityReference()
+                    .setResourceId(poolManagedIdentityResourceId)
+            log.debug "[AZURE BATCH] Using managed identity with resource ID: ${poolManagedIdentityResourceId}"
+            
+            resFiles << new ResourceFile()
+                    .setHttpUrl(AzHelper.toHttpUrl(cmdRun, null))
+                    .setFilePath(TaskRun.CMD_RUN)
+                    .setIdentityReference(identityRef)
 
-        resFiles << new ResourceFile()
-                .setHttpUrl(AzHelper.toHttpUrl(cmdScript, sas))
-                .setFilePath(TaskRun.CMD_SCRIPT)
+            resFiles << new ResourceFile()
+                    .setHttpUrl(AzHelper.toHttpUrl(cmdScript, null))
+                    .setFilePath(TaskRun.CMD_SCRIPT)
+                    .setIdentityReference(identityRef)
 
-        if( task.stdin ) {
+            if( task.stdin ) {
+                resFiles << new ResourceFile()
+                        .setHttpUrl(AzHelper.toHttpUrl(cmdScript, null))
+                        .setFilePath(TaskRun.CMD_INFILE)
+                        .setIdentityReference(identityRef)
+            }
+        }
+        else {
+            // Use traditional SAS token approach
+            resFiles << new ResourceFile()
+                    .setHttpUrl(AzHelper.toHttpUrl(cmdRun, sas))
+                    .setFilePath(TaskRun.CMD_RUN)
+
             resFiles << new ResourceFile()
                     .setHttpUrl(AzHelper.toHttpUrl(cmdScript, sas))
-                    .setFilePath(TaskRun.CMD_INFILE)
+                    .setFilePath(TaskRun.CMD_SCRIPT)
+
+            if( task.stdin ) {
+                resFiles << new ResourceFile()
+                        .setHttpUrl(AzHelper.toHttpUrl(cmdScript, sas))
+                        .setFilePath(TaskRun.CMD_INFILE)
+            }
         }
 
         return resFiles
@@ -742,6 +788,60 @@ class AzBatchService implements Closeable {
                 ? specFromPoolConfig(poolId)
                 : specFromAutoPool(task)
 
+    }
+
+    /**
+     * Get the managed identity resource ID from the pool if available
+     * @param poolId The pool ID to check
+     * @param poolIdentityClientId Can be 'auto', a specific client ID, null or false
+     * @return The resource ID of the managed identity, or null if not found/configured
+     */
+    protected String getPoolManagedIdentityResourceId(String poolId, poolIdentityClientId) {
+        // If poolIdentityClientId is null or false, return null
+        if( !poolIdentityClientId ) {
+            return null
+        }
+        
+
+        // TODO: Should we throw an error if we can't find the identity attached to the pool?
+
+        try {
+            def pool = getPool(poolId)
+            if( !pool?.identity ) {
+                return null
+            }
+            
+            def poolIdentity = pool.identity as BatchPoolIdentity
+            List<UserAssignedIdentity> identities = poolIdentity?.getUserAssignedIdentities()
+            
+            if( !identities || identities.isEmpty() ) {
+                return null
+            }
+            
+            // Handle 'auto' - use the first available identity
+            if( poolIdentityClientId == 'auto' || poolIdentityClientId == true ) {
+                def firstIdentity = identities.first()
+                log.debug "[AZURE BATCH] Using managed identity for pool '$poolId'"
+                return firstIdentity.getResourceId()
+            }
+            
+            // Handle specific client ID
+            if( poolIdentityClientId instanceof String ) {
+                def matchingIdentity = identities.find { it.getClientId() == poolIdentityClientId }
+                if( matchingIdentity ) {
+                    log.debug "[AZURE BATCH] Found managed identity for pool '$poolId'"
+                    return matchingIdentity.getResourceId()
+                }
+                return null
+            }
+            
+            // Unsupported type
+            return null
+        }
+        catch( Exception e ) {
+            log.debug "[AZURE BATCH] Error getting managed identity for pool '$poolId': ${e.message}"
+            return null
+        }
     }
 
     synchronized String getOrCreatePool(TaskRun task) {
@@ -1108,3 +1208,4 @@ class AzBatchService implements Closeable {
         return Failsafe.with(policy).get(action)
     }
 }
+


### PR DESCRIPTION
feat: Use Azure Managed identities to download and upload files

When using Managed Identities on Azure Batch, Nextflow still needed to generate a SAS token for the auxiliary files such as the .command.* files. This PR removes that requirement and means Nextflow only uses the managed identity attached to the machine.

It does this by changing the resource file and output properties of the task from a normal URL including a SAS to a URL without a SAS, and configuring the Managed Identity resource ID (ARM) as the authentication.

To do this, we have to perform an additional step where we fetch the resource ID of the managed identity by querying the node pool for available identities and matching them to the client ID. If one does not match, we use the first one as a best guess. Most users should specify a single managed ID or a specific one by client ID, so I think this should be sufficient.

This improves security for Azure Batch and allows users to switch off the ability to create SAS tokens, opening up the use of Nextflow to environments with increased security.
