### PR TITLE
Preserve method parameter names in nf-lang JAR

### DIFF
--- a/modules/nf-lang/build.gradle
+++ b/modules/nf-lang/build.gradle
@@ -17,6 +17,10 @@ plugins {
   id 'antlr'
 }
 
+compileJava {
+  options.compilerArgs << '-parameters' 
+}
+
 dependencies {
   antlr 'me.sunlan:antlr4:4.13.2.6'
   api 'org.apache.groovy:groovy:4.0.28'


### PR DESCRIPTION
This PR adds a compiler flag to nf-lang that preserves the names of method parameters in the JAR, so that the language server can render tooltips for built-in definitions (e.g. ScriptDsl, ChannelNamespace).

Required by https://github.com/nextflow-io/language-server/pull/139 . Unit tests are in that PR