### PR TITLE
Clarify fusion.exportStorageCredentials behavior [ci skip]

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -844,7 +844,23 @@ The following settings are available:
 : Enable the Fusion file system (default: `false`).
 
 `fusion.exportStorageCredentials`
-: Export the access credentials required by the underlying object storage to the task execution environment (default: `false`).
+: Export the access credentials required by the underlying object storage as environment variables to the task execution environment (default: `false`).
+
+  When enabled, this option exports cloud storage credentials as environment variables (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` for AWS S3) to tasks.
+
+  :::{note}
+  This option only exports environment variables. It does not mount or provide access to credential files such as `~/.aws/credentials`, `~/.aws/config`, or SSO cache files.
+
+  For users authenticated via AWS SSO (`aws sso login`), you must first export your credentials to environment variables before running Nextflow:
+  
+  ```bash
+  # Export SSO credentials to environment variables
+  eval "$(aws configure export-credentials --format env)"
+  
+  # Then run Nextflow with exportStorageCredentials enabled
+  nextflow run pipeline.nf -c config.nf
+  ```
+  :::
 
 `fusion.logLevel`
 : The log level of the Fusion client.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -847,16 +847,10 @@ The following settings are available:
 : Export access credentials required by the underlying object storage as environment variables (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` for AWS S3) to task execution environments (default: `false`).
 
   :::{note}
-  This option only exports environment variables. It does not mount or provide access to credential files such as `~/.aws/credentials`, `~/.aws/config`, or SSO cache files.
-
-  For users authenticated via AWS SSO (`aws sso login`), you must first export your credentials to environment variables before running Nextflow:
+  This configuration does not mount or provide access to credential files. For example, AWS credentials like `~/.aws/credentials`, `~/.aws/config`, and SSO cache files are not mounted. AWS SSO users must export credentials to environment variables:
   
   ```bash
-  # Export SSO credentials to environment variables
   eval "$(aws configure export-credentials --format env)"
-  
-  # Then run Nextflow with exportStorageCredentials enabled
-  nextflow run pipeline.nf -c config.nf
   ```
   :::
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -844,9 +844,7 @@ The following settings are available:
 : Enable the Fusion file system (default: `false`).
 
 `fusion.exportStorageCredentials`
-: Export the access credentials required by the underlying object storage as environment variables to the task execution environment (default: `false`).
-
-  When enabled, this option exports cloud storage credentials as environment variables (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` for AWS S3) to tasks.
+: Export access credentials required by the underlying object storage as environment variables (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` for AWS S3) to task execution environments (default: `false`).
 
   :::{note}
   This option only exports environment variables. It does not mount or provide access to credential files such as `~/.aws/credentials`, `~/.aws/config`, or SSO cache files.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -854,6 +854,10 @@ The following settings are available:
   ```
   :::
 
+  :::{warn}
+  This option leaks credentials is the task launcher script. It should only be used for testing and development purposes.
+  :::
+
 `fusion.logLevel`
 : The log level of the Fusion client.
 


### PR DESCRIPTION
- Specify that only environment variables are exported, not credential files
- Add guidance for AWS SSO users to export credentials manually
- Include example command for aws configure export-credentials