### PR TITLE
Add Value type for dataflow values (value channels)

### DIFF
--- a/docs/channel.md
+++ b/docs/channel.md
@@ -1,54 +1,30 @@
-(channel-page)=
+(dataflow-page)=
 
-# Channels
+# Dataflow
 
-In Nextflow, **channels** are the key data structures that facilitate the dataflow dependencies between each step (i.e. {ref}`process <process-page>`) in a pipeline.
+Nextflow uses a **dataflow** programming model to define workflows in a declarative manner. {ref}`Processes <process-page>` in a pipeline are connected to each other by *dataflow channels* and *dataflow values*.
 
-There are two kinds of channels, *queue channels* and *value channels*. Channels are created using *channel factories* and transformed using *channel operators*.
+(dataflow-type-channel)=
 
-(channel-type-queue)=
+## Channels
 
-## Queue channels
+A *dataflow channel*, or *channel* for short, is an asynchronous sequence of values.
 
-A *queue channel* is a channel that *emits* an asynchronous sequence of values.
-
-A queue channel can be created by channel factories (e.g., {ref}`channel.of <channel-of>` and {ref}`channel.fromPath <channel-path>`), operators (e.g., {ref}`operator-map` and  {ref}`operator-filter`), and processes (see {ref}`Process outputs <process-output>`).
-
-The values in a queue channel cannot be accessed directly -- they can only be accessed by passing the channel as input to an operator or process. For example:
+The values in a channel cannot be accessed directly -- they can only be accessed by passing the channel as input to an operator or process. For example:
 
 ```nextflow
-channel.of(1, 2, 3).view { v -> "queue channel emits ${v}" }
+channel.of(1, 2, 3).view { v -> "channel emits ${v}" }
 ```
 
 ```console
-queue channel emits 1
-queue channel emits 2
-queue channel emits 3
+channel emits 1
+channel emits 2
+channel emits 3
 ```
 
-(channel-type-value)=
+### Factories
 
-## Value channels
-
-A *value channel* is a channel that is *bound* to an asynchronous value.
-
-A value channel can be created with the {ref}`channel.value <channel-value>` factory, certain operators (e.g., {ref}`operator-collect` and {ref}`operator-reduce`), and processes (under {ref}`certain conditions <process-out-singleton>`).
-
-The value in a value channel cannot be accessed directly -- it can only be accessed by passing the channel as input to an operator or process. For example:
-
-```nextflow
-channel.value(1).view { v -> "value channel is ${v}" }
-```
-
-```console
-value channel is 1
-```
-
-## Channel factories
-
-Channel factories are functions that create channels from regular values.
-
-The `channel.fromPath()` factory creates a channel from a file name or glob pattern, similar to the `files()` function:
+A channel can be created by factories in the `channel` namespace. For example, the `channel.fromPath()` factory creates a channel from a file name or glob pattern, similar to the `files()` function:
 
 ```nextflow
 channel.fromPath('input/*.txt').view()
@@ -56,7 +32,7 @@ channel.fromPath('input/*.txt').view()
 
 See {ref}`channel-factory` for the full list of channel factories.
 
-## Operators
+### Operators
 
 Channel operators, or *operators* for short, are functions that consume and produce channels. Because channels are asynchronous, operators are necessary to manipulate the values in a channel. Operators are particularly useful for implementing glue logic between processes.
 
@@ -81,3 +57,23 @@ Commonly used operators include:
 - {ref}`operator-view`: print each value in a channel to standard output
 
 See {ref}`operator-page` for the full list of operators.
+
+(dataflow-type-value)=
+
+## Values
+
+A *dataflow value* is an asynchronous value.
+
+A dataflow value can be created with the {ref}`channel.value <channel-value>` factory, or by a process (under {ref}`certain conditions <process-out-singleton>`).
+
+The value in a dataflow value cannot be accessed directly -- it can only be accessed by passing the channel as input to an operator or process. For example:
+
+```nextflow
+channel.value(1).view { v -> "dataflow value is ${v}" }
+```
+
+```console
+dataflow value is 1
+```
+
+See {ref}`stdlib-types-value` for the set of available methods for dataflow values.

--- a/docs/developer/nextflow.md
+++ b/docs/developer/nextflow.md
@@ -16,6 +16,6 @@ Some classes may be excluded from the above diagram for brevity.
 
 The `Nextflow` class implements several methods that are exposed to Nextflow scripts. See {ref}`stdlib-namespaces-global` for details.
 
-The `Channel` class implements the channel factory methods, and it is exposed directly to Nextflow scripts. See {ref}`channel-page` for details.
+The `Channel` class implements the channel factory methods, and it is exposed directly to Nextflow scripts. See {ref}`dataflow-page` for details.
 
 The `Session` class is the top-level representation of a Nextflow run, or "session". See [nextflow.script](nextflow.script.md) for more details about how a `Session` is created.

--- a/docs/migrations/24-04.md
+++ b/docs/migrations/24-04.md
@@ -8,7 +8,7 @@
 
 <h3>Topic channels (first preview)</h3>
 
-A topic channel is a queue channel that can receive values from multiple sources, based on a matching name or *topic*.
+A topic channel is a channel that can receive values from multiple sources, based on a matching name or *topic*.
 
 Topic channels are particularly useful for collecting metadata from various points in a pipeline without writing all of the channel logic that is normally required (e.g., using the `mix` operator).
 

--- a/docs/migrations/25-10.md
+++ b/docs/migrations/25-10.md
@@ -41,10 +41,10 @@ Type annotations are a way to denote the *type* of a variable. They help documen
 workflow RNASEQ {
   take:
   reads: Channel<Path>
-  index: Channel<Path>
+  index: Value<Path>
 
   main:
-  samples_ch = QUANT( reads.combine(index) )
+  samples_ch = QUANT( reads, index )
 
   emit:
   samples: Channel<Path> = samples_ch
@@ -71,6 +71,8 @@ Type annotations can be appended with `?` to denote that the value can be `null`
 ```nextflow
 def x_opt: String? = null
 ```
+
+Queue channels are represented in the type system as `Channel`, while value channels are represented as `Value`. As a result, the terminology for channels has been updated to be more clear and concise. Queue channels are now called *dataflow channels* (or *channels* for short) and value channels are now called *dataflow values*. See {ref}`dataflow-page` for more information.
 
 :::{note}
 Nextflow supports Groovy-style type annotations using the `<type> <name>` syntax, but this approach is deprecated in {ref}`strict syntax <strict-syntax-page>`. While Groovy-style annotations remain valid for functions and local variables, the language server and `nextflow lint` automatically convert them to Nextflow-style annotations during code formatting.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,13 +10,11 @@ The Nextflow language is inspired by [the Unix philosophy](https://en.wikipedia.
 
 The Nextflow runtime integrates with many popular execution platforms (HPC schedulers, cloud providers) and software tools (Git, Docker, Conda), allowing you to fully describe a computational pipeline with all of its dependencies and run it in nearly any environment -- write once, run anywhere.
 
-## Processes and channels
+## Processes and dataflow
 
 In practice a Nextflow pipeline script is made by joining together different processes. Each process can be written in any scripting language that can be executed by the Linux platform (Bash, Perl, Ruby, Python, etc.).
 
-Processes are executed independently and are isolated from each other, i.e. they do not share a common (writable) state. The only way they can communicate is via asynchronous FIFO queues, called *channels* in Nextflow.
-
-Any process can define one or more channels as *input* and *output*. The interaction between these processes, and ultimately the pipeline execution flow itself, is implicitly defined by these input and output declarations.
+A process can define one or more *inputs* and *outputs*. Data flows from process to process through asynchronous dataflow structures, known as *channels* and *values* in Nextflow. The data dependencies between these processes implicitly determines the flow of execution.
 
 A Nextflow script looks like this:
 
@@ -63,9 +61,9 @@ workflow {
 
 The above example defines two processes. Their execution order is not determined by the fact that the `blast_search` process comes before `extract_top_hits` in the script (it could also be written the other way around). Instead, execution order is determined by their _dependencies_ -- `extract_top_hits` depends on the output of `blast_search`, so `blast_search` will be executed first, and then `extract_top_hits`.
 
-When the workflow is started, it will create two processes and one channel (`query_ch`) and it will link all of them. Both processes will be started at the same time and they will listen to their respective input channels. Whenever `blast_search` emits a value, `extract_top_hits` will receive it (i.e. `extract_top_hits` consumes the channel in a *reactive* way).
+When the workflow is executed, it creates two processes (`blast_search` and `extract_top_hits`) connected by the channel `query_ch`. Each process executes a task and emits a value for each input that it receives. Whenever `blast_search` emits a value, `extract_top_hits` receives it through the `query_ch` channel.
 
-Read the {ref}`Channel <channel-page>` and {ref}`Process <process-page>` sections to learn more about these features.
+Read {ref}`process-page`, {ref}`dataflow-page`, and {ref}`workflow-page` to learn more about these features.
 
 ## Execution abstraction
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -312,7 +312,7 @@ This feature makes it easier to quickly prototype the workflow logic without usi
 
 ## Inputs
 
-The `input` section allows you to define the input channels of a process, similar to function arguments. A process may have at most one input section, which must contain at least one input declaration.
+The `input` section defines the input of a process, similar to function arguments. A process may have at most one input section, which must contain at least one input declaration.
 
 The input section follows the syntax shown below:
 
@@ -321,9 +321,9 @@ input:
   <input qualifier> <input name>
 ```
 
-An input definition consists of a *qualifier* and a *name*. The input qualifier defines the type of data to be received. This information is used by Nextflow to apply the semantic rules associated with each qualifier, and handle it properly depending on the target execution platform (grid, cloud, etc).
+An input declaration consists of a *qualifier* and a *name*. The input qualifier defines the type of data to be received. This information is used by Nextflow to apply the semantic rules associated with each qualifier, and handle it properly depending on the target execution platform (grid, cloud, etc).
 
-When a process is invoked in a workflow, it must be provided a channel for each channel in the process input section, similar to calling a function with specific arguments. The examples provided in the following sections demonstrate how a process is invoked with input channels.
+When a process is invoked in a workflow, it must be provided a channel or dataflow value for each input in the process input section, similar to calling a function with specific arguments. The examples provided in the following sections demonstrate how a process is invoked.
 
 The following input qualifiers are available:
 
@@ -366,7 +366,7 @@ process job 2
 ```
 
 :::{note}
-While channels do emit items in the order that they are received, *processes* do not necessarily *process* items in the order that they are received. In the above example, the value `3` was processed before the others.
+Processes do not necessarily process items in the order that they are received. In the above example, the value `3` was processed before the others.
 :::
 
 :::{note}
@@ -655,16 +655,16 @@ hello
 
 ### Input tuples (`tuple`)
 
-The `tuple` qualifier groups multiple values into a single input definition. It can be useful when a channel emits {ref}`tuples <script-tuples>` of values that need to be handled separately. Each element in the tuple is associated with a corresponding element in the `tuple` definition. For example:
+The `tuple` qualifier groups multiple values into a single input definition. Each element in the tuple is associated with a corresponding element in the `tuple` definition. For example:
 
 ```nextflow
 process cat {
     input:
-    tuple val(x), path('input.txt')
+    tuple val(id), path('input.txt')
 
     script:
     """
-    echo "Processing $x"
+    echo "Processing $id"
     cat input.txt > copy
     """
 }
@@ -735,50 +735,22 @@ When multiple repeaters are defined, the process is executed for each *combinati
 :::
 
 :::{note}
-Input repeaters currently do not support tuples. However, you can emulate an input repeater on a channel of tuples by using the {ref}`operator-combine` or {ref}`operator-cross` operator with other input channels to produce all of the desired input combinations.
+Input repeaters do not support tuples. Use the {ref}`operator-combine` or {ref}`operator-cross` operator to combine the repeated input with the other inputs to produce all of the desired input combinations.
 :::
 
-(process-multiple-input-channels)=
+(process-multiple-inputs)=
 
-### Multiple input channels
+### Multiple inputs
 
-A key feature of processes is the ability to handle inputs from multiple channels.
+A process can declare multiple inputs, which allows it to accept inputs from multiple dataflow sources.
 
-When two or more channels are declared as process inputs, the process waits until there is a complete input configuration, i.e. until it receives a value from each input channel. When this condition is satisfied, the process consumes a value from each channel and launches a new task, repeating this logic until one or more channels are empty.
+:::{warning}
+When calling a process with multiple inputs, make sure to not supply more than one channel -- all other inputs should be dataflow values. Invoking a process with multiple channels can lead to {ref}`non-deterministic behavior <cache-nondeterministic-inputs>`.
+:::
 
-As a result, channel values are consumed sequentially and any empty channel will cause the process to wait, even if the other channels have values.
+When a process is defined with multiple inputs, it waits for a value from each input and launches a new task with the combined values. When one of the inputs is a channel, the process repeats until all values in the channel are consumed. If the channel is empty, the process will not launch any tasks.
 
 For example:
-
-```nextflow
-process echo {
-  input:
-  val x
-  val y
-
-  script:
-  """
-  echo $x and $y
-  """
-}
-
-workflow {
-  x = channel.of(1, 2)
-  y = channel.of('a', 'b', 'c')
-  echo(x, y)
-}
-```
-
-The process `echo` is executed two times because the `x` channel emits only two values, therefore the `c` element is discarded. It outputs:
-
-```
-1 and a
-2 and b
-```
-
-When a {ref}`value channel <channel-type-value>` is supplied as a process input alongside a queue channel, the process is executed for each value in the queue channel, and the value channel is re-used for each execution.
-
-For example, compare the previous example with the following:
 
 ```nextflow
 process echo {
@@ -799,7 +771,7 @@ workflow {
 }
 ```
 
-The above example executes the `echo` process three times because `x` is a value channel, therefore its value can be read as many times as needed. The process termination is determined by the contents of `y`. It outputs:
+The above example executes the `echo` process three times. Because `x` is a dataflow value, it is used once for each value in `y`. It outputs:
 
 ```
 1 and a
@@ -807,17 +779,13 @@ The above example executes the `echo` process three times because `x` is a value
 1 and c
 ```
 
-:::{note}
-In general, multiple input channels should be used to process *combinations* of different inputs, using the `each` qualifier or value channels. Having multiple queue channels as inputs is equivalent to using the {ref}`operator-merge` operator, which is not recommended as it may lead to {ref}`non-deterministic process inputs <cache-nondeterministic-inputs>`.
-:::
-
 See also: {ref}`process-out-singleton`.
 
 (process-output)=
 
 ## Outputs
 
-The `output` section allows you to define the output channels of a process, similar to function outputs. A process may have at most one output section, which must contain at least one output declaration.
+The `output` section defines the outputs of a process, similar to a function return. A process may have at most one output section, which must contain at least one output declaration.
 
 The output section follows the syntax shown below:
 
@@ -826,9 +794,9 @@ output:
   <output qualifier> <output name> [, <option>: <option value>]
 ```
 
-An output definition consists of a *qualifier* and a *name*. Some optional attributes can also be specified.
+An output declaration consists of a *qualifier* and a *name*. Some optional attributes can also be specified.
 
-When a process is invoked, each process output is returned as a channel. The examples provided in the following sections demonstrate how to access the output channels of a process.
+When a process is invoked, each process output is returned as a channel (except under {ref}`certain conditions <process-out-singleton>`). The examples provided in the following sections demonstrate how to access the outputs of a process.
 
 The following output qualifiers are available:
 
@@ -917,7 +885,7 @@ workflow {
 }
 ```
 
-In the above example, the `random_number` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding output channel. A downstream process with a compatible input channel will be able to receive it.
+In the above example, the `random_number` process creates a file named `result.txt` which contains a random number. Since a `path` output with the same name is declared, that file is emitted by the corresponding process output. A downstream process or operator with a compatible input will be able to receive it.
 
 Refer to the {ref}`process reference <process-reference-outputs>` for the list of available options for `path` outputs.
 
@@ -960,7 +928,7 @@ Some caveats on glob pattern behavior:
 - Directories are included, unless the `**` pattern is used to recurse through directories
 
 :::{warning}
-Although the input files matching a glob output declaration are not included in the resulting output channel, these files may still be transferred from the task scratch directory to the original task work directory. Therefore, to avoid unnecessary file copies, avoid using loose wildcards when defining output files, e.g. `path '*'`. Instead, use a prefix or a suffix to restrict the set of matching files to only the expected ones, e.g. `path 'prefix_*.sorted.bam'`.
+Although the input files matching an output glob pattern are not included in the resulting output, these files may still be transferred from the task scratch directory to the original task work directory. Therefore, to avoid unnecessary file copies, avoid using loose wildcards when defining output files, e.g. `path '*'`. Instead, use a prefix or a suffix to restrict the set of matching files to only the expected ones, e.g. `path 'prefix_*.sorted.bam'`.
 :::
 
 Read more about glob syntax at the following link [What is a glob?][glob]
@@ -1056,7 +1024,7 @@ If the command fails, the task will also fail. In Bash, you can append `|| true`
 
 ### Output tuples (`tuple`)
 
-The `tuple` qualifier outputs multiple values in a single channel as a {ref}`tuple <script-tuples>`. It is useful when you need to associate outputs with metadata, for example:
+The `tuple` qualifier outputs multiple values in a single output as a {ref}`tuple <script-tuples>`. For example:
 
 ```nextflow
 process blast {
@@ -1122,7 +1090,7 @@ process hello {
 
 ### Naming outputs
 
-The `emit` option can be used on a process output to define a name for the corresponding output channel, which can be used to access the channel by name from the process output. For example:
+The `emit` option is used to define the name of a process output, which can be used to access the output by name in the calling workflow. For example:
 
 ```nextflow
 process hello_bye {
@@ -1147,7 +1115,7 @@ See {ref}`workflow-process-invocation` for more details.
 
 ### Optional outputs
 
-Normally, if a specified output is not produced by the task, the task will fail. Setting `optional: true` will cause the task to not fail, and instead emit nothing to the given output channel.
+Normally, if a specified output is not produced by the task, the task will fail. Setting `optional: true` will cause the task to not fail, and instead emit nothing to the corresponding output channel.
 
 ```nextflow
 output:
@@ -1164,17 +1132,17 @@ While this option can be used with any process output, it cannot be applied to i
 
 ### Singleton outputs
 
-When a process is only supplied with value channels, regular values, or no inputs, it returns outputs as value channels. For example:
+When a process is only supplied with dataflow values, regular values, or no inputs, it returns outputs as dataflow values. For example:
 
 ```{literalinclude} snippets/process-out-singleton.nf
 :language: nextflow
 ```
 
-In the above example, the `echo` process is invoked with a regular value that is wrapped in a value channel. As a result, `echo` returns a value channel and `greet` is executed three times.
+In the above example, the `echo` process is invoked with a regular value that is wrapped in a dataflow value. As a result, `echo` returns a dataflow value and `greet` is executed three times.
 
-If the call to `echo` was changed to `echo( channel.of('hello') )`, the process would instead return a queue channel, and `greet` would be executed only once.
+If the call to `echo` was changed to `echo( channel.of('hello') )`, the process would instead return a channel, and `greet` would be executed only once.
 
-See also: {ref}`process-multiple-input-channels`.
+See also: {ref}`process-multiple-inputs`.
 
 (process-when)=
 

--- a/docs/reference/channel.md
+++ b/docs/reference/channel.md
@@ -447,7 +447,7 @@ See also: [channel.fromList](#fromlist) factory method.
 In versions of Nextflow prior to 25.04, this feature requires the `nextflow.preview.topic` feature flag to be enabled.
 :::
 
-A *topic channel* is a queue channel that can receive values from many source channels *implicitly* based on a matching *topic name*.
+A *topic channel* is a channel that can receive values from many sources *implicitly* based on a matching *topic name*.
 
 :::{tip}
 You can think of it as a channel that is shared across many different processes using the same topic name.
@@ -471,8 +471,7 @@ process bye {
 }
 ```
 
-The `channel.topic` method allows referencing the topic channel with the specified name, which can be used as a process
-input or operator composition as any other Nextflow channel:
+The `channel.topic` method allows referencing the topic channel with the specified name, which can be used as input to a process or operator, like any other channel:
 
 ```nextflow
 channel.topic('my-topic').view()
@@ -490,17 +489,14 @@ See also: {ref}`process-additional-options` for process outputs.
 
 ## value
 
-The `channel.value` method is used to create a value channel. An optional (not `null`) argument can be specified to bind
-the channel to a specific value. For example:
+The `channel.value` function creates a dataflow value bound to the given argument. For example:
 
 ```nextflow
-expl1 = channel.value()
-expl2 = channel.value( 'Hello there' )
-expl3 = channel.value( [1,2,3,4,5] )
+v1 = channel.value( 'Hello there' )
+v2 = channel.value( [1,2,3,4,5] )
 ```
 
-The first line in the example creates an 'empty' variable. The second line creates a channel and binds a string to it.
-The third line creates a channel and binds a list object to it that will be emitted as a single value.
+The first line creates a dataflow value bound to the string `'Hello there'`. The second line creates a dataflow value bound to the list `[1,2,3,4,5]`, which is treated as a single value in dataflow logic.
 
 (channel-watchpath)=
 

--- a/docs/reference/operator.md
+++ b/docs/reference/operator.md
@@ -9,7 +9,7 @@
 :::{versionadded} 19.08.0-edge
 :::
 
-*Returns: multiple queue channels or value channels, matching the source type*
+*Returns: multiple channels*
 
 The `branch` operator forwards each item from a source channel to one of multiple output channels, based on a selection criteria.
 
@@ -63,7 +63,7 @@ The `branchCriteria()` method can be used to create a branch criteria as a varia
 
 ## buffer
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `buffer` operator collects items from a source channel into subsets and emits each subset separately.
 
@@ -133,7 +133,7 @@ See also: [collate](#collate)
 
 ## collate
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `collate` operator collects items from a source channel into groups of *N* items.
 
@@ -185,7 +185,7 @@ See also: [buffer](#buffer)
 
 ## collect
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `collect` operator collects all items from a source channel into a list and emits it as a single item:
 
@@ -219,7 +219,7 @@ See also: [toList](#tolist), [toSortedList](#tosortedlist)
 
 ## collectFile
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `collectFile` operator collects the items from a source channel and saves them to one or more files, emitting the collected file(s).
 
@@ -305,7 +305,7 @@ Available options:
 
 ## combine
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `combine` operator produces the combinations (i.e. cross product, "Cartesian" product) of two source channels, or a channel and a list (as the right operand), emitting each combination separately.
 
@@ -345,7 +345,7 @@ See also: [cross](#cross), [join](#join)
 
 ## concat
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `concat` operator emits the items from two or more source channels into a single output channel. Each source channel is emitted in the order in which it was specified.
 
@@ -367,7 +367,7 @@ See also: [mix](#mix)
 
 ## count
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `count` operator computes the total number of items in a source channel and emits it:
 
@@ -409,7 +409,7 @@ An optional filter can be provided to select which items to count. The selection
 
 ## countFasta
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 Counts the total number of records in a channel of FASTA files, equivalent to `splitFasta | count`. See [splitFasta](#splitfasta) for the list of available options.
 
@@ -417,7 +417,7 @@ Counts the total number of records in a channel of FASTA files, equivalent to `s
 
 ## countFastq
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 Counts the total number of records in a channel of FASTQ files, equivalent to `splitFastq | count`. See [splitFastq](#splitfastq) for the list of available options.
 
@@ -425,7 +425,7 @@ Counts the total number of records in a channel of FASTQ files, equivalent to `s
 
 ## countJson
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 Counts the total number of records in a channel of JSON files, equivalent to `splitJson | count`. See [splitJson](#splitjson) for the list of available options.
 
@@ -433,7 +433,7 @@ Counts the total number of records in a channel of JSON files, equivalent to `sp
 
 ## countLines
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 Counts the total number of lines in a channel of text files, equivalent to `splitText | count`. See [splitLines](#splittext) for the list of available options.
 
@@ -441,7 +441,7 @@ Counts the total number of lines in a channel of text files, equivalent to `spli
 
 ## cross
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `cross` operator emits every pairwise combination of two channels for which the pair has a matching key.
 
@@ -474,7 +474,7 @@ See also: [combine](#combine)
 
 ## distinct
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `distinct` operator forwards a source channel with *consecutively* repeated items removed, such that each emitted item is different from the preceding one:
 
@@ -502,7 +502,7 @@ See also: [unique](#unique)
 
 ## dump
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `dump` operator prints each item in a source channel when the pipeline is executed with the `-dump-channels` command-line option, otherwise it does nothing. It is a useful way to inspect and debug channels quickly without having to modify the pipeline script.
 
@@ -528,7 +528,7 @@ Available options:
 
 ## filter
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `filter` operator emits the items from a source channel that satisfy a condition, discarding all other items. The filter condition can be a literal value, a {ref}`regular expression <script-regexp>`, a type qualifier (i.e. Java class), or a boolean predicate.
 
@@ -566,7 +566,7 @@ The following example filters a channel using a boolean predicate, which is a {r
 
 ## first
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `first` operator emits the first item in a source channel, or the first item that matches a condition. The condition can be a {ref}`regular expression<script-regexp>`, a type qualifier (i.e. Java class), or a boolean predicate. For example:
 
@@ -578,7 +578,7 @@ The `first` operator emits the first item in a source channel, or the first item
 
 ## flatMap
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `flatMap` operator applies a *mapping function* to each item from a source channel.
 
@@ -606,7 +606,7 @@ When the mapping function returns a map, each key-value pair in the map is emitt
 
 ## flatten
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `flatten` operator flattens each item from a source channel that is a list or other collection, such that each element in each collection is emitted separately:
 
@@ -626,7 +626,7 @@ See also: [flatMap](#flatmap)
 
 ## groupTuple
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `groupTuple` operator collects lists (i.e. *tuples*) from a source channel into groups based on a grouping key. A new tuple is emitted for each distinct key.
 
@@ -686,7 +686,7 @@ Available options:
 
 ## ifEmpty
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `ifEmpty` operator emits a source channel, or a default value if the source channel is *empty* (doesn't emit any value):
 
@@ -714,7 +714,7 @@ See also: {ref}`channel-empty` channel factory
 
 ## join
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `join` operator emits the inner product of two source channels using a matching key.
 
@@ -766,7 +766,7 @@ See also: [combine](#combine), [cross](#cross)
 
 ## last
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `last` operator emits the last item from a source channel:
 
@@ -782,7 +782,7 @@ The `last` operator emits the last item from a source channel:
 
 ## map
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `map` operator applies a *mapping function* to each item from a source channel:
 
@@ -802,7 +802,7 @@ The `map` operator applies a *mapping function* to each item from a source chann
 
 ## max
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `max` operator emits the item with the greatest value from a source channel:
 
@@ -838,7 +838,7 @@ The following examples show how to find the longest string in a channel:
 
 ## merge
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `merge` operator joins the items from two or more channels into a new channel:
 
@@ -860,11 +860,11 @@ An optional closure can be used to control how two items are merged:
 :language: console
 ```
 
-The `merge` operator may return a queue channel or value channel depending on the inputs:
+The `merge` operator may return a channel or value depending on the inputs:
 
-- If the first argument is a queue channel, the `merge` operator will return a queue channel merging as many values as are available for all inputs. Value channels will be re-used for each merged value.
+- If the first argument is a channel, the `merge` operator returns a channel merging as many values as are available for all inputs. Dataflow values are re-used for each merged value.
 
-- If the first argument is a value channel, the `merge` operator will return a value channel merging the first value from each input, regardless of whether there are queue channel inputs with additional values.
+- If the first argument is a dataflow value, the `merge` operator returns a dataflow value, merging the first value from each input, regardless of whether there are channel inputs with additional values.
 
 :::{danger}
 In general, the use of the `merge` operator is discouraged. Processes and channel operators are not guaranteed to emit items in the order that they were received, as they are executed concurrently. Therefore, if you try to merge output channels from different processes, the resulting channel may be different on each run, which will cause resumed runs to {ref}`not work properly <cache-nondeterministic-inputs>`.
@@ -876,7 +876,7 @@ You should always use a matching key (e.g. sample ID) to merge multiple channels
 
 ## min
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `min` operator emits the item with the lowest value from a source channel:
 
@@ -912,7 +912,7 @@ The following examples show how to find the shortest string in a channel:
 
 ## mix
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `mix` operator emits the items from two or more source channels into a single output channel:
 
@@ -944,7 +944,7 @@ See also: [concat](#concat)
 :::{versionadded} 19.11.0-edge
 :::
 
-*Returns: multiple queue channels or value channels, matching the source type*
+*Returns: multiple channels*
 
 The `multiMap` operator applies a set of mapping functions to a source channel, producing a separate output channel for each mapping function.
 
@@ -986,7 +986,7 @@ If you use `multiMap` to split a tuple or map into multiple channels, it is reco
 
 ## randomSample
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `randomSample` operator emits a randomly-selected subset of items from a source channel:
 
@@ -1008,7 +1008,7 @@ The above example will print 10 randomly-selected numbers between 1 and 100 (wit
 
 ## reduce
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `reduce` operator applies an *accumulator function* sequentially to each item in a source channel, and emits the final accumulated value. The accumulator function takes two parameters -- the accumulated value and the *i*-th emitted item -- and it should return the accumulated result, which is passed to the next invocation with the *i+1*-th item. This process is repeated for each item in the source channel.
 
@@ -1056,7 +1056,7 @@ See also: [tap](#tap)
 
 ## splitCsv
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `splitCsv` operator parses and splits [CSV](http://en.wikipedia.org/wiki/Comma-separated_values) files or text from a source channel into records.
 
@@ -1128,7 +1128,7 @@ Available options:
 
 ## splitFasta
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `splitFasta` operator splits [FASTA](http://en.wikipedia.org/wiki/FASTA_format) files or text from a source channel into individual sequences.
 
@@ -1200,7 +1200,7 @@ See also: [countFasta](#countfasta)
 
 ## splitFastq
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `splitFastq` operator splits [FASTQ](http://en.wikipedia.org/wiki/FASTQ_format) files or text from a source channel into individual sequences.
 
@@ -1283,7 +1283,7 @@ See also: [countFastq](#countfastq)
 
 ## splitJson
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `splitJson` operator splits [JSON](https://en.wikipedia.org/wiki/JSON) files or text from a source channel into individual records.
 
@@ -1331,7 +1331,7 @@ See also: [countJson](#countjson)
 
 ## splitText
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `splitText` operator splits multi-line text content from a source channel into chunks of *N* lines:
 
@@ -1442,7 +1442,7 @@ Available options:
 
 ## sum
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `sum` operator emits the sum of all items in a source channel:
 
@@ -1468,7 +1468,7 @@ An optional {ref}`closure <script-closure>` can be used to transform each item b
 
 ## take
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `take` operator takes the first *N* items from a source channel:
 
@@ -1488,7 +1488,7 @@ See also: [until](#until)
 
 ## tap
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `tap` operator assigns a source channel to a variable, and emits the source channel. It is a useful way to extract intermediate output channels from a chain of operators. For example:
 
@@ -1504,7 +1504,7 @@ See also: [set](#set)
 
 ## toInteger
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `toInteger` operator converts string values from a source channel to integer values:
 
@@ -1530,7 +1530,7 @@ You can also use `toLong`, `toFloat`, and `toDouble` to convert to other numeric
 
 ## toList
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `toList` operator collects all the items from a source channel into a list and emits the list as a single item:
 
@@ -1559,7 +1559,7 @@ See also: [collect](#collect)
 
 ## toSortedList
 
-*Returns: value channel*
+*Returns: dataflow value*
 
 The `toSortedList` operator collects all the items from a source channel into a sorted list and emits the list as a single item:
 
@@ -1593,7 +1593,7 @@ See also: [collect](#collect)
 
 ## transpose
 
-*Returns: queue channel*
+*Returns: channel*
 
 The `transpose` operator "transposes" each tuple from a source channel by flattening any nested list in each tuple, emitting each nested item separately.
 
@@ -1643,7 +1643,7 @@ See also: [groupTuple](#grouptuple)
 
 ## unique
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `unique` operator emits the unique items from a source channel:
 
@@ -1675,7 +1675,7 @@ See also: [distinct](#distinct)
 
 ## until
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `until` operator emits each item from a source channel until a stopping condition is satisfied:
 
@@ -1693,7 +1693,7 @@ See also: [take](#take)
 
 ## view
 
-*Returns: queue channel or value channel, matching the source type*
+*Returns: channel*
 
 The `view` operator prints each item from a source channel to standard output:
 

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -1260,7 +1260,7 @@ process hello {
 ```
 
 :::{warning}
-Files are copied into the specified directory in an *asynchronous* manner, so they may not be immediately available in the publish directory at the end of the process execution. For this reason, downstream processes should not try to access output files through the publish directory, but through channels.
+Files are copied into the specified directory in an *asynchronous* manner, so they may not be immediately available in the publish directory at the end of the process execution. For this reason, downstream processes should not try to access output files through the publish directory, but through the outputs of the originating process.
 :::
 
 Available options:

--- a/docs/reference/stdlib-types.md
+++ b/docs/reference/stdlib-types.md
@@ -44,7 +44,9 @@ Booleans in Nextflow can be backed by any of the following Java types: `boolean`
 
 ## Channel\<E\>
 
-See {ref}`channel-page` for an overview of channels. See {ref}`channel-factory` and {ref}`operator-page` for the available functions for creating and manipulating channels.
+A channel (also known as a *dataflow channel* or *queue channel*) is an asynchronous sequence of values. It is used to facilitate dataflow logic in a workflow.
+
+See {ref}`dataflow-page` for an overview of dataflow types. See {ref}`operator-page` for the available methods for channels.
 
 (stdlib-types-duration)=
 
@@ -170,7 +172,7 @@ The following methods are available for iterables:
 : Returns `true` if the iterable contains the given value.
 
 `each( action: (E) -> () )`
-: Invoke the given closure for each element in the iterable.
+: Invokes the given closure for each element in the iterable.
 
 `every( condition: (E) -> Boolean ) -> Boolean`
 : Returns `true` if every element in the iterable satisfies the given condition.
@@ -197,19 +199,23 @@ The following methods are available for iterables:
 `max() -> E`
 : Returns the maximum element in the iterable.
 
-**`max( comparator: (E) -> R ) -> E`**
+`max( comparator: (E) -> R ) -> E`
+: Returns the maximum element in the iterable according to the given closure.
+: The closure should follow the same semantics as the closure parameter of `toSorted()`.
 
 `max( comparator: (E,E) -> Integer ) -> E`
 : Returns the maximum element in the iterable according to the given closure.
 : The closure should follow the same semantics as the closure parameter of `toSorted()`.
 
 `min() -> E`
-: Returns the maximum element in the iterable.
+: Returns the minimum element in the iterable.
 
-**`min( comparator: (E) -> R ) -> E`**
+`min( comparator: (E) -> R ) -> E`
+: Returns the minimum element in the iterable according to the given closure.
+: The closure should follow the same semantics as the closure parameter of `toSorted()`.
 
 `min( comparator: (E,E) -> Integer ) -> E`
-: Returns the maximum element in the iterable according to the given closure.
+: Returns the minimum element in the iterable according to the given closure.
 : The closure should follow the same semantics as the closure parameter of `toSorted()`.
 
 `size() -> Integer`
@@ -368,7 +374,7 @@ The following methods are available for a map:
 : Returns `true` if the map maps one or more keys to the given value.
 
 `each( action: (K,V) -> () )`
-: Invoke the given closure for each key-value pair in the map. The closure should accept two parameters corresponding to the key and value of an entry.
+: Invokes the given closure for each key-value pair in the map. The closure should accept two parameters corresponding to the key and value of an entry.
 
 `entrySet() -> Set<(K,V)>`
 : Returns a set of the key-value pairs in the map.
@@ -889,7 +895,7 @@ The following methods are available for a string:
 : Returns `true` if the string is empty (i.e. `length()` is 0).
 
 `isDouble() -> Boolean`
-: Returns `true` if the string can be parsed as a 64-bit floating-point number.
+: Returns `true` if the string can be parsed as a 64-bit (double precision) floating-point number.
 
 `isFloat() -> Boolean`
 : Returns `true` if the string can be parsed as a 32-bit floating-point number.
@@ -898,7 +904,7 @@ The following methods are available for a string:
 : Returns `true` if the string can be parsed as a 32-bit integer.
 
 `isLong() -> Boolean`
-: Returns `true` if the string can be parsed as a 64-bit integer.
+: Returns `true` if the string can be parsed as a 64-bit (long) integer.
 
 `lastIndexOf( str: String ) -> Integer`
 : Returns the index within the string of the last occurrence of the given substring. Returns -1 if the string does not contain the substring.
@@ -950,7 +956,7 @@ The following methods are available for a string:
 : Returns `true` if the trimmed string is "true", "y", or "1" (ignoring case).
 
 `toDouble() -> Float`
-: Parses the string into a 64-bit floating-point number.
+: Parses the string into a 64-bit (double precision) floating-point number.
 
 `toFloat() -> Float`
 : Parses the string into a 32-bit floating-point number.
@@ -959,7 +965,7 @@ The following methods are available for a string:
 : Parses the string into a 32-bit integer.
 
 `toLong() -> Integer`
-: Parses the string into a 64-bit integer.
+: Parses the string into a 64-bit (long) integer.
 
 `toLowerCase() -> String`
 : Returns a copy of this string with all characters converted to lower case.
@@ -984,6 +990,31 @@ The following operations are supported for tuples:
 
 `[] : (Tuple, Integer) -> ?`
 : Given a tuple and an index, returns the tuple element at the index.
+
+(stdlib-types-value)=
+
+## Value\<V\>
+
+A dataflow value (also known as a *value channel*) is an asynchronous value. It is used to facilitate dataflow logic in a workflow.
+
+See {ref}`dataflow-page` for an overview of dataflow types.
+
+The following methods are available for a dataflow value:
+
+`flatMap( transform: (V) -> Iterable<R> ) -> Channel<R>`
+: Transforms the dataflow value into a collection with the given closure and emits the resulting values in a dataflow channel.
+
+`map( transform: (V) -> R ) -> Value<R>`
+: Transforms the dataflow value into another dataflow value with the given closure.
+
+`subscribe( action: (V) -> () )`
+: Invokes the given closure on the dataflow value.
+
+`view() -> Value<V>`
+: Prints the dataflow value to standard output.
+
+`view( transform: (V) -> String ) -> Value<V>`
+: Transforms the dataflow value using the given closure and print the result to standard output.
 
 (stdlib-types-versionnumber)=
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -161,7 +161,7 @@ See {ref}`stdlib-types-tuple` for the set of available tuple operations.
 Operators are symbols that perform specific functions on one or more values, and generally make code easier to read. This section highlights some of the most commonly used operators.
 
 :::{note}
-Operators in this context are different from *channel operators*, which are specialized functions for working with channels. See {ref}`channel-page` for more information.
+Operators in this context are different from *channel operators*, which are specialized functions for working with channels. See {ref}`dataflow-page` for more information.
 :::
 
 The `==` and `!=` operators can be used to test whether any two values are equal (or not equal):

--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptCompiler.java
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptCompiler.java
@@ -73,6 +73,7 @@ public class ScriptCompiler {
     private static final List<String> DEFAULT_IMPORT_NAMES = List.of(
         "java.nio.file.Path",
         "nextflow.Channel",
+        "nextflow.script.types.Value",
         "nextflow.util.Duration",
         "nextflow.util.MemoryUnit",
         "nextflow.util.VersionNumber"

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ResolveVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ResolveVisitor.java
@@ -306,13 +306,17 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         }
         if( inVariableDeclaration ) {
             // resolve type of variable declaration
-            resolveOrFail(ve.getType(), ve);
-            var origin = ve.getOriginType();
-            if( origin != ve.getType() )
-                resolveOrFail(origin, ve);
+            resolveOrFail(ve);
         }
         // if the variable is still dynamic (i.e. unresolved), it will be handled by DynamicVariablesVisitor
         return ve;
+    }
+
+    public void resolveOrFail(VariableExpression ve) {
+        resolveOrFail(ve.getType(), ve);
+        var origin = ve.getOriginType();
+        if( origin != ve.getType() )
+            resolveOrFail(origin, ve);
     }
 
     protected Expression transformPropertyExpression(PropertyExpression pe) {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
@@ -18,6 +18,7 @@ package nextflow.script.control;
 import java.util.Collections;
 import java.util.List;
 
+import nextflow.script.ast.AssignmentExpression;
 import nextflow.script.ast.FunctionNode;
 import nextflow.script.ast.OutputNode;
 import nextflow.script.ast.ParamNodeV1;
@@ -29,8 +30,12 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.DynamicVariable;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
+
+import static nextflow.script.ast.ASTUtils.*;
 
 /**
  * Resolve variable names, function names, and type names in
@@ -97,10 +102,25 @@ public class ScriptResolveVisitor extends ScriptVisitorSupport {
         for( var take : node.getParameters() )
             resolver.resolveOrFail(take.getType(), take);
         resolver.visit(node.main);
+        resolveWorkflowEmits(node.emits);
         resolver.visit(node.emits);
         resolver.visit(node.publishers);
         resolver.visit(node.onComplete);
         resolver.visit(node.onError);
+    }
+
+    private void resolveWorkflowEmits(Statement emits) {
+        for( var stmt : asBlockStatements(emits) ) {
+            var stmtX = (ExpressionStatement)stmt;
+            var emit = stmtX.getExpression();
+            var target =
+                emit instanceof AssignmentExpression ae ? ae.getLeftExpression() :
+                emit instanceof VariableExpression ve ? ve :
+                null;
+
+            if( target instanceof VariableExpression ve )
+                resolver.resolveOrFail(ve);
+        }
     }
 
     @Override

--- a/modules/nf-lang/src/main/java/nextflow/script/types/Channel.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/Channel.java
@@ -25,9 +25,9 @@ import nextflow.script.dsl.Description;
 import nextflow.script.dsl.Operator;
 
 @Description("""
-    A `Channel` is a special data structure used to facilitate the dataflow dependencies between each step in a Nextflow pipeline.
+    A channel is an asynchronous sequence of values. It is used to facilitate dataflow logic in a workflow.
 
-    [Read more](https://nextflow.io/docs/latest/reference/channel.html)
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib-types.html#channel-e)
 """)
 public interface Channel<E> {
 
@@ -385,5 +385,6 @@ public interface Channel<E> {
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#view)
     """)
     Channel view(Closure transform);
+    Channel view();
 
 }

--- a/modules/nf-lang/src/main/java/nextflow/script/types/Types.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/Types.java
@@ -40,6 +40,7 @@ public class Types {
         ClassHelper.makeCached(Duration.class),
         ClassHelper.makeCached(MemoryUnit.class),
         ClassHelper.makeCached(Path.class),
+        ClassHelper.makeCached(Value.class),
         ClassHelper.makeCached(VersionNumber.class)
     );
 

--- a/modules/nf-lang/src/main/java/nextflow/script/types/Value.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/Value.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import nextflow.script.dsl.Description;
+import nextflow.script.dsl.Operator;
+
+@Description("""
+    A dataflow value is an asynchronous value. It is used to facilitate dataflow logic in a workflow.
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib-types.html#value-v)
+""")
+public interface Value<V> {
+
+    @Operator
+    @Description("""
+        Transforms the dataflow value into a collection with the given closure and emits the resulting values in a dataflow channel.
+    """)
+    <R> Channel<R> flatMap(Function<V,Iterable<R>> transform);
+
+    @Operator
+    @Description("""
+        Transforms the dataflow value into another dataflow value with the given closure.
+    """)
+    <R> Value<R> map(Function<V,R> transform);
+
+    @Operator
+    @Description("""
+        Invokes the given closure on the dataflow value.
+    """)
+    void subscribe(Consumer<V> action);
+
+    @Operator
+    @Description("""
+        Transforms the dataflow value using the given closure and print the result to standard output.
+    """)
+    Value<V> view(Function<V,String> transform);
+    Value<V> view();
+
+}

--- a/tests/type-annotations.nf
+++ b/tests/type-annotations.nf
@@ -17,8 +17,8 @@
 
 workflow {
   words_ch = channel.of('one', 'two', 'three', 'four')
-  counts_ch = COUNT(words_ch)
-  counts_ch.collect().view { counts ->
+  counts_vl = COUNT(words_ch)
+  counts_vl.view { counts ->
     def even = counts.findAll { n -> isEven(n) }.size()
     println "counts: $counts ($even are even)"
   }
@@ -29,10 +29,14 @@ workflow COUNT {
   words: Channel<String>
 
   main:
-  counts_ch = words.map { word -> word.length() }
+  counts = words.map { word -> word.length() }.collect()
 
   emit:
-  counts: Channel<Integer> = counts_ch
+  counts: Value<Integer> = identity(counts)
+}
+
+def identity(v: Value) -> Value {
+  return v
 }
 
 def isEven(n: Integer) -> Boolean {


### PR DESCRIPTION
This PR adds the `Value` type to the Nextflow type system to distinguish value channels from queue channels.

It renames "queue channels" and value channels as "dataflow channels" and "dataflow values", or "channels and values" for short. This language is more clear and concise, since "queue channel" is somewhat redundant and "value channel" is somewhat contradictory.

There are no changes to runtime behavior aside from allowing the use of `Value` in type annotations. It is primarily a change to docs and terminology.

This change is still under discussion. We already have the `Channel` type, but we need an additional type to distinguish value channels from queue channels. `Value` was the resounding favorite in an internal poll (other options were `Async`, `Future`, `ValueChannel`).

So if we go with `Channel` and `Value`, it makes sense to update the vocabulary in the docs to match, hence the proposal of "dataflow channel" and "dataflow value".