### PR TITLE
Fix null reference error in workflow output

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -306,8 +306,10 @@ class PublishOp {
 
         // if the target resolver is a closure, use it to transform
         // the source filename to the target path
-        if( targetResolver instanceof Closure<Path> )
-            return (targetResolver.call(path.getName()) as Path).normalize()
+        if( targetResolver instanceof Closure<Path> ) {
+            final relPath = sourceDir.relativize(path).toString()
+            return (targetResolver.call(relPath) as Path).normalize()
+        }
 
         // if the target resolver is a directory, resolve the source
         // filename against it

--- a/tests/checks/output-dsl.nf/.checks
+++ b/tests/checks/output-dsl.nf/.checks
@@ -21,7 +21,9 @@ $NXF_RUN --save_bam_bai | tee stdout
 [[ -L results/quant/beta ]] || false
 [[ -L results/quant/delta ]] || false
 [[ -f results/samples.csv ]] || false
-[[ -f results/summary.txt ]] || false
+[[ -f results/summary_report.html ]] || false
+[[ -f results/summary_data/data.json ]] || false
+[[ -f results/summary_data/fastqc.txt ]] || false
 
 
 #
@@ -47,7 +49,9 @@ $NXF_RUN --save_bam_bai | tee stdout
 [[ -L results/quant/beta ]] || false
 [[ -L results/quant/delta ]] || false
 [[ -f results/samples.csv ]] || false
-[[ -f results/summary.txt ]] || false
+[[ -f results/summary_report.html ]] || false
+[[ -f results/summary_data/data.json ]] || false
+[[ -f results/summary_data/fastqc.txt ]] || false
 
 
 #
@@ -75,4 +79,6 @@ $NXF_RUN --save_bam_bai -resume | tee stdout
 [[ -L results/quant/beta ]] || false
 [[ -L results/quant/delta ]] || false
 [[ -f results/samples.csv ]] || false
-[[ -f results/summary.txt ]] || false
+[[ -f results/summary_report.html ]] || false
+[[ -f results/summary_data/data.json ]] || false
+[[ -f results/summary_data/fastqc.txt ]] || false

--- a/tests/output-dsl.nf
+++ b/tests/output-dsl.nf
@@ -67,11 +67,14 @@ process summary {
   path logs
 
   output:
-  path('summary.txt'), emit: report
+  tuple path('summary_report.html'), path('summary_data/data.json'), path('summary_data/fastqc.txt')
 
   script:
   '''
-  ls -1 *.log > summary.txt
+  touch summary_report.html
+  mkdir summary_data
+  touch summary_data/data.json
+  touch summary_data/fastqc.txt
   '''
 }
 
@@ -123,6 +126,10 @@ output {
   }
 
   summary {
-    path '.'
+    path { report, data_json, fastqc_txt ->
+      report >> './'
+      data_json >> './'
+      fastqc_txt >> './'
+    }
   }
 }


### PR DESCRIPTION
Close #6340 

This PR fixes a bug where `normalizePath()` in `PublishOp` was not supplying the correct filename to the dynamic path closure.

It was supplying the simple file name instead of the path relative to the task directory, which caused an error when the file included a nested directory.

The `output-dsl.nf` e2e test has been updated to test this condition. The `summary` task is modeled after `multiqc` which creates nested output files.