### PR TITLE
Fix false error for executor.jobName config option

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/config/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/control/VariableScopeVisitor.java
@@ -119,12 +119,8 @@ class VariableScopeVisitor extends ConfigVisitorSupport {
         var scopes = currentConfigScopes();
         inProcess = !scopes.isEmpty() && "process".equals(scopes.get(0));
         inClosure = node.value instanceof ClosureExpression;
-        if( inClosure ) {
-            if( isWorkflowHandler(scopes, node) )
-                vsc.addWarning("The use of workflow handlers in the config is deprecated -- use the entry workflow or a plugin instead", String.join(".", node.names), node);
-            else if( !inProcess )
-                vsc.addError("Dynamic config options are only allowed in the `process` scope", node);
-        }
+        if( isWorkflowHandler(scopes, node) )
+            vsc.addWarning("The use of workflow handlers in the config is deprecated -- use the entry workflow or a plugin instead", String.join(".", node.names), node);
         if( inClosure ) {
             vsc.pushScope(ScriptDsl.class);
             if( inProcess )

--- a/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
@@ -63,29 +63,6 @@ class ConfigResolveTest extends Specification {
         errors[0].getOriginalMessage() == '`process` is not defined'
     }
 
-    def 'should report an error for an invalid dynamic config option' () {
-        when:
-        def errors = check(
-            '''\
-            report.file = { "report.html" }
-            '''
-        )
-        then:
-        errors.size() == 1
-        errors[0].getStartLine() == 1
-        errors[0].getStartColumn() == 1
-        errors[0].getOriginalMessage() == 'Dynamic config options are only allowed in the `process` scope'
-
-        when:
-        errors = check(
-            '''\
-            process.clusterOptions = { "--cpus ${task.cpus}" }
-            '''
-        )
-        then:
-        errors.size() == 0
-    }
-
     def 'should report an error for an invalid config include' () {
         given:
         def root = tempDir()


### PR DESCRIPTION
This PR fixes a false error for the `executor.jobName` config option.

I originally added a check for invalid dynamic config options, since only process config options can be dynamic. However, there are some config options that explicitly expect a closure, like `executor.jobName`.

Instead of adding another special case for this, I will move this check into the language server as part of type checking. So this PR just removes the check in nf-lang to address the false error. 