### PR TITLE
Fix NPE when contributors omit contribution field in manifest

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/Manifest.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/Manifest.groovy
@@ -208,13 +208,17 @@ class Manifest implements ConfigScope {
             affiliation = opts.affiliation as String
             email = opts.email as String
             github = opts.github as String
-            contribution = opts.contribution ? 
-                (opts.contribution as List<String>).stream()
-                    .map(c -> ContributionType.valueOf(c.toUpperCase()))
-                    .sorted()
-                    .toList() : 
-                []
+            contribution = parseContributionTypes(opts.contribution)
             orcid = opts.orcid as String
+        }
+
+        private List<ContributionType> parseContributionTypes(Object value) {
+            if( value == null )
+                return []
+            return (value as List<String>).stream()
+                .map(c -> ContributionType.valueOf(c.toUpperCase()))
+                .sorted()
+                .toList()
         }
 
         Map toMap() {

--- a/modules/nextflow/src/main/groovy/nextflow/config/Manifest.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/Manifest.groovy
@@ -208,10 +208,12 @@ class Manifest implements ConfigScope {
             affiliation = opts.affiliation as String
             email = opts.email as String
             github = opts.github as String
-            contribution = (opts.contribution as List<String>).stream()
-                .map(c -> ContributionType.valueOf(c.toUpperCase()))
-                .sorted()
-                .toList()
+            contribution = opts.contribution ? 
+                (opts.contribution as List<String>).stream()
+                    .map(c -> ContributionType.valueOf(c.toUpperCase()))
+                    .sorted()
+                    .toList() : 
+                []
             orcid = opts.orcid as String
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/config/ManifestTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ManifestTest.groovy
@@ -119,6 +119,37 @@ class ManifestTest extends Specification {
         ]
     }
 
+    def 'should handle contributors without contribution field' () {
+        when:
+        def manifest = new Manifest([
+            contributors: [[
+                name: 'Alice',
+                affiliation: 'University',
+                orcid: 'https://orcid.org/0000-0000-0000-0000'
+            ]]
+        ])
+        then:
+        manifest.contributors.size() == 1
+        manifest.contributors[0].name == 'Alice' 
+        manifest.contributors[0].affiliation == 'University'
+        manifest.contributors[0].orcid == 'https://orcid.org/0000-0000-0000-0000'
+        manifest.contributors[0].contribution == []
+    }
+
+    def 'should handle contributors with empty contribution field' () {
+        when:
+        def manifest = new Manifest([
+            contributors: [[
+                name: 'Bob',
+                contribution: []
+            ]]
+        ])
+        then:
+        manifest.contributors.size() == 1
+        manifest.contributors[0].name == 'Bob'
+        manifest.contributors[0].contribution == []
+    }
+
     def 'should throw error on invalid manifest' () {
         when:
         def manifest = new Manifest([


### PR DESCRIPTION
When a contributor in manifest.contributors omits the 'contribution' field, the code would attempt to call .stream() on null, causing a NullPointerException. Now defaults to empty list when contribution field is missing.

Fixes #6382 