### PR TITLE
Add null checks in TowerClient onFlowComplete method

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -402,14 +402,17 @@ class TowerClient implements TraceObserverV2 {
         // publish runtime reports
         reports.publishRuntimeReports()
         // wait the submission of pending events
-        sender.join()
+        if( sender )
+            sender.join()
         // wait and flush reports content
         reports.flowComplete()
         // notify the workflow completion
         terminated = true
-        final req = makeCompleteReq(session)
-        final resp = sendHttpMessage(urlTraceComplete, req, 'PUT')
-        logHttpResponse(urlTraceComplete, resp)
+        if( workflowId ) {
+            final req = makeCompleteReq(session)
+            final resp = sendHttpMessage(urlTraceComplete, req, 'PUT')
+            logHttpResponse(urlTraceComplete, resp)
+        }
     }
 
     @Override


### PR DESCRIPTION
# Fix NullPointerException in nf-tower plugin when onFlowBegin fails

## Summary
Add defensive null checking for sender thread and workflowId to prevent NullPointerException when onFlowComplete is called after initialization failures in onFlowCreate or onFlowBegin methods.

- Add null checks for `sender` thread and `workflowId` in `TowerClient.onFlowComplete()`
- Prevents NullPointerException when Tower API rejects configuration with HTTP 400
- Fixes workflow failure cascade caused by early exit from `onFlowBegin` hook

## Problem

When Nextflow encounters invalid configuration (e.g., https://github.com/nextflow-io/nextflow/issues/6382 ), the following cascade occurs:

1. Nextflow sends malformed configuration to Seqera Platform via `onFlowBegin` hook
2. Platform rejects configuration and returns HTTP 400 response  
3. nf-tower plugin receives 400 response and throws `AbortOperationException` in `onFlowBegin`
4. Early exit from `onFlowBegin` prevents initialization of `sender` thread and `workflowId`
5. When workflow completes, `onFlowComplete()` calls `sender.join()` on null reference
6. NullPointerException causes workflow to fail, masking the original configuration issue

This was reported in community forum thread and Seqera internal ticket #6701, where users experienced "Workflow execution completed unsuccessfully" despite successful pipeline runs, due to Tower communication failures caused by configuration parsing issues.

## Solution

Added defensive null checks in `onFlowComplete()`:

- **`sender` thread check**: Skip thread join if sender was never initialized due to `onFlowBegin` failure
- **`workflowId` check**: Skip completion HTTP request if workflow ID was never set due to `onFlowCreate` failure

These changes ensure that initialization failures don't cause secondary NullPointerExceptions that mask the root cause, allowing users to see the actual configuration errors.

## Test Plan

- [x] Verify existing nf-tower plugin tests pass
- [x] Confirm project compilation succeeds
- [ ] ~~Test with malformed configuration to ensure graceful handling~~ (not necessary)
- [ ] ~~Verify workflow completion reporting works correctly after configuration fixes~~ (not necessary)

## Related Issues

- Community forum: https://community.seqera.io/t/nextflow-not-communicating-back-to-seqera/2353
- Ticket #6701: NullPointerException in Tower communication due to configuration parsing failures