### PR TITLE
Fix typo in task config eval

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -110,7 +110,7 @@ class TaskConfig extends LazyMap implements Cloneable {
         if( object instanceof LazyMap ) {
             result = ((LazyMap)object).getValue(path.first())
         }
-        else if( Object instanceof Map ) {
+        else if( object instanceof Map ) {
             result = ((Map)object).get(path.first())
         }
         else if( path.size()>1 ) {


### PR DESCRIPTION
Close #6390 

Property expressions like `task.ext.args.foo.bar` cause an IllegalArgumentException when computing the task hash, due to a typo in `TaskConfig::eval0()` which causes the correct branch to be skipped.