### PR TITLE
Fix groupTuple operator GString vs String key handling

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/GroupTupleOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/GroupTupleOp.groovy
@@ -91,7 +91,7 @@ class GroupTupleOp {
      */
     private void collect(List tuple) {
 
-        final key = tuple[indices]                      // the actual grouping key
+        final key = normalizeKey(tuple[indices])        // the actual grouping key
         final len = tuple.size()
 
         final List items = groups.getOrCreate(key) {    // get the group for the specified key
@@ -126,7 +126,9 @@ class GroupTupleOp {
      * finalize the grouping binding the remaining values
      */
     private void finalise(nop) {
-        groups.each { keys, items -> bindTuple(items, size ?: sizeBy(keys)) }
+        for( Map.Entry<List,List> entry : groups.entrySet() ) {
+            bindTuple(entry.value, size ?: sizeBy(entry.key))
+        }
         target.bind(Channel.STOP)
     }
 
@@ -252,6 +254,21 @@ class GroupTupleOp {
         }
         else
             return 0
+    }
+
+    /**
+     * Normalize key by converting GString objects to String to ensure consistent grouping
+     *
+     * @param key The key object or list of key objects to normalize
+     * @return The normalized key with GString objects converted to String
+     */
+    static protected List normalizeKey(List keyList) {
+        final result = new ArrayList(keyList.size())
+        for( int i=0; i<keyList.size(); i++ ) {
+            final k = keyList[i]
+            result[i] = k instanceof GString ? k.toString() : k
+        }
+        return result
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/extension/GroupTupleOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/GroupTupleOpTest.groovy
@@ -140,4 +140,42 @@ class GroupTupleOpTest extends Specification {
         result.val == [k1, ['f']]
         result.val == Channel.STOP
     }
+
+    def 'should handle GString vs String keys correctly' () {
+        given:
+        def sampleName = "sample1"
+        def gstringKey = "${sampleName}"  // GStringImpl
+        def stringKey = "sample1"         // String
+        
+        def tuples = [
+                [gstringKey, 'file1.txt'],
+                [stringKey, 'file2.txt'],
+                [gstringKey, 'file3.txt']
+        ]
+
+        when:
+        def result = tuples.channel().groupTuple()
+        then:
+        // Without fix, this would create separate groups for GString and String keys
+        // With fix, they should be grouped together
+        result.val == [gstringKey, ['file1.txt', 'file2.txt', 'file3.txt']]
+        result.val == Channel.STOP
+    }
+
+    def 'should preserve non-string key types' () {
+        given:
+        def tuples = [
+                [1, 'file1.txt'],           // Integer key
+                [new File('/tmp'), 'file2.txt'],  // File key
+                [[a: 1], 'file3.txt']       // Map key
+        ]
+
+        when:
+        def result = tuples.channel().groupTuple()
+        then:
+        result.val == [1, ['file1.txt']]
+        result.val == [new File('/tmp'), ['file2.txt']]
+        result.val == [[a: 1], ['file3.txt']]
+        result.val == Channel.STOP
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the `groupTuple` operator to consistently handle GString vs String keys that represent the same logical value.

## Problem

The `groupTuple` operator was not properly grouping items when the same logical key was represented as both GString and String objects. This occurred when:
- Channel values contained interpolated strings (`"${variable}"` - GStringImpl)  
- These were mixed with regular String literals (`"same_value"` - String)
- Despite having identical content, they were treated as separate grouping keys

## Root Cause

GString and String objects with identical content have different:
- Hash codes
- Equality behavior (`==` returns false between GString and String)
- Class types

This caused them to create separate entries in the internal grouping map.

## Solution

Added key normalization in the `groupTuple` operator:
- Convert GString objects to String before grouping
- Preserve all other data types unchanged  
- Maintain backward compatibility

## Changes

- **GroupTupleOp.groovy**: 
  - Add `normalizeKey()` method to convert GString elements to String
  - Modify `collect()` method to normalize keys before grouping
  - Use enhanced for loops as requested

- **GroupTupleOpTest.groovy**:
  - Add comprehensive unit tests for GString/String scenarios
  - Add tests for preserving non-string key types
  - All existing tests continue to pass

## Test Plan

- [x] Unit tests pass (including new GString-specific tests)
- [x] Integration tests pass (all existing groupTuple tests)
- [x] No regressions in existing functionality
- [x] Non-string key types preserved correctly

## Related Issues

Fixes #6399

🤖 Generated with [Claude Code](https://claude.ai/code)