### PR TITLE
Fix cookie policy for Seqera Platform JWT token refresh

### DIFF
--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     api 'org.pf4j:pf4j:3.12.0'
     api 'org.pf4j:pf4j-update:2.3.0'
     api 'dev.failsafe:failsafe:3.1.0'
-    api 'io.seqera:lib-httpx:2.0.0'
+    api 'io.seqera:lib-httpx:2.1.0'
     api 'io.seqera:lib-retry:2.0.0'
     // patch gson dependency required by pf4j
     api 'com.google.code.gson:gson:2.13.1'

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.12.0'
-    compileOnly 'io.seqera:lib-httpx:2.0.0'
+    compileOnly 'io.seqera:lib-httpx:2.1.0'
 
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0"
     api "com.fasterxml.jackson.core:jackson-databind:2.12.7.1"

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -320,6 +320,7 @@ class TowerClient implements TraceObserverV2 {
             config.bearerToken(token)
             config.refreshToken(refreshToken)
             config.refreshTokenUrl(refreshUrl)
+            config.refreshCookiePolicy(CookiePolicy.ACCEPT_ALL)
             return
         }
 
@@ -333,6 +334,7 @@ class TowerClient implements TraceObserverV2 {
                 // setup the refresh
                 config.refreshToken(refreshToken)
                 config.refreshTokenUrl(refreshUrl)
+                config.refreshCookiePolicy(CookiePolicy.ACCEPT_ALL)
                 return
             }
         }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerFusionToken.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerFusionToken.groovy
@@ -176,11 +176,12 @@ class TowerFusionToken implements FusionToken {
         final refreshUrl = refreshToken ? "$endpoint/oauth/access_token" : null
         // the client config
         final config = HxConfig.newBuilder()
-            .withBearerToken(accessToken)
-            .withRefreshToken(refreshToken)
-            .withRefreshTokenUrl(refreshUrl)
-            .withRetryStatusCodes(SERVER_ERRORS)
-            .withRetryConfig(RetryConfig.config())
+            .bearerToken(accessToken)
+            .refreshToken(refreshToken)
+            .refreshTokenUrl(refreshUrl)
+            .refreshCookiePolicy(CookiePolicy.ACCEPT_ALL)
+            .retryStatusCodes(SERVER_ERRORS)
+            .retryConfig(RetryConfig.config())
             .build()
         // the client builder
         final builder = HxClient.newBuilder()

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
@@ -51,7 +51,7 @@ class TowerXAuth implements XAuthProvider {
         this.refreshToken = refreshToken
         //
         // the cookie manager
-        cookieManager = new CookieManager()
+        cookieManager = new CookieManager(null, CookiePolicy.ACCEPT_ALL)
         // create http client
         this.httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -47,10 +47,10 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.12.0'
     compileOnly 'io.seqera:lib-trace:0.1.0'
-    compileOnly 'io.seqera:lib-httpx:2.0.0'
+    compileOnly 'io.seqera:lib-httpx:2.1.0'
     
     // Force lib-httpx version to avoid conflicts with older versions from nf-commons
-    testImplementation 'io.seqera:lib-httpx:2.0.0'
+    testImplementation 'io.seqera:lib-httpx:2.1.0'
 
     api 'org.apache.commons:commons-compress:1.26.1'
     api 'org.apache.commons:commons-lang3:3.18.0'

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -150,6 +150,7 @@ class WaveClient {
                 .refreshToken(tower.refreshToken)
                 .refreshTokenUrl(refreshUrl)
                 .retryConfig(config.retryOpts())
+                .refreshCookiePolicy(CookiePolicy.ACCEPT_ALL)
                 .build()
     }
 


### PR DESCRIPTION
## Summary
- Updates lib-httpx dependency to version 2.1.0 across affected modules
- Configures `CookiePolicy.ACCEPT_ALL` for JWT token refresh functionality
- Fixes cookie handling in Tower and Wave clients for proper authentication token refresh

## Changes
- **modules/nf-commons**: Bump lib-httpx from 2.0.0 to 2.1.0
- **plugins/nf-tower**: Update lib-httpx dependency and configure cookie policy for TowerClient, TowerFusionToken, and TowerXAuth
- **plugins/nf-wave**: Update lib-httpx dependency and configure cookie policy for WaveClient

## Test plan
- [ ] Verify Tower authentication and token refresh works correctly
- [ ] Verify Wave service integration maintains proper authentication
- [ ] Run existing integration tests for Tower and Wave plugins

🤖 Generated with [Claude Code](https://claude.ai/code)