### PR TITLE
Fix hardcoded queue size in cloud executors

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchExecutor.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchExecutor.groovy
@@ -129,7 +129,8 @@ class AzBatchExecutor extends Executor implements ExtensionPoint {
 
     @Override
     protected TaskMonitor createTaskMonitor() {
-        TaskPollingMonitor.create(session, config, name, 1000, Duration.of('10 sec'))
+        final capacity = config.getQueueSize(name, 1000)
+        TaskPollingMonitor.create(session, config, name, capacity, Duration.of('10 sec'))
     }
 
     @Override

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -116,7 +116,8 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
 
     @Override
     protected TaskMonitor createTaskMonitor() {
-        TaskPollingMonitor.create(session, config, name, 1000, Duration.of('10 sec'))
+        final capacity = config.getQueueSize(name, 1000)
+        TaskPollingMonitor.create(session, config, name, capacity, Duration.of('10 sec'))
     }
 
     @Override

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sExecutor.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sExecutor.groovy
@@ -86,7 +86,8 @@ class K8sExecutor extends Executor implements ExtensionPoint {
      */
     @Override
     protected TaskMonitor createTaskMonitor() {
-        TaskPollingMonitor.create(session, config, name, 100, Duration.of('5 sec'))
+        final capacity = config.getQueueSize(name, 100)
+        TaskPollingMonitor.create(session, config, name, capacity, Duration.of('5 sec'))
     }
 
     /**


### PR DESCRIPTION
Fix for #6412 where hardcoded queue size values in cloud executors that were ignoring Nextflow configuration settings.

- **Google Batch**: Now uses `config.getQueueSize(name, 1000)` instead of hardcoded 1000
- **Azure Batch**: Now uses `config.getQueueSize(name, 1000)` instead of hardcoded 1000  
- **Kubernetes**: Now uses `config.getQueueSize(name, 100)` instead of hardcoded 100

Previously, these executors ignored `executor.queueSize` or `executor.$<executor>.queueSize` settings, making config to throttle jobs ineffective.

This replaces hardcoded values with explicit configuration lookup while preserving original defaults that were set, [similar to AWS Batch](https://github.com/nextflow-io/nextflow/blob/24314b112f23d5ae17da9646f4442aee862e1392/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy#L198).
- Calls `config.getQueueSize(name, defQueueSize)`
- The `defQueueSize` parameter serves as the fallback default if no config is found/set
- Maintain configuration hierarchy: `executor.$<executor>.queueSize` → `executor.queueSize` → `NXF_EXECUTOR_QUEUESIZE `→ `defQueueSize`
