### PR TITLE
Fix nf-tower to avoid skiping logs backup when no local cloud cache   

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheManager.groovy
@@ -48,6 +48,7 @@ class CacheManager {
     @PackageScope Path localTowerConfig
     @PackageScope Path localTowerReports
     @PackageScope Path remoteWorkDir
+    @PackageScope boolean cloudCache = false
 
     @PackageScope Path getRemoteCachePath() { remoteWorkDir.resolve(".nextflow/cache/${sessionUuid}") }
     @PackageScope Path getRemoteOutFile() { remoteWorkDir.resolve(localOutFile.getName()) }
@@ -78,6 +79,8 @@ class CacheManager {
             localTowerConfig = Paths.get(env.TOWER_CONFIG_FILE)
         if( env.TOWER_REPORTS_FILE )
             localTowerReports = Paths.get(env.TOWER_REPORTS_FILE)
+        if( env.NXF_CLOUDCACHE_PATH )
+            cloudCache = true
     }
 
     protected void restoreCacheFiles() {
@@ -103,22 +106,6 @@ class CacheManager {
     protected void saveCacheFiles() {
         if( !remoteWorkDir || !sessionUuid )
             return
-
-        if( !Files.exists(localCachePath) ) {
-            log.debug "Local cache path does not exist: $localCachePath — skipping cache backup"
-            return
-        }
-
-        // upload nextflow cache metadata
-        try {
-            log.info "Saving cache: ${localCachePath.toUriString()} => ${remoteCachePath.toUriString()}"
-            remoteCachePath.deleteDir()
-            remoteCachePath.parent.mkdirs()
-            FilesEx.copyTo(localCachePath, remoteCachePath)
-        }
-        catch (Throwable e) {
-            log.warn "Failed to backup resume metadata to remote store path: ${remoteCachePath.toUriString()} — cause: ${e}", e
-        }
 
         // — upload out file
         try {
@@ -159,6 +146,29 @@ class CacheManager {
         }
         catch (Throwable e) {
             log.warn "Unable to upload tower reprts file: $localTowerReports — reason: ${e.message ?: e}", e
+        }
+
+        if( !Files.exists(localCachePath) ) {
+            if( cloudCache ){
+                // Just log as debug message when localpath doesn't exist and cloud cache path is defined.
+                // It is likely the user has use cloud cache.
+                log.debug "Local cache path does not exist: $localCachePath — skipping cache backup"
+            } else {
+                // Print warning when localCachePath doesn't exists and cloud cache path is not defined.
+                log.warn "Local cache path does not exist: $localCachePath — skipping cache backup"
+            }
+            return
+        }
+
+        // upload nextflow cache metadata
+        try {
+            log.info "Saving cache: ${localCachePath.toUriString()} => ${remoteCachePath.toUriString()}"
+            remoteCachePath.deleteDir()
+            remoteCachePath.parent.mkdirs()
+            FilesEx.copyTo(localCachePath, remoteCachePath)
+        }
+        catch (Throwable e) {
+            log.warn "Failed to backup resume metadata to remote store path: ${remoteCachePath.toUriString()} — cause: ${e}", e
         }
     }
 


### PR DESCRIPTION
This PR fixes the problem where logs are not completely uploaded to the Platform at the end of the pipeline execution. The problem is produced because Platform is now using cloud cache, and the nf-tower cache backup command executed at the end of execution is skipping the logs upload when the local cache folder doesn't exist. It is printing a debug message, but it is not visible in the stdout. Moreover, the logs of this command were not uploaded to the Platform. So, it was not an easy way to see the error. 

This PR fixes the problem by uploading the logs first, moving the cache upload to the end. So, if the local cache folder does not exist, it will just skip the cache backup. 
The PR also improves logging. When the cloud cache path is not defined and the local folder doesn't exist, it prints a warning instead of a debug message.  In that case, the message will be printed in the stdout, making the problem visible to the user. When the cloud cache path is defined, we keep the debug message as the skip is expected, and no need to warn the user. 