### PR TITLE
Fix #6182: Add Google Batch LogsPolicy PATH option for GCS bucket log…

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -447,12 +447,27 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         return Job.newBuilder()
             .addTaskGroups(taskGroup)
             .setAllocationPolicy(allocationPolicy)
-            .setLogsPolicy(
-                LogsPolicy.newBuilder()
-                    .setDestination(LogsPolicy.Destination.CLOUD_LOGGING)
-            )
+            .setLogsPolicy(createLogsPolicy())
             .putAllLabels(task.config.getResourceLabels())
             .build()
+    }
+
+    /**
+     * Create the LogsPolicy based on configuration
+     * @return LogsPolicy configured for either PATH (GCS bucket) or CLOUD_LOGGING
+     */
+    protected LogsPolicy createLogsPolicy() {
+        final logsBucket = executor.batchConfig.logsBucket
+        if( logsBucket ) {
+            return LogsPolicy.newBuilder()
+                .setDestination(LogsPolicy.Destination.PATH)
+                .setLogsPath(logsBucket)
+                .build()
+        } else {
+            return LogsPolicy.newBuilder()
+                .setDestination(LogsPolicy.Destination.CLOUD_LOGGING)
+                .build()
+        }
     }
 
     /**

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
@@ -67,4 +67,38 @@ class BatchConfigTest extends Specification {
         config.bootDiskSize == MemoryUnit.of('100GB')
     }
 
+    @Requires({System.getenv('GOOGLE_APPLICATION_CREDENTIALS')})
+    def 'should validate logs bucket config' () {
+        when:
+        def config = new BatchConfig([logsBucket: 'gs://my-logs-bucket/logs'])
+        then:
+        config.logsBucket == 'gs://my-logs-bucket/logs'
+
+        when:
+        config = new BatchConfig([:])
+        then:
+        config.logsBucket == null
+    }
+
+    @Requires({System.getenv('GOOGLE_APPLICATION_CREDENTIALS')})
+    def 'should reject invalid logs bucket paths' () {
+        when:
+        new BatchConfig([logsBucket: 'invalid-bucket'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Logs bucket path must start with 'gs://'")
+
+        when:
+        new BatchConfig([logsBucket: 'gs://'])
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message.contains("Invalid logs bucket path")
+
+        when:
+        new BatchConfig([logsBucket: 's3://bucket'])
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message.contains("Logs bucket path must start with 'gs://'")
+    }
+
 }


### PR DESCRIPTION
… storage

- Add logsBucket configuration option to BatchConfig
- Support both CLOUD_LOGGING (default) and PATH log destinations
- Add validation for GCS bucket paths (must start with gs://)
- Include comprehensive tests for new functionality
- Maintain backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)
NOTE: this change still needs human review.

Signed-off-by: David Glazer <dglazer@verily.com>