### PR TITLE
Fix cache command to use SysEnv for cloudcache path check

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheCommand.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/CacheCommand.groovy
@@ -19,6 +19,7 @@ package io.seqera.tower.plugin
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.SysEnv
 import nextflow.cli.PluginAbstractExec
 /**
  * Implements nextflow cache and restore commands
@@ -43,12 +44,17 @@ class CacheCommand implements PluginAbstractExec {
     }
 
     protected void cacheBackup() {
-        log.debug "Running Nextflow cache backup"
-        if( !getSession().cloudCachePath ) {
+        // note: use directly NXF_CLOUDCACHE_PATH instead of `session.cloudCachePath`
+        // because the latter required to be initialized via the execution
+        // CmdRun. However this command is only executed to be used  via Seqera Platform
+        // that's providing the cache path via the env variable
+        if( !SysEnv.get('NXF_CLOUDCACHE_PATH') ) {
+            log.debug "Running Nextflow cache backup (CacheManager)"
             // legacy cache manager
             new CacheManager(System.getenv()).saveCacheFiles()
         }
         else {
+            log.debug "Running Nextflow cache backup (LogsHandler)"
             new LogsHandler(getSession(), System.getenv()).saveFiles()
         }
     }


### PR DESCRIPTION
## Summary
- Fix cache command to use `SysEnv.get('NXF_CLOUDCACHE_PATH')` instead of `session.cloudCachePath`
- Add debug logging to distinguish between CacheManager and LogsHandler usage paths
- Improves handling when command is used via Seqera Platform

## Changes
- Use `SysEnv.get('NXF_CLOUDCACHE_PATH')` for environment variable check
- Add debug logs to show which backup method is being used
- Add explanatory comment about why direct env var access is used

## Context  
The `session.cloudCachePath` requires initialization via CmdRun execution, but this command is primarily used by Seqera Platform which provides the cache path via environment variable. Using `SysEnv` directly avoids the initialization dependency.

🤖 Generated with [Claude Code](https://claude.ai/code)