### PR TITLE
Standardize config schema terminology from 'children' to 'entries'

### DIFF
--- a/adrs/2025-09-22-plugin-spec.md
+++ b/adrs/2025-09-22-plugin-spec.md
@@ -86,9 +86,9 @@ The following types of definitions are allowed:
 
 **ConfigScope**
 
-Defines a top-level config scope. The spec consists of a *name*, an optional *description*, and *children*.
+Defines a top-level config scope. The spec consists of a *name*, an optional *description*, and *entries*.
 
-The children should be a list of definitions corresponding to nested config scopes and options. The following definitions are allowed:
+The entries should be a list of definitions corresponding to nested config scopes and options. The following definitions are allowed:
 
 - **ConfigOption**: Defines a config option. The spec consists of a *description* and *type*.
 
@@ -102,7 +102,7 @@ Example:
     "spec": {
         "name": "hello",
         "description": "The `hello` scope controls the behavior of the `nf-hello` plugin.",
-        "children": [
+        "entries": [
             {
                 "type": "ConfigOption",
                 "spec": {

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
@@ -69,24 +69,24 @@ class ConfigValidator {
     }
 
     private void loadPluginScopes() {
-        final children = new HashMap<String, SchemaNode>()
+        final entries = new HashMap<String, SchemaNode>()
         for( final scope : Plugins.getExtensions(ConfigScope) ) {
             final clazz = scope.getClass()
             final name = clazz.getAnnotation(ScopeName)?.value()
             final description = clazz.getAnnotation(Description)?.value()
             if( name == '' ) {
-                children.putAll(SchemaNode.Scope.of(clazz, '').children())
+                entries.putAll(SchemaNode.Scope.of(clazz, '').entries())
                 continue
             }
             if( !name )
                 continue
-            if( name in children ) {
+            if( name in entries ) {
                 log.warn "Plugin config scope `${clazz.name}` conflicts with existing scope: `${name}`"
                 continue
             }
-            children.put(name, SchemaNode.Scope.of(clazz, description))
+            entries.put(name, SchemaNode.Scope.of(clazz, description))
         }
-        pluginScopes = new SchemaNode.Scope('', children)
+        pluginScopes = new SchemaNode.Scope('', entries)
     }
 
     void validate(ConfigMap config) {
@@ -138,7 +138,7 @@ class ConfigValidator {
     boolean isValid(List<String> names) {
         if( names.size() == 1 && names.first() in HIDDEN_OPTIONS )
             return true
-        final child = SchemaNode.ROOT.getChild(names)
+        final child = SchemaNode.ROOT.getEntry(names)
         if( child instanceof SchemaNode.Option || child instanceof SchemaNode.DslOption )
             return true
         if( pluginScopes.getOption(names) )
@@ -154,7 +154,7 @@ class ConfigValidator {
      */
     private boolean isMissingCorePluginScope(String name) {
         return name in CORE_PLUGIN_SCOPES
-            && !pluginScopes.children().containsKey(name)
+            && !pluginScopes.entries().containsKey(name)
     }
 
     /**
@@ -172,7 +172,7 @@ class ConfigValidator {
         SchemaNode node = scope
         for( final name : names ) {
             if( node instanceof SchemaNode.Scope )
-                node = node.children().get(name)
+                node = node.entries().get(name)
             else if( node instanceof SchemaNode.Placeholder )
                 node = node.scope()
             else if( node instanceof SchemaNode.Option )

--- a/modules/nextflow/src/main/groovy/nextflow/config/schema/MarkdownRenderer.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/schema/MarkdownRenderer.groovy
@@ -45,10 +45,10 @@ class MarkdownRenderer {
                 result.append("\n${fromDescription(description)}\n")
             result.append("\nThe following settings are available:\n")
 
-            final options = scope.children().findAll { name, node -> node instanceof SchemaNode.Option }
+            final options = scope.entries().findAll { name, node -> node instanceof SchemaNode.Option }
             renderOptions(options, scopeName, result)
 
-            final scopes = scope.children().findAll { name, node -> node instanceof SchemaNode.Scope }
+            final scopes = scope.entries().findAll { name, node -> node instanceof SchemaNode.Scope }
             renderOptions(scopes, scopeName, result)
         }
         return result.toString()
@@ -81,9 +81,9 @@ class MarkdownRenderer {
             if( node instanceof SchemaNode.Option )
                 renderOption("${prefix}${name}", node, result)
             else if( node instanceof SchemaNode.Placeholder )
-                renderOptions(node.scope().children(), "${prefix}${name}.${node.placeholderName()}", result)
+                renderOptions(node.scope().entries(), "${prefix}${name}.${node.placeholderName()}", result)
             else if( node instanceof SchemaNode.Scope )
-                renderOptions(node.children(), "${prefix}${name}", result)
+                renderOptions(node.entries(), "${prefix}${name}", result)
             else
                 throw new IllegalStateException()
         }

--- a/modules/nextflow/src/main/groovy/nextflow/plugin/spec/ConfigSpec.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/plugin/spec/ConfigSpec.groovy
@@ -74,7 +74,7 @@ class ConfigSpec {
 
     private static Map<String,?> fromScope(SchemaNode.Scope node, String scopeName=null) {
         final description = node.description().stripIndent(true).trim()
-        final children = node.children().collect { name, child ->
+        final entries = node.entries().collect { name, child ->
             fromNode(child, name)
         }
 
@@ -83,7 +83,7 @@ class ConfigSpec {
             spec: [
                 name: scopeName,
                 description: description,
-                children: children
+                entries: entries
             ]
         ]
     }

--- a/modules/nextflow/src/test/groovy/nextflow/plugin/spec/PluginSpecTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/plugin/spec/PluginSpecTest.groovy
@@ -53,7 +53,7 @@ class PluginSpecTest extends Specification {
             spec: [
                 name: 'hello',
                 description: 'The `hello` scope controls the behavior of the `nf-hello` plugin.',
-                children: [
+                entries: [
                     [
                         type: 'ConfigOption',
                         spec: [


### PR DESCRIPTION
## Summary
- Standardizes terminology across the configuration schema system from 'children' to 'entries'
- Updates all related code, tests, and documentation for consistency
- Improves semantic clarity by using terminology that better reflects the nature of config elements

## Rationale
The term 'entries' better reflects the nature of these elements as key-value pairs in a configuration map, rather than hierarchical child nodes. This terminology is more aligned with standard configuration and data structure conventions (similar to Map.entrySet(), dictionary entries, etc.).

## Changes Made
- **SchemaNode.java**: Updated variable names and record field from `children` to `entries`
- **ConfigValidator.groovy**: Updated variable names and method calls to use `entries()`
- **ConfigSpec.groovy**: Updated variable names and output field names 
- **PluginSpecTest.groovy**: Updated test expectations to use `entries` field
- **ADR documentation**: Updated terminology in plugin spec documentation
- **MarkdownRenderer.groovy**: Updated method calls to use `entries()`

## Test Plan
- [x] All existing tests pass with updated terminology
- [x] Configuration validation continues to work correctly
- [x] Plugin spec generation uses consistent terminology
- [x] Documentation examples reflect new terminology

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the config schema map field and accessors from `children`/`getChild` to `entries`/`getEntry`, updating validators, renderers, spec generation, tests, and ADR docs.
> 
> - **Schema**:
>   - Rename `SchemaNode.Scope.children` to `entries`; update constructors and usage in `ROOT`, `processScope()`, and `Scope.of(...)`.
>   - Rename `Scope.getChild(...)` to `getEntry(...)`; adjust `getDslOption`, `getOption`, `getScope` to use it.
> - **Config validation** (`nextflow/config/ConfigValidator.groovy`):
>   - Switch internal maps and lookups from `children` to `entries`; use `ROOT.getEntry(...)` and `scope.entries()`.
> - **Markdown rendering** (`config/schema/MarkdownRenderer.groovy`):
>   - Replace all `children()` traversals with `entries()` for options/scopes recursion.
> - **Plugin spec generation** (`plugin/spec/ConfigSpec.groovy`):
>   - Emit scope `entries` instead of `children` in generated spec JSON.
> - **Tests** (`PluginSpecTest.groovy`):
>   - Update expected plugin spec to assert `entries` array.
> - **Docs** (`adrs/2025-09-22-plugin-spec.md`):
>   - Replace `children` with `entries` in spec description and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64fb43d8b271aff0a29089282f6f87fac48379e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->