### PR TITLE
Bump Google Cloud libraries to latest versions

### DIFF
--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -52,11 +52,11 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.12.0'
 
-    api 'com.google.auth:google-auth-library-oauth2-http:1.37.1'
-    api 'com.google.cloud:google-cloud-batch:0.67.0'
-    api 'com.google.cloud:google-cloud-logging:3.22.6'
-    api 'com.google.cloud:google-cloud-nio:0.127.37'
-    api 'com.google.cloud:google-cloud-storage:2.53.2'
+    api 'com.google.auth:google-auth-library-oauth2-http:1.39.1'
+    api 'com.google.cloud:google-cloud-batch:0.75.0'
+    api 'com.google.cloud:google-cloud-logging:3.23.5'
+    api 'com.google.cloud:google-cloud-nio:0.128.5'
+    api 'com.google.cloud:google-cloud-storage:2.58.0'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.apache.groovy:groovy:4.0.28"


### PR DESCRIPTION
## Summary
- Updates Google Cloud libraries in nf-google plugin to latest versions
- `google-auth-library-oauth2-http`: 1.37.1 → 1.39.1
- `google-cloud-batch`: 0.67.0 → 0.75.0
- `google-cloud-logging`: 3.22.6 → 3.23.5
- `google-cloud-nio`: 0.127.37 → 0.128.5
- `google-cloud-storage`: 2.53.2 → 2.58.0

## Test plan
- [ ] Verify build succeeds
- [ ] Run plugin tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Google auth and Google Cloud libraries in `plugins/nf-google` to newer versions.
> 
> - **Dependencies (nf-google)**:
>   - Bump `com.google.auth:google-auth-library-oauth2-http` 1.37.1 → 1.39.1
>   - Bump `com.google.cloud:google-cloud-batch` 0.67.0 → 0.75.0
>   - Bump `com.google.cloud:google-cloud-logging` 3.22.6 → 3.23.5
>   - Bump `com.google.cloud:google-cloud-nio` 0.127.37 → 0.128.5
>   - Bump `com.google.cloud:google-cloud-storage` 2.53.2 → 2.58.0
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92baf55b0c3053623e5e2f95279b4165365351b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->