### PR TITLE
Get exit code from pod to manage OOM in k8s

### DIFF
--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -424,7 +424,9 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
             }
             else {
                 // finalize the task
-                task.exitStatus = readExitFile()
+                // try to get exit code from K8s state
+                final k8sExitCode = (state.terminated as Map)?.exitCode as Integer
+                task.exitStatus = k8sExitCode ?: readExitFile()
                 task.stdout = outputFile
                 task.stderr = errorFile
             }

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -424,7 +424,9 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
             }
             else {
                 // finalize the task
-                // try to get exit code from K8s state
+                // try to get exit code from K8s container state.terminated.
+                // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstateterminated-v1-core
+                log.trace("Container Terminated state ${state.terminated}")
                 final k8sExitCode = (state.terminated as Map)?.exitCode as Integer
                 task.exitStatus = k8sExitCode ?: readExitFile()
                 task.stdout = outputFile

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -426,7 +426,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
                 // finalize the task
                 // try to get exit code from K8s container state.terminated.
                 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstateterminated-v1-core
-                log.trace("Container Terminated state ${state.terminated}")
+                log.trace("[k8s] Container Terminated state ${state.terminated}")
                 final k8sExitCode = (state.terminated as Map)?.exitCode as Integer
                 task.exitStatus = k8sExitCode ?: readExitFile()
                 task.stdout = outputFile

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -424,7 +424,11 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
             }
             else {
                 // finalize the task
-                // try to get exit code from K8s container state.terminated.
+                // read the exit code from the K8s container terminated state, if 0 (successful) or missing
+                // take the exit code from the `.exitcode` file created by nextflow
+                // the rationale is that in case of error (e.g. OOMKilled, pod eviction), the exit code from
+                // the K8s API is more reliable because the container may terminate before the exit file is written
+                // See https://github.com/nextflow-io/nextflow/issues/6436
                 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstateterminated-v1-core
                 log.trace("[k8s] Container Terminated state ${state.terminated}")
                 final k8sExitCode = (state.terminated as Map)?.exitCode as Integer

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -509,6 +509,32 @@ class K8sTaskHandlerTest extends Specification {
 
     }
 
+    def 'should use K8s exit code when available' () {
+        given:
+        def ERR_FILE = Paths.get('err.file')
+        def OUT_FILE = Paths.get('out.file')
+        def POD_NAME = 'pod-xyz'
+        def client = Mock(K8sClient)
+        def termState = [ reason: "Error",
+                          startedAt: "2018-01-13T10:09:36Z",
+                          finishedAt: "2018-01-13T10:19:36Z",
+                          exitCode: 137 ]
+        def task = new TaskRun()
+        def handler = Spy(new K8sTaskHandler(task: task, client:client, podName: POD_NAME, outputFile: OUT_FILE, errorFile: ERR_FILE))
+
+        when:
+        def result = handler.checkIfCompleted()
+        then:
+        1 * handler.getState() >> [terminated: termState]
+        1 * handler.updateTimestamps(termState)
+        0 * handler.readExitFile()
+        1 * handler.deletePodIfSuccessful(task) >> null
+        1 * handler.savePodLogOnError(task) >> null
+        handler.task.exitStatus == 137
+        handler.status == TaskStatus.COMPLETED
+        result == true
+    }
+
     def 'should kill a pod' () {
         given:
         def POD_NAME = 'pod-xyz'


### PR DESCRIPTION
close #6436

This PR improves error handling in the K8s task handler by prioritizing the exit code from the Kubernetes API over the .exitcode file created by Nextflow.

**Rationale:**
In case of errors like OOMKilled or pod eviction, the container may terminate abruptly before the exit file is written. The exit code from the K8s API (via the container's terminated state) is more reliable in these scenarios.

**Implementation:**
- First check the K8s container terminated state for the exit code
- If the K8s exit code is 0 (successful) or missing, fall back to reading from the .exitcode file
- This ensures proper error detection and reporting for abrupt container terminations

**Reference:**
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstateterminated-v1-core