### PR TITLE
Add staging events to the TraceObserverV2

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -77,6 +77,7 @@ import nextflow.trace.TraceObserverV2
 import nextflow.trace.TraceRecord
 import nextflow.trace.WorkflowStatsObserver
 import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.FileStagingEvent
 import nextflow.trace.event.TaskEvent
 import nextflow.trace.event.WorkflowOutputEvent
 import nextflow.util.Barrier
@@ -1114,6 +1115,10 @@ class Session implements ISession {
     void notifyFilePublish(FilePublishEvent event) {
         notifyEvent(observersV1, ob -> ob.onFilePublish(event.target, event.source))
         notifyEvent(observersV2, ob -> ob.onFilePublish(event))
+    }
+
+    void notifyFileStaged(FileStagingEvent event) {
+        notifyEvent(observersV2, ob -> ob.onFileStaged(event))
     }
 
     void notifyFlowComplete() {

--- a/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
@@ -39,6 +39,7 @@ import groovy.transform.ToString
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.exception.ProcessStageException
+import nextflow.trace.event.FileStagingEvent
 import nextflow.extension.FilesEx
 import nextflow.util.CacheHelper
 import nextflow.util.Duration
@@ -100,6 +101,15 @@ class FilePorter {
         if( batch.size() ) {
             log.trace "Stage foreign files: $batch"
             submitStagingActions(batch.foreignPaths)
+            
+            // Notify observers about file staging completion events
+            for( FileCopy copy : batch.foreignPaths ) {
+                session.notifyFileStaged(new FileStagingEvent(
+                    source: copy.source,
+                    target: copy.target
+                ))
+            }
+            
             log.trace "Stage foreign files completed: $batch"
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceObserverV2.groovy
@@ -21,6 +21,7 @@ import groovy.transform.CompileStatic
 import nextflow.Session
 import nextflow.processor.TaskProcessor
 import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.FileStagingEvent
 import nextflow.trace.event.TaskEvent
 import nextflow.trace.event.WorkflowOutputEvent
 
@@ -134,5 +135,12 @@ interface TraceObserverV2 {
      * @param event
      */
     default void onFilePublish(FilePublishEvent event) {}
+
+    /**
+     * Invoked when a file staging operation completes (after the file has been copied).
+     *
+     * @param event
+     */
+    default void onFileStaged(FileStagingEvent event) {}
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/event/FileStagingEvent.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/event/FileStagingEvent.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.trace.event
+
+import java.nio.file.Path
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+/**
+ * Models a file staging event.
+ *
+ * @author Robrecht Cannoodt <robrecht@data-intuitive.com>
+ */
+@Canonical
+@CompileStatic
+class FileStagingEvent {
+    /**
+     * The original source path (e.g., remote URL or path).
+     */
+    Path source
+    /**
+     * The target staged path in the work directory.
+     */
+    Path target
+}


### PR DESCRIPTION
This PR implements file staging event notifications for `TraceObserverV2`, allowing plugins to track when remote files are staged to the local work directory. This resolves #5905 by providing observers access to both the original remote file paths and their staged local paths.

## Background

Issue #5905 identified a need for provenance tracking plugins (specifically nf-lamin) to access the original remote paths of input files, not just their staged local paths. Two previous attempts were made to solve this:

- **#5907**: Added `onFileStage` to `TraceObserver` - rejected in favor of #5911
- **#5911**: Modified `FileHolder` to include remote paths - merged but then **reverted** due to concerns about cache invalidation and risk to core functionality

I met up with @bentsherman at the beginning of September. He said he wanted to have another shot at resolving this issue, and that I could reach out in a few weeks time if no progress was made.

## Solution

This implementation is a simpler solution in comparison to the two previous PRs. I added this to the TraceObserverV2:

- **`onFileStaged(FileStagingEvent event)`** - Called after a file has been successfully staged from a remote location

The `FileStagingEvent` provides:
- `source`: The original remote path (e.g., `s3://bucket/file.txt`, `https://example.com/data.csv`)
- `target`: The staged local path in the work directory (e.g., `work/.../file.txt`)

## Usage Example

For plugins that need to track file provenance (like nf-lamin):

```groovy
class ProvenanceObserver implements TraceObserverV2 {
    
    @Override
    void onFileStaged(FileStagingEvent event) {
        // event.source = original remote path
        // event.target = staged local path
        log.info "File staged: ${event.source} -> ${event.target}"
        registerFileProvenance(event.source, event.target)
    }
}
```

## Related Issues

- Resolves #5905
- Supersedes #5907 (rejected)
- Supersedes #5911 (reverted)
