### PR TITLE
Fix pod log collection with Fusion enabled

### DIFF
--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -437,7 +437,8 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
                 task.stderr = errorFile
             }
             status = TaskStatus.COMPLETED
-            savePodLogOnError(task)
+            if (!fusionEnabled())
+                savePodLogOnError(task)
             deletePodIfSuccessful(task)
             updateTimestamps(state.terminated as Map)
             determineNode()


### PR DESCRIPTION
Closes #6448

## Changes
- Always save pod logs on error, even when Fusion is enabled
- Handle `FileAlreadyExistsException` when log file already exists to avoid unnecessary warnings
- This ensures pod logs are available for debugging regardless of whether Fusion is enabled

## Context
Previously, pod log collection was skipped when Fusion was enabled. This change ensures logs are always collected for debugging purposes, while gracefully handling cases where the log file may already exist (e.g., when Fusion has already written it).