### PR TITLE
Save pod logs always in K8s executor

### DIFF
--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -438,7 +438,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
                 task.stderr = errorFile
             }
             status = TaskStatus.COMPLETED
-            savePodLogOnError(task)
+            savePodLog(task)
             deletePodIfSuccessful(task)
             updateTimestamps(state.terminated as Map)
             determineNode()
@@ -448,17 +448,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
         return false
     }
 
-    protected void savePodLogOnError(TaskRun task) {
-        if( task.isSuccess() )
-            return
-
-        if( errorFile && !errorFile.empty() )
-            return
-
-        final session = executor.getSession()
-        if( session.isAborted() || session.isCancelled() || session.isTerminated() )
-            return
-
+    protected void savePodLog(TaskRun task) {
         try {
             final stream = useJobResource()
                     ? client.jobLog(podName)


### PR DESCRIPTION
When using  k8s without fusion the .command.log file is only saved if a task fails. However, Platform try to get .command.log for all tasks executed. So for non-failed tasks it is unable to find the log file.
This PR save the logs for all executed task in K8s not just the failed ones. 

Before:
```
$ nextflow kuberun hello -v nextflow-pvc:/mnt/data/launch
Pod started: cranky-wescoff
N E X T F L O W  ~  version 25.08.0-edge
Downloading plugin nf-k8s@1.2.0
Launching `https://github.com/nextflow-io/hello` [cranky-wescoff] DSL2 - revision: 2ce0b0e294 [master]
[a0/c586d4] Submitted process > sayHello (3)
[c0/436eae] Submitted process > sayHello (2)
[05/f732d7] Submitted process > sayHello (4)
[13/79bfa7] Submitted process > sayHello (1)
Hello world!

Ciao world!

Hola world!

Bonjour world!
```
```
/tmp/k3d-storage/jorgee/work/a0/c586d4fe458bef9e07f1a39138405f$ ls -lart
total 24
drwxr-xr-x 3 root root 4096 oct  7 10:16 ..
-rw-r--r-- 1 root root   36 oct  7 10:16 .command.sh
-rw-r--r-- 1 root root 3163 oct  7 10:16 .command.run
-rw-r--r-- 1 root root    0 oct  7 10:16 .command.begin
-rw-r--r-- 1 root root   13 oct  7 10:16 .command.out
-rw-r--r-- 1 root root    0 oct  7 10:16 .command.err
drwxr-xr-x 2 root root 4096 oct  7 10:16 .
-rw-r--r-- 1 root root    1 oct  7 10:16 .exitcode
```

with this PR:

```
$ nextflow kuberun -head-image jorgeejarquea/nextflow:25.08.0-edge-7d52b47aa hello -v nextflow-pvc:/mnt/data/launch
Pod started: high-caravaggio
N E X T F L O W  ~  version 25.08.0-edge
Launching `https://github.com/nextflow-io/hello` [high-caravaggio] DSL2 - revision: 2ce0b0e294 [master]
[9d/83f7c1] Submitted process > sayHello (4)
[83/b86f0e] Submitted process > sayHello (3)
[f7/9dd060] Submitted process > sayHello (2)
[d6/bf304d] Submitted process > sayHello (1)
Hola world!

Hello world!

Ciao world!

Bonjour world!
```

```
/tmp/k3d-storage/jorgee/work/9d/83f7c1915ac279548bdd9a36168a0c$ ls -lart
total 28
drwxr-xr-x 3 root root 4096 oct  7 10:22 ..
-rw-r--r-- 1 root root   35 oct  7 10:22 .command.sh
-rw-r--r-- 1 root root 3163 oct  7 10:22 .command.run
-rw-r--r-- 1 root root    0 oct  7 10:22 .command.begin
-rw-r--r-- 1 root root    0 oct  7 10:22 .command.err
-rw-r--r-- 1 root root   12 oct  7 10:22 .command.out
-rw-r--r-- 1 root root    1 oct  7 10:22 .exitcode
-rw-r--r-- 1 root root   12 oct  7 10:22 .command.log
drwxr-xr-x 2 root root 4096 oct  7 10:22 .
```

