### PR TITLE
Add .command.log redirection in K8s container command when Fusion is not enabled

### DIFF
--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -498,6 +498,7 @@ class K8sTaskHandlerTest extends Specification {
         1 * handler.updateTimestamps(termState)
         1 * handler.readExitFile() >> EXIT_STATUS
         1 * handler.deletePodIfSuccessful(task) >> null
+        1 * handler.savePodLogOnError(task) >> null
         handler.task.exitStatus == EXIT_STATUS
         handler.task.@stdout == OUT_FILE
         handler.task.@stderr == ERR_FILE
@@ -528,6 +529,7 @@ class K8sTaskHandlerTest extends Specification {
         1 * handler.updateTimestamps(termState)
         0 * handler.readExitFile()
         1 * handler.deletePodIfSuccessful(task) >> null
+        1 * handler.savePodLogOnError(task) >> null
         handler.task.exitStatus == 137
         handler.status == TaskStatus.COMPLETED
         result == true
@@ -783,6 +785,43 @@ class K8sTaskHandlerTest extends Specification {
         then:
         1 * executor.getK8sConfig() >> new K8sConfig(cleanup: false)
         0 * client.podDelete(POD_NAME) >> null
+
+    }
+
+    def 'should save pod log' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def POD_NAME = 'the-pod-name'
+        def POD_MESSAGE = 'Hello world!'
+        def POD_LOG = new ByteArrayInputStream(new String(POD_MESSAGE).bytes)
+        def session = Mock(Session)
+        def task = Mock(TaskRun)
+        def executor = Mock(K8sExecutor)
+        def client = Mock(K8sClient)
+        and:
+        def handler = Spy(new K8sTaskHandler(executor: executor, client: client, podName: POD_NAME))
+
+        when:
+        handler.savePodLogOnError(task)
+        then:
+        task.isSuccess() >> true
+        0 * client.podLog(_)
+
+        when:
+        handler.savePodLogOnError(task)
+        then:
+        task.isSuccess() >> false
+        task.getWorkDir() >> folder
+        executor.getSession() >> session
+        session.isTerminated() >> false
+        session.isCancelled() >> false
+        session.isAborted() >> false
+        1 * client.podLog(POD_NAME) >> POD_LOG
+
+        folder.resolve( TaskRun.CMD_LOG ).text == POD_MESSAGE
+        cleanup:
+        folder?.deleteDir()
 
     }
 


### PR DESCRIPTION
When using k8s without Fusion the .command.log file is only saved if a task fails. However, Platform tries to get `.command.log` for all tasks executed. So for non-failed tasks it is unable to find the log file.

This PR changes the container command to include the redirection of `.command.run` outputs to `.command.log` when Fusion is not enabled. It replaces #6451  because getting .command.log from the pod logs for all tasks overload the Kubernetes API with large number of tasks.

See also #2782

Tested with local K3d cluster:

```
$ nextflow kuberun -head-image jorgeejarquea/nextflow:25.08.0-edge-2765d4a69 hello -v nextflow-pvc:/mnt/data/launch
Pod started: focused-noyce
N E X T F L O W  ~  version 25.08.0-edge
Pulling nextflow-io/hello ...
 downloaded from https://github.com/nextflow-io/hello.git
Launching `https://github.com/nextflow-io/hello` [focused-noyce] DSL2 - revision: 2ce0b0e294 [master]
[33/9aad8c] Submitted process > sayHello (2)
[31/17e511] Submitted process > sayHello (3)
[23/a4f15c] Submitted process > sayHello (1)
[4a/9738de] Submitted process > sayHello (4)
Ciao world!

Hello world!

Bonjour world!

Hola world!


/tmp/k3d-storage/jorgee/work/33/9aad8c9e9711ce00bd30f7a383f3ce$ ls -lart
total 28
drwxr-xr-x 3 root root 4096 oct  7 15:45 ..
-rw-r--r-- 1 root root 3163 oct  7 15:45 .command.run
-rw-r--r-- 1 root root   35 oct  7 15:45 .command.sh
-rw-r--r-- 1 root root    0 oct  7 15:46 .command.begin
-rw-r--r-- 1 root root    0 oct  7 15:46 .command.err
-rw-r--r-- 1 root root   12 oct  7 15:46 .command.out
-rw-r--r-- 1 root root   12 oct  7 15:46 .command.log
-rw-r--r-- 1 root root    1 oct  7 15:46 .exitcode
drwxr-xr-x 2 root root 4096 oct  7 15:46 .
```
