### PR TITLE
Improve plugin create confirmation prompt

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
@@ -127,8 +127,10 @@ class CmdPlugin extends CmdBase {
             // confirm and proceed
             print "All good, are you OK to continue [y/N]? "
             final confirm = readLine()
-            if( confirm?.toLowerCase()!='y' )
+            if( confirm?.toLowerCase()!='y' ) {
+                println "Plugin creation aborted."
                 return
+            }
         }
 
         // the final directory where the plugin is created


### PR DESCRIPTION
## Summary
- Accept both uppercase 'Y' and lowercase 'y' in the plugin create confirmation prompt
- Add clear "Plugin creation aborted." message when user doesn't confirm

## Test plan
- Run `nextflow plugin create` and enter 'Y' (uppercase) - should proceed with creation
- Run `nextflow plugin create` and enter 'n' or any other key - should display abort message