### PR TITLE
Type checking support

### DIFF
--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -649,7 +649,7 @@ The `disk` directive allows you to define how much local disk storage the proces
 
 ```nextflow
 process hello {
-    disk '2 GB'
+    disk 2.GB
 
     script:
     """
@@ -692,17 +692,17 @@ The `errorStrategy` directive allows you to define how the process manages an er
 
 The following error strategies are available:
 
-`terminate` (default)
+`'terminate'` (default)
 : When a task fails, terminate the pipeline immediately and report an error. Pending and running jobs are killed.
 
-`finish`
+`'finish'`
 : When a task fails, wait for submitted and running tasks to finish and then terminate the pipeline, reporting an error.
 
-`ignore`
+`'ignore'`
 : When a task fails, ignore it and continue the pipeline execution. If the `workflow.failOnIgnore` config option is set to `true`, the pipeline will report an error (i.e. return a non-zero exit code) upon completion. Otherwise, the pipeline will complete successfully.
 : See the {ref}`stdlib-namespaces-workflow` namespace for more information.
 
-`retry`
+`'retry'`
 : When a task fails, retry it.
 
 When setting the `errorStrategy` directive to `ignore` the process doesn't stop on an error condition, it just reports a message notifying you of the error event.
@@ -908,34 +908,6 @@ process hello {
 
 See also: [cpus](#cpus) and [memory](#memory).
 
-(process-maxsubmitawait)=
-
-### maxSubmitAwait
-
-The `maxSubmitAwait` directive allows you to specify how long a task can remain in submission queue without being executed.
-Elapsed this time the task execution will fail.
-
-When used along with `retry` error strategy, it can be useful to re-schedule the task to a difference queue or
-resource requirement. For example:
-
-```nextflow
-process hello {
-  errorStrategy 'retry'
-  maxSubmitAwait '10 mins'
-  maxRetries 3
-  queue "${task.submitAttempt==1 ? 'spot-compute' : 'on-demand-compute'}"
-
-  script:
-  """
-  your_command --here
-  """
-}
-```
-
-In the above example the task is submitted to the `spot-compute` on the first attempt (`task.submitAttempt==1`). If the
-task execution does not start in the 10 minutes, a failure is reported and a new submission is attempted using the
-queue named `on-demand-compute`.
-
 (process-maxerrors)=
 
 ### maxErrors
@@ -1003,6 +975,34 @@ There is a subtle but important difference between `maxRetries` and the `maxErro
 
 See also: [errorStrategy](#errorstrategy) and [maxErrors](#maxerrors).
 
+(process-maxsubmitawait)=
+
+### maxSubmitAwait
+
+The `maxSubmitAwait` directive allows you to specify how long a task can remain in submission queue without being executed.
+Elapsed this time the task execution will fail.
+
+When used along with `retry` error strategy, it can be useful to re-schedule the task to a difference queue or
+resource requirement. For example:
+
+```nextflow
+process hello {
+  errorStrategy 'retry'
+  maxSubmitAwait 10.m
+  maxRetries 3
+  queue "${task.submitAttempt==1 ? 'spot-compute' : 'on-demand-compute'}"
+
+  script:
+  """
+  your_command --here
+  """
+}
+```
+
+In the above example the task is submitted to the `spot-compute` on the first attempt (`task.submitAttempt==1`). If the
+task execution does not start in the 10 minutes, a failure is reported and a new submission is attempted using the
+queue named `on-demand-compute`.
+
 (process-memory)=
 
 ### memory
@@ -1011,7 +1011,7 @@ The `memory` directive allows you to define how much memory the process is allow
 
 ```nextflow
 process hello {
-    memory '2 GB'
+    memory 2.GB
 
     script:
     """
@@ -1746,7 +1746,7 @@ The `time` directive allows you to define how long a process is allowed to run. 
 
 ```nextflow
 process hello {
-    time '1h'
+    time 1.h
 
     script:
     """
@@ -1757,15 +1757,13 @@ process hello {
 
 The following time unit suffixes can be used when specifying the duration value:
 
-| Unit                            | Description  |
-| ------------------------------- | ------------ |
-| `ms`, `milli`, `millis`         | Milliseconds |
-| `s`, `sec`, `second`, `seconds` | Seconds      |
-| `m`, `min`, `minute`, `minutes` | Minutes      |
-| `h`, `hour`, `hours`            | Hours        |
-| `d`, `day`, `days`              | Days         |
-
-Multiple units can be used in a single declaration, for example: `'1day 6hours 3minutes 30seconds'`
+| Unit | Description  |
+| ---- | ------------ |
+| `ms` | Milliseconds |
+| `s`  | Seconds      |
+| `m`  | Minutes      |
+| `h`  | Hours        |
+| `d`  | Days         |
 
 See {ref}`stdlib-types-duration` for more information.
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptCompiler.java
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptCompiler.java
@@ -42,6 +42,7 @@ import nextflow.script.control.ProcessNameResolver;
 import nextflow.script.control.ResolveIncludeVisitor;
 import nextflow.script.control.ScriptResolveVisitor;
 import nextflow.script.control.ScriptToGroovyVisitor;
+import nextflow.script.control.StripTypesVisitor;
 import nextflow.script.control.TypeCheckingVisitor;
 import nextflow.script.parser.ScriptParserPluginFactory;
 import org.codehaus.groovy.ast.ASTNode;
@@ -290,6 +291,7 @@ public class ScriptCompiler {
 
             // convert to Groovy
             new ScriptToGroovyVisitor(source).visit();
+            new StripTypesVisitor(source).visitClass(cn);
             new PathCompareVisitor(source).visitClass(cn);
             new OpCriteriaVisitor(source).visitClass(cn);
             new GStringToStringVisitor(source).visitClass(cn);

--- a/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
@@ -232,4 +232,26 @@ class ScriptLoaderV2Test extends Dsl2Spec {
         noExceptionThrown()
     }
 
+    def 'should strip unsupported type annotations' () {
+
+        given:
+        def session = new Session()
+        def parser = new ScriptLoaderV2(session)
+
+        def TEXT = '''
+            // strip cast type
+            ['1', '1.fastq', '2.fastq'] as Tuple<String,String,String>
+
+            // strip type annotation in variable declaration
+            def ch: Channel = channel.empty()
+            '''
+
+        when:
+        parser.parse(TEXT)
+        parser.runScript()
+
+        then:
+        noExceptionThrown()
+    }
+
 }

--- a/modules/nf-lang/src/main/java/nextflow/config/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/control/VariableScopeVisitor.java
@@ -285,9 +285,11 @@ class VariableScopeVisitor extends ConfigVisitorSupport {
         if( !node.isImplicitThis() )
             return;
         var name = node.getMethodAsString();
-        var defNode = vsc.findDslFunction(name, node);
-        if( defNode != null )
-            node.putNodeMetaData(ASTNodeMarker.METHOD_TARGET, defNode);
+        var methods = vsc.findDslFunction(name, node);
+        if( methods.size() == 1 )
+            node.putNodeMetaData(ASTNodeMarker.METHOD_TARGET, methods.get(0));
+        else if( !methods.isEmpty() )
+            node.putNodeMetaData(ASTNodeMarker.METHOD_OVERLOADS, methods);
         else if( !KEYWORDS.contains(name) )
             vsc.addError("`" + name + "` is not defined", node.getMethod());
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ASTNodeMarker.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ASTNodeMarker.java
@@ -27,6 +27,9 @@ public enum ASTNodeMarker {
     // denotes that an assignment is an implicit declaration
     IMPLICIT_DECLARATION,
 
+    // the inferred return type of a closure expression
+    INFERRED_RETURN_TYPE,
+
     // the inferred type of an expression
     INFERRED_TYPE,
 
@@ -39,6 +42,9 @@ public enum ASTNodeMarker {
     // the verbatim text of a Groovy-style type annotation (ClassNode)
     LEGACY_TYPE,
 
+    // the list of candidate MethodNode's for a MethodCallExpression
+    METHOD_OVERLOADS,
+
     // the MethodNode targeted by a MethodCallExpression
     METHOD_TARGET,
 
@@ -47,6 +53,9 @@ public enum ASTNodeMarker {
 
     // denotes a nullable type annotation (ClassNode)
     NULLABLE,
+
+    // the FieldNode targeted by a PropertyExpression
+    PROPERTY_TARGET,
 
     // the starting quote sequence of a string literal or gstring expression
     QUOTE_CHAR,

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ASTUtils.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ASTUtils.java
@@ -18,10 +18,13 @@ package nextflow.script.ast;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import groovy.transform.NamedParams;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.AnnotatedNode;
@@ -30,9 +33,12 @@ import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.Variable;
+import org.codehaus.groovy.ast.expr.AnnotationConstantExpression;
+import org.codehaus.groovy.ast.expr.ClassExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.ListExpression;
 import org.codehaus.groovy.ast.expr.MapExpression;
 import org.codehaus.groovy.ast.expr.MapEntryExpression;
 import org.codehaus.groovy.ast.expr.MethodCall;
@@ -143,6 +149,40 @@ public class ASTUtils {
         return args.size() > 0 && args.get(0) instanceof NamedArgumentListExpression nale
             ? nale.getMapEntryExpressions()
             : Collections.emptyList();
+    }
+
+    /**
+     * Given a parameter with a @NamedParams annotation,
+     * return the map of named params.
+     *
+     * @param parameter
+     */
+    public static Map<String, AnnotationNode> asNamedParams(Parameter parameter) {
+        var namedParams = new LinkedHashMap<String, AnnotationNode>();
+        parameter.getAnnotations().stream()
+            .filter(an -> an.getClassNode().getName().equals(NamedParams.class.getName()))
+            .flatMap(an -> {
+                var value = an.getMember("value");
+                return value instanceof ListExpression le
+                    ? le.getExpressions().stream()
+                    : Stream.empty();
+            })
+            .forEach((value) -> {
+                if( !(value instanceof AnnotationConstantExpression) )
+                    return;
+                var ace = (AnnotationConstantExpression) value;
+                var namedParam = (AnnotationNode) ace.getValue();
+                var name = namedParam.getMember("value").getText();
+                namedParams.put(name, namedParam);
+            });
+        return namedParams;
+    }
+
+    public static Parameter asNamedParam(AnnotationNode node) {
+        var name = node.getMember("value").getText();
+        var typeX = (ClassExpression) node.getMember("type");
+        var type = typeX != null ? typeX.getType() : ClassHelper.dynamicType();
+        return new Parameter(type, name);
     }
 
     public static VariableExpression asVarX(Statement statement) {

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/OutputNode.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/OutputNode.java
@@ -15,8 +15,8 @@
  */
 package nextflow.script.ast;
 
-import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.stmt.Statement;
 
 /**
@@ -24,14 +24,11 @@ import org.codehaus.groovy.ast.stmt.Statement;
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
-public class OutputNode extends ASTNode {
-    public final String name;
-    public final ClassNode type;
+public class OutputNode extends Parameter {
     public final Statement body;
 
     public OutputNode(String name, ClassNode type, Statement body) {
-        this.name = name;
-        this.type = type;
+        super(type, name);
         this.body = body;
     }
 }

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ProcessNodeV2.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ProcessNodeV2.java
@@ -69,30 +69,28 @@ public class ProcessNodeV2 extends ProcessNode {
         if( outputs.size() == 1 ) {
             var first = outputs.get(0);
             var output = ((ExpressionStatement) first).getExpression();
-            if( outputName(output) == null )
+            if( outputTarget(output) == null )
                 return output.getType();
         }
         var cn = new ClassNode(Record.class);
         outputs.stream()
             .map(stmt -> ((ExpressionStatement) stmt).getExpression())
-            .map(output -> outputName(output))
-            .filter(name -> name != null)
-            .forEach((name) -> {
-                var type = ClassHelper.dynamicType();
-                var fn = new FieldNode(name, Modifier.PUBLIC, type, cn, null);
+            .map(output -> outputTarget(output))
+            .filter(target -> target != null)
+            .forEach((target) -> {
+                var fn = new FieldNode(target.getName(), Modifier.PUBLIC, target.getType(), cn, null);
                 fn.setDeclaringClass(cn);
                 cn.addField(fn);
             });
         return cn;
     }
 
-    private static String outputName(Expression output) {
+    private static VariableExpression outputTarget(Expression output) {
         if( output instanceof VariableExpression ve ) {
-            return ve.getName();
+            return ve;
         }
-        else if( output instanceof AssignmentExpression ae ) {
-            var target = (VariableExpression)ae.getLeftExpression();
-            return target.getName();
+        if( output instanceof AssignmentExpression ae ) {
+            return (VariableExpression)ae.getLeftExpression();
         }
         return null;
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/WorkflowNode.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/WorkflowNode.java
@@ -16,7 +16,6 @@
 package nextflow.script.ast;
 
 import java.lang.reflect.Modifier;
-import java.util.Optional;
 
 import nextflow.script.types.Record;
 import org.codehaus.groovy.ast.ClassHelper;
@@ -65,28 +64,33 @@ public class WorkflowNode extends MethodNode {
         return getLineNumber() == -1;
     }
 
-    private static ClassNode dummyReturnType(Statement emits) {
+    private static ClassNode dummyReturnType(Statement block) {
+        var emits = asBlockStatements(block);
+        if( emits.size() == 1 ) {
+            var first = emits.get(0);
+            var emit = ((ExpressionStatement) first).getExpression();
+            if( emitTarget(emit) == null )
+                return emit.getType();
+        }
         var cn = new ClassNode(Record.class);
-        asBlockStatements(emits).stream()
+        emits.stream()
             .map(stmt -> ((ExpressionStatement) stmt).getExpression())
-            .map(emit -> emitName(emit))
-            .filter(name -> name != null)
-            .forEach((name) -> {
-                var type = ClassHelper.dynamicType();
-                var fn = new FieldNode(name, Modifier.PUBLIC, type, cn, null);
+            .map(emit -> emitTarget(emit))
+            .filter(target -> target != null)
+            .forEach((target) -> {
+                var fn = new FieldNode(target.getName(), Modifier.PUBLIC, target.getType(), cn, null);
                 fn.setDeclaringClass(cn);
                 cn.addField(fn);
             });
         return cn;
     }
 
-    private static String emitName(Expression emit) {
+    private static VariableExpression emitTarget(Expression emit) {
         if( emit instanceof VariableExpression ve ) {
-            return ve.getName();
+            return ve;
         }
-        else if( emit instanceof AssignmentExpression ae ) {
-            var left = (VariableExpression)ae.getLeftExpression();
-            return left.getName();
+        if( emit instanceof AssignmentExpression ae ) {
+            return (VariableExpression)ae.getLeftExpression();
         }
         return null;
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
@@ -103,20 +103,20 @@ public class ScriptResolveVisitor extends ScriptVisitorSupport {
         for( var take : node.getParameters() )
             resolver.resolveOrFail(take.getType(), take);
         resolver.visit(node.main);
-        resolveWorkflowEmits(node.emits);
+        resolveTypedOutputs(node.emits);
         resolver.visit(node.emits);
         resolver.visit(node.publishers);
         resolver.visit(node.onComplete);
         resolver.visit(node.onError);
     }
 
-    private void resolveWorkflowEmits(Statement emits) {
-        for( var stmt : asBlockStatements(emits) ) {
+    private void resolveTypedOutputs(Statement block) {
+        for( var stmt : asBlockStatements(block) ) {
             var stmtX = (ExpressionStatement)stmt;
-            var emit = stmtX.getExpression();
+            var output = stmtX.getExpression();
             var target =
-                emit instanceof AssignmentExpression ae ? ae.getLeftExpression() :
-                emit instanceof VariableExpression ve ? ve :
+                output instanceof AssignmentExpression ae ? ae.getLeftExpression() :
+                output instanceof VariableExpression ve ? ve :
                 null;
 
             if( target instanceof VariableExpression ve )
@@ -130,6 +130,7 @@ public class ScriptResolveVisitor extends ScriptVisitorSupport {
             resolver.resolveOrFail(input.getType(), input);
         resolver.visit(node.directives);
         resolver.visit(node.stagers);
+        resolveTypedOutputs(node.outputs);
         resolver.visit(node.outputs);
         resolver.visit(node.topics);
         resolver.visit(node.when);
@@ -159,6 +160,7 @@ public class ScriptResolveVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitOutput(OutputNode node) {
+        resolver.resolveOrFail(node.getType(), node.getType());
         resolver.visit(node.body);
     }
 

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -144,8 +144,8 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
         var main = node.main instanceof BlockStatement block ? block : new BlockStatement();
         visitWorkflowEmits(node.emits, main);
         visitWorkflowPublishers(node.publishers, main);
-        visitWorkflowHandler(node.onComplete, "onComplete", main);
-        visitWorkflowHandler(node.onError, "onError", main);
+        visitWorkflowHandler(node.onComplete, "setOnComplete", main);
+        visitWorkflowHandler(node.onError, "setOnError", main);
 
         var bodyDef = stmt(createX(
             "nextflow.script.BodyDef",
@@ -239,7 +239,7 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
         var statements = node.declarations.stream()
             .map((output) -> {
                 new PublishDslVisitor().visit(output.body);
-                var name = constX(output.name);
+                var name = constX(output.getName());
                 var body = closureX(null, output.body);
                 return stmt(callThisX("declare", args(name, body)));
             })

--- a/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script.control;
+
+import java.util.List;
+
+import nextflow.script.types.Record;
+import nextflow.script.types.Tuple;
+import nextflow.script.types.Value;
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.expr.CastExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.DeclarationExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ * Strip type annotations that are used by the Nextflow type checker
+ * but not supported by the Groovy runtime.
+ *
+ * For example, Nextflow allows the Tuple type to be specified
+ * with variable type arguments, which is not supported by the JVM,
+ * so these type annotations must be removed.
+ *
+ * @author Ben Sherman <bentshermman@gmail.com>
+ */
+public class StripTypesVisitor extends ClassCodeExpressionTransformer {
+
+    private static final List<ClassNode> STRIP_TYPES = List.of(
+        ClassHelper.makeWithoutCaching("nextflow.Channel"),
+        ClassHelper.makeCached(Record.class),
+        ClassHelper.makeCached(Tuple.class),
+        ClassHelper.makeCached(Value.class)
+    );
+
+    private SourceUnit sourceUnit;
+
+    public StripTypesVisitor(SourceUnit sourceUnit) {
+        this.sourceUnit = sourceUnit;
+    }
+
+    @Override
+    protected SourceUnit getSourceUnit() {
+        return sourceUnit;
+    }
+
+    @Override
+    public Expression transform(Expression node) {
+        if( node instanceof CastExpression ce )
+            return stripTypeAnnotation(ce);
+
+        if( node instanceof ClosureExpression ce )
+            super.visitClosureExpression(ce);
+
+        if( node instanceof DeclarationExpression de )
+            stripTypeAnnotation(de);
+
+        return super.transform(node);
+    }
+
+    private Expression stripTypeAnnotation(CastExpression node) {
+        return STRIP_TYPES.contains(node.getType())
+            ? node.getExpression()
+            : node;
+    }
+
+    private Expression stripTypeAnnotation(DeclarationExpression node) {
+        if( node.getLeftExpression() instanceof VariableExpression ve ) {
+            if( STRIP_TYPES.contains(ve.getType()) )
+                node.setLeftExpression(new VariableExpression(ve.getName()));
+        }
+        return node;
+    }
+
+}

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import groovy.transform.NamedParam;
+import groovy.transform.NamedParams;
 import nextflow.script.types.Duration;
 import nextflow.script.types.MemoryUnit;
 import nextflow.script.types.TaskConfig;
@@ -49,7 +51,16 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#accelerator)
         """)
-        void accelerator(Map<String,?> value);
+        void accelerator(
+            @NamedParams({
+                @NamedParam(value = "request", type = Integer.class),
+                @NamedParam(value = "limit", type = Integer.class),
+                @NamedParam(value = "type", type = String.class),
+            })
+            Map<String,?> opts
+        );
+        void accelerator(Map<String,?> opts, Integer value);
+        void accelerator(Integer value);
 
         @Description("""
             The `afterScript` directive allows you to execute a custom (Bash) snippet *after* the task script.
@@ -63,6 +74,14 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#arch)
         """)
+        void arch(
+            @NamedParams({
+                @NamedParam(value = "name", type = String.class),
+                @NamedParam(value = "target", type = String.class),
+            })
+            Map<String,?> opts
+        );
+        void arch(Map<String,?> opts, String value);
         void arch(String value);
 
         @Description("""
@@ -85,6 +104,7 @@ public interface ProcessDsl extends DslScope {
             [Read more](https://nextflow.io/docs/latest/reference/process.html#cache)
         """)
         void cache(String value);
+        void cache(Boolean value);
 
         @Description("""
             The `clusterOptions` directive allows the usage of any native configuration option accepted by your cluster submit command. You can use it to request non-standard resources or use settings that are specific to your cluster and not supported out of the box by Nextflow.
@@ -92,6 +112,8 @@ public interface ProcessDsl extends DslScope {
             [Read more](https://nextflow.io/docs/latest/reference/process.html#clusteroptions)
         """)
         void clusterOptions(String value);
+        void clusterOptions(List<String> values);
+        void clusterOptions(String... values);
 
         @Description("""
             The `conda` directive allows for the definition of the process dependencies using the [Conda](https://conda.io) package manager.
@@ -126,13 +148,21 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#debug)
         """)
-        void debug(boolean value);
+        void debug(Boolean value);
 
         @Description("""
             The `disk` directive allows you to define how much local disk storage the process is allowed to use.
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#disk)
         """)
+        void disk(
+            @NamedParams({
+                @NamedParam(value = "request", type = MemoryUnit.class),
+                @NamedParam(value = "type", type = String.class),
+            })
+            Map<String,?> opts
+        );
+        void disk(Map<String,?> opts, MemoryUnit value);
         void disk(MemoryUnit value);
 
         @Description("""
@@ -161,7 +191,7 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#fair)
         """)
-        void fair(boolean value);
+        void fair(Boolean value);
 
         @Description("""
             The `label` directive allows you to annotate a process with a mnemonic identifier of your choice.
@@ -182,7 +212,7 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#maxerrors)
         """)
-        void maxErrors(int value);
+        void maxErrors(Integer value);
 
         @Description("""
             The `maxForks` directive allows you to define the maximum number of tasks (per process) that can be executed in parallel.
@@ -196,7 +226,7 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#maxretries)
         """)
-        void maxRetries(int value);
+        void maxRetries(Integer value);
 
         @Description("""
             The `maxSubmitAwait` directives allows you to specify how long a task can remain in the submission queue. If a task remains in the queue beyond this time limit, it will fail.
@@ -231,14 +261,18 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#pod)
         """)
-        void pod(List<?> value);
+        void pod(Map<String,?> opts);
+        void pod(List<Map<String,?>> entries);
 
         @Description("""
             The `publishDir` directive allows you to publish the process output files to a directory.
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#publishdir)
         """)
-        void publishDir(List<?> value);
+        void publishDir(Map<String,?> opts);
+        void publishDir(Map<String,?> opts, String value);
+        void publishDir(String value);
+        void publishDir(List<Map<String,?>> entries);
 
         @Description("""
             The `queue` directive allows you to specify the queue to which jobs are submitted when using a grid executor.
@@ -259,7 +293,15 @@ public interface ProcessDsl extends DslScope {
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#resourcelimits)
         """)
-        void resourceLimits(Map<String,?> value);
+        void resourceLimits(
+            @NamedParams({
+                @NamedParam(value = "cpus", type = Integer.class),
+                @NamedParam(value = "disk", type = MemoryUnit.class),
+                @NamedParam(value = "memory", type = MemoryUnit.class),
+                @NamedParam(value = "time", type = Duration.class),
+            })
+            Map<String,?> opts
+        );
 
         @Description("""
             The `scratch` directive allows you to execute each task in a temporary directory that is local to the compute node.
@@ -267,6 +309,7 @@ public interface ProcessDsl extends DslScope {
             [Read more](https://nextflow.io/docs/latest/reference/process.html#scratch)
         """)
         void scratch(String value);
+        void scratch(Boolean value);
 
         @Description("""
             The `secret` directive allows you to securely provide secrets to a process.
@@ -281,6 +324,8 @@ public interface ProcessDsl extends DslScope {
             [Read more](https://nextflow.io/docs/latest/reference/process.html#shell)
         """)
         void shell(String value);
+        void shell(List<String> values);
+        void shell(String... values);
 
         @Description("""
             The `spack` directive allows you to provide software dependencies using the [Spack](https://spack.io) package manager.
@@ -409,13 +454,37 @@ public interface ProcessDsl extends DslScope {
         @Description("""
             Get a file from the task environment that matches the given pattern.
         """)
-        Path file(Map<String,?> opts, String name);
+        Path file(
+            @NamedParams({
+                @NamedParam(value = "followLinks", type = Boolean.class),
+                @NamedParam(value = "glob", type = Boolean.class),
+                @NamedParam(value = "hidden", type = Boolean.class),
+                @NamedParam(value = "includeInputs", type = Boolean.class),
+                @NamedParam(value = "maxDepth", type = Integer.class),
+                @NamedParam(value = "optional", type = Boolean.class),
+                @NamedParam(value = "type", type = String.class),
+            })
+            Map<String,?> opts,
+            String name
+        );
         Path file(String name);
 
         @Description("""
             Get the files from the task environment that match the given pattern.
         """)
-        Set<Path> files(Map<String,?> opts, String pattern);
+        Set<Path> files(
+            @NamedParams({
+                @NamedParam(value = "followLinks", type = Boolean.class),
+                @NamedParam(value = "glob", type = Boolean.class),
+                @NamedParam(value = "hidden", type = Boolean.class),
+                @NamedParam(value = "includeInputs", type = Boolean.class),
+                @NamedParam(value = "maxDepth", type = Integer.class),
+                @NamedParam(value = "optional", type = Boolean.class),
+                @NamedParam(value = "type", type = String.class),
+            })
+            Map<String,?> opts, 
+            String pattern
+        );
         Set<Path> files(String pattern);
 
         @Description("""

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ScriptDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ScriptDsl.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 import groovy.lang.Closure;
+import groovy.transform.NamedParam;
+import groovy.transform.NamedParams;
 import nextflow.script.namespaces.ChannelNamespace;
 import nextflow.script.namespaces.LogNamespace;
 import nextflow.script.namespaces.NextflowNamespace;
@@ -131,13 +133,35 @@ public interface ScriptDsl extends DslScope {
 
         *NOTE: This function will return a collection if the glob pattern yields zero or multiple files. Use `files()` to get a collection of files.*
     """)
-    Path file(Map<String,?> opts, String filePattern);
+    Path file(
+        @NamedParams({
+            @NamedParam(value = "checkIfExists", type = Boolean.class),
+            @NamedParam(value = "followLinks", type = Boolean.class),
+            @NamedParam(value = "glob", type = Boolean.class),
+            @NamedParam(value = "hidden", type = Boolean.class),
+            @NamedParam(value = "maxDepth", type = Integer.class),
+            @NamedParam(value = "type", type = String.class),
+        })
+        Map<String,?> opts,
+        String filePattern
+    );
     Path file(String filePattern);
 
     @Description("""
         Get a collection of files from a file name or glob pattern.
     """)
-    Collection<Path> files(Map<String,?> opts, String filePattern);
+    Collection<Path> files(
+        @NamedParams({
+            @NamedParam(value = "checkIfExists", type = Boolean.class),
+            @NamedParam(value = "followLinks", type = Boolean.class),
+            @NamedParam(value = "glob", type = Boolean.class),
+            @NamedParam(value = "hidden", type = Boolean.class),
+            @NamedParam(value = "maxDepth", type = Integer.class),
+            @NamedParam(value = "type", type = String.class),
+        })
+        Map<String,?> opts,
+        String filePattern
+    );
     Collection<Path> files(String filePattern);
 
     @Description("""

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -271,8 +271,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             visitTypedInputs(takes);
         }
         if( !node.main.isEmpty() ) {
-            fmt.appendNewLine();
             if( takes.length > 0 || !node.emits.isEmpty() || !node.publishers.isEmpty() ) {
+                fmt.appendNewLine();
                 fmt.appendIndent();
                 fmt.append("main:\n");
             }
@@ -607,10 +607,10 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
     public void visitOutput(OutputNode node) {
         fmt.appendLeadingComments(node);
         fmt.appendIndent();
-        fmt.append(node.name);
-        if( fmt.hasType(node.type) ) {
+        fmt.append(node.getName());
+        if( fmt.hasType(node) ) {
             fmt.append(": ");
-            fmt.visitTypeAnnotation(node.type);
+            fmt.visitTypeAnnotation(node.getType());
         }
         fmt.append(" {\n");
         fmt.incIndent();

--- a/modules/nf-lang/src/main/java/nextflow/script/namespaces/ChannelNamespace.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/namespaces/ChannelNamespace.java
@@ -20,9 +20,12 @@ import java.util.Collection;
 import java.util.Map;
 
 import groovy.lang.Closure;
+import groovy.transform.NamedParam;
+import groovy.transform.NamedParams;
 import nextflow.script.dsl.Description;
 import nextflow.script.dsl.Namespace;
 import nextflow.script.types.Channel;
+import nextflow.script.types.Value;
 
 public interface ChannelNamespace extends Namespace {
 
@@ -31,7 +34,7 @@ public interface ChannelNamespace extends Namespace {
 
         [Read more](https://nextflow.io/docs/latest/reference/channel.html#empty)
     """)
-    Channel empty();
+    Channel<?> empty();
 
     @Deprecated
     @Description("""
@@ -56,7 +59,7 @@ public interface ChannelNamespace extends Namespace {
 
         [Read more](https://nextflow.io/docs/latest/reference/channel.html#fromfilepairs)
     """)
-    Channel fromFilePairs(Map<String,?> opts, String pattern, Closure grouping);
+    Channel<?> fromFilePairs(Map<String,?> opts, String pattern, Closure grouping);
 
     @Description("""
         Create a channel that emits all paths matching a name or glob pattern.
@@ -77,7 +80,19 @@ public interface ChannelNamespace extends Namespace {
 
         [Read more](https://nextflow.io/docs/latest/reference/channel.html#frompath)
     """)
-    Channel<Path> fromPath(Map<String,?> opts, String pattern);
+    Channel<Path> fromPath(
+        @NamedParams({
+            @NamedParam(value = "checkIfExists", type = Boolean.class),
+            @NamedParam(value = "followLinks", type = Boolean.class),
+            @NamedParam(value = "glob", type = Boolean.class),
+            @NamedParam(value = "hidden", type = Boolean.class),
+            @NamedParam(value = "maxDepth", type = Integer.class),
+            @NamedParam(value = "relative", type = Boolean.class),
+            @NamedParam(value = "type", type = String.class),
+        })
+        Map<String,?> opts,
+        String pattern
+    );
     Channel<Path> fromPath(String pattern);
 
     @Description("""
@@ -85,7 +100,14 @@ public interface ChannelNamespace extends Namespace {
 
         [Read more](https://nextflow.io/docs/latest/reference/channel.html#fromsra)
     """)
-    Channel fromSRA(Map<String,?> opts, String query);
+    Channel<?> fromSRA(Map<String,?> opts, String query);
+
+    @Description("""
+        Create a channel that emits an incrementing index (starting from zero) at a periodic interval.
+
+        [Read more](https://nextflow.io/docs/latest/reference/channel.html#interval)
+    """)
+    Channel<Integer> interval(String interval);
 
     @Description("""
         Create a channel that emits each argument.
@@ -99,14 +121,14 @@ public interface ChannelNamespace extends Namespace {
 
         [Read more](https://nextflow.io/docs/latest/reference/channel.html#topic)
     """)
-    Channel topic(String name);
+    Channel<?> topic(String name);
 
     @Description("""
         Create a value channel.
 
         [Read more](https://nextflow.io/docs/latest/reference/channel.html#value)
     """)
-    <E> Channel<E> value(E value);
+    <V> Value<V> value(V value);
 
     @Description("""
         Create a channel that watches for filesystem events for all files matching the given pattern.

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -448,7 +448,7 @@ public class ScriptAstBuilder {
             collectSyntaxError(new SyntaxException("The `stage:` section is not supported in a legacy process", stagers));
 
         if( !previewTypes && !topics.isEmpty() )
-            collectSyntaxError(new SyntaxException("The `topic:` section is not supported in a legacy process", stagers));
+            collectSyntaxError(new SyntaxException("The `topic:` section is not supported in a legacy process", topics));
 
         if( ctx.body.blockStatements() != null ) {
             if( !directives.isEmpty() || ctx.body.processInputs() != null || !outputs.isEmpty() || !topics.isEmpty() )
@@ -503,8 +503,8 @@ public class ScriptAstBuilder {
             : processTupleInput(type, names, ctx);
         for( var name : names )
             checkInvalidVarName(name, result);
-        if( ctx.type() == null )
-            collectSyntaxError(new SyntaxException("Process input must have a type annotation", result));
+        if( names.size() == 1 && ctx.type() == null )
+            collectWarning("Process input should have a type annotation", names.get(0), result);
         saveTrailingComment(result, ctx);
         return result;
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/types/Channel.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/Channel.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import groovy.lang.Closure;
+import groovy.transform.NamedParam;
+import groovy.transform.NamedParams;
 import nextflow.script.dsl.Description;
 import nextflow.script.dsl.Operator;
 
@@ -41,7 +43,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#branch)
     """)
-    Record branch(Closure closure);
+    Record branch(Function<E,?> closure);
 
     @Operator
     @Description("""
@@ -49,7 +51,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#buffer)
     """)
-    Channel buffer(Closure openingCondition, Closure closingCondition);
+    Channel<?> buffer(Closure openingCondition, Closure closingCondition);
 
     @Operator
     @Description("""
@@ -57,7 +59,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#collate)
     """)
-    Channel collate(int size, int step, boolean remainder);
+    Channel<?> collate(int size, int step, boolean remainder);
 
     @Operator
     @Description("""
@@ -73,7 +75,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#collectfile)
     """)
-    Channel collectFile(Map<String,?> opts, Closure closure);
+    Channel<?> collectFile(Map<String,?> opts, Closure closure);
+    Channel<?> collectFile(Closure closure);
 
     @Operator
     @Description("""
@@ -81,9 +84,16 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#combine)
     """)
-    Channel combine(Map<String,?> opts, Channel right);
-    Channel combine(Channel right);
-    Channel combine(Collection right);
+    Channel<Tuple> combine(
+        @NamedParams({
+            @NamedParam(value = "by")
+        })
+        Map<String,?> opts,
+        Channel<?> right
+    );
+    Channel<Tuple> combine(Channel<?> right);
+    Channel<Tuple> combine(Value<?> right);
+    Channel<Tuple> combine(Collection right);
 
     @Operator
     @Description("""
@@ -91,7 +101,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#concat)
     """)
-    Channel concat(Channel... others);
+    Channel<E> concat(Channel... others);
 
     @Operator
     @Description("""
@@ -107,7 +117,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#cross)
     """)
-    Channel cross(Channel right);
+    Channel<Tuple> cross(Channel<?> right);
 
     @Operator
     @Description("""
@@ -115,7 +125,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#distinct)
     """)
-    Channel distinct();
+    Channel<E> distinct();
 
     @Operator
     @Description("""
@@ -124,6 +134,7 @@ public interface Channel<E> {
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#dump)
     """)
     Channel<E> dump(Map<String,?> opts);
+    Channel<E> dump();
 
     @Operator
     @Description("""
@@ -158,7 +169,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#flatten)
     """)
-    Channel flatten();
+    Channel<?> flatten();
 
     @Operator
     @Description("""
@@ -166,7 +177,16 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#grouptuple)
     """)
-    Channel groupTuple(Map<String,?> opts);
+    Channel<Tuple> groupTuple(
+        @NamedParams({
+            @NamedParam(value = "by"),
+            @NamedParam(value = "remainder", type = Boolean.class),
+            @NamedParam(value = "size", type = Integer.class),
+            @NamedParam(value = "sort")
+        })
+        Map<String,?> opts
+    );
+    Channel<Tuple> groupTuple();
 
     @Operator
     @Description("""
@@ -174,7 +194,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#ifempty)
     """)
-    Channel ifEmpty(Object value);
+    Channel<?> ifEmpty(Object value);
 
     @Operator
     @Description("""
@@ -182,8 +202,17 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#join)
     """)
-    Channel join(Map<String,?> opts, Channel right);
-    Channel join(Channel right);
+    Channel<Tuple> join(
+        @NamedParams({
+            @NamedParam(value = "by"),
+            @NamedParam(value = "failOnDuplicate", type = Boolean.class),
+            @NamedParam(value = "failOnMismatch", type = Boolean.class),
+            @NamedParam(value = "remainder", type = Boolean.class)
+        })
+        Map<String,?> opts,
+        Channel<Tuple> right
+    );
+    Channel<Tuple> join(Channel<Tuple> right);
 
     @Operator
     @Description("""
@@ -215,7 +244,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#merge)
     """)
-    Channel merge(Channel... others);
+    Channel<?> merge(Channel... others);
 
     @Operator
     @Description("""
@@ -239,7 +268,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#multimap)
     """)
-    Record multiMap(Closure closure);
+    Record multiMap(Function<E,?> closure);
 
     @Operator
     @Description("""
@@ -247,7 +276,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#randomsample)
     """)
-    Channel randomSample(int n, Long seed);
+    Channel<E> randomSample(int n, Long seed);
 
     @Operator
     @Description("""
@@ -272,8 +301,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#splitcsv)
     """)
-    Channel splitCsv(Map<String,?> opts);
-    Channel splitCsv();
+    Channel<?> splitCsv(Map<String,?> opts);
+    Channel<?> splitCsv();
 
     @Operator
     @Description("""
@@ -281,8 +310,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#splitfasta)
     """)
-    Channel splitFasta(Map<String,?> opts);
-    Channel splitFasta();
+    Channel<?> splitFasta(Map<String,?> opts);
+    Channel<?> splitFasta();
 
     @Operator
     @Description("""
@@ -290,8 +319,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#splitfastq)
     """)
-    Channel splitFastq(Map<String,?> opts);
-    Channel splitFastq();
+    Channel<?> splitFastq(Map<String,?> opts);
+    Channel<?> splitFastq();
 
     @Operator
     @Description("""
@@ -299,8 +328,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#splitjson)
     """)
-    Channel splitJson(Map<String,?> opts);
-    Channel splitJson();
+    Channel<?> splitJson(Map<String,?> opts);
+    Channel<?> splitJson();
 
     @Operator
     @Description("""
@@ -308,8 +337,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#splittext)
     """)
-    Channel splitText(Map<String,?> opts);
-    Channel splitText();
+    Channel<?> splitText(Map<String,?> opts);
+    Channel<?> splitText();
 
     @Operator
     @Description("""
@@ -325,7 +354,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#sum)
     """)
-    Value sum(Closure transform);
+    Value<?> sum(Closure transform);
 
     @Operator
     @Description("""
@@ -333,7 +362,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#take)
     """)
-    Channel take(int n);
+    Channel<E> take(int n);
 
     @Operator
     @Description("""
@@ -341,7 +370,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#tap)
     """)
-    Channel tap(Closure holder);
+    Channel<?> tap(Closure holder);
 
     @Operator
     @Description("""
@@ -349,7 +378,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#to;ist)
     """)
-    Value toList();
+    Value<?> toList();
 
     @Operator
     @Description("""
@@ -357,7 +386,7 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#tosortedlist)
     """)
-    Value toSortedList();
+    Value<?> toSortedList();
 
     @Operator
     @Description("""
@@ -365,7 +394,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#transpose)
     """)
-    Channel transpose(Map<String,?> opts);
+    Channel<?> transpose(Map<String,?> opts);
+    Channel<?> transpose();
 
     @Operator
     @Description("""
@@ -373,8 +403,8 @@ public interface Channel<E> {
 
         [Read more](https://nextflow.io/docs/latest/reference/operator.html#unique)
     """)
-    Channel unique(Closure comparator);
-    Channel unique();
+    Channel<E> unique(Closure comparator);
+    Channel<E> unique();
 
     @Operator
     @Description("""

--- a/modules/nf-lang/src/main/java/nextflow/script/types/TaskConfig.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/TaskConfig.java
@@ -214,7 +214,7 @@ public interface TaskConfig {
 
         [Read more](https://nextflow.io/docs/latest/reference/process.html#ext)
     """)
-    Map<String,?> getExt();
+    Map<String,String> getExt();
 
     @Constant("fair")
     @Description("""

--- a/modules/nf-lang/src/main/java/nextflow/script/types/Types.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/Types.java
@@ -131,7 +131,7 @@ public class Types {
         else
             builder.append(getName(type.getNameWithoutPackage()));
 
-        if( !placeholder && type.isUsingGenerics() ) {
+        if( !placeholder && type.getGenericsTypes() != null ) {
             builder.append('<');
             genericsTypeNames(type.getGenericsTypes(), builder);
             builder.append('>');

--- a/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
@@ -202,6 +202,45 @@ class ScriptResolveTest extends Specification {
         when:
         def errors = check(
             '''\
+            'hello' as FooBar
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 1
+        errors[0].getOriginalMessage() == '`FooBar` is not defined'
+
+        when:
+        errors = check(
+            '''\
+            [] as List<FooBar>
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 1
+        errors[0].getOriginalMessage() == '`FooBar` is not defined'
+
+        when:
+        errors = check(
+            '''\
+            [:] as Map<Foo,Bar>
+            '''
+        )
+        then:
+        errors.size() == 2
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 1
+        errors[0].getOriginalMessage() == '`Foo` is not defined'
+        errors[1].getStartLine() == 1
+        errors[1].getStartColumn() == 1
+        errors[1].getOriginalMessage() == '`Bar` is not defined'
+
+        when:
+        errors = check(
+            '''\
             x = new FooBar()
             '''
         )


### PR DESCRIPTION
This PR adds a few things to nf-lang to help enable type checking in the language server.

The full type checker will eventually be incorporated into nf-lang, but for now it will reside in the language server while we continue to develop it. This way I can release improvements to the type checker without requiring a Nextflow patch release

No unit tests because these changes are covered by language server unit tests for now.

Summary of changes:

- Save method overloads in `VariableScopeVisitor` when a method call matches multiple possible methods (used by type checker to select method or provide appropriate error message)

- Add `@NamedParams` annotation to standard library functions (used by type checker to validate named params)

- Fix resolution of output types for processes and workflows

- Resolve `params` block during name checking (was previously done only by language server)

- Minor bug fixes