### PR TITLE
Fix e2e automation

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -110,6 +110,12 @@ task copyPluginBuilds {
                 into new File("${pluginDir}/META-INF")
             }
 
+            // Copy zip archive
+            project.copy {
+                from subproject.file('build/distributions')
+                into pluginsDir
+            }
+
             println "Copied plugin: ${pluginName}-${pluginVersion}"
         }
     }


### PR DESCRIPTION
This PR attempts to restore the structure of `build/plugins` that was present in Nextflow 25.04 and likely was removed by #6379 

```console
build/plugins/
├── nf-amazon-3.3.0
│   ├── classes
│   │   ├── META-INF
│   │   │   ├── extensions.idx
│   │   │   └── services
│   │   │       └── java.nio.file.spi.FileSystemProvider
│   │   └── nextflow
│   │       └── cloud
│   │           └── aws
│   │               ├── AmazonPlugin.class
│   │               ├── ...
│   ├── lib
│   │   ├── annotations-2.33.2.jar
│   │   ├── apache-client-2.33.2.jar
│   │   ├── arns-2.33.2.jar
│   │   ├── ...
│   └── META-INF
│       └── MANIFEST.MF
```

This structure is required by the e2e automation to bake the local plugin builds in the launcher image

I just added a Gradle task to re-create this structure with direct file copies, but I assume there is a more idiomatic way to do it