### PR TITLE
Simplify S3 configuration options

### DIFF
--- a/docs/guides/aws-java-sdk-v2.md
+++ b/docs/guides/aws-java-sdk-v2.md
@@ -2,7 +2,7 @@
 
 # AWS Java SDK v2
 
-AWS Java SDK v1 will reach end of life at the end of 2025. Starting with version `25.06.0-edge`, Nextflow uses AWS Java SDK v2 in the `nf-amazon` plugin.
+AWS Java SDK v1 will reach end of life at the end of 2025. Starting in Nextflow 25.10, Nextflow uses AWS Java SDK v2 in the `nf-amazon` plugin.
 
 This migration introduces several breaking changes to the `aws.client` config scope, including new and removed options. This page describes these changes and how they affect your Nextflow configuration.
 
@@ -16,18 +16,21 @@ The HTTP client in SDK v2 does not support overriding certain advanced HTTP opti
 - `aws.client.socketSendBufferSizeHint`
 - `aws.client.userAgent`
 
-## S3 transfer manager
+## Parallel S3 operations
 
-The *S3 transfer manager* is a subsystem of SDK v2 that handles S3 uploads and downloads.
+Nextflow manages S3 transfers, including uploads, downloads, and S3-to-S3 copies, separately from other S3 API calls such as listing a directory or retrieving object metadata.
 
-You can configure the concurrency and throughput of the S3 transfer manager manually using the `aws.client.maxConcurrency` and `aws.client.maxNativeMemory` configuration options. Alternatively, you can use the `aws.client.targetThroughputInGbps` option to set both values automatically based on a target throughput.
+Use the `aws.client.targetThroughputInGbps` option to control the concurrency of S3 transfers based on the available network bandwidth. This setting defaults to `10`, which allows Nextflow to perform concurrent S3 transfers up to 10 Gbps of network throughput.
+
+Use the `aws.client.maxConnections` config option to control the maximum number of concurrent HTTP connections for all other S3 API calls.
 
 ## Multi-part transfers
 
-Multi-part transfer are handled by the S3 transfer manager. You can use the `aws.client.minimumPartSize` and `aws.client.multipartThreshold` config options to control when and how multi-part transfers are performed. 
-Concurrent multi-part downloads can consume large heap memory space due to the buffer size created per transfer. To avoid out of memory errors, the size consumed by these buffers is limited to 400 MB. You can use `aws.client.maxDownloadHeapMemory` to change this value.
+Nextflow transfers large files to and from S3 as multipart transfers. Use the `aws.client.minimumPartSize` and `aws.client.multipartThreshold` configuration options to control when and how multipart transfers are performed.
 
-The following multi-part upload config options are no longer supported:
+Concurrent multipart downloads can consume a large amount of heap memory due to the buffer allocated by each transfer. To avoid out-of-memory errors, the size consumed by these buffers is limited to 400 MB by default. Use the `aws.client.maxDownloadHeapMemory` option to control this value.
+
+The following multipart upload config options are no longer supported:
 
 - `aws.client.uploadChunkSize`
 - `aws.client.uploadMaxAttempts`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -167,13 +167,8 @@ The following settings are available:
 `aws.client.endpoint`
 : The AWS S3 API entry point e.g. `https://s3-us-west-1.amazonaws.com`. The endpoint must include the protocol prefix e.g. `https://`.
 
-`aws.client.maxConcurrency`
-: :::{versionadded} 25.06.0-edge
-  :::
-: The maximum number of concurrent S3 transfers used by the S3 transfer manager. By default, this setting is determined by `aws.client.targetThroughputInGbps`. Modifying this value can affect the amount of memory used for S3 transfers.
-
 `aws.client.maxConnections`
-: The maximum number of open HTTP connections used by the S3 transfer manager (default: `50`).
+: The maximum number of open HTTP connections used by the S3 client (default: `50`).
 
 `aws.client.maxDownloadHeapMemory`
 : The maximum size for the heap memory buffer used by concurrent downloads. It must be at least 10 times the `minimumPartSize` (default:`400 MB`).
@@ -181,20 +176,15 @@ The following settings are available:
 `aws.client.maxErrorRetry`
 : The maximum number of retry attempts for failed retryable requests (default: `-1`).
 
-`aws.client.maxNativeMemory`
-: :::{versionadded} 25.06.0-edge
-  :::
-: The maximum native memory used by the S3 transfer manager. By default, this setting is determined by `aws.client.targetThroughputInGbps`.
-
 `aws.client.minimumPartSize`
 : :::{versionadded} 25.06.0-edge
   :::
-: The minimum part size used by the S3 transfer manager for multi-part uploads (default: `8 MB`).
+: The minimum part size used for multipart S3 transfers (default: `8 MB`).
 
 `aws.client.multipartThreshold`
 : :::{versionadded} 25.06.0-edge
   :::
-: The object size threshold used by the S3 transfer manager for performing multi-part uploads (default: same as `aws.cllient.minimumPartSize`).
+: The object size threshold used for multipart S3 transfers (default: same as `aws.cllient.minimumPartSize`).
 
 `aws.client.protocol`
 : :::{deprecated} 25.06.0-edge
@@ -265,12 +255,7 @@ The following settings are available:
 `aws.client.targetThroughputInGbps`
 : :::{versionadded} 25.06.0-edge
   :::
-: The target network throughput (in Gbps) used by the S3 transfer manager (default: `10`). This setting is not used when `aws.client.maxConcurrency` and `aws.client.maxNativeMemory` are specified.
-
-`aws.client.transferManagerThreads`
-: :::{versionadded} 25.06.0-edge
-  :::
-: The number of threads used by the S3 transfer manager (default: `10`).
+: The target network throughput (in Gbps) used for S3 uploads and downloads (default: `10`).
 
 `aws.client.userAgent`
 : :::{deprecated} 25.06.0-edge

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
@@ -58,15 +58,16 @@ class AwsS3Config implements ConfigScope {
     """)
     final String endpoint
 
+    /**
+     * Maximum number of concurrent transfers used by S3 transfer manager. By default,
+     * it is determined automatically by `targetThroughputInGbps`.
+     */
     @ConfigOption
-    @Description("""
-        The maximum number of concurrent S3 transfers used by the S3 transfer manager. By default, this setting is determined by `aws.client.targetThroughputInGbps`. Modifying this value can affect the amount of memory used for S3 transfers.
-    """)
     final Integer maxConcurrency
 
     @ConfigOption
     @Description("""
-        The maximum number of open HTTP connections used by the S3 transfer manager (default: `50`).
+        The maximum number of open HTTP connections used by the S3 client (default: `50`).
     """)
     final Integer maxConnections
 
@@ -82,21 +83,22 @@ class AwsS3Config implements ConfigScope {
     """)
     final Integer maxErrorRetry
 
+    /**
+     * Maximum native memory used by S3 transfer manager. By default, it is
+     * determined automatically by `targetThroughputInGbps`.
+     */
     @ConfigOption
-    @Description("""
-        The maximum native memory used by the S3 transfer manager. By default, this setting is determined by `aws.client.targetThroughputInGbps`.
-    """)
     final MemoryUnit maxNativeMemory
 
     @ConfigOption
     @Description("""
-        The minimum part size used by the S3 transfer manager for multi-part uploads (default: `8 MB`).
+        The minimum part size used for multipart uploads to S3 (default: `8 MB`).
     """)
     final MemoryUnit minimumPartSize
 
     @ConfigOption
     @Description("""
-        The object size threshold used by the S3 transfer manager for performing multi-part uploads (default: same as `aws.cllient.minimumPartSize`).
+        The object size threshold used for multipart uploads to S3 (default: same as `aws.cllient.minimumPartSize`).
     """)
     final MemoryUnit multipartThreshold
 
@@ -174,15 +176,9 @@ class AwsS3Config implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        The target network throughput (in Gbps) used by the S3 transfer manager (default: `10`). This setting is not used when `aws.client.maxConcurrency` and `aws.client.maxNativeMemory` are specified.
+        The target network throughput (in Gbps) used for S3 uploads and downloads (default: `10`).
     """)
     final Double targetThroughputInGbps
-
-    @ConfigOption
-    @Description("""
-        The number of threads used by the S3 transfer manager (default: `10`).
-    """)
-    final Integer transferManagerThreads
 
     // deprecated
 
@@ -255,7 +251,6 @@ class AwsS3Config implements ConfigScope {
         this.storageEncryption = parseStorageEncryption(opts.storageEncryption as String)
         this.storageKmsKeyId = opts.storageKmsKeyId
         this.targetThroughputInGbps = opts.targetThroughputInGbps as Double
-        this.transferManagerThreads = opts.transferManagerThreads as Integer
         this.uploadChunkSize = opts.uploadChunkSize as MemoryUnit
         this.uploadMaxAttempts = opts.uploadMaxAttempts as Integer
         this.uploadMaxThreads = opts.uploadMaxThreads as Integer
@@ -314,7 +309,6 @@ class AwsS3Config implements ConfigScope {
             storage_encryption: storageEncryption?.toString(),
             storage_kms_key_id: storageKmsKeyId?.toString(),
             target_throughput_in_gbps: targetThroughputInGbps?.toString(),
-            transfer_manager_threads: transferManagerThreads?.toString(),
             upload_chunk_size: uploadChunkSize?.toBytes()?.toString(),
             upload_max_attempts: uploadMaxAttempts?.toString(),
             upload_max_threads: uploadMaxThreads?.toString(),

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
@@ -266,19 +266,6 @@ public class S3Client {
 		log.debug("Setting S3 requester pays enabled={}", isRequesterPaysEnabled);
 	}
 
-	public void setTransferManagerThreads(String value) {
-		if( value==null )
-			return;
-
-		try {
-			this.transferManagerThreads = Integer.valueOf(value);
-			log.debug("Setting S3 upload max threads={}", transferManagerThreads);
-		}
-		catch( NumberFormatException e ) {
-			log.warn("Not a valid AWS S3 upload max threads: `{}` -- Using default", value);
-		}
-	}
-
 	public ObjectCannedACL getCannedAcl() {
 		return cannedAcl;
 	}
@@ -320,8 +307,7 @@ public class S3Client {
 
 	synchronized ExtendedS3TransferManager transferManager() {
 		if( transferManager == null ) {
-			log.debug("Creating S3 transfer manager pool - max-treads={};", transferManagerThreads);
-			transferPool = ThreadPoolManager.create("S3TransferManager", transferManagerThreads);
+			transferPool = ThreadPoolManager.create("S3TransferManager");
 			var delegate = S3TransferManager.builder()
 					.s3Client(factory.getS3AsyncClient(S3AsyncClientConfiguration.create(props), global))
 					.executor(transferPool)
@@ -391,14 +377,14 @@ public class S3Client {
                 if( log.isTraceEnabled())
                     log.trace("Download file: " + current + " -> "+ FilesEx.toUriString(newFile));
                 try {
-                S3Path s3Path = (S3Path)current;
+                    S3Path s3Path = (S3Path)current;
                     DownloadFileRequest downloadFileRequest = DownloadFileRequest.builder()
                         .getObjectRequest(b -> b.bucket(s3Path.getBucket()).key(s3Path.getKey()))
                         .destination(newFile)
                         .build();
                     FileDownload it = transferManager().downloadFile(downloadFileRequest, attr.size());
                     allDownloads.add(new OngoingFileDownload(s3Path.getBucket(), s3Path.getKey(), it));
-                }catch (InterruptedException e) {
+                } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     // Don't throw immediately - store the exception and continue to clean-up
                     traversalInterruption[0] = new InterruptedIOException(String.format("S3 download directory: s3://%s/%s interrupted", source.getBucket(), source.getKey()));
@@ -432,7 +418,7 @@ public class S3Client {
                     }
                 }
             }
-            
+
             // Throw traversal interruption first if it occurred
             if (traversalInterruption != null) {
                 if (firstException != null) {
@@ -440,7 +426,7 @@ public class S3Client {
                 }
                 throw traversalInterruption;
             }
-            
+
             // Throw download failures if any occurred
             if (firstException != null) {
                 throw new IOException(String.format("Some transfers from S3 download directory: s3://%s/%s failed", source.getBucket(), source.getKey()), firstException);
@@ -456,13 +442,12 @@ public class S3Client {
         }
     }
 
-	public void uploadFile(File source, S3Path target) throws IOException {
-		PutObjectRequest.Builder req = PutObjectRequest.builder().bucket(target.getBucket()).key(target.getKey());
-		preparePutObjectRequest(req, target.getTagsList(), target.getContentType(), target.getStorageClass());
-		// initiate transfer
-		FileUpload upload = transferManager().uploadFile(UploadFileRequest.builder().putObjectRequest(req.build()).source(source).build());
-        try{
-		    upload.completionFuture().get();
+    public void uploadFile(File source, S3Path target) throws IOException {
+        var req = PutObjectRequest.builder().bucket(target.getBucket()).key(target.getKey());
+        preparePutObjectRequest(req, target.getTagsList(), target.getContentType(), target.getStorageClass());
+        var uploadRequest = UploadFileRequest.builder().putObjectRequest(req.build()).source(source).build();
+        try {
+            transferManager().uploadFile(uploadRequest).completionFuture().get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new InterruptedIOException(String.format("S3 upload file: s3://%s/%s interrupted", target.getBucket(), target.getKey()));
@@ -497,11 +482,9 @@ public class S3Client {
 				.uploadFileRequestTransformer(transformUploadRequest(target.getTagsList()))
 				.build();
 
-		// initiate transfer
-		DirectoryUpload upload = transferManager().uploadDirectory(request);
 		try {
-			CompletedDirectoryUpload completed = upload.completionFuture().get();
-			if (!completed.failedTransfers().isEmpty()){
+			CompletedDirectoryUpload completed = transferManager().uploadDirectory(request).completionFuture().get();
+			if (!completed.failedTransfers().isEmpty()) {
 				log.debug("S3 upload directory: s3://{}/{} failed transfers", target.getBucket(), target.getKey());
 				throw new IOException("Some transfers in S3 upload directory: s3://"+ target.getBucket() +"/"+ target.getKey() +" has failed - Transfers: " +  completed.failedTransfers() );
 			}
@@ -540,9 +523,9 @@ public class S3Client {
 		if( log.isTraceEnabled() ) {
 			log.trace("S3 CopyObject request {}", req);
 		}
-		Copy copy = transferManager().copy(CopyRequest.builder().copyObjectRequest(req).build());
+		CopyRequest copyRequest = CopyRequest.builder().copyObjectRequest(req).build();
         try {
-            copy.completionFuture().get();
+			transferManager().copy(copyRequest).completionFuture().get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new InterruptedIOException(String.format("S3 copy s3://%s/%s to s3://%s/%s interrupted", req.sourceBucket(), req.sourceKey(), req.destinationBucket(), req.destinationKey()));

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
@@ -747,7 +747,6 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
 		client.setCannedAcl(getProp(props, "s_3_acl", "s3_acl", "s3acl", "s3Acl"));
 		client.setStorageEncryption(props.getProperty("storage_encryption"));
 		client.setKmsKeyId(props.getProperty("storage_kms_key_id"));
-		client.setTransferManagerThreads(props.getProperty("transfer_manager_threads"));
         client.setRequesterPaysEnabled(props.getProperty("requester_pays"));
 
 		if( props.getProperty("glacier_auto_retrieval") != null )

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/ExtendedS3TransferManager.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/ExtendedS3TransferManager.java
@@ -35,9 +35,15 @@ import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import static nextflow.cloud.aws.config.AwsS3Config.*;
 
 /**
- * Extends the S3 Transfer manager functionality limiting the number of concurrent downloads according to a target heap memory consumption.
- * Implemented to fix https://github.com/aws/aws-sdk-java-v2/issues/6323 where several concurrent downloads with CRT client can consume large heap memory space.
- * This is due to the inital download buffer allocated for each transfer that by default it is 10 * part size.
+ * Extends the S3 Transfer Manager with semaphores to limit concurrent
+ * transfers based on available resources.
+ *
+ * Copies and uploads are limited based on the `maxConnections` setting.
+ *
+ * Downloads are limited based on the `maxDownloadHeapMemory` setting. The
+ * CRT client allocates a buffer of 10 * part size for each transfer by default.
+ *
+ * @see https://github.com/aws/aws-sdk-java-v2/issues/6323
  *
  * @author Jorge Ejarque (jorge.ejarque@seqera.io)
  */
@@ -46,47 +52,66 @@ public class ExtendedS3TransferManager {
     private static final Logger log = LoggerFactory.getLogger(ExtendedS3TransferManager.class);
 
     private S3TransferManager transferManager;
-    private Semaphore concurrentDownloadSemaphore;
+    private Semaphore semaphore;
     private long partSize;
-    private int maxPartsTotal;
-
+    private int downloadPermits;
+    private Semaphore downloadSemaphore;
 
     public ExtendedS3TransferManager( S3TransferManager transferManager, Properties props){
         this.transferManager = transferManager;
-        setDownloadBufferProperties(props);
-        this.concurrentDownloadSemaphore = new Semaphore(maxPartsTotal);
+        setDefaultSemaphore(props);
+        setDownloadSemaphore(props);
     }
 
-    public FileDownload downloadFile(DownloadFileRequest downloadFileRequest, long size) throws InterruptedException {
-        final int parts = estimateParts(size);
-        FileDownload downloadFile;
-        concurrentDownloadSemaphore.acquire(parts);
-        try {
-            downloadFile = transferManager.downloadFile(downloadFileRequest);
-        } catch (Throwable e) {
-            // Release semaphore when runtime exception during the downloadFile submission
-            concurrentDownloadSemaphore.release(parts);
-            throw e;
+    private void setDefaultSemaphore(Properties props) {
+        int permits = 100;
+        if( props.containsKey("max_connections")) {
+            permits = Integer.parseInt(props.getProperty("max_connections"));
         }
-        // Ensure permits are always released after completion
-        downloadFile
-            .completionFuture()
-            .whenComplete((result, error) -> concurrentDownloadSemaphore.release(parts));
-        return downloadFile;
+        this.semaphore = new Semaphore(permits);
     }
 
-    private void setDownloadBufferProperties(Properties props) {
-        long maxBuffer = DEFAULT_MAX_DOWNLOAD_BUFFER_SIZE;
+    private void setDownloadSemaphore(Properties props) {
+        long maxBufferSize = DEFAULT_MAX_DOWNLOAD_BUFFER_SIZE;
         if( props.containsKey("max_download_heap_memory")) {
             log.trace("AWS client config - max_download_heap_memory: {}", props.getProperty("max_download_heap_memory"));
-            maxBuffer = Long.parseLong(props.getProperty("max_download_heap_memory"));
+            maxBufferSize = Long.parseLong(props.getProperty("max_download_heap_memory"));
         }
+
         this.partSize = DEFAULT_PART_SIZE;
         if( props.containsKey("minimum_part_size")) {
             log.trace("AWS client config - minimum_part_size: {}", props.getProperty("minimum_part_size"));
             this.partSize = Long.parseLong(props.getProperty("minimum_part_size"));
         }
-        this.maxPartsTotal = (int) Math.floor((double) maxBuffer / partSize);
+
+        this.downloadPermits = (int) Math.floor((double) maxBufferSize / partSize);
+        this.downloadSemaphore = new Semaphore(downloadPermits);
+    }
+
+    public long getPartSize() {
+        return partSize;
+    }
+
+    public int getDownloadPermits() {
+        return downloadPermits;
+    }
+
+    public FileDownload downloadFile(DownloadFileRequest request, long size) throws InterruptedException {
+        int parts = estimateParts(size);
+        FileDownload fileDownload;
+        downloadSemaphore.acquire(parts);
+        try {
+            fileDownload = transferManager.downloadFile(request);
+        } catch (Throwable e) {
+            // Release semaphore when runtime exception during the downloadFile submission
+            downloadSemaphore.release(parts);
+            throw e;
+        }
+        // Ensure permits are always released after completion
+        fileDownload
+            .completionFuture()
+            .whenComplete((result, error) -> downloadSemaphore.release(parts));
+        return fileDownload;
     }
 
     protected int estimateParts(long size) {
@@ -96,24 +121,49 @@ public class ExtendedS3TransferManager {
         return Math.min(parts, DEFAULT_INIT_BUFFER_PARTS);
     }
 
-    public FileUpload uploadFile(UploadFileRequest request) {
-        return transferManager.uploadFile(request);
+    public FileUpload uploadFile(UploadFileRequest request) throws InterruptedException {
+        FileUpload fileUpload;
+        semaphore.acquire();
+        try {
+            fileUpload = transferManager.uploadFile(request);
+        } catch (Throwable e) {
+            semaphore.release();
+            throw e;
+        }
+        fileUpload
+            .completionFuture()
+            .whenComplete((result, error) -> semaphore.release());
+        return fileUpload;
     }
 
-    public DirectoryUpload uploadDirectory(UploadDirectoryRequest request)  {
-        return transferManager.uploadDirectory(request);
+    public DirectoryUpload uploadDirectory(UploadDirectoryRequest request) throws InterruptedException {
+        DirectoryUpload directoryUpload;
+        semaphore.acquire();
+        try {
+            directoryUpload = transferManager.uploadDirectory(request);
+        } catch (Throwable e) {
+            semaphore.release();
+            throw e;
+        }
+        directoryUpload
+            .completionFuture()
+            .whenComplete((result, error) -> semaphore.release());
+        return directoryUpload;
     }
 
-    public Copy copy(CopyRequest request)  {
-        return transferManager.copy(request);
-    }
-
-    public long getPartSize() {
-        return partSize;
-    }
-
-    public int getMaxPartsTotal() {
-        return maxPartsTotal;
+    public Copy copy(CopyRequest request) throws InterruptedException {
+        Copy copy;
+        semaphore.acquire();
+        try {
+            copy = transferManager.copy(request);
+        } catch (Throwable e) {
+            semaphore.release();
+            throw e;
+        }
+        copy
+            .completionFuture()
+            .whenComplete((result, error) -> semaphore.release());
+        return copy;
     }
 
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3FileSystemProviderTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3FileSystemProviderTest.groovy
@@ -51,7 +51,6 @@ class S3FileSystemProviderTest extends Specification {
                 proxyPassword: 'pass',
                 storageEncryption: 'AES256',
                 storageKmsKeyId: 'arn:key:id',
-                transferManagerThreads: 20,
                 uploadMaxThreads: 15,
                 uploadChunkSize: '7MB',
                 uploadMaxAttempts: 4,
@@ -68,7 +67,6 @@ class S3FileSystemProviderTest extends Specification {
         fs.getBucketName() == 'bucket'
         def client = fs.getClient()
         client.client != null
-        client.transferManagerThreads == 20
         client.cannedAcl == ObjectCannedACL.PRIVATE
         client.storageEncryption == ServerSideEncryption.AES256
         client.isRequesterPaysEnabled == true

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/ExtendedS3TransferManagerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/ExtendedS3TransferManagerTest.groovy
@@ -39,7 +39,7 @@ class ExtendedS3TransferManagerTest extends Specification {
 
         then:
         extendedManager.partSize == 8 * 1024 * 1024 // 8 MB
-        extendedManager.maxPartsTotal == 50 // 400MB / 8MB
+        extendedManager.downloadPermits == 50 // 400MB / 8MB
     }
 
     def 'should initialize with custom properties'() {
@@ -54,7 +54,7 @@ class ExtendedS3TransferManagerTest extends Specification {
 
         then:
         extendedManager.partSize == 16 * 1024 * 1024 // 16 MB
-        extendedManager.maxPartsTotal == 11 // 200MB / 16MB (floor) = 11.92... -> 11
+        extendedManager.downloadPermits == 11 // 200MB / 16MB (floor) = 11.92... -> 11
     }
 
     @Unroll
@@ -80,7 +80,7 @@ class ExtendedS3TransferManagerTest extends Specification {
     }
 
 
-    def 'should calculate maxPartsTotal correctly'() {
+    def 'should calculate downloadPermits correctly'() {
         given:
         def mockTransferManager = Mock(S3TransferManager)
         def props = new Properties()
@@ -91,7 +91,7 @@ class ExtendedS3TransferManagerTest extends Specification {
         def extendedManager = new ExtendedS3TransferManager(mockTransferManager, props)
 
         then:
-        extendedManager.maxPartsTotal == expectedMaxParts
+        extendedManager.downloadPermits == expectedMaxParts
 
         where:
         maxBuffer     | partSize     | expectedMaxParts


### PR DESCRIPTION
This PR simplifies the new S3 config options that were added as part of the upgrade to AWS SDK v2, in preparation for the 25.10 release

Spun off from #6369 

- **Replace `transferManagerThreads` config option with semaphores**
  - transfer manager uses semaphore to limit copies and uploads to prevent out-of-memory error
  - transfer manager already uses semaphore to limit downloads based on download buffer size

- **Make the docs more user friendly**
  - use aws `targetThroughputInGbps` to limit S3 transfers
  - use aws `maxConnections` to limit all other S3 API calls
  - remove `maxConcurrency` and `maxNativeMemory` from docs -- they will remain as hidden options for now