### PR TITLE
Fix no secrets in AWS Batch jobs

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/model/ContainerPropertiesModel.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/model/ContainerPropertiesModel.groovy
@@ -281,6 +281,7 @@ class ContainerPropertiesModel {
             ", networkConfiguration=" + networkConfiguration +
             ", ephemeralStorage=" + ephemeralStorage +
             ", runtimePlatform=" + runtimePlatform +
+            ", secrets=" + secrets +
             '}';
     }
 }


### PR DESCRIPTION
This PR include the secrets to the ContainerProperties builder used for AWS Batch jobs. They were missed during the AWS SDK v2 refactor.