### PR TITLE
Improve static types migration docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -384,9 +384,8 @@ class NextflowLexer(RegexLexer):
             (r'/\*.*?\*/', Comment.Multiline),
             # keywords: go before method names to avoid lexing "throw new XYZ"
             # as a method signature
-            (r'(assert|catch|else|'
-             r'if|instanceof|new|return|throw|try|in|as)\b',
-             Keyword),
+            (r'(assert|catch|else|if|instanceof|new|return|throw|try|in|as)\b', Keyword),
+            (r'(channel|log)', Name.Namespace),
             # method names
             (r'^(\s*(?:[a-zA-Z_][\w.\[\]]*\s+)+?)'  # return arguments
              r'('
@@ -397,9 +396,8 @@ class NextflowLexer(RegexLexer):
              r'(\s*)(\()',                          # signature start
              bygroups(using(this), Name.Function, Whitespace, Operator)),
             (r'@[a-zA-Z_][\w.]*', Name.Decorator),
-            (r'(def|enum|include|from|output|process|workflow)\b', Keyword.Declaration),
-            (r'(boolean|byte|char|double|float|int|long|short|void)\b',
-             Keyword.Type),
+            (r'(def|enum|include|from|output|params|process|workflow)\b', Keyword.Declaration),
+            (r'(boolean|byte|char|double|float|int|long|short|void)\b', Keyword.Type),
             (r'(true|false|null)\b', Keyword.Constant),
             (r'""".*?"""', String.Double),
             (r"'''.*?'''", String.Single),

--- a/docs/migrations/25-10.md
+++ b/docs/migrations/25-10.md
@@ -138,8 +138,14 @@ def x_opt: String? = null
 
 In the type system, queue channels are represented as `Channel`, while value channels are represented as `Value`. To make the terminology clearer and more concise, queue channels are now called *dataflow channels* (or simply *channels*), and value channels are now called *dataflow values*. See {ref}`dataflow-page` for more information.
 
-:::{note}
-Nextflow supports Groovy-style type annotations using the `<type> <name>` syntax, but this approach is deprecated in {ref}`strict syntax <strict-syntax-page>`. While Groovy-style annotations remain valid for functions and local variables, the language server and `nextflow lint` automatically convert them to Nextflow-style annotations during code formatting.
+Groovy-style type annotations (e.g., `String x`) are still supported for functions and local variables. However, the language server and `nextflow lint` will automatically convert them to Nextflow-style annotations during code formatting.
+
+:::{warning}
+Since Nextflow-style type annotations are new in Nextflow 25.10, formatting code with Groovy-style type annotations will make it incompatible with previous versions of Nextflow. If you need your code to remain compatible with versions prior to 25.10, run the formatter with Nextflow 25.04:
+
+```bash
+NXF_VER=25.04.8 nextflow lint -format .
+```
 :::
 
 See {ref}`migrating-static-types` for details.

--- a/docs/process.md
+++ b/docs/process.md
@@ -678,6 +678,8 @@ In the above example, the `tuple` input consists of the value `x` and the file `
 
 A `tuple` definition may contain any of the following qualifiers, as previously described: `val`, `env`, `path` and `stdin`. Files specified with the `path` qualifier are treated exactly the same as standalone `path` inputs.
 
+(process-input-each)=
+
 ### Input repeaters (`each`)
 
 The `each` qualifier allows you to repeat the execution of a process for each item in a collection, each time a new value is received. For example:
@@ -735,7 +737,7 @@ When multiple repeaters are defined, the process is executed for each *combinati
 :::
 
 :::{note}
-Input repeaters do not support tuples. Use the {ref}`operator-combine` or {ref}`operator-cross` operator to combine the repeated input with the other inputs to produce all of the desired input combinations.
+Input repeaters do not support tuples. Use the {ref}`operator-combine` operator to combine the repeated input with the other inputs to produce all of the desired input combinations.
 :::
 
 (process-multiple-inputs)=

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -942,6 +942,14 @@ Lint and format all files in the current directory (and subdirectories) and use 
 $ nextflow lint -format -spaces 2 .
 ```
 
+:::{note}
+Formatting code with the `lint` command in Nextflow 25.10 or later may make your code incompatible with previous versions of Nextflow. If you need your code to remain compatible with versions prior to 25.10, run the formatter with Nextflow 25.04:
+
+```bash
+NXF_VER=25.04.8 nextflow lint -format .
+```
+:::
+
 (cli-list)=
 
 ### `list`

--- a/docs/strict-syntax.md
+++ b/docs/strict-syntax.md
@@ -8,7 +8,7 @@ This page explains how to update Nextflow scripts and config files to adhere to 
 If you are still using DSL1, see {ref}`dsl1-page` to learn how to migrate your Nextflow pipelines to DSL2 before consulting this guide.
 :::
 
-:::{versionadded} 25.02.0-edge
+:::{versionadded} 25.04.0
 The strict syntax can be enabled in Nextflow by setting the environment variable `NXF_SYNTAX_PARSER=v2`.
 :::
 
@@ -222,7 +222,7 @@ In the strict syntax, use `System.getenv()` instead:
 println "PWD = ${System.getenv('PWD')}"
 ```
 
-:::{versionadded} 24.11.0-edge
+:::{versionadded} 24.04.0
 The `env()` function should be used instead of `System.getenv()`:
 
 ```nextflow
@@ -472,21 +472,40 @@ workflow {
 }
 ```
 
-:::{note}
-A more concise syntax for workflow handlers will be addressed in a future version of the Nextflow language specification.
+:::{versionadded} 25.10.0
 :::
+
+Workflow handlers can be specified as sections in the entry workflow:
+
+```nextflow
+workflow {
+    main:
+    // ...
+
+    onComplete:
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+}
+```
+
+See {ref}`workflow-handlers` for details.
+
+(strict-syntax-deprecated)=
 
 ## Deprecated syntax
 
 The following patterns are deprecated, and the strict syntax reports warnings for them. These warnings will become errors in the future.
 
-### Process shell section
+### `channel` vs `Channel`
 
-The process `shell` section is deprecated. Use the `script` section instead. The strict syntax provides error checking to help distinguish between Nextflow variables and Bash variables.
+Channel factories should be accessed using the `channel` namespace instead of the `Channel` type:
 
-## Best practices
+```nextflow
+Channel.of(1, 2, 3) // incorrect
+channel.of(1, 2, 3) // correct
+```
 
-The following patterns are discouraged. The language server reports informative messages for these patterns, which are disabled by default. Enable them by setting the error reporiting mode (**Nextflow > Error reporting mode** in the extension settings) to `paranoid`. These messages may become warnings or errors in the future.
+See {ref}`stdlib-namespaces-channel` and {ref}`stdlib-types-channel` for more information.
 
 ### Implicit closure parameter
 
@@ -496,12 +515,22 @@ In Groovy, a closure with no parameters is assumed to have a single parameter na
 ch.map { it * 2 }
 ```
 
-As a best practice, the closure parameter should be explicitly declared:
+In the strict syntax, the closure parameter should be explicitly declared:
 
 ```nextflow
 ch.map { v -> v * 2 }   // correct
 ch.map { it -> it * 2 } // also correct
 ```
+
+### Process shell section
+
+The process `shell` section is deprecated. Use the `script` section instead. The strict syntax provides error checking to help distinguish between Nextflow variables and Bash variables.
+
+## Best practices
+
+The following patterns are discouraged and may become warnings or errors in future Nextflow versions. The language server can detect these patterns, but does not report them by default.
+
+To enable these checks, set **Nextflow > Error reporting mode** to **paranoid** in the extension settings.
 
 ### Using params outside the entry workflow
 
@@ -538,7 +567,7 @@ The process {ref}`process-when` section is discouraged. As a best practice, cond
 
 ## Configuration syntax
 
-:::{versionadded} 25.02.0-edge
+:::{versionadded} 25.04.0
 The strict config syntax can be enabled in Nextflow by setting the environment variable `NXF_SYNTAX_PARSER=v2`.
 :::
 

--- a/docs/tutorials/static-types.md
+++ b/docs/tutorials/static-types.md
@@ -344,6 +344,146 @@ While `List<Path>` and `Bag<Path>` are also valid path collection types, `Set<Pa
 
 Apply the same migration principles from the previous processes to migrate `INDEX`.
 
+(preparing-static-types)=
+
+## Preparing for static types
+
+While static types can be adopted progressively with existing code, some coding patterns cannot be statically typed and will prevent the type checker from validating your entire pipeline.
+
+This section provides best practices for writing Nextflow code that works well with static types.
+
+<h3>Use the strict syntax</h3>
+
+The {ref}`strict syntax <strict-syntax-page>` remains optional in Nextflow 25.10. However, it is required to use type annotations.
+
+Before you migrate to static types, ensure your code adheres to the strict syntax using `nextflow lint` or the language server.
+
+<h3>Avoid deprecated patterns</h3>
+
+When preparing for the strict syntax, try to address {ref}`deprecation warnings <strict-syntax-deprecated>` as much as possible. For example:
+
+```nextflow
+Channel.from(1, 2, 3).map { it * 2 }    // deprecated
+channel.of(1, 2, 3).map { v -> v * 2 }  // best practice
+```
+
+The above example shows how to avoid three deprecated patterns:
+
+1. Using `Channel` to access channel factories (use `channel` instead)
+2. Using the deprecated `channel.from` factory (use `channel.of` or `channel.fromList` instead)
+3. Using the implicit `it` closure parameter (declare the parameter explicitly instead) 
+
+<h3>Avoid <code>set</code> and <code>tap</code> operators</h3>
+
+Nextflow provides three ways to assign a channel: a standard assignment, the `set` operator, and the `tap` operator:
+
+```nextflow
+ch = channel.of(1, 2, 3)            // standard assignment
+channel.of(10, 20, 30).set { ch }   // set
+channel.of(10, 20, 30).tap { ch }   // tap
+```
+
+However, the type checker cannot validate code that uses `set` or `tap`. Use standard assignments in your dataflow logic to enable full type checking.
+
+<h3>Avoid <code>each</code> input qualifier</h3>
+
+The {ref}`each <process-input-each>` input qualifier is not supported by typed processes. Use the {ref}`operator-combine` operator to create a single tuple channel instead.
+
+For example:
+
+```nextflow
+process align {
+    input:
+    path seq
+    each mode
+
+    script:
+    """
+    t_coffee -in $seq -mode $mode > result
+    """
+}
+
+workflow {
+    sequences = channel.fromPath('*.fa')
+    methods = ['regular', 'espresso', 'psicoffee']
+
+    align(sequences, methods)
+}
+```
+
+Rewrite the script to use the `combine` operator. It becomes:
+
+```nextflow
+process align {
+    input:
+    tuple path(seq), val(mode)
+
+    script:
+    """
+    t_coffee -in $seq -mode $mode > result
+    """
+}
+
+workflow {
+    sequences = channel.fromPath('*.fa')
+    methods = ['regular', 'espresso', 'psicoffee']
+
+    align(sequences.combine(methods))
+}
+```
+
+:::{tip}
+The `each` qualifier is discouraged in modern Nextflow code. While it provides a convenient shorthand for combining multiple inputs, it couples the process definition with external workflow logic. Since the introduction of DSL2, Nextflow aims to treat processes as standalone modules that are decoupled from workflow logic.
+:::
+
+<h3>Aviod functions with ambiguous return types</h3>
+
+Some {ref}`standard library <stdlib-types>` functions and {ref}`operators <operator-page>` have ambiguous return types. While you can still use them with static types, the type checker will not be able to fully validate your code.
+
+You can tell whether a function has an ambiguous return type by inspecting the function signature. The return type is ambiguous if it is `?` or contains `?` as a type argument.
+
+For example, the `flatten` operator has the following signature:
+
+```nextflow
+def flatten() -> Channel<?>
+```
+
+Use alternatives that have well-defined return types. For example, use `flatMap` instead of `flatten`.
+
+:::{tip}
+The commonly-used operators listed under {ref}`dataflow-type-channel` have well-defined return types and are recommended for use with static types.
+:::
+
+If you cannot avoid an ambiguously-typed function, you can use a *hard cast* to specify the expected type, provided you know what the type will be at runtime.
+
+For example:
+
+```nextflow
+channel.fromPath('samplesheet.csv')
+    .splitCsv()
+    .view()
+```
+
+The `splitCsv` operator has an ambiguous return type (`Channel<?>`).  It emits lists by default but emits maps when `header` is enabled, making the return type dependent on runtime conditions.
+
+
+To address this issue:
+
+1. Replace the `splitCsv` operation with a `flatMap` operation that calls the `splitCsv` method (defined for `Path`).
+
+2. Add a `map` operation that casts the emitted rows as `List<String>`.
+
+It becomes:
+
+```nextflow
+channel.fromPath('samplesheet.csv')
+    .flatMap { csv -> csv.splitCsv() }
+    .map { row -> row as List<String> }
+    .view()
+```
+
+The resulting channel has type `Channel<List<String>>`, and the type checker can validate any downstream code that uses this channel.
+
 ## Additional resources
 
 See the following links to learn more about static types:

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -22,6 +22,11 @@ To view all diagnostics for the workspace, open the **Problems** tab. Here, you 
 The language server parses scripts and config files according to the {ref}`Nextflow language specification <syntax-page>`, which is more strict than the Nextflow CLI. See {ref}`strict-syntax-page` for more information.
 :::
 
+:::{versionadded} 25.10.0
+:::
+
+The extension can perform static type checking. Enable it using the **Nextflow > Type Checking** extension setting. See {ref}`migrating-static-types` for more information about migrating to static types.
+
 ### Hover hints
 
 When you hover over certain source code elements, such as variable names and function calls, the extension provides a tooltip with related information, such as the definition and/or documentation for the element.
@@ -71,6 +76,14 @@ The extension can generate a workflow DAG that includes the workflow inputs, out
 
 To preview the DAG of a workflow, select the **Preview DAG** CodeLens above the workflow definition.
 
+### Automatic code migration
+
+The extension can automatiicaly migrate scripts to static types. See {ref}`migrating-static-types` for details.
+
+To migrate a script, open the Command Palette, search for **Convert script to static types**, and select it.
+
+To migrate an entire pipeline, use the **Convert pipeline to static types** command.
+
 ## Troubleshooting
 
 In the event of a language server error, you can use the **Nextflow: Restart language server** command in the command palette to restart the language server.
@@ -79,11 +92,22 @@ Report issues at [nextflow-io/vscode-language-nextflow](https://github.com/nextf
 
 ## Limitations
 
-- The language server does not detect certain filesystem changes, such as changing the current Git branch. Restart the language server from the command palette to sync it with your workspace.
+<h3>Git filesystem changes</h3>
 
-- The language server does not recognize configuration options from third-party plugins and will report "Unrecognized config option" warnings for them.
+The language server does not detect certain filesystem changes, such as changing the current Git branch. Restart the language server from the command palette to sync it with your workspace.
 
-- The language server provides limited support for Groovy scripts in the `lib` directory. Errors in Groovy scripts are not reported as diagnostics, and changing a Groovy script does not automatically re-compile the Nextflow scripts that reference it. Edit the Nextflow script or close and re-open it to refresh the diagnostics.
+<h3>Plugin definitions</h3>
+
+The language server does not recognize configuration options from third-party plugins and will report "Unrecognized config option" warnings for them.
+
+:::{versionadded} 25.10.0
+:::
+
+The language server can recognize plugin definitions, including configuration options and functions, for plugins that use the {ref}`Nextflow Gradle plugin <gradle-plugin-page>` and require Nextflow >=25.10. Custom factories and operators are not currently recognized.
+
+<h3>The <code>lib</code> directory</h3>
+
+The language server provides limited support for Groovy scripts in the `lib` directory. Errors in Groovy scripts are not reported as diagnostics, and changing a Groovy script does not automatically re-compile the Nextflow scripts that reference it. Edit the Nextflow script or close and re-open it to refresh the diagnostics.
 
 (vscode-language-server)=
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -168,6 +168,27 @@ The result of the above workflow can be accessed using `my_workflow.out.my_data`
 Every output must be assigned to a name when multiple outputs are declared.
 :::
 
+:::{versionadded} 25.10.0
+:::
+
+When using the {ref}`strict syntax <strict-syntax-page>`, workflow takes and emits can specify a type annotation:
+
+```nextflow
+workflow my_workflow {
+    take:
+    data: Channel<Path>
+
+    main:
+    ch_hello = hello(data)
+    ch_bye = bye(ch_hello.collect())
+
+    emit:
+    my_data: Value<Path> = ch_bye
+}
+```
+
+In the above example, `my_workflow` takes a channel of files (`Channel<Path>`) and emits a dataflow value with a single file (`Value<Path>`). See {ref}`stdlib-types` for the list of available types.
+
 (workflow-process-invocation)=
 
 ## Calling processes and workflows


### PR DESCRIPTION
- Add best practices section to static types migration tutorial
- Update strict syntax guidelines for 25.10
- Add missing docs for type annotations, language server updates
- Add note about code formatting and backwards compatibility
- Add best practice tips/warnings for operators