### PR TITLE
Fix csv splitter when skipping empty lines

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/splitter/CsvSplitter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/splitter/CsvSplitter.groovy
@@ -129,7 +129,7 @@ class CsvSplitter extends AbstractTextSplitter {
         String line
         int z = 0
 
-        while( z++ < skipLines && reader.readLine()) { /* nope */ }
+        while( z++ < skipLines && reader.readLine() != null ) { /* nope */ }
 
         if( firstLineAsHeader ) {
             line = reader.readLine()

--- a/modules/nextflow/src/test/groovy/nextflow/splitter/CsvSplitterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/splitter/CsvSplitterTest.groovy
@@ -90,6 +90,22 @@ class CsvSplitterTest extends Specification {
         items[0] == ['gamma', '', 'zeta']
         items[1] == ['eta', 'theta', 'iota']
         items[2] == ['mu', 'nu', 'xi']
+
+        when:
+        def LINES = '''
+                alpha,beta,delta
+
+                gamma,,zeta
+                eta,theta,iota
+                pi,rho,sigma
+                '''
+                .stripIndent().trim()
+        items = new CsvSplitter().target(LINES).options(skip:3).list()
+        then:
+        items.size() == 2
+        items[0] instanceof List
+        items[0] == ['eta', 'theta', 'iota']
+        items[1] == ['pi', 'rho', 'sigma']
     }
 
     def testSplitWithCount() {


### PR DESCRIPTION
Close #6422 

This PR fixes a bug with `splitCsv`  when using the `skip` option. The loop that skips lines was exiting early because an empty line was treated the same as reaching the end-of-stream. Instead the loop should exit early only if the end-of-stream is reached.