### PR TITLE
Fix issues with rsync stage-out mode

### DIFF
--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -1656,17 +1656,17 @@ The `stageOutMode` directive defines how output files are staged out from the sc
 : Output files are copied from the scratch directory to the work directory.
 
 `'fcp'`
-: :::{versionadded} 23.02.0-edge
+: :::{versionadded} 23.04.0
   :::
-: Output files are copied from the scratch directory to the work directory by using the [fcp](https://github.com/Svetlitski/fcp) utility (note: it must be available in your cluster computing nodes).
+: Output files are copied from the scratch directory to the work directory by using the [fcp](https://github.com/Svetlitski/fcp) utility (note: it must be available in the task environment).
 
 `'move'`
 : Output files are moved from the scratch directory to the work directory.
 
 `'rclone'`
-: :::{versionadded} 23.01.0-edge
+: :::{versionadded} 23.04.0
   :::
-: Output files are copied from the scratch directory to the work directory by using the [rclone](https://rclone.org) utility (note: it must be available in your cluster computing nodes).
+: Output files are copied from the scratch directory to the work directory by using the [rclone](https://rclone.org) utility (note: it must be available in the task environment).
 
 `'rsync'`
 : Output files are copied from the scratch directory to the work directory by using the `rsync` utility.

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -87,7 +87,10 @@ nxf_fs_move() {
 }
 
 nxf_fs_rsync() {
-  rsync -rRl $1 $2
+  local source=$1
+  local target=$2
+  mkdir -p $target
+  rsync -rRl $source $target
 }
 
 nxf_fs_rclone() {

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -261,7 +261,10 @@ nxf_fs_move() {
 }
 
 nxf_fs_rsync() {
-  rsync -rRl $1 $2
+  local source=$1
+  local target=$2
+  mkdir -p $target
+  rsync -rRl $source $target
 }
 
 nxf_fs_rclone() {

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
@@ -69,7 +69,10 @@ nxf_fs_move() {
 }
 
 nxf_fs_rsync() {
-  rsync -rRl $1 $2
+  local source=$1
+  local target=$2
+  mkdir -p $target
+  rsync -rRl $source $target
 }
 
 nxf_fs_rclone() {

--- a/tests/checks/stage-out-rsync.nf/.checks
+++ b/tests/checks/stage-out-rsync.nf/.checks
@@ -1,0 +1,29 @@
+
+echo "Initial run"
+$NXF_RUN | tee stdout
+
+[[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > test'` == 3 ]] || false
+
+grep 'cache/test/1.txt' stdout
+grep 'cache/test/2.txt' stdout
+grep 'cache/test/3.txt' stdout
+
+
+echo "Stored run"
+$NXF_RUN | tee stdout
+
+[[ `grep 'INFO' .nextflow.log | grep -c 'Stored process > test'` == 3 ]] || false
+
+grep 'cache/test/1.txt' stdout
+grep 'cache/test/2.txt' stdout
+grep 'cache/test/3.txt' stdout
+
+
+echo "Resumed stored run"
+$NXF_RUN -resume | tee stdout
+
+[[ `grep 'INFO' .nextflow.log | grep -c 'Stored process > test'` == 3 ]] || false
+
+grep 'cache/test/1.txt' stdout
+grep 'cache/test/2.txt' stdout
+grep 'cache/test/3.txt' stdout

--- a/tests/stage-out-rsync.nf
+++ b/tests/stage-out-rsync.nf
@@ -1,0 +1,22 @@
+
+process test {
+    tag "$number"
+    storeDir 'cache/test'
+    stageOutMode 'rsync'
+
+    input:
+    val number
+
+    output:
+    path('*.txt')
+
+    script:
+    """
+    echo "This is an example process with number: ${number}" > ${number}.txt
+    """
+}
+
+workflow {
+    numbers = channel.of(1, 2, 3)
+    test(numbers).view()
+}


### PR DESCRIPTION
Close #6214 #6447 

This PR fixes the `nxf_fs_rsync()` function in the `.command.run` template

The problem was that `rsync` does not actually initialize the target directory prior to copying, whereas I think we assumed that it did. This led to multiple issues:

- sometimes rsync will copy the source file "as" the target rather than "into" the target (#6214)

- rsync will fail if the target parent directory doesn't already exist (#6447)