### PR TITLE
Allow the use of pre-existing write-protected plugins directory

### DIFF
--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -255,7 +255,7 @@ class PluginsFacade implements PluginStateListener {
 
         log.debug "Setting up plugin manager > mode=${mode}; embedded=$embedded; plugins-dir=$root; core-plugins: ${defaultPlugins.toSortedString()}"
         // make sure plugins dir exists
-        if( mode!=DEV_MODE && !FilesEx.mkdirs(root) )
+        if( mode!=DEV_MODE && !FilesEx.exists(root) && !FilesEx.mkdirs(root) )
             throw new IOException("Unable to create plugins dir: $root")
 
         this.manager = createManager(root, embedded)


### PR DESCRIPTION
Close #6562 

This PR updates the plugin system to create the plugins directory only if it doesn't already exist. While not normally needed, it is useful in this case because the plugins directory might be read-only, and calling `mkdirs()` on a read-only directory would cause a permissions error

The assumption in this case is that the user pipeline will not try to download new plugins because they will already be cached. If a user does try to download a plugin, it will fail with the expected permissions error and they can take it up with their sysadmin