### PR TITLE
Update Docker image `latest` tag when making a new release

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,9 +25,13 @@ build-arm: dist/docker/arm64
 
 release: build
 	docker push nextflow/nextflow:${version}
+	docker tag nextflow/nextflow:${version} nextflow/nextflow:latest
+	docker push nextflow/nextflow:latest
 	#
 	docker tag nextflow/nextflow:${version} public.cr.seqera.io/nextflow/nextflow:${version}
 	docker push public.cr.seqera.io/nextflow/nextflow:${version}
+	docker tag nextflow/nextflow:${version} public.cr.seqera.io/nextflow/nextflow:latest
+	docker push public.cr.seqera.io/nextflow/nextflow:latest
 
 #Static builds can now be found at:
 #


### PR DESCRIPTION
Close #6564 

This PR updates the release process to also update the `latest` tag

However, I guess we might not always want to do this, e.g. when patching an older version or making an edge release. Maybe we can put this logic in a separate rule (e.g. `update-latest`) and tell Claude to run it only when it's for the latest stable version