### PR TITLE
Do not delete K8s jobs when ttlSecondsAfterFinished is set

### DIFF
--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -416,8 +416,10 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
 
     @Override
     boolean checkIfCompleted() {
-        if( !podName ) throw new IllegalStateException("Missing K8s ${resourceType.lower()} name - cannot check if complete")
-        def state = getState()
+        if( !podName )
+            throw new IllegalStateException("Missing K8s ${resourceType.lower()} name - cannot check if complete")
+
+        final state = getState()
         if( state && state.terminated ) {
             if( state.nodeTermination instanceof NodeTerminationException ||
                 state.nodeTermination instanceof PodUnschedulableException ) {
@@ -441,8 +443,8 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
                 task.stderr = errorFile
             }
             status = TaskStatus.COMPLETED
-            savePodLogOnError(task)
-            deletePodIfSuccessful(task)
+            saveJobLogOnError(task)
+            deleteJobIfSuccessful(task)
             updateTimestamps(state.terminated as Map)
             determineNode()
             return true
@@ -451,7 +453,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
         return false
     }
 
-    protected void savePodLogOnError(TaskRun task) {
+    protected void saveJobLogOnError(TaskRun task) {
         if( task.isSuccess() )
             return
 
@@ -491,26 +493,21 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
      */
     @Override
     protected void killTask() {
+        if( !podName )
+            return
+
         if( cleanupDisabled() )
             return
         
-        if( podName ) {
-            log.trace "[K8s] deleting ${resourceType.lower()} name=$podName"
-            if ( useJobResource() )
-                client.jobDelete(podName)
-            else
-                client.podDelete(podName)
-        }
-        else {
-            log.debug "[K8s] Invalid delete action"
-        }
+        log.trace "[K8s] deleting ${resourceType.lower()} name=$podName"
+        delete0(podName)
     }
 
     protected boolean cleanupDisabled() {
         !k8sConfig.getCleanup()
     }
 
-    protected void deletePodIfSuccessful(TaskRun task) {
+    protected void deleteJobIfSuccessful(TaskRun task) {
         if( !podName )
             return
 
@@ -521,10 +518,14 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
         if( !task.isSuccess() )
             return
 
-        // k8s cluster will cleanup job on its own if ttl is set
+        // k8s cluster will cleanup job on its own if TTL is set
         if( useJobResource() && getPodOptions().getTtlSecondsAfterFinished() != null )
             return
 
+        delete0(podName)
+    }
+
+    private void delete0(String podName) {
         try {
             if ( useJobResource() )
                 client.jobDelete(podName)
@@ -532,15 +533,15 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
                 client.podDelete(podName)
         }
         catch( Exception e ) {
-            log.warn "Unable to cleanup ${resourceType.lower()}: $podName -- see the log file for details", e
+            log.warn "Unable to delete ${resourceType.lower()}: $podName -- see the log file for details", e
         }
     }
 
-    private void determineNode(){
+    private void determineNode() {
         try {
             if ( k8sConfig.fetchNodeName() && !runsOnNode )
                 runsOnNode = client.getNodeOfPod( podName )
-        } catch ( Exception e ){
+        } catch ( Exception e ) {
             log.warn ("Unable to get the node name of pod $podName -- see the log file for details", e)
         }
     }


### PR DESCRIPTION
Close #6452 

This PR changes the K8s task handler to not delete jobs when `ttlSecondsAfterFinished` is set. When this option is set, the K8s cluster will delete these jobs on its own.

This change should solve two issues:

- It is possible for the K8s cluster to delete the job before Nextflow tries to delete it, which causes an error as shown in the linked issue

- The current approach to deleting jobs can block the task polling monitor, since the monitor must wait for the job to be deleted before proceeding to the next task in the running queue. This can delay the submission of pending jobs when the running queue is full

cc @BioWilko , it would be good if you could test this change in your environment