### PR TITLE
Bump Wiremock to fix security vulnerabilities

### DIFF
--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testFixturesImplementation(project(":nextflow"))
 
     testImplementation "org.apache.groovy:groovy-json:4.0.29" // needed by wiremock
-    testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-1') { exclude module: 'groovy-all' }
+    testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-10') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 }
 

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     /* testImplementation inherited from top gradle build file */
     testImplementation "org.apache.groovy:groovy-json:4.0.29" // needed by wiremock
-    testImplementation ('com.github.tomakehurst:wiremock:1.57') { exclude module: 'groovy-all' }
+    testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-10') { exclude module: 'groovy-all' }
     testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
 
     testImplementation(testFixtures(project(":nextflow")))


### PR DESCRIPTION
This PR bumps Wiremock to 3.0.0-beta10 to fix security vulnerabilities [#76](https://github.com/nextflow-io/nextflow/security/dependabot/76) [#109](https://github.com/nextflow-io/nextflow/security/dependabot/109) [#106](https://github.com/nextflow-io/nextflow/security/dependabot/106). 
It is the highest version still supporting `wiremock-groovy`. 