### PR TITLE
Replace tests using wiremock-groovy by Wiremock Java 

### DIFF
--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     testFixturesImplementation(project(":nextflow"))
 
     testImplementation "org.apache.groovy:groovy-json:4.0.29" // needed by wiremock
-    testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-10') { exclude module: 'groovy-all' }
-    testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
+    testImplementation ('org.wiremock:wiremock:3.13.1') { exclude module: 'groovy-all' }
 }
 

--- a/modules/nf-commons/src/test/nextflow/plugin/HttpPluginRepositoryTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/HttpPluginRepositoryTest.groovy
@@ -5,21 +5,20 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
-import com.github.tomjankes.wiremock.WireMockGroovy
 import nextflow.BuildInfo
 import org.junit.Rule
 import org.pf4j.PluginRuntimeException
 import spock.lang.Specification
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
 class HttpPluginRepositoryTest extends Specification {
     @Rule
     WireMockRule wiremock = new WireMockRule(0)
 
-    def wm
     HttpPluginRepository unit
 
     def setup() {
-        wm = new WireMockGroovy(wiremock.port())
         unit = new HttpPluginRepository("test-repo", new URI(wiremock.baseUrl()))
     }
 
@@ -27,23 +26,17 @@ class HttpPluginRepositoryTest extends Specification {
 
     def 'prefetch metadata for plugin with no releases'() {
         given:
-        wm.stub {
-            request {
-                method 'GET'
-                url "/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"
-            }
-            response {
-                status 200
-                body """{
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("""{
                   "plugins": [
                     {
                       "id": "nf-fake"
                     }
                   ]
                 }
-                """
-            }
-        }
+                """)))
 
         when:
         unit.prefetch([new PluginRef("nf-fake")])
@@ -57,14 +50,10 @@ class HttpPluginRepositoryTest extends Specification {
 
     def 'prefetch plugin metadata with release'() {
         given:
-        wm.stub {
-            request {
-                method 'GET'
-                url "/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"
-            }
-            response {
-                status 200
-                body """{
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("""{
                   "plugins": [
                     {
                       "id": "nf-fake",
@@ -80,9 +69,7 @@ class HttpPluginRepositoryTest extends Specification {
                     }
                   ]
                 }
-                """
-            }
-        }
+                """)))
 
         when:
         unit.prefetch([new PluginRef("nf-fake")])
@@ -119,16 +106,10 @@ class HttpPluginRepositoryTest extends Specification {
 
     def 'handle prefetch error when metadata service returns an error response'() {
         given:
-        wm.stub {
-            request {
-                method 'GET'
-                url "/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"
-            }
-            response {
-                status 500
-                body "Server error!"
-            }
-        }
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(500)
+                .withBody("Server error!")))
 
         when:
         unit.prefetch([new PluginRef("nf-fake")])
@@ -145,23 +126,17 @@ class HttpPluginRepositoryTest extends Specification {
 
     def 'handle prefetch error when metadata service sends back incorrectly formatted response'() {
         given:
-        wm.stub {
-            request {
-                method 'GET'
-                url "/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"
-            }
-            response {
-                status 200
-                body """{
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("""{
                   "not-plugins": [
                     {
                       "id": "nf-fake"
                     }
                   ]
                 }
-                """
-            }
-        }
+                """)))
 
         when:
         unit.prefetch([new PluginRef("nf-fake")])
@@ -175,19 +150,13 @@ class HttpPluginRepositoryTest extends Specification {
 
     def 'handle prefetch error caused by nextflow sending a bad request to metadata service'() {
         given:
-        wm.stub {
-            request {
-                method 'GET'
-                url "/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"
-            }
-            response {
-                status 400
-                body """{
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(400)
+                .withBody("""{
                   "type": "SOME_ERROR",
                   "message": "Unparseable request"
-                }"""
-            }
-        }
+                }""")))
 
         when:
         unit.prefetch([new PluginRef("nf-fake")])
@@ -205,15 +174,11 @@ class HttpPluginRepositoryTest extends Specification {
         def utcDateStr = "2023-12-25T14:30:45Z"
         def estDateStr = "2023-06-15T09:15:30-05:00"
         def cestDateStr = "2023-08-10T16:45:00+02:00"
-        
-        wm.stub {
-            request {
-                method 'GET'
-                url "/v1/plugins/dependencies?plugins=date-test-plugin&nextflowVersion=${BuildInfo.version}"
-            }
-            response {
-                status 200
-                body """{
+
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=date-test-plugin&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("""{
                   "plugins": [
                     {
                       "id": "date-test-plugin",
@@ -251,9 +216,7 @@ class HttpPluginRepositoryTest extends Specification {
                     }
                   ]
                 }
-                """
-            }
-        }
+                """)))
 
         when:
         unit.prefetch([new PluginRef("date-test-plugin")])

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -36,8 +36,7 @@ dependencies {
 
     /* testImplementation inherited from top gradle build file */
     testImplementation "org.apache.groovy:groovy-json:4.0.29" // needed by wiremock
-    testImplementation ('com.github.tomakehurst:wiremock:3.0.0-beta-10') { exclude module: 'groovy-all' }
-    testImplementation ('com.github.tomjankes:wiremock-groovy:0.2.0') { exclude module: 'groovy-all' }
+    testImplementation ('org.wiremock:wiremock:3.13.1') { exclude module: 'groovy-all' }
 
     testImplementation(testFixtures(project(":nextflow")))
 }

--- a/modules/nf-httpfs/src/test/nextflow/file/http/HttpFilesTests.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/HttpFilesTests.groovy
@@ -22,7 +22,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
-import com.github.tomjankes.wiremock.WireMockGroovy
 import com.sun.net.httpserver.BasicAuthenticator
 import com.sun.net.httpserver.Headers
 import com.sun.net.httpserver.HttpExchange
@@ -34,6 +33,8 @@ import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 import test.TestHelper
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
 
 /**
  *
@@ -47,27 +48,18 @@ class HttpFilesTests extends Specification {
     def 'should read http file from WireMock' () {
 
         given:
-        def wireMock = new WireMockGroovy(wireMockRule.port())
         def localhost = "http://localhost:${wireMockRule.port()}"
-        wireMock.stub {
-            request {
-                method "GET"
-                url "/index.html"
-            }
-            response {
-                status 200
-                body """a
+        wireMockRule.stubFor(get(urlEqualTo("/index.html"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("""a
                  b
                  c
                  d
-                 """
-                headers {
-                    "Content-Type" "text/html"
-                    "Content-Length" "10"
-                    "Last-Modified" "Fri, 04 Nov 2016 21:50:34 GMT"
-                }
-            }
-        }
+                 """)
+                .withHeader("Content-Type", "text/html")
+                .withHeader("Content-Length", "10")
+                .withHeader("Last-Modified", "Fri, 04 Nov 2016 21:50:34 GMT")))
 
         when:
         def path = Paths.get(new URI("${localhost}/index.html"))
@@ -208,23 +200,14 @@ class HttpFilesTests extends Specification {
 
     def 'should read with a newByteChannel' () {
         given:
-        def wireMock = new WireMockGroovy(wireMockRule.port())
         def localhost = "http://localhost:${wireMockRule.port()}"
-        wireMock.stub {
-            request {
-                method "GET"
-                url "/index.txt"
-            }
-            response {
-                status 200
-                body "01234567890123456789012345678901234567890123456789"
-                headers {
-                    "Content-Type" "text/html"
-                    "Content-Length" "50"
-                    "Last-Modified" "Fri, 04 Nov 2016 21:50:34 GMT"
-                }
-            }
-        }
+        wireMockRule.stubFor(get(urlEqualTo("/index.txt"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("01234567890123456789012345678901234567890123456789")
+                .withHeader("Content-Type", "text/html")
+                .withHeader("Content-Length", "50")
+                .withHeader("Last-Modified", "Fri, 04 Nov 2016 21:50:34 GMT")))
 
         when:
         def path = Paths.get(new URI("${localhost}/index.txt"))

--- a/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
@@ -20,11 +20,12 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
-import com.github.tomjankes.wiremock.WireMockGroovy
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
 /**
  * Created by emilio on 08/11/16.
  */
@@ -163,51 +164,29 @@ class XFileSystemProviderTest extends Specification {
     @Unroll
     def 'should follow a redirect when read a http file '() {
         given:
-        def wireMock = new WireMockGroovy(wireMockRule.port())
         def localhost = "http://localhost:${wireMockRule.port()}"
-        wireMock.stub {
-            request {
-                method "GET"
-                url "/index.html"
-            }
-            response {
-                status HTTP_CODE
-                headers {
-                    "Location" "${localhost}${REDIRECT_TO}"
-                }
-            }
-        }
-        wireMock.stub {
-            request {
-                method "GET"
-                url "/index2.html"
-            }
-            response {
-                status HTTP_CODE
-                headers {
-                    "Location" "${localhost}/target.html"
-                }
-            }
-        }
-        wireMock.stub {
-            request {
-                method "GET"
-                url "/target.html"
-            }
-            response {
-                status 200
-                body """a
+        wireMockRule.stubFor(get(urlEqualTo("/index.html"))
+            .willReturn(aResponse()
+                .withStatus(HTTP_CODE)
+                .withHeader("Location", "${localhost}${REDIRECT_TO}")))
+
+        wireMockRule.stubFor(get(urlEqualTo("/index2.html"))
+            .willReturn(aResponse()
+                .withStatus(HTTP_CODE)
+                .withHeader("Location", "${localhost}/target.html")))
+
+        wireMockRule.stubFor(get(urlEqualTo("/target.html"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody("""a
                  b
                  c
                  d
-                 """
-                headers {
-                    "Content-Type" "text/html"
-                    "Content-Length" "10"
-                    "Last-Modified" "Fri, 04 Nov 2016 21:50:34 GMT"
-                }
-            }
-        }
+                 """)
+                .withHeader("Content-Type", "text/html")
+                .withHeader("Content-Length", "10")
+                .withHeader("Last-Modified", "Fri, 04 Nov 2016 21:50:34 GMT")))
+
         and:
         def provider = new HttpFileSystemProvider()
         when:


### PR DESCRIPTION
The wiremock-groovy library is not maintained, and newer official versions of Wiremock are not compatible with this library. 

This pull request updates how WireMock is used in our test suites by removing the deprecated `wiremock-groovy` dependency and switching to the official WireMock Java client. It also updates WireMock to a newer version and refactors all test stubs to use the new API, which improves maintainability and future compatibility.
