### PR TITLE
Fix TowerJsonGenerator thread-safety issue

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerJsonGenerator.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerJsonGenerator.groovy
@@ -40,7 +40,7 @@ import org.apache.groovy.json.internal.CharBuf
 @CompileStatic
 class TowerJsonGenerator extends DefaultJsonGenerator {
 
-    List<String> stack = new ArrayList<>(10)
+    private List<String> stack = new ArrayList<>(10)
     Map<String,Integer> scheme
 
     static TowerJsonGenerator create(Map<String,Integer> scheme) {
@@ -74,8 +74,8 @@ class TowerJsonGenerator extends DefaultJsonGenerator {
     }
 
     @Override
-    protected void writeObject(String key, Object object, CharBuf buffer) {
-        final pos=stack.size()
+    protected synchronized void writeObject(String key, Object object, CharBuf buffer) {
+        final pos = stack.size()
         if(key) stack.add(pos, key)
         final fqn = stack.join('.')
         try {


### PR DESCRIPTION
## Summary
Fix IndexOutOfBoundsException in TowerJsonGenerator caused by concurrent access to the shared stack field from multiple executor threads.

## Problem
When multiple executor threads (e.g., AWSBatch-executor-1, AWSBatch-executor-2) serialize JSON simultaneously using the same TowerJsonGenerator instance, they concurrently modify the shared stack ArrayList. This causes race conditions where one thread's saved position becomes invalid after another thread modifies the stack.

## Solution
Add synchronized to the writeObject method to ensure thread-safe access to the shared stack field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)