### PR TITLE
docs: Update config page

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -19,7 +19,7 @@ You can use the `-C <config-file>` option to specify a fixed set of configuratio
 
 ## Syntax
 
-Nextflow configuration uses a similar syntax as Nextflow {ref}`<scripts> syntax-page`. Configuration options must be set declaratively, but the value of a config option can be an arbitrary expression.
+Nextflow configuration uses a similar syntax as Nextflow scripts. Configuration options must be set declaratively, but the value of a config option can be an arbitrary expression.
 
 A config file may contain any number of [assignments](#assignments), [blocks](#blocks), and [includes](#includes). You can add comments just like in scripts.
 
@@ -35,7 +35,7 @@ process.maxErrors = 10
 
 The config option consists of an *option name* prefixed by any number of *scopes*. Scopes group related config options. See {ref}`config-options` for the full set of config options.
 
-The value is typically a literal value, such as a number, boolean, or string. However, you can use any expression:
+The value is typically a literal value, such as a number, boolean, or string. However, you can use any {ref}`expression <syntax-expressions>`:
 
 ```groovy
 params.helper_file = "${projectDir}/assets/helper.txt"
@@ -320,7 +320,7 @@ nextflow run main.nf -profile standard,cloud
 Nextflow applies config profiles in the order in which they were defined in the config, regardless of the order you specify them on the command line.
 
 :::{versionadded} 25.04.0
-When using the {ref}`strict config syntax <updating-config-syntax>`, Nextflow applies profiles in the order you specify them on the command line.
+When using the {ref}`strict syntax <strict-syntax-page>`, Nextflow applies profiles in the order you specify them on the command line.
 :::
 
 (config-workflow-handlers)=

--- a/docs/reference/stdlib-types.md
+++ b/docs/reference/stdlib-types.md
@@ -731,7 +731,7 @@ The following methods are available for listing and traversing directories:
 : Returns the first-level elements (files and directories) in a directory.
 
 `listFiles() -> Iterable<Path>`
-: :::{deprecated}
+: :::{deprecated} 26.04.0
   Use `listDirectory()` instead.
   :::
 : Returns the first-level elements (files and directories) in a directory.

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -602,6 +602,8 @@ catch( IOException e ) {
 
 The try block will be executed, and if an error is raised and matches the expected error type of a catch clause, the code in that catch clause will be executed. If no catch clause is matched, the error will be raised to the next enclosing try/catch statement, or to the Nextflow runtime.
 
+(syntax-expressions)=
+
 ## Expressions
 
 An expression represents a value. A *literal* value is an expression whose value is known at compile-time, such as a number, string, or boolean. All other expressions must be evaluated at run-time.
@@ -1010,4 +1012,3 @@ The following legacy features were excluded from this page because they are depr
 - The `addParams` and `params` clauses of include declarations. See {ref}`module-params` for more information.
 - The `when:` section of a process definition. See {ref}`process-when` for more information.
 - The `shell:` section of a process definition. See {ref}`process-shell` for more information.
-- The implicit `it` closure parameter. See {ref}`script-closure` for more information.


### PR DESCRIPTION
- Refining language in the config page to make it more concise and user-focused.
- Remove reference from conceptual config page. Exists elsewhere.