### PR TITLE
PoC: multi-provider buckets in Fusion tasks

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/Executor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/Executor.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.executor
 
+import nextflow.fusion.FusionHelper
+
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
@@ -128,6 +130,8 @@ abstract class Executor {
     }
 
     boolean isForeignFile(Path path) {
+        if ( isFusionEnabled() && path.scheme in FusionHelper.SUPPORTED_CLOUD_SCHEMES )
+            return false
         path.scheme != getStageDir().scheme
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionEnv.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionEnv.groovy
@@ -17,6 +17,8 @@
 
 package nextflow.fusion
 
+import java.nio.file.Path
+
 /**
  * Allow importing platform specific env variables in the Fusion context
  *
@@ -25,4 +27,6 @@ package nextflow.fusion
 interface FusionEnv {
 
     Map<String,String> getEnvironment(String scheme, FusionConfig config)
+
+    Map<String,String> getEnvironmentFromPath(Path path, FusionConfig config)
 }

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionEnvProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionEnvProvider.groovy
@@ -21,6 +21,9 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.exception.ReportWarningException
 import nextflow.plugin.Plugins
+
+import java.nio.file.Path
+
 /**
  * Provider strategy for {@link FusionEnv}
  *
@@ -49,6 +52,19 @@ class FusionEnvProvider {
             result.FUSION_CACHE_SIZE = "${config.cacheSize().toMega()}M"
         return result
     }
+    Map<String,String> getEnvironmentFromPath(Path p) {
+        final config = FusionConfig.getConfig()
+        final list =Plugins.getExtensions(FusionEnv)
+        log.debug "Fusion environment extensions=$list"
+        final result = new HashMap<String,String>()
+        for( FusionEnv it : list ) {
+            final env = it.getEnvironmentFromPath(p,config)
+            log.debug "Env for $p: $env"
+            if( env )
+                result.putAll(env)
+        }
+        return result
+    }
 
     protected Map<String,String> getFusionEnvironment(String scheme, FusionConfig config) {
         final list = Plugins.getExtensions(FusionEnv)
@@ -56,6 +72,7 @@ class FusionEnvProvider {
         final result = new HashMap<String,String>()
         for( FusionEnv it : list ) {
             final env = it.getEnvironment(scheme,config)
+            log.debug "Env for $scheme: $env"
             if( env )
                 result.putAll(env)
         }

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionHelper.groovy
@@ -35,6 +35,7 @@ import nextflow.io.BucketParser
  */
 @CompileStatic
 class FusionHelper {
+    public static List<String> SUPPORTED_CLOUD_SCHEMES = ['s3', 'az']
 
     @Memoized
     static boolean isFusionEnabled(Session session) {

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/fusion/AwsFusionEnv.groovy
@@ -22,6 +22,9 @@ import nextflow.cloud.aws.config.AwsConfig
 import nextflow.fusion.FusionConfig
 import nextflow.fusion.FusionEnv
 import org.pf4j.Extension
+
+import java.nio.file.Path
+
 /**
  * Implements {@link FusionEnv} for AWS cloud
  *
@@ -70,5 +73,9 @@ class AwsFusionEnv implements FusionEnv {
             return List.<String>of(SysEnv.get('AWS_ACCESS_KEY_ID'), SysEnv.get('AWS_SECRET_ACCESS_KEY'))
         else
             return List.<String>of()
+    }
+
+    Map<String, String> getEnvironmentFromPath(Path path, FusionConfig config) {
+        return getEnvironment(path.scheme,config)
     }
 }


### PR DESCRIPTION
This pull request is a PoC to validate that Nextflow and Fusion can work with buckets hosted in different providers. It allow to have task input files in different cloud storage schemes (AWS S3 and Azure in this PoC) without requiring to manage as foreign files. Instead of copying files to the task workdir, files are directly accessed from Fusion. 

Two main changes have been applied, one to allow input files form :

**Cloud scheme support and foreign file detection:**

* Introduced a `SUPPORTED_CLOUD_SCHEMES` list in `FusionHelper` (currently 's3' and 'az'), and updated the `Executor.isForeignFile` method to properly recognize files from supported cloud schemes as local when Fusion is enabled. [[1]](diffhunk://#diff-0f576362e8813a13e83815212f7f72587fca29f5919edb6f7817e85e82121ceaR38) [[2]](diffhunk://#diff-2e7463e57ee951cf5b7ecf530e6e2a9d548e9898300ad2d2b6e7181447347026R133-R134)

**Fusion environment handling :**

The following changes are just for testing purposes, not considering to merge to master as they are.

* Added a new method `getEnvironmentFromPath(Path, FusionConfig)` to the `FusionEnv` interface and implemented it in both AWS and Azure Fusion environment providers. This enables environment variables to be set based on the specific scheme of each input file path, not just the overall task scheme. [[1]](diffhunk://#diff-0c007c0b636c4ffaec49d35d7b0bcd604141bf280070aed28c6860263718f31dR30-R31) [[2]](diffhunk://#diff-251ef9b7f5f96c9d87a3f26aeac2a4268a3890704ac8a6c3e1c0136114156b8aR77-R80) [[3]](diffhunk://#diff-13c752e9f7b1dc7e37d78cc9ad9487a41d2a4b2a5a5812f02548b2c8003b64b8R55-R61)
* Updated `FusionEnvProvider` to aggregate environment variables from all relevant `FusionEnv` extensions for each external input file, using the new `getEnvironmentFromPath` method.
* Modified `FusionScriptLauncher` to track input files with schemes different from the task's main scheme ("external inputs") and to request environment variables for each of these from the relevant provider. This ensures that the correct authentication and configuration are available for files stored in different cloud providers. [[1]](diffhunk://#diff-0278af97c92c6be4c8df460a0c392ee7a4ed839ac38348ef3ed318527e4eed19R43) [[2]](diffhunk://#diff-0278af97c92c6be4c8df460a0c392ee7a4ed839ac38348ef3ed318527e4eed19R54-R63) [[3]](diffhunk://#diff-0278af97c92c6be4c8df460a0c392ee7a4ed839ac38348ef3ed318527e4eed19L64-R80) [[4]](diffhunk://#diff-0278af97c92c6be4c8df460a0c392ee7a4ed839ac38348ef3ed318527e4eed19R99-R101)

** Test pipeline

A pipeline has been created to check a external file is correctly mounted and accessible in a task managed by Fusion

*main.nf:
```
process list {
        input:
                path in_file
        script:
        """
        ls -l $in_file
        cat $in_file
        """
}

workflow {
        list (file(params.input))
}
```

* nextflow.config
```
profiles{
        amazon {
                process.executor = 'awsbatch'
                process.queue = 'TowerForge-xxxxx'
                workDir = 's3://jorgee-eu-west1-test1/work/'
        }
        azure {
                process.executor = 'azurebatch'
                workDir = 'az://test-nf-jorgee/work/'
        }
        google {
                process.executor = 'google-batch'
                workDir = 'gs://nf-test-jorgee/work/'
        }
}
aws.region = 'eu-west-1'
aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'

google.project = 'xxx'
google.location = 'europe-west1'

azure {
  storage {
    accountName = "nfazurestore"
    accountKey = "xxxxx"
  }
  batch {
    location = 'westeurope'
    accountName = 'nfbatchtest'
    accountKey = 'xxxxx'
    autoPoolMode = true
  }
}
process.container = 'quay.io/nextflow/bash'
wave.enabled=true
fusion.enabled=true
fusion.exportStorageCredentials=true
```

* Tested cases:
```
$ nextflow run main.nf -profile azure --input s3://jorgee-eu-west1-test1/greetings.csv
$ nextflow run main.nf -profile google --input s3://jorgee-eu-west1-test1/greetings.csv
$ nextflow run main.nf -profile google --input az://test-nf-jorgee/greetings.csv
$ nextflow run main.nf -profile amazon --input az://test-nf-jorgee/greetings.csv
```
