### PR TITLE
Fix WaveClient sending Bearer token to public S3 URLs

### DIFF
--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -142,6 +142,12 @@ class WaveClient {
     /* only for testing */
     protected WaveClient() { }
 
+    /**
+     * Creates the main HTTP client for Wave/Tower API communication.
+     * This client includes Bearer token authentication for secure API calls.
+     *
+     * @return An {@link HxClient} configured with authentication tokens
+     */
     protected HxClient newHttpClient() {
         final refreshUrl = tower.refreshToken ? "${tower.endpoint}/oauth/access_token" : null
         return HxClient.newBuilder()
@@ -154,6 +160,11 @@ class WaveClient {
                 .build()
     }
 
+    /**
+     * Creates the underlying Java HTTP client with common configuration.
+     *
+     * @return A configured {@link HttpClient} instance
+     */
     protected HttpClient newHttpClient0() {
         final builder = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
@@ -164,6 +175,24 @@ class WaveClient {
             builder.executor(Executors.newVirtualThreadPerTaskExecutor())
         // build and return the new client
         return builder.build()
+    }
+
+    /**
+     * Creates an HTTP client without authentication for fetching external resources.
+     * <p>
+     * This client is used for requests to external URLs (e.g., public S3 buckets)
+     * that do not require or support Bearer token authentication. Services like
+     * AWS S3 reject requests with unsupported Authorization headers.
+     *
+     * @return An {@link HxClient} without authentication configuration
+     * @see #newHttpClient() for authenticated Wave/Tower API calls
+     */
+    @Memoized
+    protected HxClient plainHttpClient() {
+        return HxClient.newBuilder()
+                .httpClient(newHttpClient0())
+                .retryConfig(config.retryOpts())
+                .build()
     }
 
     WaveConfig config() { return config }
@@ -402,7 +431,7 @@ class WaveClient {
                 .GET()
                 .build()
 
-        final resp = httpClient.sendAsString(req)
+        final resp = plainHttpClient().sendAsString(req)
         final code = resp.statusCode()
         final body = resp.body()
         if( code>=200 && code<400 ) {

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -1410,4 +1410,47 @@ class WaveClientTest extends Specification {
             cached: resp.cached )
     }
 
+    def 'should fetch container config without bearer token' () {
+        given: 'a server that rejects requests with Authorization header (like S3)'
+        def configJson = JsonOutput.toJson(new ContainerConfig(entrypoint: ['test.sh']))
+        HttpHandler handler = { HttpExchange exchange ->
+            // Check if Authorization header is present (like S3 would reject Bearer tokens)
+            def authHeader = exchange.requestHeaders.getFirst('Authorization')
+            if( authHeader ) {
+                // S3 returns 400 for unsupported auth types
+                def errorMsg = "Unsupported Authorization Type: ${authHeader}"
+                exchange.sendResponseHeaders(400, errorMsg.size())
+                exchange.getResponseBody() << errorMsg
+                exchange.getResponseBody().close()
+            }
+            else {
+                exchange.getResponseHeaders().add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, configJson.size())
+                exchange.getResponseBody() << configJson
+                exchange.getResponseBody().close()
+            }
+        }
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(9902), 0)
+        server.createContext("/", handler)
+        server.start()
+
+        and: 'a wave client configured with tower access token'
+        def config = [
+            wave: [containerConfigUrl: 'http://localhost:9902/config.json'],
+            tower: [accessToken: 'test-jwt-token', endpoint: 'https://tower.nf']
+        ]
+        def session = Mock(Session) { getConfig() >> config }
+        def client = new WaveClient(session)
+
+        when: 'fetching container config from URL that rejects Bearer tokens'
+        def result = client.resolveContainerConfig()
+
+        then: 'request succeeds because no Bearer token was sent'
+        result.entrypoint == ['test.sh']
+
+        cleanup:
+        server?.stop(0)
+    }
+
 }


### PR DESCRIPTION
## Summary
- Fix WaveClient sending Bearer token to external URLs (e.g., public S3 buckets) when fetching container configs
- Add dedicated `plainHttpClient()` without authentication for external resource requests
- S3 and similar services reject requests with unsupported Authorization headers

## Changes
- Added `plainHttpClient()` factory method with `@Memoized` annotation for lazy initialization
- Updated `fetchContainerConfig()` to use the plain client instead of the authenticated client
- Added Javadoc to explain the rationale for each HTTP client
- Added unit test that verifies container config fetch works without Bearer token

Fixes #6671

## Test plan
- [x] Unit test added that simulates S3 behavior (rejects Bearer tokens)
- [x] All existing nf-wave tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)