### PR TITLE
[BACKPORT 25.10] Add default maxSpotAttempts for fusion snapshots in Google Batch (#6652)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionConfig.groovy
@@ -49,6 +49,8 @@ class FusionConfig implements ConfigScope {
 
     final static public String DEFAULT_TAGS = "[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true)"
 
+    final static public int DEFAULT_SNAPSHOT_MAX_SPOT_ATTEMPTS = 5
+
     final static public String FUSION_PATH = '/usr/bin/fusion'
 
     final static private String PRODUCT_NAME = 'fusion'

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -38,6 +38,7 @@ import nextflow.exception.ProcessSubmitException
 import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.BashWrapperBuilder
 import nextflow.fusion.FusionAwareTask
+import nextflow.fusion.FusionConfig
 import nextflow.processor.BatchContext
 import nextflow.processor.BatchHandler
 import nextflow.processor.TaskArrayRun
@@ -753,7 +754,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
             return result
         // when fusion snapshot is enabled max attempt should be > 0
         // to enable to allow snapshot retry the job execution in a new ec2 instance
-        return fusionEnabled() && fusionConfig().snapshotsEnabled() ? 5 : 0
+        return fusionEnabled() && fusionConfig().snapshotsEnabled() ? FusionConfig.DEFAULT_SNAPSHOT_MAX_SPOT_ATTEMPTS : 0
     }
 
     protected String getJobName(TaskRun task) {


### PR DESCRIPTION
Sets default `maxSpotAttempts` when Fusion snapshots are enabled for Google Batch, providing feature parity with AWS Batch.

(cherry picked from commit 458ef97a9f47e256da26a13c6dfa27ba2eb258c9)