### PR TITLE
Add accelerator usage field in trace record

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -254,7 +254,7 @@ abstract class TaskHandler {
                 log.debug "[WARN] Cannot read trace file: $file -- Cause: ${e.message}"
             }
             // If Fusion is enabled read parse the use of accelerator form .command.log
-            if( FusionHelper.isFusionEnabled(Global.session as Session) )
+            if( Global.session && FusionHelper.isFusionEnabled(Global.session as Session) )
                 record.parseFusionAccelerator(task.workDir?.resolve(TaskRun.CMD_LOG))
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -255,7 +255,7 @@ abstract class TaskHandler {
             }
             // If Fusion is enabled read parse the use of accelerator form .command.log
             if( Global.session && FusionHelper.isFusionEnabled(Global.session as Session) )
-                record.parseFusionAccelerator(task.workDir?.resolve(TaskRun.CMD_LOG))
+                record.parseFusionAcceleratorUsage(task.workDir?.resolve(TaskRun.CMD_LOG))
         }
 
         return record

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -16,6 +16,10 @@
 
 package nextflow.processor
 
+import nextflow.Global
+import nextflow.Session
+import nextflow.fusion.FusionHelper
+
 import static nextflow.processor.TaskStatus.*
 
 import java.nio.file.NoSuchFileException
@@ -249,6 +253,9 @@ abstract class TaskHandler {
             catch( IOException e ) {
                 log.debug "[WARN] Cannot read trace file: $file -- Cause: ${e.message}"
             }
+            // If Fusion is enabled read parse the use of accelerator form .command.log
+            if( FusionHelper.isFusionEnabled(Global.session as Session) )
+                record.parseFusionAccelerator(task.workDir?.resolve(TaskRun.CMD_LOG))
         }
 
         return record

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -122,6 +122,7 @@ class TraceRecord implements Serializable {
     transient private CloudMachineInfo machineInfo
     transient private ContainerMeta containerMeta
     transient private Integer numSpotInterruptions
+    transient private Boolean accelerator
 
     /**
      * Convert the given value to a string
@@ -627,4 +628,48 @@ class TraceRecord implements Serializable {
     void setContainerMeta(ContainerMeta meta) {
         this.containerMeta = meta
     }
+
+    Boolean getAccelerator() {
+        return accelerator
+    }
+
+    void setAccelerator(Boolean acc) {
+        this.accelerator = acc
+    }
+
+    void parseFusionAccelerator(Path file) {
+        this.accelerator = parseFusionAccelerator0(file)
+    }
+
+    /**
+     * Parses the Fusion accelerator value.
+     * Fusion writes FUSION_GPU_USED=true|false in the first line of the log file.
+     */
+    private Boolean parseFusionAccelerator0(Path file) {
+        if ( !file.exists() ) {
+            return null
+        }
+
+        String line = file.withReader { it.readLine() }
+
+        if (!line) {
+            return null
+        }
+
+        line = line.trim()
+
+        if (!line.startsWith("FUSION_GPU_USED=")) {
+            return null
+        }
+
+        String value = line.substring("FUSION_GPU_USED=".length()).trim()
+
+        if (!value.equalsIgnoreCase("true") && !value.equalsIgnoreCase("false")) {
+            return null
+        }
+
+        return value.toBoolean()
+    }
+
+
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -122,7 +122,7 @@ class TraceRecord implements Serializable {
     transient private CloudMachineInfo machineInfo
     transient private ContainerMeta containerMeta
     transient private Integer numSpotInterruptions
-    transient private Boolean accelerator
+    transient private Boolean acceleratorUsage
 
     /**
      * Convert the given value to a string
@@ -629,16 +629,16 @@ class TraceRecord implements Serializable {
         this.containerMeta = meta
     }
 
-    Boolean getAccelerator() {
-        return accelerator
+    Boolean getAcceleratorUsage() {
+        return acceleratorUsage
     }
 
-    void setAccelerator(Boolean acc) {
-        this.accelerator = acc
+    void setAcceleratorUsage(Boolean acc) {
+        this.acceleratorUsage = acc
     }
 
-    void parseFusionAccelerator(Path file) {
-        this.accelerator = parseFusionAccelerator0(file)
+    void parseFusionAcceleratorUsage(Path file) {
+        this.acceleratorUsage = parseFusionAccelerator0(file)
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
@@ -374,30 +374,30 @@ class TraceRecordTest extends Specification {
         def rec = new TraceRecord()
 
         expect:
-        rec.getAccelerator() == null
+        rec.getAcceleratorUsage() == null
         and:
-        rec.accelerator == null
+        rec.acceleratorUsage == null
 
         when:
-        rec.setAccelerator(true)
+        rec.setAcceleratorUsage(true)
 
         then:
-        rec.getAccelerator() == true
-        rec.accelerator == true
+        rec.getAcceleratorUsage() == true
+        rec.acceleratorUsage == true
 
         when:
-        rec.setAccelerator(false)
+        rec.setAcceleratorUsage(false)
 
         then:
-        rec.getAccelerator() == false
-        rec.accelerator == false
+        rec.getAcceleratorUsage() == false
+        rec.acceleratorUsage == false
 
         when:
         def buf = rec.serialize()
         def rec2 = TraceRecord.deserialize(buf)
 
         then:
-        rec2.getAccelerator() == null
+        rec2.getAcceleratorUsage() == null
     }
 
     @Unroll
@@ -408,10 +408,10 @@ class TraceRecordTest extends Specification {
         file.text = CONTENT
 
         when:
-        rec.parseFusionAccelerator(file)
+        rec.parseFusionAcceleratorUsage(file)
 
         then:
-        rec.getAccelerator() == EXPECTED
+        rec.getAcceleratorUsage() == EXPECTED
 
         where:
         CONTENT                              | EXPECTED
@@ -437,10 +437,10 @@ class TraceRecordTest extends Specification {
         def file = Path.of('/non/existent/file.log')
 
         when:
-        rec.parseFusionAccelerator(file)
+        rec.parseFusionAcceleratorUsage(file)
 
         then:
-        rec.getAccelerator() == null
+        rec.getAcceleratorUsage() == null
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
@@ -369,4 +369,78 @@ class TraceRecordTest extends Specification {
         rec2.getNumSpotInterruptions() == null
     }
 
+    def 'should manage accelerator field and not persist it across serialization'() {
+        given:
+        def rec = new TraceRecord()
+
+        expect:
+        rec.getAccelerator() == null
+        and:
+        rec.accelerator == null
+
+        when:
+        rec.setAccelerator(true)
+
+        then:
+        rec.getAccelerator() == true
+        rec.accelerator == true
+
+        when:
+        rec.setAccelerator(false)
+
+        then:
+        rec.getAccelerator() == false
+        rec.accelerator == false
+
+        when:
+        def buf = rec.serialize()
+        def rec2 = TraceRecord.deserialize(buf)
+
+        then:
+        rec2.getAccelerator() == null
+    }
+
+    @Unroll
+    def 'should parse fusion accelerator from file'() {
+        given:
+        def rec = new TraceRecord()
+        def file = TestHelper.createInMemTempFile('fusion-log')
+        file.text = CONTENT
+
+        when:
+        rec.parseFusionAccelerator(file)
+
+        then:
+        rec.getAccelerator() == EXPECTED
+
+        where:
+        CONTENT                              | EXPECTED
+        'FUSION_GPU_USED=true\n'             | true
+        'FUSION_GPU_USED=false\n'            | false
+        'FUSION_GPU_USED=TRUE\n'             | true
+        'FUSION_GPU_USED=FALSE\n'            | false
+        '  FUSION_GPU_USED=true  \n'         | true
+        '  FUSION_GPU_USED=false  \n'        | false
+        'FUSION_GPU_USED=true  \nother line' | true
+        'FUSION_GPU_USED=false\nother line'  | false
+        'other content\n'                    | null
+        'FUSION_GPU=true\n'                  | null
+        'FUSION_GPU_USED=\n'                 | null
+        'FUSION_GPU_USED=invalid\n'          | null
+        'FUSION_GPU_USED=123\n'              | null
+        ''                                   | null
+    }
+
+    def 'should parse fusion accelerator when file does not exist'() {
+        given:
+        def rec = new TraceRecord()
+        def file = Path.of('/non/existent/file.log')
+
+        when:
+        rec.parseFusionAccelerator(file)
+
+        then:
+        rec.getAccelerator() == null
+    }
+
 }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -661,7 +661,7 @@ class TowerClient implements TraceObserverV2 {
         record.machineType = trace.getMachineInfo()?.type
         record.priceModel = trace.getMachineInfo()?.priceModel?.toString()
         record.numSpotInterruptions = trace.getNumSpotInterruptions()
-        record.accelerator = trace.getAccelerator()
+        record.acceleratorUsage = trace.getAcceleratorUsage()
 
         return record
     }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -661,6 +661,7 @@ class TowerClient implements TraceObserverV2 {
         record.machineType = trace.getMachineInfo()?.type
         record.priceModel = trace.getMachineInfo()?.priceModel?.toString()
         record.numSpotInterruptions = trace.getNumSpotInterruptions()
+        record.accelerator = trace.getAccelerator()
 
         return record
     }

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -560,4 +560,29 @@ class TowerClientTest extends Specification {
         req.tasks[0].numSpotInterruptions == 3
     }
 
+    def 'should include accelerator in task map'() {
+        given:
+        def client = Spy(new TowerClient())
+        client.getWorkflowProgress(true) >> new WorkflowProgress()
+
+        def now = System.currentTimeMillis()
+        def trace = new TraceRecord([
+            taskId: 42,
+            process: 'foo',
+            workdir: "/work/dir",
+            cpus: 1,
+            submit: now-2000,
+            start: now-1000,
+            complete: now
+        ])
+        trace.setAccelerator(true)
+
+        when:
+        def req = client.makeTasksReq([trace])
+
+        then:
+        req.tasks.size() == 1
+        req.tasks[0].accelerator == true
+    }
+
 }

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -575,14 +575,14 @@ class TowerClientTest extends Specification {
             start: now-1000,
             complete: now
         ])
-        trace.setAccelerator(true)
+        trace.setAcceleratorUsage(true)
 
         when:
         def req = client.makeTasksReq([trace])
 
         then:
         req.tasks.size() == 1
-        req.tasks[0].accelerator == true
+        req.tasks[0].acceleratorUsage == true
     }
 
 }


### PR DESCRIPTION
This pull request introduces support for tracking and reporting the use of hardware accelerators (such as GPUs) in Fusion-enabled Nextflow tasks. The changes add a new transient `accelerator` field to the `TraceRecord`, ensure this field is populated by parsing Fusion logs, and propagate this information to Tower reporting. Comprehensive tests are included to validate the new functionality.

**Fusion accelerator tracking and reporting:**

* Added a transient `accelerator` field to the `TraceRecord` class, along with getter, setter, and a method (`parseFusionAccelerator`) to parse the accelerator usage from Fusion log files. The parsing logic checks for the `FUSION_GPU_USED=true|false` line in the log. (`[[1]](diffhunk://#diff-9c0cf79e841529211bb8765c37a7c63a11841f9b9294bd0e36982d21b10a9793R125)`, `[[2]](diffhunk://#diff-9c0cf79e841529211bb8765c37a7c63a11841f9b9294bd0e36982d21b10a9793R631-R674)`)
* Modified `TaskHandler` to invoke `parseFusionAccelerator` on the `.command.log` file when Fusion is enabled, ensuring the `accelerator` field is set during task record creation. (`[modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovyR256-R258](diffhunk://#diff-cc608a283b4ad19f97e1926e7b4e60347d59fa544285e1200893893d990e13a3R256-R258)`)
* Updated the `TowerClient` to include the `accelerator` value when creating the task map for reporting to Tower. (`[plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovyR664](diffhunk://#diff-4e7968503d8e56d6d5f2eff04e734382b6b79fee49dc22668d9a3803c91113e2R664)`)

**Testing and validation:**

* Added unit tests in `TraceRecordTest` to verify correct management, parsing, and (non-)serialization of the `accelerator` field, including various edge cases for log file content. (`[modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovyR372-R445](diffhunk://#diff-a0fd6cbe04bc7f51d64dfd2475161fe33dc5a65b163dcee567e29022ef27e18bR372-R445)`)
* Added a test in `TowerClientTest` to ensure the `accelerator` field is included in the Tower task map. (`[plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovyR563-R587](diffhunk://#diff-463f0ed6e146304ec6d2d8252af59dc42ba32ef8851ae68c371708e3823157c3R563-R587)`)

**Imports and dependencies:**

* Added necessary imports for Fusion and session handling in `TaskHandler.groovy`. (`[modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovyR19-R22](diffhunk://#diff-cc608a283b4ad19f97e1926e7b4e60347d59fa544285e1200893893d990e13a3R19-R22)`)