### PR TITLE
Patch to ignore multi-revision folder in CmdList

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -541,10 +541,10 @@ class AssetManager {
             return result
 
         root.eachDir { File org ->
-            if( org.name != MULTI_REVISION_SUBDIR) {
-                org.eachDir { File it ->
-                    result << "${org.getName()}/${it.getName()}".toString()
-                }
+            if( org.name == MULTI_REVISION_SUBDIR )
+                return
+            org.eachDir { File it ->
+                result << "${org.getName()}/${it.getName()}".toString()
             }
         }
 


### PR DESCRIPTION
This pull request introduces a small update to the `AssetManager` class to improve how directories are listed, specifically by excluding a new subdirectory used for multi-revision repositories.

Directory listing improvements:

* Added a new constant `MULTI_REVISION_SUBDIR` (set to `.repos`) to represent a subdirectory that should be excluded from asset listing.
* Updated the directory traversal logic in the method that lists installed pipeline scripts to skip the `.repos` subdirectory, ensuring only relevant directories are included in the result.