### PR TITLE
Improve config syntax errors

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
@@ -316,6 +316,7 @@ public class ConfigAstBuilder {
         var target = configPrimary(ctx.target);
         var statements = ctx.configBlockStatement().stream()
             .map(this::configBlockStatement)
+            .filter(stmt -> stmt != null)
             .toList();
         return new ConfigBlockNode(kind, target, statements);
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -232,7 +232,7 @@ public class ScriptAstBuilder {
         if( hasDeclarations ) {
             for( var stmt : statements ) {
                 if( !(stmt instanceof InvalidDeclaration) )
-                    collectSyntaxError(new SyntaxException("Statements cannot be mixed with script declarations -- move statements into a process or workflow", stmt));
+                    collectSyntaxError(new SyntaxException("Statements cannot be mixed with script declarations -- move statements into a process, workflow, or function", stmt));
             }
         }
 

--- a/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/control/ConfigResolveTest.groovy
@@ -61,6 +61,18 @@ class ConfigResolveTest extends Specification {
         errors[0].getStartLine() == 1
         errors[0].getStartColumn() == 36
         errors[0].getOriginalMessage() == '`process` is not defined'
+
+        when:
+        errors = check(
+            '''\
+            process.clusterOptions = "--cpus $PROCESS_CPUS"
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 34
+        errors[0].getOriginalMessage() == "`PROCESS_CPUS` is not defined (hint: use `env('...')` to access environment variable)"
     }
 
     def 'should report an error for an invalid config include' () {

--- a/modules/nf-lang/src/test/groovy/nextflow/config/parser/ConfigAstBuilderTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/parser/ConfigAstBuilderTest.groovy
@@ -76,6 +76,27 @@ class ConfigAstBuilderTest extends Specification {
         when:
         errors = check(
             '''\
+            process {
+                withName: 'HELLO' {
+                    if( true ) {
+                        cpus = 8
+                    }
+                    else {
+                        cpus = 4
+                    }
+                }
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 3
+        errors[0].getStartColumn() == 9
+        errors[0].getOriginalMessage() == "If statements cannot be mixed with config statements"
+
+        when:
+        errors = check(
+            '''\
             try {
                 process.cpus = 4
             }


### PR DESCRIPTION
This PR makes a few minor improvements to linter errors:

- Report a better error message for an if statement in a config selector block. Should fix the four pipelines currently showing "Parse error" over at [strict-syntax-health](https://github.com/ewels/strict-syntax-health).

- Add a hint about using the `env()` function when an undefined variable in the config looks like an environment variable

See the PR changes for a concrete example of each improvement