### PR TITLE
Fix: `nextflow inspect` not resolving config-based container overrides

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsDsl2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/params/ParamsDsl2Test.groovy
@@ -34,7 +34,6 @@ class ParamsDsl2Test extends Dsl2Spec {
         def script = loadScript(SCRIPT)
         and:
         def process = ScriptMeta.get(script).getProcess('alpha')
-        process.initialize()
 
         then:
         def inputs = process.processConfig.getInputs()
@@ -70,7 +69,6 @@ class ParamsDsl2Test extends Dsl2Spec {
         def script = loadScript(SCRIPT)
         and:
         def process = ScriptMeta.get(script).getProcess('beta')
-        process.initialize()
 
         then:
         def inputs = process.processConfig.getInputs()


### PR DESCRIPTION
Fixes #6734

The `nextflow inspect` command was returning containers defined in process source files instead of the overridden values from profile configuration files (e.g., withName selectors).

Root cause: In ProcessDef.createTaskProcessor(), the condition `if( !processConfig )` was meant to call `initialize()` if config wasn't set:

https://github.com/nextflow-io/nextflow/blob/24cc59e273325fd2a88902ee07935fce32adf9d8/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy#L263-L265

But `processConfig` is always non-empty (initialized with `DEFAULT_CONFIG` values in the constructor), so `initialize()` was never called through this code path.

The `initialize()  method is responsible for applying config file settings (`withName` / `withLabel` selectors) to the process config, including container overrides.

Fix:
- Add an `initialized` flag to track whether config has been applied
- Make `initialize()` idempotent by checking the flag
- Always call `initialize()` in `createTaskProcessor()` (safe due to idempotency)
- Reset initialized flag in `clone()` so cloned processes can be re-initialized

This ensures that when `ContainersInspector` calls `createTaskProcessor()` to create task previews, the config file settings are properly applied first.