### PR TITLE
Fix type detection of CLI params in v2 config parser

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -128,13 +128,61 @@ class ConfigDsl extends Script {
         }
     }
 
+    /**
+     * Assign a value to a config option.
+     *
+     * When assigning a param, if the param was specified
+     * on the command line, then the command line value takes
+     * precedence. CLI params are applied here in order to ensure
+     * that if the param is referenced later in the config file,
+     * the command line value is used.
+     *
+     * @param names
+     * @param value
+     */
     void assign(List<String> names, Object value) {
         if( names.size() == 2 && names.first() == 'params' ) {
-            declareParam(names.last(), value)
-            if( cliParams.containsKey(names.last()) )
-                return
+            final name = names.last()
+            declareParam(name, value)
+            if( cliParams.containsKey(name) )
+                value = asDeclaredType(cliParams[name], value)
         }
         navigate(names.init()).put(names.last(), value)
+    }
+
+    /**
+     * Convert a CLI param override to an appropriate type based
+     * on the default param value in the config file.
+     *
+     * Note: this applies only to numbers and booleans.
+     *
+     * @param value
+     * @param declValue
+     */
+    private Object asDeclaredType(Object value, Object declValue) {
+        if( value == null )
+            return null
+
+        if( value !instanceof CharSequence )
+            return value
+
+        final str = value.toString()
+
+        if( declValue instanceof Boolean ) {
+            if( str.toLowerCase() == 'true' ) return Boolean.TRUE
+            if( str.toLowerCase() == 'false' ) return Boolean.FALSE
+        }
+
+        if( declValue instanceof Number ) {
+            if( str.isInteger() ) return str.toInteger()
+            if( str.isLong() ) return str.toLong()
+            if( str.isBigInteger() ) return str.toBigInteger()
+            if( str.isFloat() ) return str.toFloat()
+            if( str.isDouble() ) return str.toDouble()
+            if( str.isBigDecimal() ) return str.toBigDecimal()
+        }
+
+        return value
     }
 
     private Map navigate(List<String> names) {
@@ -248,8 +296,8 @@ class ConfigDsl extends Script {
             this.scope = scope
         }
 
-        void assign(List<String> names, Object right) {
-            dsl.assign(scope + names, right)
+        void assign(List<String> names, Object value) {
+            dsl.assign(scope + names, value)
         }
 
         void block(String name, Closure closure) {
@@ -310,7 +358,7 @@ class ConfigDsl extends Script {
         }
 
         @Override
-        void assign(List<String> names, Object right) {
+        void assign(List<String> names, Object value) {
             throw new ConfigParseException("Only profile blocks are allowed in the `profiles` scope")
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -736,6 +736,31 @@ class ConfigParserV2Test extends Specification {
         config.report.file == 'my-results/report.html'
     }
 
+    def 'should convert CLI params to appropriate type based on config params' () {
+        given:
+        def cliParams = [
+            igenomes_ignore: 'true',
+            max_cpus: '8',
+            publish_mode: 'symlink',
+            config_profile_name: 'Test profile'
+        ]
+        and:
+        def CONFIG = '''
+            params.igenomes_ignore = false
+            params.max_cpus = 4
+            params.publish_mode = 'copy'
+            params.config_profile_name = null
+            '''
+
+        when:
+        def config = new ConfigParserV2().setParams(cliParams).parse(CONFIG)
+        then:
+        config.params.igenomes_ignore == true
+        config.params.max_cpus == 8
+        config.params.publish_mode == 'symlink'
+        config.params.config_profile_name == 'Test profile'
+    }
+
     static class ConfigFileHandler implements HttpHandler {
 
         Path folder


### PR DESCRIPTION
Spun off from https://github.com/nextflow-io/nextflow/issues/6760#issuecomment-3806146712

This PR applies the CLI type detection from the `params` block to also work with config params. When a CLI param overrides a config param, the CLI param is converted to the appropriate type based on the default param value in the config.

Type annotations can't be specified in the config like they can in the script, but we can almost always infer the intended type from the default value:

```groovy
params.igenomes_ignore = false      // Boolean
params.max_cpus = 4                 // Integer
params.publish_mode = 'copy'        // String
params.config_profile_name = null   // (assume String)
```

Without this, users would have to assume that all config params are strings and convert them appropriately. But with this PR I think we can recover all of the functionality of the legacy type detection that users rely on, and even make it a bit more robust.

@ewels let me know if this change makes sense