### PR TITLE
fix(nf-seqera): Remove @ConfigOption from machineRequirement to fix config warnings

### DIFF
--- a/plugins/nf-seqera/src/main/io/seqera/config/SeqeraConfig.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/config/SeqeraConfig.groovy
@@ -62,7 +62,6 @@ class SeqeraConfig implements ConfigScope {
     """)
     final Duration batchFlushInterval
 
-    @ConfigOption
     @Description("""
         Machine/infrastructure requirements for session tasks.
     """)


### PR DESCRIPTION
fix(nf-seqera): Remove `@ConfigOption` from machineRequirement to fix config warnings
The config validator checks `@ConfigOption` FIRST - if present, it treats
the field as a leaf Option and doesn't recurse into nested ConfigScope
types.

This caused spurious warnings for machineRequirement nested options:

    WARN: Unrecognized config option 'seqera.machineRequirement.provisioning'
    WARN: Unrecognized config option 'seqera.machineRequirement.maxSpotAttempts'

Removing `@ConfigOption` allows the validator to recognize that
MachineRequirementOpts implements `ConfigScope` and properly discover
its nested `@ConfigOption` fields.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>