### PR TITLE
Fusion Snapshots support in nf-seqera

### DIFF
--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.12.0'
-    api 'io.seqera:sched-client:0.19.0-SNAPSHOT'
+    api 'io.seqera:sched-client:0.20.1'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.apache.groovy:groovy:4.0.29"

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -103,11 +103,12 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
             if( accelerator.type )
                 resourceReq.acceleratorName(accelerator.type)
         }
-        // build machine requirement merging config settings with task arch and disk
+        // build machine requirement merging config settings with task arch, disk, and snapshot settings
         final machineReq = MapperUtil.toMachineRequirement(
             executor.getSeqeraConfig().machineRequirement,
             task.getContainerPlatform(),
-            task.config.getDisk()
+            task.config.getDisk(),
+            fusionConfig().snapshotsEnabled()
         )
         // validate container - Seqera executor requires all processes to specify a container image
         final container = task.getContainer()


### PR DESCRIPTION
## Summary

Add support for Fusion snapshots in the Seqera scheduler executor.

## Changes

- Extended `MapperUtil.toMachineRequirement()` to accept a `snapshotEnabled` parameter
- Pass Fusion snapshot configuration (`fusionConfig().snapshotsEnabled()`) when building machine requirements
- Set `snapshotEnabled` on `MachineRequirement` API object when snapshots are enabled
- As is done in the other plugins, when snapshots is enabled, if it does not have any value `maxSpotAttempts` will default to `5`

## Related

This enables the Seqera scheduler to provision machines with snapshot support when Fusion snapshots are enabled in the pipeline configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)