### PR TITLE
Add input files metrics to Seqera executor task submission

### DIFF
--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.12.0'
-    api 'io.seqera:sched-client:0.16.0-SNAPSHOT'
+    api 'io.seqera:sched-client:0.16.0'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.apache.groovy:groovy:4.0.29"

--- a/plugins/nf-seqera/src/main/io/seqera/executor/InputFilesComputer.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/InputFilesComputer.groovy
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.executor
+
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.seqera.sched.api.schema.v1a1.InputFilesBin
+import io.seqera.sched.api.schema.v1a1.InputFilesMetrics
+import nextflow.file.FileHolder
+import nextflow.processor.TaskRun
+
+/**
+ * Computes input files metrics for a task.
+ * Follows symlinks and recursively computes directory sizes.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+class InputFilesComputer {
+
+    static final long KB = 1024L
+    static final long MB = KB * 1024
+    static final long GB = MB * 1024
+
+    private static final List<Long> THRESHOLDS = [1*MB, 10*MB, 100*MB, 1*GB]
+    private static final List<String> LABELS = ['<=1MB', '<=10MB', '<=100MB', '<=1GB', '>1GB']
+
+    /**
+     * Compute input files metrics for a task.
+     *
+     * @param task The task to compute metrics for
+     * @return InputFilesMetrics or null if no input files
+     */
+    static InputFilesMetrics compute(TaskRun task) {
+        final files = task?.inputFiles
+        if( !files || files.isEmpty() )
+            return null
+
+        return compute0(files)
+    }
+
+    /**
+     * Compute input files metrics from a list of file holders.
+     *
+     * @param files List of FileHolder objects
+     * @return InputFilesMetrics or null if list is empty
+     */
+    static InputFilesMetrics compute(List<FileHolder> files) {
+        if( !files || files.isEmpty() )
+            return null
+
+        return compute0(files)
+    }
+
+    private static InputFilesMetrics compute0(List<FileHolder> files) {
+        final sizes = new ArrayList<Long>(files.size())
+
+        for( FileHolder fh : files ) {
+            sizes.add(getSize(fh.storePath))
+        }
+
+        final binCounts = new int[5]
+        long totalBytes = 0
+
+        for( long size : sizes ) {
+            totalBytes += size
+            binCounts[findBinIndex(size)]++
+        }
+
+        final bins = new ArrayList<InputFilesBin>(5)
+        for( int i = 0; i < LABELS.size(); i++ ) {
+            bins.add(new InputFilesBin().range(LABELS[i]).count(binCounts[i]))
+        }
+
+        return new InputFilesMetrics()
+            .count(sizes.size())
+            .totalBytes(totalBytes)
+            .bins(bins)
+    }
+
+    /**
+     * Find the bin index for a given file size.
+     */
+    private static int findBinIndex(long size) {
+        for( int i = 0; i < THRESHOLDS.size(); i++ ) {
+            if( size <= THRESHOLDS[i] )
+                return i
+        }
+        return 4  // >1GB
+    }
+
+    /**
+     * Get the size of a path, following symlinks and recursively summing directories.
+     *
+     * @param path The path to measure
+     * @return Size in bytes, or 0 if unable to determine
+     */
+    private static long getSize(Path path) {
+        if( path == null )
+            return 0
+
+        try {
+            if( Files.isDirectory(path) ) {
+                return computeDirSize(path)
+            }
+            // Files.size() follows symlinks by default
+            return Files.size(path)
+        }
+        catch( Exception e ) {
+            log.warn "Unable to determine size for input file: ${path} - ${e.message}"
+            return 0
+        }
+    }
+
+    /**
+     * Recursively compute the total size of a directory.
+     *
+     * @param dir The directory path
+     * @return Total size in bytes
+     */
+    private static long computeDirSize(Path dir) {
+        final long[] total = [0L]
+
+        Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                total[0] += attrs.size()
+                return FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult visitFileFailed(Path file, IOException exc) {
+                log.warn "Unable to access file during size computation: ${file} - ${exc.message}"
+                return FileVisitResult.CONTINUE
+            }
+        })
+
+        return total[0]
+    }
+}

--- a/plugins/nf-seqera/src/test/io/seqera/executor/InputFilesComputerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/InputFilesComputerTest.groovy
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.executor
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import nextflow.file.FileHolder
+import nextflow.processor.TaskRun
+import spock.lang.Specification
+import spock.lang.TempDir
+
+/**
+ * Tests for InputFilesComputer
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class InputFilesComputerTest extends Specification {
+
+    @TempDir
+    Path tempDir
+
+    def 'should return null for null task'() {
+        expect:
+        InputFilesComputer.compute((TaskRun) null) == null
+    }
+
+    def 'should return null for task with no input files'() {
+        given:
+        def task = Mock(TaskRun) {
+            getInputFiles() >> []
+        }
+
+        expect:
+        InputFilesComputer.compute(task) == null
+    }
+
+    def 'should return null for empty file list'() {
+        expect:
+        InputFilesComputer.compute([]) == null
+    }
+
+    def 'should return null for null file list'() {
+        expect:
+        InputFilesComputer.compute((List) null) == null
+    }
+
+    def 'should compute metrics for single small file'() {
+        given:
+        def file = tempDir.resolve('small.txt')
+        Files.write(file, 'hello'.bytes)
+        def files = [new FileHolder(file)]
+
+        when:
+        def metrics = InputFilesComputer.compute(files)
+
+        then:
+        metrics.count == 1
+        metrics.totalBytes == 5
+        metrics.bins.size() == 5
+        metrics.bins[0].range == '<=1MB'
+        metrics.bins[0].count == 1
+        metrics.bins[1].count == 0
+        metrics.bins[2].count == 0
+        metrics.bins[3].count == 0
+        metrics.bins[4].count == 0
+    }
+
+    def 'should compute metrics for multiple files in different bins'() {
+        given:
+        // Create files of different sizes
+        def smallFile = tempDir.resolve('small.txt')
+        Files.write(smallFile, new byte[500])  // 500 bytes - <=1MB bin
+
+        def mediumFile = tempDir.resolve('medium.dat')
+        Files.write(mediumFile, new byte[2 * 1024 * 1024])  // 2MB - <=10MB bin
+
+        def largeFile = tempDir.resolve('large.dat')
+        Files.write(largeFile, new byte[50 * 1024 * 1024])  // 50MB - <=100MB bin
+
+        def files = [
+            new FileHolder(smallFile),
+            new FileHolder(mediumFile),
+            new FileHolder(largeFile)
+        ]
+
+        when:
+        def metrics = InputFilesComputer.compute(files)
+
+        then:
+        metrics.count == 3
+        metrics.totalBytes == 500 + (2 * 1024 * 1024) + (50 * 1024 * 1024)
+        metrics.bins[0].count == 1  // <=1MB
+        metrics.bins[1].count == 1  // <=10MB
+        metrics.bins[2].count == 1  // <=100MB
+        metrics.bins[3].count == 0  // <=1GB
+        metrics.bins[4].count == 0  // >1GB
+    }
+
+    def 'should compute directory size recursively'() {
+        given:
+        def dir = tempDir.resolve('mydir')
+        Files.createDirectory(dir)
+        Files.write(dir.resolve('file1.txt'), new byte[100])
+        Files.write(dir.resolve('file2.txt'), new byte[200])
+
+        def subDir = dir.resolve('subdir')
+        Files.createDirectory(subDir)
+        Files.write(subDir.resolve('file3.txt'), new byte[300])
+
+        def files = [new FileHolder(dir)]
+
+        when:
+        def metrics = InputFilesComputer.compute(files)
+
+        then:
+        metrics.count == 1
+        metrics.totalBytes == 600  // 100 + 200 + 300
+        metrics.bins[0].count == 1  // <=1MB
+    }
+
+    def 'should follow symlinks'() {
+        given:
+        def realFile = tempDir.resolve('real.txt')
+        Files.write(realFile, new byte[1000])
+
+        def symlink = tempDir.resolve('link.txt')
+        Files.createSymbolicLink(symlink, realFile)
+
+        def files = [new FileHolder(symlink)]
+
+        when:
+        def metrics = InputFilesComputer.compute(files)
+
+        then:
+        metrics.count == 1
+        metrics.totalBytes == 1000
+    }
+
+    def 'should handle non-existent file gracefully'() {
+        given:
+        def missingFile = tempDir.resolve('does-not-exist.txt')
+        def files = [new FileHolder(missingFile)]
+
+        when:
+        def metrics = InputFilesComputer.compute(files)
+
+        then:
+        metrics.count == 1
+        metrics.totalBytes == 0  // Unable to read, returns 0
+    }
+
+    def 'should compute from TaskRun'() {
+        given:
+        def file = tempDir.resolve('task-input.txt')
+        Files.write(file, new byte[2048])
+
+        def task = Mock(TaskRun) {
+            getInputFiles() >> [new FileHolder(file)]
+        }
+
+        when:
+        def metrics = InputFilesComputer.compute(task)
+
+        then:
+        metrics.count == 1
+        metrics.totalBytes == 2048
+    }
+
+    def 'should have correct bin labels'() {
+        given:
+        def file = tempDir.resolve('tiny.txt')
+        Files.write(file, 'x'.bytes)
+        def files = [new FileHolder(file)]
+
+        when:
+        def metrics = InputFilesComputer.compute(files)
+
+        then:
+        metrics.bins*.range == ['<=1MB', '<=10MB', '<=100MB', '<=1GB', '>1GB']
+    }
+}


### PR DESCRIPTION
## Summary

- Add `InputFilesComputer` to compute file metrics from task input files
- Modify `SeqeraBatchSubmitter` for async metrics computation using a dedicated thread pool
- Include input file statistics in task submission payload to Sched API

## Changes

| File | Change |
|------|--------|
| `InputFilesComputer.groovy` | New class to compute file count, total size, and size distribution |
| `SeqeraBatchSubmitter.groovy` | Async metrics computation with configurable timeout |
| `InputFilesComputerTest.groovy` | Unit tests for the computer class |
| `build.gradle` | Update sched-client to 0.16.0 |

## Metrics Payload Structure

```json
{
  "inputFilesMetrics": {
    "count": 12,
    "totalBytes": 4500000000,
    "bins": [
      {"range": "<=1MB", "count": 2},
      {"range": "<=10MB", "count": 5},
      {"range": "<=100MB", "count": 3},
      {"range": "<=1GB", "count": 2},
      {"range": ">1GB", "count": 0}
    ]
  }
}
```

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `NXF_SEQERA_METRICS_TIMEOUT` | 30 sec | Timeout for metrics computation |

## Test plan

- [x] Unit tests for `InputFilesComputer`
- [ ] Integration test with actual Sched API

🤖 Generated with [Claude Code](https://claude.com/claude-code)