### PR TITLE
Added isCompleted check in getNumSpotInterruptions

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -925,7 +925,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
      * @return The number of times this job was retried due to spot instance reclamation
      */
     protected Integer getNumSpotInterruptions(String jobId) {
-        if (!jobId)
+        if (!jobId || !isCompleted())
             return null
 
         try {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -908,7 +908,7 @@ class AwsBatchTaskHandlerTest extends Specification {
         when:
         def trace = handler.getTraceRecord()
         then:
-        1 * handler.isCompleted() >> false
+        2 * handler.isCompleted() >> false
         1 * handler.getMachineInfo() >> new CloudMachineInfo('x1.large', 'us-east-1b', PriceModel.spot)
         
         and:
@@ -1297,12 +1297,14 @@ class AwsBatchTaskHandlerTest extends Specification {
         when:
         def resultNoAttempts = handler.getNumSpotInterruptions('job-123')
         then:
+        1 * handler.isCompleted() >> true
         1 * handler.describeJob('job-123') >> JobDetail.builder().attempts([]).build()
         resultNoAttempts == 0
 
         when:
         def resultNonSpot = handler.getNumSpotInterruptions('job-456')
         then:
+        1 * handler.isCompleted() >> true
         1 * handler.describeJob('job-456') >> JobDetail.builder().attempts([attempt1, attempt2]).build()
         resultNonSpot == 0
     }
@@ -1314,18 +1316,21 @@ class AwsBatchTaskHandlerTest extends Specification {
         when:
         def resultNotCompleted = handler.getNumSpotInterruptions('job-123')
         then:
-        1 * handler.describeJob(_)
+        1 * handler.isCompleted() >> false
+        0 * handler.describeJob(_)
         resultNotCompleted == null
 
         when:
         def resultNullJobId = handler.getNumSpotInterruptions(null)
         then:
+        0 * handler.isCompleted()
         0 * handler.describeJob(_)
         resultNullJobId == null
 
         when:
         def resultException = handler.getNumSpotInterruptions('job-789')
         then:
+        1 * handler.isCompleted() >> true
         1 * handler.describeJob('job-789') >> { throw new RuntimeException("Error") }
         resultException == null
     }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -782,7 +782,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
      */
 
     protected Integer getNumSpotInterruptions(String jobId) {
-        if (!jobId || !taskId) {
+        if (!jobId || !taskId  || !isCompleted()) {
             return null
         }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -423,7 +423,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         when:
         def trace = handler.getTraceRecord()
         then:
-        1 * handler.isCompleted() >> true
+        2 * handler.isCompleted() >> true
         1 * client.getTaskStatus('xyz-123', '0') >> taskStatus
         and:
         trace.native_id == 'xyz-123/0/789'
@@ -918,6 +918,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def result = handler.getNumSpotInterruptions('job-123')
 
         then:
+        handler.isCompleted() >> true
         result == 0
     }
 
@@ -949,6 +950,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def result = handler.getNumSpotInterruptions('job-123')
 
         then:
+        handler.isCompleted() >> true
         result == 2
     }
 
@@ -962,6 +964,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def resultIncompleteTask = handler.getNumSpotInterruptions('job-123')
 
         then:
+        handler.isCompleted() >> false
         resultNullJobId == null
         resultIncompleteTask == null
     }
@@ -978,6 +981,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         def result = handler.getNumSpotInterruptions('job-123')
 
         then:
+        handler.isCompleted() >> true
         result == null
     }
 


### PR DESCRIPTION
This Pr fixes the deadlock reported here https://github.com/nextflow-io/nextflow/issues/6802

  Prevents the deadlock because:
  - Spot interruption counts are only meaningful after task completion
  - Returns null immediately for non-completed tasks
  - Avoids calling describeJob() and triggering the batching mechanism
  - Only queries AWS Batch API when the task is completed and we actually need the spot interruption count
