### PR TITLE
Fix: Reporting the correct number of utilized CPUs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceRecord.groovy
@@ -105,7 +105,8 @@ class TraceRecord implements Serializable {
             hostname: 'str',
             cpu_model:  'str',
             accelerator: 'num',
-            accelerator_type: 'str'
+            accelerator_type: 'str',
+            used_cpus: 'num'
     ]
 
     static public Map<String,Closure<String>> FORMATTER = [

--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -179,6 +179,7 @@ nxf_write_trace() {
         "nextflow.trace/v2" \
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
+        "used_cpus=$used_cpus" \
         "cpu_model=$cpu_model" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
@@ -199,6 +200,7 @@ nxf_trace_mac() {
     local ucpu=''
     local cpu_model=''
     local io_stat1=('' '' '' '' '' '')
+    local used_cpus=''
     nxf_write_trace
 }
 
@@ -235,7 +237,7 @@ nxf_trace_linux() {
     local mem_proc=$!
 
     ## Report number of used CPUs via polling
-    local cpus=$(nxf_cpu_watch "$task")
+    local used_cpus=$(nxf_cpu_watch "$task")
 
     wait $task
 
@@ -254,18 +256,7 @@ nxf_trace_linux() {
     local wall_time=$((end_millis-start_millis))
     [ $NXF_DEBUG = 1 ] && echo "+++ STATS %CPU=$ucpu TIME=$wall_time I/O=${io_stat1[*]}"
 
-    printf "%s\n" \
-        "nextflow.trace/v2" \
-        "realtime=$wall_time" \
-        "%cpu=$ucpu" \
-        "cpus=$cpus" \
-        "cpu_model=$cpu_model" \
-        "rchar=${io_stat1[0]}" \
-        "wchar=${io_stat1[1]}" \
-        "syscr=${io_stat1[2]}" \
-        "syscw=${io_stat1[3]}" \
-        "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" >| "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+    nxf_write_trace
 
     ## join nxf_mem_watch
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceRecordTest.groovy
@@ -161,6 +161,7 @@ class TraceRecordTest extends Specification {
             nextflow.trace/v2
             realtime=12021
             %cpu=997
+            used_cpus=32
             rchar=50838
             wchar=317
             syscr=120
@@ -181,6 +182,7 @@ class TraceRecordTest extends Specification {
         then:
         trace.realtime == 12021
         trace.'%cpu' == 99.7
+        trace.used_cpus == 32
         trace.rchar == 50838
         trace.wchar == 317
         trace.syscr == 120

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -160,6 +160,7 @@ nxf_write_trace() {
         "nextflow.trace/v2" \
         "realtime=$wall_time" \
         "%cpu=$ucpu" \
+        "used_cpus=$used_cpus" \
         "cpu_model=$cpu_model" \
         "rchar=${io_stat1[0]}" \
         "wchar=${io_stat1[1]}" \
@@ -179,6 +180,7 @@ nxf_trace_mac() {
     local ucpu=''
     local cpu_model=''
     local io_stat1=('' '' '' '' '' '')
+    local used_cpus=''
     nxf_write_trace
 }
 
@@ -206,7 +208,7 @@ nxf_trace_linux() {
     eval "exec $mem_fd> >(nxf_mem_watch $task)"
     local mem_proc=$!
 
-    local cpus=$(nxf_cpu_watch "$task")
+    local used_cpus=$(nxf_cpu_watch "$task")
 
     wait $task
 
@@ -224,18 +226,7 @@ nxf_trace_linux() {
     local wall_time=$((end_millis-start_millis))
     [ $NXF_DEBUG = 1 ] && echo "+++ STATS %CPU=$ucpu TIME=$wall_time I/O=${io_stat1[*]}"
 
-    printf "%s\n" \
-        "nextflow.trace/v2" \
-        "realtime=$wall_time" \
-        "%cpu=$ucpu" \
-        "cpus=$cpus" \
-        "cpu_model=$cpu_model" \
-        "rchar=${io_stat1[0]}" \
-        "wchar=${io_stat1[1]}" \
-        "syscr=${io_stat1[2]}" \
-        "syscw=${io_stat1[3]}" \
-        "read_bytes=${io_stat1[4]}" \
-        "write_bytes=${io_stat1[5]}" >| "$trace_file" || >&2 echo "Error: Failed to write to file: $trace_file"
+    nxf_write_trace
 
     [ -e /proc/$mem_proc ] && eval "echo 'DONE' >&$mem_fd" || true
     wait $mem_proc 2>/dev/null || true


### PR DESCRIPTION
As stated in #6743, a problem with flexible scheduling of tasks is that the rules for execution constraints upon logical cores is not enforced, or enforced with wiggle room.

In the instance of a Docker executor, `--cpu-shared 2048` is used instead of `--cpus 2` which prioritizes resource utilization, but is no hard cutoff (see https://docs.docker.com/engine/containers/resource_constraints/#configure-the-default-cfs-scheduler).
https://github.com/nextflow-io/nextflow/blob/887443e77f6eb0bc0cea9dfc606da4933a884965/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy#L128-L129

This behavior has many upsides, but the number of `cpus` in the trace is often reported incorrectly, as it takes the value set by the user in `process.cpus` for granted, even if it was not enforced.

The PR adds a sampling script which utilizes breadth-first search to extract the tasks and its children's last used logical CPU and record them in a list. In the end, this is summed to the total value of utilized CPUs.

The current sampling rate is at `0.1s`. I tried `1.0s`, but this missed several short processes in the `demo` pipeline, although I suspect this effect may vanish for longer processes. I could see no large changes in execution time and memory utilization for the tasks for either option. Sampling was chosen, because other ways either require root permission (tracking at kernel level with `perf`) or only reported minima (`ceil(%cpu / 100)`) and maxima (`grep Cpus_allowed_list /proc/$pid/status`) for the number of utilized CPUs. In practice I observed, that the number of actually used CPUs was most of the time close to the maximum, so if an approximation was to be used that does not rely on sampling, I would suggest `grep Cpus_allowed_list /proc/$pid/status`, which was my original solution in the first commit (have a look if you want).

- Closes #6743

Edits:
- Changed the parameter that is reported from `cpus` to a new `TraceRecord` field `used_cpus`.
- Replaced trace writing with already existing method `nxf_write_trace` to align `nxf_trace_linux` with `nxf_trace_mac` and save a few lines. This could also be put into a new PR, if deemed too much deviation from the main task.