### PR TITLE
Add `workflow.report` config scopes

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1748,7 +1748,7 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
   $ nextflow run main.nf -profile docker
   ```
 
-- Execute a pipeline and generate the summary HTML report. For more information on the metrics, please refer the {ref}`tracing-page` section:
+- Execute a pipeline and generate the summary HTML report. For more information on the metrics, please refer the {ref}`reports-page` section:
 
   ```console
   $ nextflow run main.nf -with-report

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -552,6 +552,10 @@ The following settings are available:
 
 ## `dag`
 
+:::{deprecated} 26.04.0
+Use the `workflow.report.dag` scope instead.
+:::
+
 The `dag` scope controls the generation of the {ref}`workflow-diagram`.
 
 The following settings are available:
@@ -1350,6 +1354,10 @@ The following settings are available:
 
 ## `report`
 
+:::{deprecated} 26.04.0
+Use the `workflow.report.execution` scope instead.
+:::
+
 The `report` scope controls the generation of the {ref}`execution-report`.
 
 The following settings are available:
@@ -1570,6 +1578,10 @@ The following settings are available:
 
 ## `timeline`
 
+:::{deprecated} 26.04.0
+Use the `workflow.report.timeline` scope instead.
+:::
+
 The `timeline` scope controls the generation of the {ref}`timeline-report`.
 
 The following settings are available:
@@ -1621,6 +1633,10 @@ The following settings are available:
 (config-trace)=
 
 ## `trace`
+
+:::{deprecated} 26.04.0
+Use the `workflow.report.trace` scope instead.
+:::
 
 The `trace` scope controls the generation of the {ref}`trace-report`.
 
@@ -1905,9 +1921,6 @@ The following settings are available:
 
 ## `workflow`
 
-:::{versionadded} 24.10.0
-:::
-
 The `workflow` scope provides workflow execution options.
 
 The following settings are available:
@@ -1918,10 +1931,25 @@ The following settings are available:
 : When `true`, the pipeline will exit with a non-zero exit code if any failed tasks are ignored using the `ignore` {ref}`error strategy <process-error-strategy>` (default: `false`).
 
 `workflow.onComplete`
+: :::{deprecated} 25.10.0
+  Use a {ref}`trace observer <plugins-trace-observers>` in a plugin to add custom workflow handlers to a pipeline via configuration.
+  :::
 : Specify a closure that will be invoked at the end of a workflow run (including failed runs). See {ref}`workflow-handlers` for more information.
 
 `workflow.onError`
+: :::{deprecated} 25.10.0
+  Use a {ref}`trace observer <plugins-trace-observers>` in a plugin to add custom workflow handlers to a pipeline via configuration.
+  :::
 : Specify a closure that will be invoked if a workflow run is terminated. See {ref}`workflow-handlers` for more information.
+
+### `workflow.output`
+
+:::{versionadded} 24.10.0
+:::
+
+The `workflow.output` scope controls how workflow outputs are published.
+
+The following settings are available:
 
 `workflow.output.contentType`
 : *Currently only supported for S3.*
@@ -1995,3 +2023,79 @@ The following settings are available:
   ```groovy
   workflow.output.tags = [FOO: 'hello', BAR: 'world']
   ```
+
+### `workflow.report`
+
+:::{versionadded} 26.04.0
+:::
+
+The `workflow.report` scope controls the standard {ref}`reports <reports-page>` provided by Nextflow.
+
+The following settings are available:
+
+**`workflow.report.dag`**
+
+`workflow.report.dag.depth`
+: *Supported by the HTML and Mermaid renderers.*
+: Controls the maximum depth at which to render sub-workflows (default: no limit).
+
+`workflow.report.dag.direction`
+: *Supported by the Graphviz, DOT, HTML and Mermaid renderers.*
+: Controls the direction of the DAG, can be `'LR'` (left-to-right) or `'TB'` (top-to-bottom) (default: `'TB'`).
+
+`workflow.report.dag.enabled`
+: Create the {ref}`workflow-diagram` on workflow completion (default: `false`).
+
+`workflow.report.dag.file`
+: DAG file path relative to the output directory (default: `'dag-<timestamp>.html'`).
+: The output format is inferred from the file extension. See {ref}`config-dag` for the list of supported formats.
+
+`workflow.report.dag.overwrite`
+: When `true` overwrites any existing DAG file with the same name (default: `false`).
+
+`workflow.report.dag.verbose`
+: *Only supported by the HTML and Mermaid renderers.*
+: When `false`, channel names are omitted, operators are collapsed, and empty workflow inputs are removed (default: `false`).
+
+**`workflow.report.execution`**
+
+`workflow.report.execution.enabled`
+: Create the {ref}`execution-report` on workflow completion (default: `false`).
+
+`workflow.report.execution.file`
+: Report file path relative to the output directory (default: `'report-<timestamp>.html'`).
+
+`workflow.report.execution.overwrite`
+: Overwrite any existing report file with the same name (default: `false`).
+
+**`workflow.report.timeline`**
+
+`workflow.report.timeline.enabled`
+: Create the {ref}`timeline-report` on workflow completion (default: `false`).
+
+`workflow.report.timeline.file`
+: Timeline file path relative to the output directory (default: `'timeline-<timestamp>.html'`).
+
+`workflow.report.timeline.overwrite`
+: Overwrite any existing timeline file with the same name (default: `false`).
+
+**`workflow.report.trace`**
+
+`workflow.report.trace.enabled`
+: Create the {ref}`trace-report` on workflow completion (default: `false`).
+
+`workflow.report.trace.fields`
+: Comma-separated list of fields to include in the trace file.
+: See {ref}`config-trace` for the list of available fields.
+
+`workflow.report.trace.file`
+: Trace file path relative to the output directory (default: `'trace-<timestamp>.txt'`).
+
+`workflow.report.trace.overwrite`
+: Overwrite any existing trace file with the same name (default: `false`).
+
+`workflow.report.trace.raw`
+: Report trace metrics as raw numbers where applicable, i.e. report duration values in milliseconds and memory values in bytes (default: `false`).
+
+`workflow.report.trace.sep`
+: Character used to separate values in each row (default: `\t`).

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,4 +1,4 @@
-(tracing-page)=
+(reports-page)=
 
 # Reports
 
@@ -121,6 +121,24 @@ report {
 
 See {ref}`config-report` for the list of available config options.
 
+:::{versionadded} 26.04.0
+:::
+
+Use the `workflow.report.execution` scope instead:
+
+```groovy
+workflow {
+    report {
+        execution {
+            enabled = true
+            file = 'report.html'
+        }
+    }
+}
+```
+
+It will automatically create the execution report in the pipeline output directory instead of the launch directory.
+
 ### Summary
 
 The **Summary** section reports the execution status, the launch command, overall execution time, and other workflow metadata:
@@ -185,6 +203,24 @@ timeline {
 
 See {ref}`config-timeline` for the list of available config options.
 
+:::{versionadded} 26.04.0
+:::
+
+Use the `workflow.report.timeline` scope instead:
+
+```groovy
+workflow {
+    report {
+        timeline {
+            enabled = true
+            file = 'timeline.html'
+        }
+    }
+}
+```
+
+It will automatically create the timeline report in the pipeline output directory instead of the launch directory.
+
 (trace-report)=
 
 ## Trace file
@@ -231,6 +267,24 @@ trace {
 
 See {ref}`config-trace` for the list of available config options.
 
+:::{versionadded} 26.04.0
+:::
+
+Use the `workflow.report.trace` scope instead:
+
+```groovy
+workflow {
+    report {
+        trace {
+            enabled = true
+            file = 'trace.txt'
+        }
+    }
+}
+```
+
+It will automatically create the trace report in the pipeline output directory instead of the launch directory.
+
 (workflow-diagram)=
 
 ## Workflow diagram
@@ -259,3 +313,21 @@ nextflow run rnaseq-nf -preview -with-dag
 ```
 
 See {ref}`config-dag` for the list of available config options.
+
+:::{versionadded} 26.04.0
+:::
+
+Use the `workflow.report.dag` scope instead:
+
+```groovy
+workflow {
+    report {
+        dag {
+            enabled = true
+            file = 'dag.html'
+        }
+    }
+}
+```
+
+It will automatically create the DAG report in the pipeline output directory instead of the launch directory.

--- a/modules/nextflow/src/main/groovy/nextflow/config/WorkflowConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/WorkflowConfig.groovy
@@ -20,6 +20,10 @@ import nextflow.config.spec.ConfigOption
 import nextflow.config.spec.ConfigScope
 import nextflow.config.spec.ScopeName
 import nextflow.script.dsl.Description
+import nextflow.trace.config.DagConfig
+import nextflow.trace.config.ReportConfig
+import nextflow.trace.config.TimelineConfig
+import nextflow.trace.config.TraceConfig
 
 @ScopeName("workflow")
 @Description("""
@@ -34,12 +38,14 @@ class WorkflowConfig implements ConfigScope {
     """)
     final boolean failOnIgnore
 
+    @Deprecated
     @ConfigOption
     @Description("""
         Specify a closure that will be invoked at the end of a workflow run (including failed runs).
     """)
     final Closure onComplete
 
+    @Deprecated
     @ConfigOption
     @Description("""
         Specify a closure that will be invoked if a workflow run is terminated.
@@ -47,11 +53,18 @@ class WorkflowConfig implements ConfigScope {
     final Closure onError
 
     @Description("""
-        The `workflow.output` scope provides options for publishing workflow outputs.
-
+        The `workflow.output` scope controls how workflow outputs are published.
+    
         [Read more](https://nextflow.io/docs/latest/reference/config.html#workflow)
     """)
     final WorkflowOutputConfig output
+
+    @Description("""
+        The `workflow.report` scope controls the standard reports provided by Nextflow.
+    
+        [Read more](https://nextflow.io/docs/latest/reference/config.html#workflow)
+    """)
+    final WorkflowReportConfig report
 
     /* required by extension point -- do not remove */
     WorkflowConfig() {}
@@ -61,6 +74,7 @@ class WorkflowConfig implements ConfigScope {
         onComplete = opts.onComplete as Closure
         onError = opts.onError as Closure
         output = new WorkflowOutputConfig(opts.output as Map ?: Collections.emptyMap())
+        report = new WorkflowReportConfig(opts.report as Map ?: Collections.emptyMap())
     }
 
 }
@@ -124,9 +138,6 @@ class WorkflowOutputConfig implements ConfigScope {
     """)
     final Map tags
 
-    /* required by extension point -- do not remove */
-    WorkflowOutputConfig() {}
-
     WorkflowOutputConfig(Map opts) {
         contentType = opts.contentType
         copyAttributes = opts.copyAttributes as boolean
@@ -136,6 +147,26 @@ class WorkflowOutputConfig implements ConfigScope {
         overwrite = opts.overwrite
         storageClass = opts.storageClass
         tags = opts.tags as Map
+    }
+
+}
+
+@CompileStatic
+class WorkflowReportConfig implements ConfigScope {
+
+    final DagConfig dag
+
+    final ReportConfig execution
+
+    final TimelineConfig timeline
+
+    final TraceConfig trace
+
+    WorkflowReportConfig(Map opts) {
+        dag = new DagConfig(opts.dag as Map ?: Collections.emptyMap())
+        execution = new ReportConfig(opts.execution as Map ?: Collections.emptyMap())
+        timeline = new TimelineConfig(opts.timeline as Map ?: Collections.emptyMap())
+        trace = new TraceConfig(opts.trace as Map ?: Collections.emptyMap())
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.trace
 
+import java.nio.file.Path
+
 import groovy.transform.CompileStatic
 import nextflow.Session
 import nextflow.trace.config.DagConfig
@@ -30,6 +32,8 @@ import nextflow.trace.config.TraceConfig
  */
 @CompileStatic
 class DefaultObserverFactory implements TraceObserverFactoryV2 {
+
+    private static final Path launchDir = Path.of('.').complete()
 
     private Session session
 
@@ -65,31 +69,59 @@ class DefaultObserverFactory implements TraceObserverFactoryV2 {
     }
 
     protected void createReportObserver(Collection<TraceObserverV2> result) {
-        final opts = session.config.report as Map ?: Collections.emptyMap()
+        def opts = session.config.navigate('workflow.report.execution') as Map
+        def baseDir = session.outputDir
+
+        if( !opts ) {
+            opts = session.config.report as Map ?: Collections.emptyMap()
+            baseDir = launchDir
+        }
+
         final config = new ReportConfig(opts)
         if( config.enabled )
-            result << new ReportObserver(config)
+            result << new ReportObserver(config, baseDir)
     }
 
     protected void createTimelineObserver(Collection<TraceObserverV2> result) {
-        final opts = session.config.timeline as Map ?: Collections.emptyMap()
+        def opts = session.config.navigate('workflow.report.timeline') as Map
+        def baseDir = session.outputDir
+
+        if( !opts ) {
+            opts = session.config.timeline as Map ?: Collections.emptyMap()
+            baseDir = launchDir
+        }
+
         final config = new TimelineConfig(opts)
         if( config.enabled )
-            result << new TimelineObserver(config)
+            result << new TimelineObserver(config, baseDir)
     }
 
     protected void createGraphObserver(Collection<TraceObserverV2> result) {
-        final opts = session.config.dag as Map ?: Collections.emptyMap()
+        def opts = session.config.navigate('workflow.report.dag') as Map
+        def baseDir = session.outputDir
+
+        if( !opts ) {
+            opts = session.config.dag as Map ?: Collections.emptyMap()
+            baseDir = launchDir
+        }
+
         final config = new DagConfig(opts)
         if( config.enabled )
-            result << new GraphObserver(config)
+            result << new GraphObserver(config, baseDir)
     }
 
     protected void createTraceFileObserver(Collection<TraceObserverV2> result) {
-        final opts = session.config.trace as Map ?: Collections.emptyMap()
+        def opts = session.config.navigate('workflow.report.trace') as Map
+        def baseDir = session.outputDir
+
+        if( !opts ) {
+            opts = session.config.trace as Map ?: Collections.emptyMap()
+            baseDir = launchDir
+        }
+
         final config = new TraceConfig(opts)
         if( config.enabled )
-            result << new TraceFileObserver(config)
+            result << new TraceFileObserver(config, baseDir)
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/GraphObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/GraphObserver.groovy
@@ -56,9 +56,9 @@ class GraphObserver implements TraceObserverV2 {
 
     String getName() { name }
 
-    GraphObserver(DagConfig config) {
+    GraphObserver(DagConfig config, Path baseDir) {
         this.config = config
-        this.file = FileHelper.asPath(config.file)
+        this.file = baseDir.resolve(config.file)
         this.name = file.baseName
         this.format = file.getExtension().toLowerCase() ?: 'html'
     }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
@@ -73,8 +73,8 @@ class ReportObserver implements TraceObserverV2 {
      */
     private boolean overwrite
 
-    ReportObserver(ReportConfig config) {
-        this.reportFile = FileHelper.asPath(config.file)
+    ReportObserver(ReportConfig config, Path baseDir) {
+        this.reportFile = baseDir.resolve(config.file)
         this.maxTasks = config.maxTasks
         this.overwrite = config.overwrite
     }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TimelineObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TimelineObserver.groovy
@@ -61,8 +61,8 @@ class TimelineObserver implements TraceObserverV2 {
 
     private boolean overwrite
 
-    TimelineObserver(TimelineConfig config) {
-        this.reportFile = FileHelper.asPath(config.file)
+    TimelineObserver(TimelineConfig config, Path baseDir) {
+        this.reportFile = baseDir.resolve(config.file)
         this.overwrite = config.overwrite
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
@@ -75,8 +75,8 @@ class TraceFileObserver implements TraceObserverV2 {
 
     private boolean useRawNumber
 
-    TraceFileObserver(TraceConfig config) {
-        tracePath = FileHelper.asPath(config.file)
+    TraceFileObserver(TraceConfig config, Path baseDir) {
+        tracePath = baseDir.resolve(config.file)
         overwrite = config.overwrite
         separator = config.sep
         useRawNumbers(config.raw)

--- a/modules/nextflow/src/test/groovy/nextflow/trace/GraphObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/GraphObserverTest.groovy
@@ -39,7 +39,9 @@ class GraphObserverTest extends Specification {
     DAG test_dag
 
     def createObserver(Path file) {
-        new GraphObserver(new DagConfig(file: file.toString()))
+        def config = new DagConfig(file: file.getFileName().toString())
+        def baseDir = file.getParent()
+        return new GraphObserver(config, baseDir)
     }
 
     def setup() {

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ReportObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ReportObserverTest.groovy
@@ -17,7 +17,7 @@
 package nextflow.trace
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.time.OffsetDateTime
 
 import groovy.json.JsonSlurper
@@ -150,7 +150,7 @@ class ReportObserverTest extends Specification {
     def 'should increment workflow stats' () {
         given:
         def workflow = new WorkflowMetadata(
-                workDir: Paths.get('/work/dir'),
+                workDir: Path.of('/work/dir'),
                 stats: new WorkflowStats(),
                 nextflow: new NextflowMeta('0.27.9', 3232, '2017-12-12')
         )
@@ -198,7 +198,7 @@ class ReportObserverTest extends Specification {
     def 'should render not tasks payload' () {
 
         given:
-        def observer = Spy(new ReportObserver(new ReportConfig([:])))
+        def observer = Spy(new ReportObserver(new ReportConfig([:]), Path.of('.')))
         def BIG = Mock(Map)
         BIG.size() >> ReportConfig.DEF_MAX_TASKS+1
 
@@ -211,7 +211,7 @@ class ReportObserverTest extends Specification {
 
     def 'should render tasks payload' () {
         given:
-        def observer = Spy(new ReportObserver(new ReportConfig([:])))
+        def observer = Spy(new ReportObserver(new ReportConfig([:]), Path.of('.')))
 
         def TASKID1 = TaskId.of(10)
         def TASKID2 = TaskId.of(20)

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
@@ -17,6 +17,7 @@
 package nextflow.trace
 
 import java.nio.file.Files
+import java.nio.file.Path
 
 import nextflow.Session
 import nextflow.executor.Executor
@@ -46,7 +47,7 @@ class TraceFileObserverTest extends Specification {
 
     def createObserver() {
         def config = new TraceConfig([:])
-        return new TraceFileObserver(config)
+        return new TraceFileObserver(config, Path.of('.'))
     }
 
     def 'test set fields'() {
@@ -101,7 +102,7 @@ class TraceFileObserverTest extends Specification {
 
         given:
         def testFolder = Files.createTempDirectory('trace-dir')
-        def file = testFolder.resolve('trace')
+        def file = testFolder.resolve('trace.txt')
 
         // the handler
         def task = new TaskRun(id:TaskId.of(111), name:'simple_task', hash: CacheHelper.hasher(1).hash(), config: new TaskConfig())
@@ -115,8 +116,8 @@ class TraceFileObserverTest extends Specification {
         def now = System.currentTimeMillis()
 
         // the observer class under test
-        def config = new TraceConfig(file: file.toString())
-        def observer = new TraceFileObserver(config)
+        def config = new TraceConfig(file: 'trace.txt')
+        def observer = new TraceFileObserver(config, testFolder)
 
         when:
         observer.onFlowCreate(null)
@@ -260,7 +261,7 @@ class TraceFileObserverTest extends Specification {
 
         // observer with overwrite=false (the default)
         def config = new TraceConfig(file: file.toString())
-        def observer = new TraceFileObserver(config)
+        def observer = new TraceFileObserver(config, testFolder)
 
         when: 'onFlowCreate fails to create the file'
         observer.onFlowCreate(null)


### PR DESCRIPTION
This PR adds the `workflow.report` config scope as a replacement for the existing report scopes:

- `dag` -> `workflow.report.dag`
- `report` -> `workflow.report.execution`
- `timeline` -> `workflow.report.timeline`
- `trace` -> `workflow.report.trace`

The config settings are otherwise identical, except that the `file` option is resolved against the workflow output directory instead of the launch directory.

This makes the standard reports easier to use with workflow outputs.