### PR TITLE
Fix spurious WARN when workflow fails before onFlowBegin

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -410,7 +410,8 @@ class TowerClient implements TraceObserverV2 {
         // wait and flush reports content
         reports.flowComplete()
         // notify the workflow completion
-        if( workflowId ) {
+        // note: only send complete if onFlowBegin was invoked (sender is set there)
+        if( workflowId && sender ) {
             final req = makeCompleteReq(session)
             final resp = sendHttpMessage(urlTraceComplete, req, 'PUT')
             logHttpResponse(urlTraceComplete, resp)

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -523,6 +523,22 @@ class TowerClientTest extends Specification {
         client.getNewContainers([trace1, trace2, trace3]) == [c2]
     }
 
+    def 'should not send complete request when onFlowBegin was not invoked' () {
+        given:
+        def client = Spy(new TowerClient())
+        client.@workflowId = 'xyz-123'
+        client.@sender = null
+        client.@reports = Mock(TowerReports)
+
+        when:
+        client.onFlowComplete()
+
+        then:
+        1 * client.@reports.publishRuntimeReports()
+        1 * client.@reports.flowComplete()
+        0 * client.sendHttpMessage(_, _, _)
+    }
+
     def 'should handle HTTP request with content'() {
         given: 'a TowerClient'
         def tower = new TowerClient()


### PR DESCRIPTION
## Summary
- When a workflow fails before `onFlowBegin` is invoked (e.g., script parsing error), `onFlowComplete` still sends a `/complete` request to the Platform API, which gets rejected with 403 and produces a confusing WARN message
- Fix: skip sending the complete request when `onFlowBegin` was never called, by checking that the `sender` thread (only set in `onFlowBegin`) is non-null
- Added unit test to verify the complete request is not sent when begin was not invoked

## Test plan
- [x] New unit test: `should not send complete request when onFlowBegin was not invoked`
- [ ] Manual: run `./launch.sh run t.nf -with-tower` with a script that fails immediately — verify no WARN about unexpected HTTP response

🤖 Generated with [Claude Code](https://claude.com/claude-code)