### PR TITLE
Stop Seqera Platform tracing monitoring when consistent connection failure 

### DIFF
--- a/modules/nf-commons/src/main/nextflow/extension/FilesEx.groovy
+++ b/modules/nf-commons/src/main/nextflow/extension/FilesEx.groovy
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.SeekableByteChannel
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.FileSystemException
+import java.nio.file.FileVisitOption
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.LinkOption
@@ -649,17 +650,18 @@ class FilesEx {
      * @param self
      */
     static Collection<Path> listDirectory(Path self) {
-        return listFiles0(self)
+        return listFiles0(self, null, true)
     }
 
-    private static Collection<Path> listFiles0(Path self, Closure<Boolean> filter=null) {
+    private static Collection<Path> listFiles0(Path self, Closure<Boolean> filter=null, boolean followLinks=false) {
 
         if( !self.isDirectory() )
             return null
 
         final result = []
+        final opts = followLinks ? EnumSet.of(FileVisitOption.FOLLOW_LINKS) : EnumSet.noneOf(FileVisitOption)
 
-        Files.walkFileTree(self, new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(self, opts, Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
 
             FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if( filter == null || invokeFilter(filter, file, attrs) )

--- a/modules/nf-commons/src/test/nextflow/extension/FilesExTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/extension/FilesExTest.groovy
@@ -603,6 +603,51 @@ class FilesExTest extends Specification {
         sourceFolder.deleteDir()
     }
 
+    def 'listFiles should not follow symlinked directory' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def realDir = folder.resolve('realDir')
+        Files.createDirectories(realDir)
+        realDir.resolve('file1.txt').text = 'Hello1'
+        realDir.resolve('file2.txt').text = 'Hello2'
+        def linkDir = folder.resolve('linkDir')
+        Files.createSymbolicLink(linkDir, realDir)
+
+        when:
+        def paths = linkDir.listFiles()
+
+        then:
+        // without FOLLOW_LINKS, walkFileTree treats the symlink as a file
+        paths.size() == 1
+        paths[0] == linkDir
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'listDirectory should follow symlinked directory' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def realDir = folder.resolve('realDir')
+        Files.createDirectories(realDir)
+        realDir.resolve('file1.txt').text = 'Hello1'
+        realDir.resolve('file2.txt').text = 'Hello2'
+        def linkDir = folder.resolve('linkDir')
+        Files.createSymbolicLink(linkDir, realDir)
+
+        when:
+        def paths = linkDir.listDirectory()
+
+        then:
+        paths.size() == 2
+        paths.collect { it.name }.sort() == ['file1.txt', 'file2.txt']
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
 
     def testSetReadonly() {
 


### PR DESCRIPTION
This pull request enhances the robustness of the `TowerClient` in the `nf-tower` plugin by introducing logic to detect and handle consistent failures when communicating with the Seqera Platform. If repeated failures occur over a certain time interval, the client will skip sending further trace reports to avoid unnecessary resource consumption. The changes also include corresponding tests for this new behavior.

A consistent failure is determined when more than 20 consecutive trace calls have failed, and the last success was at least 10 alive intervals ago. Nextflow will stop sending traces when failures are constantly repeated for 10-20 mins.

**Failure detection and handling improvements:**

* Added failure tracking fields (`failuresThreshold`, `failuresCount`, `lastSuccess`) and constants to `TowerClient` to monitor the number of consecutive failed trace calls and the time since the last successful call. [[1]](diffhunk://#diff-4e7968503d8e56d6d5f2eff04e734382b6b79fee49dc22668d9a3803c91113e2R73-R76) [[2]](diffhunk://#diff-4e7968503d8e56d6d5f2eff04e734382b6b79fee49dc22668d9a3803c91113e2R131-R139)
* Implemented a new method `hasConsistentFailures()` that determines if failures have exceeded the threshold and sufficient time has passed since the last success, triggering the skip logic.
* Modified the main sending loop to check for consistent failures and, if detected, skip sending heartbeat and progress reports, and clear pending tasks to prevent memory issues.
* Updated HTTP response handling to reset failure counters on success and increment them on failure, while also updating the last success timestamp. [[1]](diffhunk://#diff-4e7968503d8e56d6d5f2eff04e734382b6b79fee49dc22668d9a3803c91113e2R403) [[2]](diffhunk://#diff-4e7968503d8e56d6d5f2eff04e734382b6b79fee49dc22668d9a3803c91113e2R736-R741)

**Testing:**

* Added a new test in `TowerClientTest` to verify the consistent failure detection logic under various scenarios. [[1]](diffhunk://#diff-463f0ed6e146304ec6d2d8252af59dc42ba32ef8851ae68c371708e3823157c3R608-R637) [[2]](diffhunk://#diff-463f0ed6e146304ec6d2d8252af59dc42ba32ef8851ae68c371708e3823157c3R20-R21)