### PR TITLE
Don't include container in task trace when containers are not enabled

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHandler.groovy
@@ -207,7 +207,7 @@ abstract class TaskHandler {
         record.process = task.processor.getName()
         record.tag = task.config.tag
         record.module = task.config.module
-        record.container = task.getContainer()
+        record.container = task.isContainerEnabled() ? task.getContainer() : null
         record.attempt = task.config.attempt
 
         record.script = task.getTraceScript()


### PR DESCRIPTION
This PR changes the task trace to only include the task container if containers were enabled for the run.

This way, when a run uses e.g. conda environments instead of containers, the task detail in Platform won't show a container.