### PR TITLE
Fix missing space before revision in launch info

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -506,7 +506,7 @@ class CmdRun extends CmdBase implements HubOptions {
             fmt.a("Launching").fg(Color.MAGENTA).a(" `$repo` ").reset()
             fmt.a(Attribute.INTENSITY_FAINT).a("[").reset()
             fmt.bold().fg(Color.CYAN).a(runName).reset()
-            fmt.a(Attribute.INTENSITY_FAINT).a("]")
+            fmt.a(Attribute.INTENSITY_FAINT).a("] ").reset()
             fmt.fg(Color.CYAN).a("revision: ").reset()
             fmt.fg(Color.CYAN).a(revision).reset()
             fmt.a("\n")


### PR DESCRIPTION
## Summary

- Fix missing blank space between run name and revision in the ANSI launch info line

Before: `Launching `repo` [run_name]revision: abc123 [master]`
After: `Launching `repo` [run_name] revision: abc123 [master]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)