### PR TITLE
Implement image streaming for Google Batch

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -971,6 +971,13 @@ The following settings are available:
 : The Google Cloud Storage path where job logs should be stored, e.g. `gs://my-logs-bucket/logs`.
 : When specified, Google Batch will write job logs to this location instead of [Cloud Logging](https://cloud.google.com/logging/docs). The bucket must be accessible and writable by the service account.
 
+`google.batch.enableImageStreaming`
+: :::{versionadded} 26.02.1-edge
+  :::
+: Enable container image streaming to speed up job start-up (default: `false`). This can reduce latency for large images but comes with some
+[limitations](https://docs.cloud.google.com/batch/docs/use-image-streaming).
+: Notably, `process.containerOptions` is ignored when image streaming is enabled.
+
 `google.batch.maxSpotAttempts`
 : :::{versionadded} 23.11.0-edge
   :::

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -974,9 +974,11 @@ The following settings are available:
 `google.batch.enableImageStreaming`
 : :::{versionadded} 26.02.1-edge
   :::
-: Enable container image streaming to speed up job start-up (default: `false`). This can reduce latency for large images but comes with some
-[limitations](https://docs.cloud.google.com/batch/docs/use-image-streaming).
-: Notably, `process.containerOptions` is ignored when image streaming is enabled.
+: Enable container image streaming to speed up job start-up (default: `false`). This can reduce latency for large images but comes with some [limitations](https://cloud.google.com/batch/docs/use-image-streaming), including:
+
+  - `process.containerOptions` is ignored when image streaming is enabled.
+  - Image streaming only supports container images stored in Artifact Registry. If you currently use Container Registry, you should [transition to Artifact Registry](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr).
+  - You must run your Batch job's VMs in the same [location](https://cloud.google.com/artifact-registry/docs/repositories/repo-locations) as the Artifact Registry storing the container image.
 
 `google.batch.maxSpotAttempts`
 : :::{versionadded} 23.11.0-edge

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -313,6 +313,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             .setImageUri(task.container)
             .addAllCommands(cmd)
             .addAllVolumes(launcher.getContainerMounts())
+            .setEnableImageStreaming(batchConfig?.enableImageStreaming ?: false)
 
         def containerOptions = task.config.getContainerOptions() ?: ''
         if( fusionEnabled() ) {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -92,6 +92,15 @@ class BatchConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        Enable container image streaming for faster startup. process.containerOptions
+        is ignored when image streaming is enabled. See
+        [documentation](https://docs.cloud.google.com/batch/docs/use-image-streaming)
+        for a full list of other limitations (default: `false`).
+    """)
+    final boolean enableImageStreaming
+
+    @ConfigOption
+    @Description("""
         Max number of execution attempts of a job interrupted by a Compute Engine Spot reclaim event (default: `0`).
     """)
     final int maxSpotAttempts
@@ -148,6 +157,7 @@ class BatchConfig implements ConfigScope {
         gcsfuseOptions = opts.gcsfuseOptions as List<String> ?: DEFAULT_GCSFUSE_OPTS
         installGpuDrivers = opts.installGpuDrivers as boolean
         logsPath = opts.logsPath
+        enableImageStreaming = opts.enableImageStreaming != null ? opts.enableImageStreaming as boolean : false
         maxSpotAttempts = opts.maxSpotAttempts != null ? opts.maxSpotAttempts as int : DEFAULT_MAX_SPOT_ATTEMPTS
         network = opts.network
         networkTags = opts.networkTags as List<String> ?: Collections.emptyList()

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -92,10 +92,17 @@ class BatchConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        Enable container image streaming for faster startup. process.containerOptions
-        is ignored when image streaming is enabled. See
-        [documentation](https://docs.cloud.google.com/batch/docs/use-image-streaming)
-        for a full list of other limitations (default: `false`).
+        Enable container image streaming to speed up job start-up (default: `false`).
+        This can reduce latency for large images but comes with some
+        [limitations](https://cloud.google.com/batch/docs/use-image-streaming), including:
+
+        - `process.containerOptions` is ignored when image streaming is enabled.
+        - Image streaming only supports container images stored in Artifact Registry.
+          If you currently use Container Registry, you should 
+          [transition to Artifact Registry](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr).
+        - You must run your Batch job's VMs in the same
+          [location](https://cloud.google.com/artifact-registry/docs/repositories/repo-locations)
+          as the Artifact Registry storing the container image.
     """)
     final boolean enableImageStreaming
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchConfigTest.groovy
@@ -31,6 +31,8 @@ class BatchConfigTest extends Specification {
         then:
         !config.getSpot()
         and:
+        !config.enableImageStreaming
+        and:
         config.retryConfig.maxAttempts == 5
         config.maxSpotAttempts == 0
         config.autoRetryExitCodes == [50001]
@@ -44,6 +46,7 @@ class BatchConfigTest extends Specification {
         given:
         def opts = [
             spot: true,
+            enableImageStreaming: true,
             maxSpotAttempts: 8,
             autoRetryExitCodes: [50001, 50003, 50005],
             retryPolicy: [maxAttempts: 10],


### PR DESCRIPTION
Closes #4719. This improves startup time for jobs in my workflow from ~2.5 minutes to ~1 minute (image about 600MB compressed). It does, however, come with some pretty important limitations, most notably ignoring the `process.containerOptions` setting.