### PR TITLE
Fix ResourcesAggregator deadlock with virtual thread executor

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
@@ -113,7 +113,7 @@ class ReportObserver implements TraceObserverV2 {
     @Override
     void onFlowCreate(Session session) {
         this.session = session
-        this.aggregator = new ResourcesAggregator(session)
+        this.aggregator = new ResourcesAggregator()
         // check if the process exists
         if( Files.exists(reportFile) && !overwrite )
             throw new AbortOperationException("Report file already exists: ${reportFile.toUriString()} -- enable the 'report.overwrite' option in your config file to overwrite existing files")

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ResourcesAggregatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ResourcesAggregatorTest.groovy
@@ -2,10 +2,7 @@ package nextflow.trace
 
 import spock.lang.Specification
 
-import java.util.concurrent.Executors
-
 import groovy.json.JsonSlurper
-import nextflow.Session
 
 /**
  *
@@ -21,12 +18,7 @@ class ResourcesAggregatorTest extends Specification {
 
     def 'should render summary json' () {
         given:
-        def executor = Executors.newCachedThreadPool()
-        def session = Mock(Session) {
-            getExecService() >> executor
-        }
-
-        def observer = new ResourcesAggregator(session)
+        def observer = new ResourcesAggregator()
         observer.aggregate(r1)
         observer.aggregate(r2)
         observer.aggregate(r3)
@@ -119,21 +111,13 @@ class ResourcesAggregatorTest extends Specification {
         result[1].timeUsage.q2 == 102.50
         result[1].timeUsage.q3 == 108.75
         result[1].timeUsage.mean == 102.50
-
-        cleanup:
-        observer?.executor?.shutdown()
     }
 
 
     def 'should compute summary list' () {
 
         given:
-        def executor = Executors.newCachedThreadPool()
-        def session = Mock(Session) {
-            getExecService() >> executor
-        }
-
-        def observer = new ResourcesAggregator(session)
+        def observer = new ResourcesAggregator()
         observer.aggregate(r1)
         observer.aggregate(r2)
         observer.aggregate(r3)
@@ -156,20 +140,12 @@ class ResourcesAggregatorTest extends Specification {
         result[1].mem."max" == 22000.0
         result[1].time.min == 18000
         result[1].time.max == 23000
-
-        cleanup:
-        observer?.executor?.shutdown()
     }
 
 
     def 'should maintain insertion order' () {
         given:
-        def executor = Executors.newCachedThreadPool()
-        def session = Mock(Session) {
-            getExecService() >> executor
-        }
-
-        def observer = new ResourcesAggregator(session)
+        def observer = new ResourcesAggregator()
         observer.aggregate(new TraceRecord([process: 'gamma', name: 'gamma-1']))
         observer.aggregate(new TraceRecord([process: 'delta', name: 'delta-1']))
         observer.aggregate(new TraceRecord([process: 'delta', name: 'delta-2']))

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -271,7 +271,7 @@ class TowerClient implements TraceObserverV2 {
         log.debug "Creating Seqera Platform observer -- endpoint=$endpoint; requestInterval=$requestInterval; aliveInterval=$aliveInterval; maxRetries=$maxRetries; backOffBase=$backOffBase; backOffDelay=$backOffDelay"
 
         this.session = session
-        this.aggregator = new ResourcesAggregator(session)
+        this.aggregator = new ResourcesAggregator()
         this.runName = session.getRunName()
         this.runId = session.getUniqueId()
         this.httpClient = newHttpClient()


### PR DESCRIPTION
## Summary

Fix a deadlock in `ResourcesAggregator.computeSummaryMap()` that causes Nextflow to hang indefinitely during shutdown when generating the execution report.

## Problem

`ResourcesAggregator` used the shared session `ExecutorService` — a `ThreadPerTaskExecutor` backed by virtual threads — to parallelize summary stats computation via `invokeAll()`. 

When other virtual threads (e.g. `PublishDir` file transfers) saturate or pin all ForkJoinPool carrier threads, the new tasks submitted by `invokeAll` can never be scheduled. Since `invokeAll` blocks until **all** futures complete, this creates a **starvation deadlock**: the main thread waits forever at `computeSummaryMap()` during `onFlowComplete`.

**Observed in production** — thread dump shows the main thread stuck at:
```
at java.util.concurrent.ThreadPerTaskExecutor.invokeAll(ThreadPerTaskExecutor.java:365)
at nextflow.trace.ResourcesAggregator.computeSummaryMap(ResourcesAggregator.groovy:75)
at nextflow.trace.ResourcesAggregator.computeSummaryList(ResourcesAggregator.groovy:90)
at nextflow.trace.ResourcesAggregator.renderSummaryJson(ResourcesAggregator.groovy:105)
at nextflow.trace.ReportObserver.renderSummaryJson(ReportObserver.groovy:201)
...
at nextflow.Session.shutdown0(Session.groovy:777)
```

This is related to but independent of #6833 — that PR fixes one cause of carrier thread saturation (S3 delete), but `ResourcesAggregator` is vulnerable to **any** scenario where carrier threads are busy.

## Fix

Replace the shared session virtual thread executor with a dedicated `FixedThreadPool` scoped to the `computeSummaryMap()` call. This is CPU-bound computation that:
- Benefits from platform threads (no I/O waiting)
- Must not compete with virtual threads for carrier thread scheduling
- Only runs once during shutdown, so the pool creation overhead is negligible

This also removes the `Session` dependency from `ResourcesAggregator`, simplifying both the class and its tests.

## Test plan

- [x] Existing `ResourcesAggregatorTest` tests pass (summary computation, JSON rendering, insertion order)
- [x] `ReportObserverTest` passes
- [x] `nf-tower` plugin compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)