### PR TITLE
Update default Azure Batch VM image to Ubuntu 24.04

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -573,14 +573,14 @@ By default, Nextflow creates pool nodes suitable for most bioinformatics workloa
 
 Below are example configurations for common operating systems used in scientific computing:
 
-**Ubuntu 22.04 (default)**
+**Ubuntu 24.04 (default)**
 
 ```groovy
 azure {
     batch {
         pools {
             <POOL_NAME> {
-                sku = "batch.node.ubuntu 22.04"
+                sku = "batch.node.ubuntu 24.04"
                 offer = "ubuntu-hpc"
                 publisher = "microsoft-dsvm"
             }

--- a/plugins/nf-azure/changelog.txt
+++ b/plugins/nf-azure/changelog.txt
@@ -1,5 +1,8 @@
 nf-azure changelog
 ===================
+1.21.1
+- Update default Azure Batch VM image SKU to Ubuntu 24.04
+
 1.21.0 - 28 Nov 2025
 - Optimize exit code handling by relying on scheduler status for successful executions (#6484) [454a2ae85]
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -40,7 +40,7 @@ class AzPoolOpts implements CacheFunnel, ConfigScope {
 
     static public final String DEFAULT_PUBLISHER = "microsoft-dsvm"
     static public final String DEFAULT_OFFER = "ubuntu-hpc"
-    static public final String DEFAULT_SKU = "batch.node.ubuntu 22.04"
+    static public final String DEFAULT_SKU = "batch.node.ubuntu 24.04"
     static public final String DEFAULT_VM_TYPE = "Standard_D4a_v4"
     static public final OSType DEFAULT_OS_TYPE = OSType.LINUX
     static public final String DEFAULT_SHARE_ROOT_PATH = "/mnt/batch/tasks/fsmounts"

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -499,7 +499,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-e3331cce25aa1563d6046b3de9ec2d93-Standard_X1'
+        spec.poolId == 'nf-pool-54b43e2c3ba867ea4e05393dde7745fd-Standard_X1'
         spec.metadata == [foo: 'bar']
 
     }


### PR DESCRIPTION
## Summary

- Updates the default Azure Batch VM image SKU from Ubuntu 22.04 to Ubuntu 24.04 (`batch.node.ubuntu 24.04`)
- Updates documentation to reflect the new default
- Adds changelog entry for nf-azure plugin

## Changes

| File | Change |
|------|--------|
| `plugins/nf-azure/.../AzPoolOpts.groovy` | `DEFAULT_SKU` → `"batch.node.ubuntu 24.04"` |
| `docs/azure.md` | Updated heading and example config |
| `plugins/nf-azure/changelog.txt` | Added entry for SKU update |