### PR TITLE
Speed up submission of Google Batch array jobs

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
@@ -187,11 +187,8 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint, TaskArrayExec
     protected TaskMonitor createTaskMonitor() {
 
         // create the throttling executor
-        // note this is invoke only the very first time a AWS Batch executor is created
-        // therefore it's safe to assign to a static attribute
-        submitter = createExecutorService('AWSBatch-executor')
-
-        reaper = createExecutorService('AWSBatch-reaper')
+        this.submitter = createExecutorService('AWSBatch-executor')
+        this.reaper = createExecutorService('AWSBatch-reaper')
 
         final pollInterval = config.getPollInterval(name, Duration.of('10 sec'))
         final dumpInterval = config.getMonitorDumpInterval(name)
@@ -230,7 +227,7 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint, TaskArrayExec
      * @return Creates a {@link ThrottlingExecutor} service to throttle
      * the API requests to the AWS Batch service.
      */
-    private ThrottlingExecutor createExecutorService(String name) {
+    private ThrottlingExecutor createExecutorService(String poolName) {
 
         // queue size can be overridden by submitter options below
         final qs = 5_000
@@ -247,7 +244,7 @@ class AwsBatchExecutor extends Executor implements ExtensionPoint, TaskArrayExec
                 .withKeepAlive(Duration.of('1 min'))
                 .withAutoThrottle(true)
                 .withMaxRetries(10)
-                .withPoolName(name)
+                .withPoolName(poolName)
 
         ThrottlingExecutor.create(opts)
     }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -19,7 +19,10 @@ package nextflow.cloud.google.batch
 import static nextflow.cloud.google.batch.GoogleBatchScriptLauncher.*
 
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
+import com.google.api.gax.rpc.DeadlineExceededException
+import com.google.api.gax.rpc.UnavailableException
 import com.google.cloud.storage.contrib.nio.CloudStoragePath
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -33,11 +36,14 @@ import nextflow.executor.Executor
 import nextflow.executor.TaskArrayExecutor
 import nextflow.extension.FilesEx
 import nextflow.fusion.FusionHelper
+import nextflow.processor.ParallelPollingMonitor
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskMonitor
-import nextflow.processor.TaskPollingMonitor
 import nextflow.processor.TaskRun
 import nextflow.util.Duration
+import nextflow.util.RateUnit
+import nextflow.util.ThreadPoolHelper
+import nextflow.util.ThrottlingExecutor
 import nextflow.util.Escape
 import nextflow.util.ServiceName
 import org.pf4j.ExtensionPoint
@@ -55,6 +61,16 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
     private GoogleOpts googleOpts
     private Path remoteBinDir
     private BatchLogging logging
+
+    /**
+     * Executor service to throttle job submission requests
+     */
+    private ThrottlingExecutor submitter
+
+    /**
+     * Executor service to throttle job deletion requests
+     */
+    private ThrottlingExecutor reaper
 
     private final Set<String> deletedJobs = new HashSet<>()
 
@@ -115,7 +131,61 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
 
     @Override
     protected TaskMonitor createTaskMonitor() {
-        TaskPollingMonitor.create(session, config, name, 1000, Duration.of('10 sec'))
+        // create the throttling executor services
+        submitter = createExecutorService('GoogleBatch-executor')
+        reaper = createExecutorService('GoogleBatch-reaper')
+
+        final pollInterval = config.getPollInterval(name, Duration.of('10 sec'))
+        final dumpInterval = config.getMonitorDumpInterval(name)
+        final capacity = config.getQueueSize(name, 1000)
+
+        final def params = [
+                name: name,
+                session: session,
+                config: config,
+                pollInterval: pollInterval,
+                dumpInterval: dumpInterval,
+                capacity: capacity
+        ]
+
+        log.debug "Creating parallel monitor for executor '$name' > capacity=$capacity; pollInterval=$pollInterval; dumpInterval=$dumpInterval"
+        new ParallelPollingMonitor(submitter, params)
+    }
+
+    /**
+     * Creates a {@link ThrottlingExecutor} service to throttle
+     * API requests to the Google Batch service.
+     *
+     * @param name The executor service name
+     * @return A {@link ThrottlingExecutor} instance
+     */
+    private ThrottlingExecutor createExecutorService(String name) {
+        final qs = 5_000
+        final limit = config.getExecConfigProp(name, 'submitRateLimit', '50/s') as String
+        final size = Runtime.runtime.availableProcessors() * 5
+
+        final opts = new ThrottlingExecutor.Options()
+                .retryOn { Throwable t ->
+                    t instanceof UnavailableException ||
+                    t instanceof DeadlineExceededException ||
+                    t instanceof IOException ||
+                    t.cause instanceof IOException
+                }
+                .onFailure { Throwable t -> session?.abort(t) }
+                .onRateLimitChange { RateUnit rate -> logRateLimitChange(rate) }
+                .withRateLimit(limit)
+                .withQueueSize(qs)
+                .withPoolSize(size)
+                .withKeepAlive(Duration.of('1 min'))
+                .withAutoThrottle(true)
+                .withMaxRetries(10)
+                .withPoolName(name)
+
+        ThrottlingExecutor.create(opts)
+    }
+
+    protected void logRateLimitChange(RateUnit rate) {
+        log.debug "New submission rate limit: $rate"
     }
 
     @Override
@@ -123,10 +193,33 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
         return new GoogleBatchTaskHandler(task, this)
     }
 
+    ThrottlingExecutor getReaper() { reaper }
+
     @Override
     void shutdown() {
+        // shutdown the submitter executor
+        def tasks = submitter.shutdownNow()
+        if( tasks ) log.warn "Execution interrupted -- cleaning up execution pool"
+        submitter.awaitTermination(5, TimeUnit.MINUTES)
+
+        // shutdown the reaper executor
+        reaper.shutdown()
+        final waitMsg = "[GOOGLE BATCH] Waiting jobs reaper to complete (%d jobs to be terminated)"
+        final exitMsg = "[GOOGLE BATCH] Exiting before jobs reaper thread pool complete -- Some jobs may not be terminated"
+        awaitCompletion(reaper, Duration.of('60min'), waitMsg, exitMsg)
+
+        // close batch client and logging
         client.shutdown()
         logging.close()
+    }
+
+    protected void awaitCompletion(ThrottlingExecutor executor, Duration duration, String waitMsg, String exitMsg) {
+        try {
+            ThreadPoolHelper.await(executor, duration, waitMsg, exitMsg)
+        }
+        catch( java.util.concurrent.TimeoutException e ) {
+            log.warn(e.message, e)
+        }
     }
 
     @Override

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -21,8 +21,7 @@ import static nextflow.cloud.google.batch.GoogleBatchScriptLauncher.*
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
-import com.google.api.gax.rpc.DeadlineExceededException
-import com.google.api.gax.rpc.UnavailableException
+import com.google.api.gax.rpc.ResourceExhaustedException
 import com.google.cloud.storage.contrib.nio.CloudStoragePath
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -132,8 +131,8 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
     @Override
     protected TaskMonitor createTaskMonitor() {
         // create the throttling executor services
-        submitter = createExecutorService('GoogleBatch-executor')
-        reaper = createExecutorService('GoogleBatch-reaper')
+        this.submitter = createExecutorService('GoogleBatch-executor')
+        this.reaper = createExecutorService('GoogleBatch-reaper')
 
         final pollInterval = config.getPollInterval(name, Duration.of('10 sec'))
         final dumpInterval = config.getMonitorDumpInterval(name)
@@ -156,21 +155,19 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
      * Creates a {@link ThrottlingExecutor} service to throttle
      * API requests to the Google Batch service.
      *
-     * @param name The executor service name
+     * @param poolName The executor service thread pool name
      * @return A {@link ThrottlingExecutor} instance
      */
-    private ThrottlingExecutor createExecutorService(String name) {
+    private ThrottlingExecutor createExecutorService(String poolName) {
         final qs = 5_000
         final limit = config.getExecConfigProp(name, 'submitRateLimit', '50/s') as String
         final size = Runtime.runtime.availableProcessors() * 5
 
         final opts = new ThrottlingExecutor.Options()
-                .retryOn { Throwable t ->
-                    t instanceof UnavailableException ||
-                    t instanceof DeadlineExceededException ||
-                    t instanceof IOException ||
-                    t.cause instanceof IOException
-                }
+                // note: transient errors (unavailable, deadline exceeded, I/O) are already
+                // retried by the retry policy in BatchClient, therefore only the quota
+                // exhaustion error is handled here to trigger the submission auto-throttle
+                .retryOn { Throwable t -> t instanceof ResourceExhaustedException }
                 .onFailure { Throwable t -> session?.abort(t) }
                 .onRateLimitChange { RateUnit rate -> logRateLimitChange(rate) }
                 .withRateLimit(limit)
@@ -179,7 +176,7 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
                 .withKeepAlive(Duration.of('1 min'))
                 .withAutoThrottle(true)
                 .withMaxRetries(10)
-                .withPoolName(name)
+                .withPoolName(poolName)
 
         ThrottlingExecutor.create(opts)
     }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -807,7 +807,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         if( isActive() ) {
             log.trace "[GOOGLE BATCH] Process `${task.lazyName()}` - deleting job name=$jobId"
             if( executor.shouldDeleteJob(jobId) )
-                client.deleteJob(jobId)
+                executor.reaper.submit({ client.deleteJob(jobId) })
         }
         else {
             log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - invalid delete action"

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -52,6 +52,7 @@ import nextflow.script.BaseScript
 import nextflow.script.ProcessConfig
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
+import nextflow.util.ThrottlingExecutor
 import spock.lang.Specification
 /**
  *
@@ -621,6 +622,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
         given:
         def client = Mock(BatchClient)
         def executor = Mock(GoogleBatchExecutor)
+        def reaper = Mock(ThrottlingExecutor)
         def task = Mock(TaskRun)
         def handler = Spy(GoogleBatchTaskHandler)
         handler.@executor = executor
@@ -642,6 +644,8 @@ class GoogleBatchTaskHandlerTest extends Specification {
         then:
         handler.isActive() >> true
         1 * executor.shouldDeleteJob('job1') >> true
+        1 * executor.getReaper() >> reaper
+        1 * reaper.submit(_) >> { List args -> args[0].asType(Runnable).run(); null }
         and:
         1 * client.deleteJob('job1') >> null
 


### PR DESCRIPTION
I noticed that Nextflow was submitting my Google Batch array jobs very slowly, maybe about one submission every 3 seconds. That was despite no explicit submission throttling in my Nextflow config. In my investigation, I identified two sources of latency.

First, the Google Batch executor uses `TaskPollingMonitor` to submit jobs. This blocks on each submission and greatly limits the achievable throughput compared to the `ParallelPollingMonitor` used by the AWS Batch executor. To fix this, I essentially copied [the `AwsBatchExecutor` logic](https://github.com/nextflow-io/nextflow/blob/master/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy) in `GoogleBatchExecutor`. The retry exceptions were sourced from [`BatchClient`](https://github.com/nextflow-io/nextflow/blob/master/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy) and [documented here](https://docs.cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.rpc#exceptions).

Second, creation of task runs for job arrays happens sequentially in a for loop. I parallelized that.

I tested these changes using the following config and Nextflow script:

```nextflow
process {
    executor = 'google-batch'
    container = 'ubuntu:22.04'
    machineType = 'e2-medium'
    cpus = 1
    memory = '4 GB'
}

google {
    // Set your project ID
    project = 'PROJECT_ID'
    location = 'us-central1'
    batch {
        spot = true
        maxSpotAttempts = 3
    }
}
```

```nextflow
params.num_tasks = 50

process sayHello {
    tag "$task_id"

    array 5
    
    input:
    val task_id

    output:
    stdout

    script:
    """
    echo "Hello from task $task_id on \$(hostname)"
    sleep 5
    echo "Task $task_id completed"
    """
}

workflow {
    task_ids = Channel.of(1..params.num_tasks)
    sayHello(task_ids) | view
}
```
By reading `.nextflow.log`, I got the following times from starting Nextflow to submission of the final job:
| No changes | `ParallelPollingMonitor` | Parallel `createTaskArray` | Both |
| --- | ---| --- | --- | 
| 27 s | 28 s | 17 s | 8 s |