### PR TITLE
Read exit code from file for successful Google Batch jobs to avoid intermediate states

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -669,7 +669,10 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         if( state in COMPLETED ) {
             log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - terminated job=$jobId; task=$taskId; state=$state"
             // finalize the task
-            task.exitStatus = getExitCode()
+            // For SUCCEEDED state, read exit code from .exitcode file to avoid picking up
+            // intermediate exit codes (e.g., 50001 from spot preemption) from task events.
+            // For FAILED state, use getExitCode() which checks task events first.
+            task.exitStatus = (state == 'SUCCEEDED') ? readExitFile() : getExitCode()
             if( state == 'FAILED' ) {
                 // When no exit code or 500XX codes, get the jobError reason from events
                 if( task.exitStatus == Integer.MAX_VALUE || task.exitStatus >= 50000)


### PR DESCRIPTION
When `google.batch.maxSpotAttempts` is set to a value greater than 0, Google Batch handles retrying of jobs on VMs that fail with exit code 50001 ([spot preemption](https://docs.cloud.google.com/batch/docs/troubleshooting#vm_preemption_50001)). While retrying, the job continues to stay in a `RUNNING` state. Once the job finishes, Batch marks the job as `SUCCEEDED`, which triggers the block of code I modified in this PR.

Even though the `getExitCode` function is supposed to read all task exit codes and pick the most recent one, I frequently found that it picks up the 50001 exit code instead of the final exit code for jobs internally retried due to preemption. This causes the workflow to fail if the 50001 exit code is not handled in Nextflow as well, which defeats the purpose of letting Batch handle it. In all these cases, the `.exitcode` does have the correct final exit code of 0 (job was successful after all). Thus, to handle this case, I propose always reading from `.exitcode` for successful jobs as it appears to be more reliable than the Batch API when there is a preemption event.

Example messages in `.nextflow.log`
```bash
$ cat .nextflow.log | grep "sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000)"
Feb-19 13:14:01.659 [Task submitter] INFO  nextflow.Session - [3b/4416b0] Submitted process > sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000)
Feb-19 13:33:15.584 [Task monitor] DEBUG n.c.g.batch.GoogleBatchTaskHandler - [GOOGLE BATCH] Process `sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000)` - terminated job=nf-a4266646-1771506841059; task=0; state=SUCCEEDED
Feb-19 13:33:15.659 [Task monitor] DEBUG n.processor.TaskPollingMonitor - Task completed > TaskHandler[id: 3935; name: sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000); status: COMPLETED; exit: 50001; error: -; workDir: gs://vecoli-us-south/test-t2d-south/nextflow/nextflow_workdirs/3b/4416b09a42ab1f4c6d16c0e966e7fe]
  task: name=sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000); work-dir=gs://vecoli-us-south/test-t2d-south/nextflow/nextflow_workdirs/3b/4416b09a42ab1f4c6d16c0e966e7fe
  error [nextflow.exception.ProcessFailedException]: Process `sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000)` terminated with an error exit status (50001)
Feb-19 13:33:16.152 [TaskFinalizer-5] INFO  nextflow.processor.TaskProcessor - [3b/4416b0] NOTE: Process `sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000)` terminated with an error exit status (50001) -- Error is ignored
Feb-19 13:33:16.536 [TaskFinalizer-5] DEBUG nextflow.Session - Setting fail-on-ignore flag due to ignored task 'sim_gen_12 (variant=1/seed=8/generation=12/agent_id=000000000000)'
```