### PR TITLE
Fix S3 lookup unbounded pagination with double call

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3ObjectSummaryLookup.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3ObjectSummaryLookup.java
@@ -71,18 +71,27 @@ public class S3ObjectSummaryLookup {
 
         throw new NoSuchFileException("s3://" + s3Path.getBucket() + "/" + s3Path.getKey());
     }
+
     /**
-     * Lookup for the object summary for the specified object key
-     * by using a `listObjects` request.
+     * Lookup for the S3 object matching the specified path using at most two bounded
+     * {@code listObjects} calls (replaces the previous unbounded pagination loop).
      *
-     * It tries first with 2 results : the exact key match or its first
-     * child (key + "/"). Fetching more would cause unbounded pagination
-     * on prefixes with millions of objects.
-     *
-     * If not found in first 2 results try with 'key/' to check if it is a directory
-     **/
+     * @param s3Path the S3 path to look up
+     * @param client the S3 client
+     * @return the matching {@link S3Object}, or {@code null} if not found
+     */
     private S3Object getS3Object(S3Path s3Path, S3Client client) {
 
+        // Call 1: list up to 2 objects whose key starts with the target key.
+        //
+        // Why maxKeys(2) instead of paginating all results?
+        // The previous implementation used an unbounded while(true) loop fetching 250 keys
+        // per page. On prefixes with millions of objects this caused excessive S3 LIST API
+        // calls, high latency, and potential timeouts. Two results are enough to cover
+        // the common cases:
+        //   - Exact file match: the key itself exists as an object (e.g. "data.txt")
+        //   - Directory match: a child object (e.g. "data/file1") appears within the
+        //     first 2 lexicographic results
         ListObjectsRequest request = ListObjectsRequest.builder()
                 .bucket(s3Path.getBucket())
                 .prefix(s3Path.getKey())
@@ -97,7 +106,25 @@ public class S3ObjectSummaryLookup {
                 return item;
             }
         }
-        // Not found with provided key, try with directory 'key/'
+
+        // Call 2 (fallback): list 1 object with prefix "key/" to detect directories
+        // that Call 1 missed.
+        //
+        // Why can Call 1 miss a directory?
+        // S3 lists keys in lexicographic (UTF-8 byte) order, and several common characters
+        // sort *before* '/' (0x2F) — notably '-' (0x2D) and '.' (0x2E).
+        //
+        // Example: given keys "a-a/file-3", "a.txt", and "a/file-1", S3 returns them as:
+        //   a-a/file-3   ← '-' (0x2D) < '/' (0x2F)
+        //   a.txt         ← '.' (0x2E) < '/' (0x2F)
+        //   a/file-1      ← '/' (0x2F) — the actual directory child
+        //
+        // With maxKeys(2), Call 1 only sees "a-a/file-3" and "a.txt" — neither matches
+        // key "a" via matchName(). The directory child "a/file-1" is pushed beyond the
+        // result window by sibling keys that sort earlier.
+        //
+        // By searching with prefix "a/" directly, we skip all those siblings and find
+        // "a/file-1", confirming that "a" is a directory.
         request = ListObjectsRequest.builder()
                 .bucket(s3Path.getBucket())
                 .prefix(s3Path.getKey()+'/')

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
@@ -1432,6 +1432,12 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         deleteBucket(bucket1)
     }
 
+    // In S3, keys are listed in lexicographic order and characters such as '-' and '.'
+    // sort before '/'. For example, given keys 'a/', 'a-a/' and 'a.txt', the listing order
+    // is: 'a-a/', 'a.txt', 'a/' — the directory 'a/' appears last.
+    // This means a lookup for the directory 'a' may not find the 'a/' marker in the first
+    // page of results, so the implementation needs a fallback second call to reliably
+    // detect directories when sibling keys with smaller-than-'/' characters exist.
     def 'should exists file with similar files' () {
         given:
         def bucketName = createBucket()


### PR DESCRIPTION
## Problem

`S3ObjectSummaryLookup.lookup()` used an unbounded `while(true)` pagination loop that iterated through **all** objects sharing a given prefix (fetching 250 keys per page). On S3 buckets with large prefixes containing millions of objects, this caused excessive LIST API calls, high latency, and potential timeouts — just to check whether a single path exists.

## Solution

Replace the unbounded loop with at most **two** bounded `listObjects` calls:

1. **Call 1** — `prefix(key)`, `maxKeys(2)`: covers the common cases where the exact key or its first directory child appears within the first 2 lexicographic results.

2. **Call 2 (fallback)** — `prefix(key + "/")`, `maxKeys(1)`: needed because S3 lists keys in lexicographic (UTF-8 byte) order, and characters like `-` (0x2D) and `.` (0x2E) sort **before** `/` (0x2F). This means sibling keys such as `a-a/` and `a.txt` appear before `a/` in the listing, potentially pushing the directory child outside Call 1's result window. Call 2 searches with prefix `key/` directly, bypassing those siblings.

### Example of the lexicographic ordering issue

Given keys `a-a/file-3`, `a.txt`, and `a/file-1`, S3 returns them as:
```
a-a/file-3   ← '-' (0x2D) < '/' (0x2F)
a.txt         ← '.' (0x2E) < '/' (0x2F)
a/file-1      ← '/' (0x2F) — the actual directory child
```
With `maxKeys(2)`, Call 1 only sees `a-a/file-3` and `a.txt` — neither matches. Call 2 with prefix `a/` finds `a/file-1`, confirming that `a` is a directory.

Alternative to #6849