### PR TITLE
Report actual GCP zone in Google Batch trace records

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -561,6 +561,7 @@ class TaskRun implements Cloneable {
     static final public String CMD_STAGE = '.command.stage'
     static final public String CMD_TRACE = '.command.trace'
     static final public String CMD_ENV = '.command.env'
+    static final public String CMD_ZONE = '.command.zone'
 
 
     String toString( ) {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -109,6 +109,8 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
             result += 'chmod +x $HOME/.nextflow-bin/*\n'
             result += 'export PATH=$HOME/.nextflow-bin:$PATH\n'
         }
+        // capture the actual GCP zone from the instance metadata service
+        result += "curl -sf -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/zone > ${Escape.path(bean.workDir)}/${TaskRun.CMD_ZONE} 2>/dev/null || true\n"
         return result
     }
 


### PR DESCRIPTION
## Summary

Fixes #6646

The Google Batch API does not expose the actual zone where a task executes — it only provides the configured region (e.g. `europe-west2`). This means trace records report the region rather than the specific zone (e.g. `europe-west2-a`), which is important for cost analysis and debugging placement decisions.

This PR implements the workaround suggested by @pditommaso: querying the [GCP instance metadata service](https://cloud.google.com/compute/docs/metadata/overview) from within the task to capture the real zone.

## Changes

- **`TaskRun.groovy`** — Added `CMD_ZONE = '.command.zone'` constant for the zone metadata file
- **`GoogleBatchScriptLauncher.groovy`** — Inject a `curl` call to the GCP metadata endpoint (`http://metadata.google.internal/computeMetadata/v1/instance/zone`) in `headerScript()`, writing the result to `.command.zone` in the task work directory. The call is silent and non-fatal (`2>/dev/null || true`)
- **`GoogleBatchTaskHandler.groovy`** — On task completion, read `.command.zone`, parse the zone name from the metadata format (`projects/<id>/zones/<zone>`), and update the `CloudMachineInfo` with the actual zone. Uses a `volatile boolean zoneUpdated` flag to ensure the file is read at most once (avoiding repeated remote I/O on gcsfuse)

## Design decisions

- **Zone capture in `headerScript()`** — This runs at the top of `.command.run`, which executes for both regular tasks and array task children (each child runs its own `.command.run`). The parent array launcher (`.command.sh`) does not capture zone since each child writes its own `.command.zone`
- **Graceful degradation** — If the metadata service is unreachable (e.g. non-GCP environments, Fusion-enabled tasks that bypass `GoogleBatchScriptLauncher`), the trace record falls back to the configured region as before
- **Read-once semantics** — The `zoneUpdated` flag is set in a `finally` block, so even if reading fails, we don't retry on every `getMachineInfo()` call (which is invoked frequently by the polling monitor, Tower observer, and error handlers)

## Test plan

- [x] `GoogleBatchScriptLauncherTest` — 2 new tests: zone capture present in header script; zone capture absent from array launch command
- [x] `GoogleBatchTaskHandlerTest` — 6 new tests:
  - Zone updated from file on completion
  - Original zone preserved when file is missing
  - Null machineInfo returns null
  - Zone not updated when task is not completed
  - Malformed file content handled gracefully
  - Zone file read only once across multiple `getMachineInfo()` calls
- [x] All 76 tests pass (7 launcher + 69 handler), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)