### PR TITLE
feat: add a repository devcontainer for contributor onboarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Nextflow Dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "21"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "nextflow.nextflow",
+        "vscjava.vscode-java-pack",
+        "EditorConfig.EditorConfig"
+      ]
+    }
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=nextflow-gradle-cache,target=/home/vscode/.gradle,type=volume"
+  ],
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "updateContentCommand": "./gradlew --no-daemon help",
+  "containerEnv": {
+    "GRADLE_USER_HOME": "/home/vscode/.gradle"
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[devcontainer] Bootstrapping Nextflow development dependencies..."
+
+# Trigger Gradle wrapper download and prime common local build tasks.
+./gradlew --no-daemon --version
+./gradlew --no-daemon buildInfo compile
+
+echo "[devcontainer] Done."

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .nextflow*
 .node-nextflow*
 .devcontainer
+!.devcontainer/
+!.devcontainer/devcontainer.json
+!.devcontainer/post-create.sh
 .vscode/*
 .lineage/
 */*/bin/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,4 +44,6 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 
 The process is automatically managed by the [Probot](https://probot.github.io/apps/dco/) app for GitHub.
 
+If you prefer a reproducible local setup with minimal host dependencies, use the repository dev container in `.devcontainer/devcontainer.json` and open the project with VS Code's **Dev Containers: Reopen in Container** command.
+
 For more information about working on the Nextflow source code, visit the [Nextflow docs](https://nextflow.io/docs/latest/developer/).

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -38,6 +38,24 @@ After installing IntelliJ IDEA, use the following steps to use it with Nextflow:
 
 New files must include the appropriate license header boilerplate and the author name(s) and contact email(s) ([see for example](https://github.com/nextflow-io/nextflow/blob/e8945e8b6fc355d3f2eec793d8f288515db2f409/modules/nextflow/src/main/groovy/nextflow/Const.groovy#L1-L15)).
 
+## Dev Containers
+
+For a reproducible setup with minimal local dependencies, this repository includes a Development Container configuration in `.devcontainer/devcontainer.json`.
+
+It includes:
+
+- Java 21 (matching the configured Gradle toolchain)
+- Docker access for container-related development and tests
+- A persistent Gradle cache volume to speed up rebuilds
+
+To use it in VS Code:
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open the Nextflow repository in VS Code.
+3. Run **Dev Containers: Reopen in Container**.
+
+On first start, `.devcontainer/post-create.sh` runs to initialize Gradle dependencies and compile the project.
+
 ## Groovy
 
 Nextflow is written in [Groovy](http://groovy-lang.org/), which is itself a programming language based on [Java](https://www.java.com/). Groovy is designed to be highly interoperable with Java -- Groovy programs compile to Java bytecode, and nearly any Java program is also a valid Groovy program. However, Groovy adds several language features (e.g. closures, list and map literals, optional typing, optional semicolons, meta-programming) and standard libraries (e.g. JSON and XML parsing) that greatly improve the overall experience of developing for the Java virtual machine.


### PR DESCRIPTION
## Summary
This adds an opt-in Development Container configuration for contributors who want a reproducible local setup with minimal host dependencies.

### What is included
- `.devcontainer/devcontainer.json` with:
  - Java 21 (matching the configured Gradle toolchain)
  - Docker access (`docker-outside-of-docker`)
  - Persistent Gradle cache volume
  - Useful VS Code extensions for Nextflow and Java development
- `.devcontainer/post-create.sh` to bootstrap Gradle wrapper/dependencies and compile the project on first container creation
- Documentation updates in `docs/developer/index.md` and `CONTRIBUTING.md` showing how to use the dev container
- `.gitignore` updates to track the shared devcontainer config files

## Why
Issue #6791 requests first-class devcontainer support to reduce setup friction and make contributor environments reproducible.

## Validation
- `jq -e . .devcontainer/devcontainer.json`
- `bash -n .devcontainer/post-create.sh`
- I could not run Gradle tasks on the host because this environment does not have a local Java runtime installed.

Closes #6791
