### PR TITLE
docs: clarify Path.name for staged process path inputs

### DIFF
--- a/docs/reference/stdlib-types.md
+++ b/docs/reference/stdlib-types.md
@@ -521,8 +521,7 @@ The following properties are available:
 
 `name: String`
 : The path name, e.g. `/some/path/file.txt` -> `file.txt`.
-  For process `path` inputs staged into a subdirectory, this includes the staged relative path
-  (e.g. `my-dir/file.txt`). Use `fileName.name` to get only the file name in that case.
+: For files staged as a task input, the path name is the path relative to the task directory (e.g., `my-dir/file.txt`). Use `fileName.name` for task paths to get only the file name.
 
 `parent: Path`
 : The path parent path, e.g. `/some/path/file.txt` -> `/some/path`.


### PR DESCRIPTION
## Summary
Clarifies `Path.name` behavior in the stdlib reference for process task paths.

The current `name` property description says it returns only the file name, but for process `path` inputs staged into subdirectories it can include the staged relative path (for example `my-dir/file.txt`). This PR adds that caveat and points users to `fileName.name` for the leaf filename.

## Change
- Updated `docs/reference/stdlib-types.md` under `name: String`.

## Why
This keeps `stdlib-types` consistent with the behavior documented in `process.md` and avoids confusion reported in #5718.

Refs: #5718
