### PR TITLE
Propagate errors from workflow outputs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -34,7 +34,7 @@ class OutputDsl {
 
     private Map<String,Map> declarations = [:]
 
-    private Map<String,DataflowVariable> output = [:]
+    private Map<String,DataflowVariable> dataflowOutputs = [:]
 
     void declare(String name, Closure closure) {
         if( declarations.containsKey(name) )
@@ -71,7 +71,12 @@ class OutputDsl {
             final opts = publishOptions(name, defaults, overrides)
 
             if( opts.enabled == null || opts.enabled )
-                output[name] = new PublishOp(session, name, CH.getReadChannel(source), opts).apply()
+                dataflowOutputs[name] = new PublishOp(session, name, CH.getReadChannel(source), opts).apply()
+        }
+
+        // retrieve workflow outputs in order to propagate any errors
+        session.addIgniter {
+            getOutput()
         }
     }
 
@@ -94,7 +99,7 @@ class OutputDsl {
     }
 
     Map<String,Object> getOutput() {
-        output.collectEntries { name, dv -> [name, dv.get()] }
+        dataflowOutputs.collectEntries { name, dv -> [name, dv.get()] }
     }
 
     static class DeclareDsl {

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -77,7 +77,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         outputDir.resolve('foo/file1.txt').text == 'Hello'
@@ -122,7 +121,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         outputDir.resolve('file1.txt').text == 'Hello'
@@ -162,7 +160,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         0 * session.notifyFilePublish(_)
@@ -223,7 +220,9 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid path directive' () {
         when:
-        def session = new Session(outputDir: Path.of('results'))
+        def session = new Session(outputDir: Path.of('results')) {
+            void abort(Throwable cause) { throw cause }
+        }
 
         session.outputs.put('foo', Channel.of(1, 2, 3))
 
@@ -233,7 +232,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -243,7 +241,9 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid publish target' () {
         when:
-        def session = new Session(outputDir: Path.of('results'))
+        def session = new Session(outputDir: Path.of('results')) {
+            void abort(Throwable cause) { throw cause }
+        }
         def file = Path.of('output.txt')
 
         session.outputs.put('foo', Channel.of([file, file, file]))
@@ -254,7 +254,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -263,7 +262,9 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid publish source' () {
         when:
-        def session = new Session(outputDir: Path.of('results'))
+        def session = new Session(outputDir: Path.of('results')) {
+            void abort(Throwable cause) { throw cause }
+        }
 
         session.outputs.put('foo', Channel.of(42))
 
@@ -273,7 +274,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -283,7 +283,9 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid index file extension' () {
         when:
-        def session = new Session(outputDir: Path.of('results'))
+        def session = new Session(outputDir: Path.of('results')) {
+            void abort(Throwable cause) { throw cause }
+        }
 
         session.outputs.put('foo', Channel.empty())
 
@@ -295,7 +297,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -304,7 +305,9 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid published value' () {
         when:
-        def session = new Session(outputDir: Path.of('results'))
+        def session = new Session(outputDir: Path.of('results')) {
+            void abort(Throwable cause) { throw cause }
+        }
 
         session.outputs.put('foo', Channel.of(42))
 
@@ -313,7 +316,6 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
-        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)


### PR DESCRIPTION
Close #6870 

This PR adds an explicit call to `getOutput()` in OutputDsl, to ensure that any errors from PublishOp are propagated to the top

Errors thrown in PublishOp are bound to the op's dataflow variable, so that they are thrown when `OutputDsl::getOutput()` calls `get()` on each variable. But `getOutput()` was only being called in the unit tests, not the run itself

To fix this, we simply add a session igniter that awaits the output

NOTE: The output igniter needs to be added after all other dataflow igniters, or else the run will hang. This ordering is guaranteed by BaseScript:

https://github.com/nextflow-io/nextflow/blob/6bd2f6a617b1ba3580eb7e512b67d18b3ebced1a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy#L244-L246