### PR TITLE
Add logStreamId to Tower task record

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -667,6 +667,7 @@ class TowerClient implements TraceObserverV2 {
         record.machineType = trace.getMachineInfo()?.type
         record.priceModel = trace.getMachineInfo()?.priceModel?.toString()
         record.numSpotInterruptions = trace.getNumSpotInterruptions()
+        record.logStreamId = trace.getLogStreamId()
 
         return record
     }

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -605,6 +605,31 @@ class TowerClientTest extends Specification {
         req.tasks[0].numSpotInterruptions == 3
     }
 
+    def 'should include logStreamId in task map'() {
+        given:
+        def client = Spy(new TowerClient())
+        client.getWorkflowProgress(true) >> new WorkflowProgress()
+
+        def now = System.currentTimeMillis()
+        def trace = new TraceRecord([
+            taskId: 42,
+            process: 'foo',
+            workdir: "/work/dir",
+            cpus: 1,
+            submit: now-2000,
+            start: now-1000,
+            complete: now
+        ])
+        trace.setLogStreamId('arn:aws:logs:us-east-1:123456789:log-group:/ecs/task:log-stream:abc123')
+
+        when:
+        def req = client.makeTasksReq([trace])
+
+        then:
+        req.tasks.size() == 1
+        req.tasks[0].logStreamId == 'arn:aws:logs:us-east-1:123456789:log-group:/ecs/task:log-stream:abc123'
+    }
+
     def 'should include accelerator request in task map'() {
         given:
         def client = Spy(new TowerClient())


### PR DESCRIPTION
## Summary
- Propagate `logStreamId` from `TraceRecord` to the Tower task record so Seqera Platform can link tasks to their cloud log streams
- Add test coverage for the new field in `TowerClientTest`

## Test plan
- [x] Existing `TowerClientTest` tests pass
- [x] New test verifies `logStreamId` is included in the task map

🤖 Generated with [Claude Code](https://claude.com/claude-code)