### PR TITLE
bot attempt to figure the bug, based on reproducible example

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -796,7 +796,7 @@ class TaskProcessor {
     @CompileStatic
     final protected void checkCachedOrLaunchTask( TaskRun task, HashCode hash, boolean shouldTryCache ) {
 
-        int tries = task.failCount +1
+        int tries = 1
         while( true ) {
             hash = HashBuilder.defaultHasher().putBytes(hash.asBytes()).putInt(tries).hash()
 
@@ -1050,8 +1050,13 @@ class TaskProcessor {
                 final taskCopy = task.makeCopy()
                 session.getExecService().submit {
                     try {
+                        // Compute the base hash with attempt=1 so the hash chain is consistent
+                        // with what checkCachedOrLaunchTask produces on -resume (which always
+                        // starts from a fresh task with attempt=1).
+                        taskCopy.config.attempt = 1
+                        final retryHash = new TaskHasher(taskCopy).compute()
                         taskCopy.runType = RunType.RETRY
-                        checkCachedOrLaunchTask( taskCopy, taskCopy.hash, false )
+                        checkCachedOrLaunchTask( taskCopy, retryHash, false )
                     }
                     catch( Throwable e ) {
                         log.error("Unable to re-submit task `${taskCopy.name}`", e)
@@ -1170,11 +1175,17 @@ class TaskProcessor {
                 final taskCopy = task.makeCopy()
                 session.getExecService().submit({
                     try {
+                        // Compute the base hash with attempt=1 so the hash chain is consistent
+                        // with what checkCachedOrLaunchTask produces on -resume (which always
+                        // starts from a fresh task with attempt=1).  This must happen before
+                        // taskCopy.config.attempt is bumped to the retry attempt number.
+                        taskCopy.config.attempt = 1
+                        final retryHash = new TaskHasher(taskCopy).compute()
                         taskCopy.config.attempt = taskErrCount+1
                         taskCopy.config.submitAttempt = submitRetries+1
                         taskCopy.runType = RunType.RETRY
                         taskCopy.resolve(taskBody)
-                        checkCachedOrLaunchTask( taskCopy, taskCopy.hash, false )
+                        checkCachedOrLaunchTask( taskCopy, retryHash, false )
                     }
                     catch( Throwable e ) {
                         log.error("Unable to re-submit task `${safeTaskName(taskCopy)}`", e)


### PR DESCRIPTION
Related to issue #6884

I (and other people in my team) have long been suffering from seemingly random cache failures of Nextflow, here and there. I think I have tracked down the culprit and posted a reproducible example on the relevant [issue above](https://github.com/nextflow-io/nextflow/issues/6884) and at a [blog post](https://community.seqera.io/t/steps-for-reproducible-example-for-broken-nextflow-cache-after-successful-retries/2600).

I fed this example to the bots and they tried to pinpoint the culprit, so this PR is to potentially give the direction to where the bug-fix might be hiding.

Hope this helps!

Bot report:
```
Root Cause

  The bug is a hash chain mismatch between the retry path and the resume path.

  checkCachedOrLaunchTask builds a chain:
  H1 = hash(H_base + 1)
  H2 = hash(H1   + 2)
  H3 = hash(H2   + 3)   ← tries increments each iteration

  The resume always starts with tries=1 from H_base (a fresh task with attempt=1), correctly traversing the chain.

  The retry (old code) called checkCachedOrLaunchTask(taskCopy, taskCopy.hash, false), where taskCopy.hash was the chained hash of the last
  failed attempt (e.g. H2) — not H_base. Then internally used tries = task.failCount + 1.

  In the user's scenario (one killed prior attempt + one OOM failure before the successful retry):

  ┌─────────────────┬───────────────┬────────────┬──────────────────────────┐
  │      Path       │ Starting hash │ tries used │          Result          │
  ├─────────────────┼───────────────┼────────────┼──────────────────────────┤
  │ Retry (old)     │ H2            │ 2          │ hash(H2 + 2) = H3_retry  │
  ├─────────────────┼───────────────┼────────────┼──────────────────────────┤
  │ Resume (step 3) │ H_base → ...  │ 3          │ hash(H2 + 3) = H3_resume │
  └─────────────────┴───────────────┴────────────┴──────────────────────────┘

  H3_retry ≠ H3_resume — the resume never finds the cached result.

  Fix (3 changes to TaskProcessor.groovy)

  1. checkCachedOrLaunchTask (line 799): tries = task.failCount + 1 → tries = 1. The loop always starts at position 1 and naturally advances
  past any existing directories.
  2. Path 1 retry (spot preemption / transient errors): Inside the submit block, set taskCopy.config.attempt = 1 and compute retryHash = new
  TaskHasher(taskCopy).compute() (= H_base). Pass retryHash instead of taskCopy.hash.
  3. Path 2 retry (RETRY error strategy): Same pattern — compute H_base with attempt=1 before taskCopy.config.attempt is bumped to
  taskErrCount+1. The loop then traverses H1→H2→H3 exactly as the resume will, landing on the same hash position.
  ```