### PR TITLE
Add Google Batch secret variables support

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchExecutor.groovy
@@ -70,6 +70,11 @@ class GoogleBatchExecutor extends Executor implements ExtensionPoint, TaskArrayE
     }
 
     @Override
+    final boolean isSecretNative() {
+        return true
+    }
+
+    @Override
     String containerConfigEngine() {
         return 'docker'
     }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -34,10 +34,12 @@ import com.google.cloud.batch.v1.TaskSpec
 import com.google.cloud.batch.v1.Volume
 import com.google.cloud.storage.contrib.nio.CloudStoragePath
 import com.google.protobuf.Duration
+import groovy.json.JsonSlurper
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
+import nextflow.SysEnv
 import nextflow.cloud.google.batch.client.BatchClient
 import nextflow.cloud.google.batch.client.BatchConfig
 import nextflow.cloud.types.CloudMachineInfo
@@ -327,14 +329,41 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         if( containerOptions )
             container.setOptions(containerOptions)
 
-        final env = Environment.newBuilder()
+        final envBuilder = Environment.newBuilder()
             .putAllVariables(launcher.getEnvironment())
-            .build()
+        final secretVars = getSecretVariables()
+        if( secretVars )
+            envBuilder.putAllSecretVariables(secretVars)
+        final env = envBuilder.build()
 
         return Runnable.newBuilder()
             .setContainer(container)
             .setEnvironment(env)
             .build()
+    }
+
+    /**
+     * Reads the GCP Secret Manager variable references set by Seqera Platform
+     * via the {@code NXF_GOOGLE_SECRET_VARS} environment variable.
+     *
+     * The value is a Base64-encoded JSON map of secret names to Secret Manager
+     * resource paths, e.g.:
+     * {@code {"MY_SECRET":"projects/my-project/secrets/tower-wf123-MY_SECRET/versions/latest"}}
+     *
+     * @return A map of secret variable names to GCP Secret Manager paths, or null if not set.
+     */
+    protected Map<String,String> getSecretVariables() {
+        final encoded = SysEnv.get('NXF_GOOGLE_SECRET_VARS')
+        if( !encoded )
+            return null
+        try {
+            final json = new String(encoded.decodeBase64())
+            return (Map<String,String>) new JsonSlurper().parseText(json)
+        }
+        catch( Exception e ) {
+            log.warn "[GOOGLE BATCH] Failed to decode NXF_GOOGLE_SECRET_VARS - ${e.message}"
+            return null
+        }
     }
 
     /**

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchExecutorTest.groovy
@@ -140,6 +140,13 @@ class GoogleBatchExecutorTest extends Specification {
         false   | true        | '/nfs/work/dir'     | 'bash /nfs/work/dir/.command.run 2>&1 > /nfs/work/dir/.command.log'
     }
 
+    def 'should report secret native' () {
+        given:
+        def executor = Spy(GoogleBatchExecutor)
+        expect:
+        executor.isSecretNative()
+    }
+
     def 'should validate shouldDeleteJob method' () {
         given:
         def executor = Spy(GoogleBatchExecutor)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -1225,6 +1225,107 @@ class GoogleBatchTaskHandlerTest extends Specification {
         'picks first zone match'    | [StatusEvent.newBuilder().setDescription('no zone here').build(), StatusEvent.newBuilder().setDescription('on zones/us-east1-b/instances/i-1').build()]                      | 'us-east1-b'
     }
 
+    def 'should return null secret variables when env var is not set' () {
+        given:
+        def handler = Spy(GoogleBatchTaskHandler)
+
+        when:
+        def result = handler.getSecretVariables()
+
+        then:
+        result == null
+    }
+
+    def 'should decode secret variables from base64 encoded JSON' () {
+        given:
+        def secrets = '{"ALT_USER":"projects/my-project/secrets/tower-wf123-ALT_USER/versions/latest","ALT_PASS":"projects/my-project/secrets/tower-wf123-ALT_PASS/versions/latest"}'
+        def encoded = secrets.bytes.encodeBase64().toString()
+        SysEnv.push(NXF_GOOGLE_SECRET_VARS: encoded)
+        def handler = Spy(GoogleBatchTaskHandler)
+
+        when:
+        def result = handler.getSecretVariables()
+
+        then:
+        result == [
+            ALT_USER: 'projects/my-project/secrets/tower-wf123-ALT_USER/versions/latest',
+            ALT_PASS: 'projects/my-project/secrets/tower-wf123-ALT_PASS/versions/latest'
+        ]
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should return null for invalid secret variables encoding' () {
+        given:
+        SysEnv.push(NXF_GOOGLE_SECRET_VARS: 'not-valid-base64!!!')
+        def handler = Spy(GoogleBatchTaskHandler)
+
+        when:
+        def result = handler.getSecretVariables()
+
+        then:
+        result == null
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should build container runnable with secret variables' () {
+        given:
+        def secrets = '{"MY_SECRET":"projects/test-project/secrets/tower-wf1-MY_SECRET/versions/latest"}'
+        def encoded = secrets.bytes.encodeBase64().toString()
+        SysEnv.push(NXF_GOOGLE_SECRET_VARS: encoded)
+        and:
+        def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')
+        def exec = Mock(GoogleBatchExecutor)
+        def task = Mock(TaskRun) {
+            getHashLog() >> 'abcd1234'
+            getWorkDir() >> WORK_DIR
+            getContainer() >> 'ubuntu:latest'
+            getConfig() >> Mock(TaskConfig) {
+                getContainerOptions() >> ''
+            }
+        }
+        def handler = Spy(new GoogleBatchTaskHandler(task, exec))
+        def launcher = new GoogleBatchLauncherSpecMock('bash .command.run', [], [], [VAR1: 'value1'])
+
+        when:
+        def result = handler.buildContainerRunnable(task, launcher)
+
+        then:
+        handler.fusionEnabled() >> false
+        result.getEnvironment().getVariablesMap() == [VAR1: 'value1']
+        result.getEnvironment().getSecretVariablesMap() == [MY_SECRET: 'projects/test-project/secrets/tower-wf1-MY_SECRET/versions/latest']
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should build container runnable without secret variables when env var is not set' () {
+        given:
+        def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')
+        def exec = Mock(GoogleBatchExecutor)
+        def task = Mock(TaskRun) {
+            getHashLog() >> 'abcd1234'
+            getWorkDir() >> WORK_DIR
+            getContainer() >> 'ubuntu:latest'
+            getConfig() >> Mock(TaskConfig) {
+                getContainerOptions() >> ''
+            }
+        }
+        def handler = Spy(new GoogleBatchTaskHandler(task, exec))
+        def launcher = new GoogleBatchLauncherSpecMock('bash .command.run', [], [], [VAR1: 'value1'])
+
+        when:
+        def result = handler.buildContainerRunnable(task, launcher)
+
+        then:
+        handler.fusionEnabled() >> false
+        result.getEnvironment().getVariablesMap() == [VAR1: 'value1']
+        result.getEnvironment().getSecretVariablesMap() == [:]
+    }
+
     def 'should build container runnable with fusion privileged' () {
         given:
         def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')


### PR DESCRIPTION
## Summary

Enable native secret injection for Google Batch worker tasks via GCP Secret Manager, fixing [COMP-1403](https://seqera.atlassian.net/browse/COMP-1403).

Currently, secrets stored by Seqera Platform in GCP Secret Manager (`tower-{workflowId}-{secretName}`) are never injected into running Google Batch task containers. This is because:
1. `GoogleBatchExecutor` doesn't override `isSecretNative()` → Nextflow tries (and fails) to inject secrets via bash wrapper
2. `GoogleBatchTaskHandler.buildContainerRunnable()` never calls `putAllSecretVariables()` on the worker task `Environment`

Unlike AWS Batch (which reuses job definitions with secrets baked in), Google Batch creates a **new job per worker task** from Nextflow. So the task handler needs to explicitly set `secretVariables` on each worker task's Environment proto.

## Changes

- **`GoogleBatchExecutor`**: Override `isSecretNative()` to return `true` — tells Nextflow to skip bash wrapper secret injection (`{{secrets_env}}`)
- **`GoogleBatchTaskHandler`**: Add `getSecretVariables()` method that reads `NXF_GOOGLE_SECRET_VARS` (base64-encoded JSON map set by Platform on the head job) and call `putAllSecretVariables()` in `buildContainerRunnable()`

## Contract with Platform

Platform sets `NXF_GOOGLE_SECRET_VARS` as a regular env var on the head job. The value is a Base64-encoded JSON map:
```json
{
  "ALT_USER": "projects/my-project/secrets/tower-wf123-ALT_USER/versions/latest",
  "ALT_PASS": "projects/my-project/secrets/tower-wf123-ALT_PASS/versions/latest"
}
```

This is not a secret itself — it only contains Secret Manager **paths**, not actual values. GCP resolves them at runtime.

**Companion Platform PR**: [seqeralabs/platform#10356](https://github.com/seqeralabs/platform/pull/10356) (needs additional changes to set `NXF_GOOGLE_SECRET_VARS` and `NXF_ENABLE_SECRETS=true`)

## End-to-end flow

```mermaid
sequenceDiagram
    participant P as Platform
    participant SM as GCP Secret Manager
    participant H as Nextflow (head job)
    participant W as Google Batch (worker tasks)

    Note over P: Launch workflow with secrets

    P->>SM: storeSecret("tower-wf123-ALT_USER", value)
    P->>SM: storeSecret("tower-wf123-ALT_PASS", value)

    Note over P: Build head job request
    P->>P: secretVariables = {ALT_USER: "projects/.../versions/latest"}
    P->>P: env.NXF_GOOGLE_SECRET_VARS = base64(json(secretVariables))
    P->>P: env.NXF_ENABLE_SECRETS = "true"

    P->>H: Submit head job (env + secretVariables)

    SM-->>H: GCP injects secrets as env vars
    Note over H: ALT_USER=actual_value<br/>NXF_GOOGLE_SECRET_VARS=base64

    H->>H: isSecretNative() = true<br/>(skip bash wrapper injection)

    Note over H: For each process task:
    H->>H: getSecretVariables()<br/>decode NXF_GOOGLE_SECRET_VARS
    H->>W: Submit worker job<br/>putAllSecretVariables()

    SM-->>W: GCP injects secrets as env vars
    Note over W: ALT_USER=actual_value
```

## Test plan

- [x] Unit test: `getSecretVariables()` returns null when env var not set
- [x] Unit test: `getSecretVariables()` decodes valid base64 JSON correctly
- [x] Unit test: `getSecretVariables()` returns null on invalid encoding (with warning)
- [x] Unit test: `buildContainerRunnable()` includes `secretVariablesMap` when env var set
- [x] Unit test: `buildContainerRunnable()` has empty `secretVariablesMap` when env var absent
- [x] Unit test: `isSecretNative()` returns true
- [ ] E2E: Launch workflow with secrets on Google Batch CE and verify secrets are accessible in process scripts (requires Platform companion changes)

[COMP-1403]: https://seqera.atlassian.net/browse/COMP-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ