### PR TITLE
Increase tasks.cloudZone width from 15 to 25

### DIFF
--- a/plugins/nf-tower/src/resources/tower-schema.properties
+++ b/plugins/nf-tower/src/resources/tower-schema.properties
@@ -70,7 +70,7 @@ tasks.nativeId = 100
 tasks.module = 255
 tasks.executor = 25
 tasks.machineType = 25
-tasks.cloudZone = 15
+tasks.cloudZone = 25
 tasks.priceModel = 15
 # process progress
 progress.name = 255


### PR DESCRIPTION
## Summary

- Increase `tasks.cloudZone` column width in `tower-schema.properties` from 15 to 25 to match the Tower schema.
- AWS zone names fit within 15 characters, but GCP has zones exceeding that limit (e.g. `australia-southeast2-a` at 24 chars), causing truncation.
- Aligns Nextflow with the actual Tower column width of 25.