### PR TITLE
feat: add native support for TPUs and multi-vendor hardware accelerators

### DIFF
--- a/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -683,10 +683,9 @@ class PodSpecBuilder {
         // Default to standard NVIDIA GPU if left entirely blank.
         def type = accelerator.type?.toLowerCase() ?: 'nvidia.com'
 
-        if (type.contains('/')) {
+        if ( type.contains('/') )
             // Assume the user has fully specified the resource type.
             return type
-        }
 
         // Map common vendor shorthands to their standard K8s Extended Resource strings.
         if (type =~ /\b(nvidia|tesla|ampere|h100|a100)\b/)  return 'nvidia.com/gpu'

--- a/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -680,28 +680,28 @@ class PodSpecBuilder {
     @PackageScope
     String getAcceleratorType(AcceleratorResource accelerator) {
 
-    // Default to standard NVIDIA GPU if left entirely blank.
-    def type = accelerator.type?.toLowerCase() ?: 'nvidia.com/gpu'
+        // Default to standard NVIDIA GPU if left entirely blank.
+        def type = accelerator.type?.toLowerCase() ?: 'nvidia.com'
 
-    if (type.contains('/')) {
-        // Assume the user has fully specified the resource type.
-        return type
+        if (type.contains('/')) {
+            // Assume the user has fully specified the resource type.
+            return type
+        }
+
+        // Map common vendor shorthands to their standard K8s Extended Resource strings.
+        if (type =~ /\b(nvidia|tesla|ampere|h100|a100)\b/)  return 'nvidia.com/gpu'
+        if (type =~ /\b(amd|radeon|instinct)\b/)            return 'amd.com/gpu'
+        if (type =~ /\b(tpu|google)\b/)                     return 'google.com/tpu'
+        if (type =~ /\b(neuron|inferentia|trainium|aws)\b/) return 'aws.amazon.com/neuron'
+        if (type =~ /\b(intel|gaudi)\b/)                    return 'gpu.intel.com/i915'
+
+        // keep custom domain names
+        if( !type.contains('.') ) type += '.com'
+
+        // Append /gpu if not there yet
+        return "${type}/gpu"
+
     }
-
-    // Map common vendor shorthands to their standard K8s Extended Resource strings.
-    if (type =~ /\b(nvidia|tesla|ampere|h100|a100)\b/)  return 'nvidia.com/gpu'
-    if (type =~ /\b(amd|radeon|instinct)\b/)            return 'amd.com/gpu'
-    if (type =~ /\b(tpu|google)\b/)                     return 'google.com/tpu'
-    if (type =~ /\b(neuron|inferentia|trainium|aws)\b/) return 'aws.amazon.com/neuron'
-    if (type =~ /\b(intel|gaudi)\b/)                    return 'gpu.intel.com/i915'
-
-    // keep custom domain names
-    if( !type.contains('.') ) type += '.com'
-
-    // Append /gpu if not there yet
-    return "${type}/gpu"
-
-}
 
 
     @PackageScope

--- a/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -680,18 +680,28 @@ class PodSpecBuilder {
     @PackageScope
     String getAcceleratorType(AcceleratorResource accelerator) {
 
-        def type = accelerator.type ?: 'nvidia.com'
+    // Default to standard NVIDIA GPU if left entirely blank.
+    def type = accelerator.type?.toLowerCase() ?: 'nvidia.com/gpu'
 
-        if ( type.contains('/') )
-            // Assume the user has fully specified the resource type.
-            return type
-
-        // Assume we're using GPU and update as necessary.
-        if( !type.contains('.') ) type += '.com'
-        type += '/gpu'
-
+    if (type.contains('/')) {
+        // Assume the user has fully specified the resource type.
         return type
     }
+
+    // Map common vendor shorthands to their standard K8s Extended Resource strings.
+    if (type =~ /\b(nvidia|tesla|ampere|h100|a100)\b/)  return 'nvidia.com/gpu'
+    if (type =~ /\b(amd|radeon|instinct)\b/)            return 'amd.com/gpu'
+    if (type =~ /\b(tpu|google)\b/)                     return 'google.com/tpu'
+    if (type =~ /\b(neuron|inferentia|trainium|aws)\b/) return 'aws.amazon.com/neuron'
+    if (type =~ /\b(intel|gaudi)\b/)                    return 'gpu.intel.com/i915'
+
+    // keep custom domain names
+    if( !type.contains('.') ) type += '.com'
+
+    // Append /gpu if not there yet
+    return "${type}/gpu"
+
+}
 
 
     @PackageScope

--- a/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/model/PodSpecBuilder.groovy
@@ -695,12 +695,11 @@ class PodSpecBuilder {
         if (type =~ /\b(neuron|inferentia|trainium|aws)\b/) return 'aws.amazon.com/neuron'
         if (type =~ /\b(intel|gaudi)\b/)                    return 'gpu.intel.com/i915'
 
-        // keep custom domain names
+        // Assume we're using GPU and update as necessary.
         if( !type.contains('.') ) type += '.com'
+        type += '/gpu'
 
-        // Append /gpu if not there yet
-        return "${type}/gpu"
-
+        return type
     }
 
 

--- a/plugins/nf-k8s/src/test/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -622,7 +622,7 @@ class PodSpecBuilderTest extends Specification {
         inputType              | req | lim | existing              | expectedReq                        | expectedLim
         null                   | 2   | 5   | null                  | ['nvidia.com/gpu': 2]              | ['nvidia.com/gpu': 5]
         'foo'                  | null| 5   | null                  | ['foo.com/gpu': 5]                 | ['foo.com/gpu': 5]
-        'foo.org'              | 5   | null| null                  | ['foo.org/gpu': 5]                | null
+        'foo.org'              | 5   | null| null                  | ['foo.org/gpu': 5]                 | null
         'foo.org'              | 5   | null| [requests: [cpu: 2]]  | [cpu: 2, 'foo.org/gpu': 5]         | null
         'foo.org'              | 5   | 10  | [requests: [cpu: 2]]  | [cpu: 2, 'foo.org/gpu': 5]         | ['foo.org/gpu': 10]
         'example.com/fpga'     | 5   | null| null                  | ['example.com/fpga': 5]            | null

--- a/plugins/nf-k8s/src/test/nextflow/k8s/model/PodSpecBuilderTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/model/PodSpecBuilderTest.groovy
@@ -613,47 +613,24 @@ class PodSpecBuilderTest extends Specification {
         given:
         def builder = new PodSpecBuilder()
 
-        when:
-        def res = builder.addAcceleratorResources(new AcceleratorResource(request:2, limit: 5), null)
-        then:
-        res.requests == ['nvidia.com/gpu': 2]
-        res.limits == ['nvidia.com/gpu': 5]
+        expect:
+        def res = builder.addAcceleratorResources(new AcceleratorResource(request: req, limit: lim, type: inputType), existing)
+        res.requests == expectedReq
+        res.limits == expectedLim
 
-        when:
-        res = builder.addAcceleratorResources(new AcceleratorResource(limit: 5, type:'foo'), null)
-        then:
-        res.requests == ['foo.com/gpu': 5]
-        res.limits == ['foo.com/gpu': 5]
-
-        when:
-        res = builder.addAcceleratorResources(new AcceleratorResource(request: 5, type:'foo.org'), null)
-        then:
-        res.requests == ['foo.org/gpu': 5]
-        res.limits == null
-
-        when:
-        res = builder.addAcceleratorResources(new AcceleratorResource(request: 5, type: 'foo.org'), [requests: [cpu: 2]])
-        then:
-        res.requests == [cpu: 2, 'foo.org/gpu': 5]
-        res.limits == null
-
-        when:
-        res = builder.addAcceleratorResources(new AcceleratorResource(request: 5, limit: 10, type: 'foo.org'), [requests: [cpu: 2]])
-        then:
-        res.requests == [cpu: 2, 'foo.org/gpu': 5]
-        res.limits == ['foo.org/gpu': 10]
-
-        when:
-        res = builder.addAcceleratorResources(new AcceleratorResource(request: 5, type:'example.com/fpga'), null)
-        then:
-        res.requests == ['example.com/fpga': 5]
-        res.limits == null
-
-        when:
-        res = builder.addAcceleratorResources(new AcceleratorResource(request: 5, limit: 10, type: 'example.com/fpga'), [requests: [cpu: 2]])
-        then:
-        res.requests == [cpu: 2, 'example.com/fpga': 5]
-        res.limits == ['example.com/fpga': 10]
+        where:
+        inputType              | req | lim | existing              | expectedReq                        | expectedLim
+        null                   | 2   | 5   | null                  | ['nvidia.com/gpu': 2]              | ['nvidia.com/gpu': 5]
+        'foo'                  | null| 5   | null                  | ['foo.com/gpu': 5]                 | ['foo.com/gpu': 5]
+        'foo.org'              | 5   | null| null                  | ['foo.org/gpu': 5]                | null
+        'foo.org'              | 5   | null| [requests: [cpu: 2]]  | [cpu: 2, 'foo.org/gpu': 5]         | null
+        'foo.org'              | 5   | 10  | [requests: [cpu: 2]]  | [cpu: 2, 'foo.org/gpu': 5]         | ['foo.org/gpu': 10]
+        'example.com/fpga'     | 5   | null| null                  | ['example.com/fpga': 5]            | null
+        'nvidia-tesla-k80'     | 4   | 4   | null                  | ['nvidia.com/gpu': 4]              | ['nvidia.com/gpu': 4]
+        'tpu-v5-lite-podslice' | 8   | 8   | null                  | ['google.com/tpu': 8]              | ['google.com/tpu': 8]
+        'amd-instinct-mi300'   | 2   | 2   | null                  | ['amd.com/gpu': 2]                 | ['amd.com/gpu': 2]
+        'aws-trn1-32xlarge'    | 8   | 8   | null                  | ['aws.amazon.com/neuron': 8]       | ['aws.amazon.com/neuron': 8]
+        'intel-gaudi-3'        | 1   | 1   | null                  | ['gpu.intel.com/i915': 1]          | ['gpu.intel.com/i915': 1]
     }
 
     def 'should add resources limits' () {


### PR DESCRIPTION
This PR extends the PodSpecBuilder to natively support a wider range of hardware accelerators, specifically targeting Google TPUs (GKE), AMD GPUs, AWS Neuron (Inferentia/Trainium), and Intel Gaudi devices. It removes the need for manual pod directive overrides by automatically mapping common hardware shorthands to their correct Kubernetes Extended Resource strings.

Previously, the getAcceleratorType logic was heavily biased toward NVIDIA GPUs (nvidia.com/gpu). If a user requested a TPU or an AMD GPU using shorthand (e.g., accelerator: 'tpu'), the builder would either fail to map it correctly or produce an invalid resource string like tpu.com/gpu. This forced AI/ML practitioners to manually override Pod specs to run workloads on non-NVIDIA hardware.