### PR TITLE
Fix stageAs method signature in typed process

### DIFF
--- a/adr/20260306-record-types.md
+++ b/adr/20260306-record-types.md
@@ -357,7 +357,7 @@ process PROKKA {
 
     output:
     record(
-        id: sample.meta.id,
+        meta: sample.meta,
         gff: file("${prefix}/*.gff"),
         gbk: file("${prefix}/*.gbk"),
         fna: file("${prefix}/*.fna"),

--- a/docs/process-typed.md
+++ b/docs/process-typed.md
@@ -75,7 +75,7 @@ process cat_opt {
     input: Path?
 
     stage:
-    stageAs 'input.txt', input
+    stageAs input, 'input.txt'
 
     output:
     stdout()
@@ -202,6 +202,10 @@ process cat {
 
 ### Custom file staging
 
+:::{versionchanged} 26.04.0
+The method signature for `stageAs` was changed from `(filePattern, value)` to `(value, filePattern)`.
+:::
+
 The `stageAs` directive stages an input file (or files) under a custom file pattern:
 
 ```nextflow
@@ -210,7 +214,7 @@ process blast {
     fasta: Path
 
     stage:
-    stageAs 'query.fa', fasta
+    stageAs fasta, 'query.fa'
 
     script:
     """
@@ -228,7 +232,7 @@ process grep {
     fasta: Path
 
     stage:
-    stageAs "${id}.fa", fasta
+    stageAs fasta, "${id}.fa"
 
     script:
     """
@@ -316,7 +320,10 @@ process fastqc {
     }
 
     output:
-    record(id: sample.id, fastqc: file('fastqc_logs'))
+    record(
+        id: sample.id,
+        fastqc: file('fastqc_logs')
+    )
 
     script:
     // ...

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -73,10 +73,10 @@ The following directives can be used in the `stage:` section of a typed process:
 `env( name: String, String value )`
 : Declares an environment variable with the specified name and value in the task environment.
 
-`stageAs( filePattern: String, value: Path )`
+`stageAs( value: Path, filePattern: String )`
 : Stages a file into the task directory under the given alias.
 
-`stageAs( filePattern: String, value: Iterable<Path> )`
+`stageAs( value: Iterable<Path>, filePattern: String )`
 : Stages a collection of files into the task directory under the given alias.
 
 `stdin( value: String )`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -266,8 +266,8 @@ Outputs can be conditionally published using pipeline parameters:
 output {
     samples {
         path { sample ->
-            sample.fastqc >> "fastqc"
-            sample.bam >> params.save_bams ? "align" : null
+            sample.fastqc >> "fastqc/"
+            sample.bam >> (params.save_bams ? "align/" : null)
         }
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessDslV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessDslV2.groovy
@@ -100,10 +100,10 @@ class ProcessDslV2 extends ProcessBuilder {
      * Declare a file or collection of files to be staged into
      * the task directory under the given file pattern.
      *
-     * @param filePattern [String | Closure]
      * @param value       [Path | Collection<Path> | Closure]
+     * @param filePattern [String | Closure]
      */
-    void stageAs(Object filePattern, Object value) {
+    void stageAs(Object value, Object filePattern) {
         inputs.addFile(new ProcessFileInput(filePattern, value))
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessDslV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessDslV2Test.groovy
@@ -40,7 +40,7 @@ class ProcessDslV2Test extends Specification {
         dsl._input_('infile', Path, false)
         dsl._input_('x', String, false)
         dsl._input_('y', String, false)
-        dsl.stageAs('filename.fa', { infile })
+        dsl.stageAs({ infile }, 'filename.fa')
         dsl.stdin { y }
 
         then:
@@ -112,7 +112,7 @@ class ProcessDslV2Test extends Specification {
         dsl.memory '10 GB'
         dsl._input_('foo', String, false)
         dsl._input_('sample', Path, false)
-        dsl.stageAs('sample.txt', { sample })
+        dsl.stageAs({ sample }, 'sample.txt')
         dsl._output_('result', Path, { file('$file0') })
         dsl._unstage_files('$file0', 'result.txt')
 

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -381,12 +381,12 @@ public interface ProcessDsl extends DslScope {
         @Description("""
             Stage a file into the task directory under the given alias.
         """)
-        void stageAs(String filePattern, Path value);
+        void stageAs(Path value, String filePattern);
 
         @Description("""
             Stage a collection of files into the task directory under the given alias.
         """)
-        void stageAs(String filePattern, Iterable<Path> value);
+        void stageAs(Iterable<Path> value, String filePattern);
 
         @Description("""
             Stage the given value as the standard input (i.e. `stdin`) to the task script.

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -207,7 +207,7 @@ class ScriptFormatterTest extends Specification {
             nextflow.preview.types=true
 
             process hello{
-            debug(true) ; input: (id,infile):Tuple<String,Path> ; index:Path ; stage: stageAs('input.txt',infile) ; output: result=tuple(id,file('output.txt')) ; script: 'cat input.txt > output.txt'
+            debug(true) ; input: (id,infile):Tuple<String,Path> ; index:Path ; stage: stageAs(infile,'input.txt') ; output: result=tuple(id,file('output.txt')) ; script: 'cat input.txt > output.txt'
             }
             ''',
             '''\
@@ -221,7 +221,7 @@ class ScriptFormatterTest extends Specification {
                 index: Path
 
                 stage:
-                stageAs 'input.txt', infile
+                stageAs infile, 'input.txt'
 
                 output:
                 result = tuple(id, file('output.txt'))

--- a/tests/collect-tuple-typed.nf
+++ b/tests/collect-tuple-typed.nf
@@ -32,8 +32,8 @@ process merge {
   (barcode, seq_ids, bam, bai): Tuple<String, Bag<String>, Bag<Path>, Bag<Path>>
 
   stage:
-  stageAs 'bam?', bam
-  stageAs 'bai?', bai
+  stageAs bam, 'bam?'
+  stageAs bai, 'bai?'
 
   script:
   """

--- a/tests/dynamic-filename-typed.nf
+++ b/tests/dynamic-filename-typed.nf
@@ -27,7 +27,7 @@ process foo {
   (name, txt): Tuple<String, Path>
 
   stage:
-  stageAs "${params.prefix}_${name}.txt", txt
+  stageAs txt, "${params.prefix}_${name}.txt"
 
   output:
   file("${params.prefix}_${name}.txt")

--- a/tests/nullable-path.nf
+++ b/tests/nullable-path.nf
@@ -20,7 +20,7 @@ process bar {
     input: Path?
 
     stage:
-    stageAs 'input.txt', input
+    stageAs input, 'input.txt'
 
     output:
     stdout()


### PR DESCRIPTION
Change the method signature for typed process `stageAs` from `(filePattern, value)` to `(value, filePattern)`

This change comes from user feedback in the beta testing group, who found the new signature more intuitive (similar to `cp <source> <target>`). It's also what I intended to do originally but switched for some reason

Safe to do since typed processes are still in preview. Will be documented in the 26.04 release notes