### PR TITLE
Default stageOutMode to 'copy' for Google Batch executor

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchScriptLauncher.groovy
@@ -26,6 +26,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.cloud.google.GoogleOpts
 import nextflow.executor.BashWrapperBuilder
+import nextflow.executor.SimpleFileCopyStrategy
 import nextflow.extension.FilesEx
 import nextflow.processor.TaskBean
 import nextflow.processor.TaskRun
@@ -56,6 +57,13 @@ class GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatc
 
     GoogleBatchScriptLauncher(TaskBean bean, Path remoteBinDir) {
         super(bean)
+        // Default to 'copy' stage-out mode on Google Batch. Task outputs are
+        // unstaged from local scratch to a gcsfuse-mounted work directory, which
+        // is always a cross-device operation. Using 'mv' for this fails when
+        // output declarations overlap (directory moved before its children) or
+        // when staged input symlinks resolve to the target path.
+        if( !bean.stageOutMode )
+            ((SimpleFileCopyStrategy) copyStrategy).stageoutMode = 'copy'
         // keep track the google storage work dir
         this.remoteWorkDir = (CloudStoragePath) bean.workDir
         this.remoteBinDir = toContainerMount(remoteBinDir)


### PR DESCRIPTION
## Summary

- Default `stageOutMode` to `copy` for Google Batch tasks when not explicitly set by the user
- Fixes task failures during output unstaging when running on Google Batch with scratch enabled

## Problem

On Google Batch, task outputs are unstaged from local scratch (local SSD) to a gcsfuse-mounted work directory, which is always a cross-device operation. The default `move` mode uses `mv` which fails in two scenarios:

1. **Overlapping output declarations**: When a process declares both a directory and files inside it (e.g. `path("outdir/")` and `path("outdir/*.txt")`), `mv` moves the directory first (with all contents), causing subsequent file moves to fail with `No such file or directory`

2. **Symlinked inputs**: When staged input files are symlinks pointing back to the work directory, `mv` detects source and target as the same file and fails with `'X' and 'Y' are the same file`

## Fix

After `super(bean)` in `GoogleBatchScriptLauncher`, default `stageoutMode` to `copy` on the `SimpleFileCopyStrategy` if the user hasn't explicitly set a `stageOutMode`. This uses `cp -fRL` instead of `mv -f` for unstaging, which handles both failure scenarios.

## Test plan

- [x] Tested with a minimal pipeline on Google Batch with overlapping output declarations (`path("outdir/")` + `path("outdir/*.txt")`) — both tasks succeeded
- [x] Verified that explicitly setting `stageOutMode` in config still takes precedence (the fix only applies when `bean.stageOutMode` is not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)