### PR TITLE
Fix K8s token refresh by delegating getClient() to K8sConfig cache

### DIFF
--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sExecutor.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sExecutor.groovy
@@ -41,20 +41,20 @@ import org.pf4j.ExtensionPoint
 class K8sExecutor extends Executor implements ExtensionPoint {
 
     /**
-     * The Kubernetes HTTP client
-     */
-    private K8sClient client
-
-    protected K8sClient getClient() {
-        client
-    }
-
-    /**
      * @return The `k8s` configuration scope in the nextflow configuration object
      */
     @Memoized
     protected K8sConfig getK8sConfig() {
         new K8sConfig( (Map<String,Object>)session.config.k8s )
+    }
+
+    /**
+     * @return The Kubernetes HTTP client. Delegates to {@link K8sConfig#getClient()} on each
+     * invocation so that the underlying Guava cache can refresh the client configuration
+     * (including the service account token) when it expires.
+     */
+    protected K8sClient getClient() {
+        new K8sClient(k8sConfig.getClient())
     }
 
     /**
@@ -65,7 +65,6 @@ class K8sExecutor extends Executor implements ExtensionPoint {
         super.register()
         final k8sConfig = getK8sConfig()
         final clientConfig = k8sConfig.getClient()
-        this.client = new K8sClient(clientConfig)
         log.debug "[K8s] config=$k8sConfig; API client config=$clientConfig"
     }
 

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -93,7 +93,7 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
     K8sTaskHandler( TaskRun task, K8sExecutor executor ) {
         super(task)
         this.executor = executor
-        this.client = executor.client
+        this.client = executor.getClient()
         this.outputFile = task.workDir.resolve(TaskRun.CMD_OUTFILE)
         this.errorFile = task.workDir.resolve(TaskRun.CMD_ERRFILE)
         this.exitFile = task.workDir.resolve(TaskRun.CMD_EXIT)


### PR DESCRIPTION
## Summary

Fixes #6918

### Problem

PR #6742 added a Guava cache to `K8sConfig.getClient()` with a 50-minute expiry to refresh the service account token. However, the cache was never actually consulted after startup because:

- `K8sExecutor.register()` called `k8sConfig.getClient()` **once** and stored the result in a private `K8sClient` field
- `K8sExecutor.getClient()` returned that stored field directly (never re-calling `K8sConfig`)
- `K8sTaskHandler` stored `executor.client` in its constructor, bypassing `getClient()` entirely

This caused **401 Unauthorized errors after ~60 minutes** on clusters with short-lived projected service account tokens (e.g. AKS, RKE2 with default ~1hr token lifetime).

### Fix

- Remove the `private K8sClient client` field from `K8sExecutor`
- Change `K8sExecutor.getClient()` to delegate to `k8sConfig.getClient()` on each invocation — the Guava cache handles deduplication and refreshes the token when the 50-minute window expires
- Fix `K8sTaskHandler` constructor to use `executor.getClient()` instead of accessing `executor.client` directly (the direct field access bypassed `getClient()` entirely)