### PR TITLE
Fix incorrect evaluation of `secret` process directive

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -1249,6 +1249,7 @@ All directives can be assigned a dynamic value except the following:
 - {ref}`process-executor`
 - {ref}`process-label`
 - {ref}`process-maxforks`
+- {ref}`process-secret`
 
 :::{versionadded} 25.10
 :::

--- a/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Files
 
 import nextflow.Session
 import nextflow.exception.ScriptCompilationException
+import nextflow.processor.TaskProcessor
 import nextflow.script.BaseScript
 import nextflow.script.ScriptMeta
 import nextflow.script.WorkflowDef
@@ -221,7 +222,7 @@ class ScriptLoaderV2Test extends Dsl2Spec {
         session.executorFactory = new MockExecutorFactory()
         def parser = new ScriptLoaderV2(session)
 
-        def TEXT = '''
+        def TEXT = '''\
             process HELLO {
                 tag props.name
 
@@ -244,6 +245,37 @@ class ScriptLoaderV2Test extends Dsl2Spec {
         parser.parse(TEXT)
         parser.runScript()
 
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should not wrap process directives that cannot be dynamic' () {
+
+        given:
+        def session = new Session()
+        session.executorFactory = new MockExecutorFactory()
+        def parser = new ScriptLoaderV2(session)
+
+        def TEXT = '''\
+            process ECHO {
+                secret secrets.NCBI_API_KEY ? "NCBI_API_KEY" : ""
+
+                script:
+                """
+                echo "NCBI_API_KEY=\\$NCBI_API_KEY"
+                """
+            }
+
+            workflow {
+                ECHO()
+            }
+            '''
+
+        when:
+        parser.parse(TEXT)
+        parser.runScript()
+        and:
+        TaskProcessor.currentProcessor().createTaskPreview().toTaskBean()
         then:
         noExceptionThrown()
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ProcessToGroovyVisitorV1.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ProcessToGroovyVisitorV1.java
@@ -76,11 +76,27 @@ public class ProcessToGroovyVisitorV1 {
         return stmt(callThisX("process", args(constX(node.getName()), closure)));
     }
 
+    private static final List<String> NON_DYNAMIC_DIRECTIVES = List.of(
+        "executor",
+        "label",
+        "maxForks",
+        "module",
+        "pod",
+        "publishDir",
+        "secret"
+    );
+
     private void visitProcessDirectives(Statement directives) {
         asDirectives(directives).forEach((call) -> {
+            var name = call.getMethodAsString();
+            // don't wrap directives that can't be dynamic
+            if( NON_DYNAMIC_DIRECTIVES.contains(name) )
+                return;
+            // don't wrap directives with multiple arguments
             var arguments = asMethodCallArguments(call);
             if( arguments.size() != 1 )
                 return;
+            // don't wrap directives that already have a closure
             var firstArg = arguments.get(0);
             if( firstArg instanceof ClosureExpression )
                 return;


### PR DESCRIPTION
Close #6895 

This PR fixes a bug in the v2 syntax parser, where certain process directives such as `secret` were lazily evaluated even though they cannot be dynamic