### PR TITLE
Add docs tip for relocating Docker storage on Azure Batch nodes

### DIFF
--- a/docs/azure.mdx
+++ b/docs/azure.mdx
@@ -525,6 +525,8 @@ Resource overprovisioning can occur if tasks consume more than their allocated s
 Azure virtual machines come with fixed storage disks that are not expandable. Tasks will fail if the tasks running concurrently on a node use more storage than the machine has available.
 :::
 
+By default, Docker and containerd store image layers on the OS disk, which can fill up quickly when pulling large container images. On VMs with an attached data disk (e.g., `Standard_E16ds_v5`), you can use a pool [start task](#start-tasks) to relocate Docker and containerd storage to `$AZ_BATCH_NODE_ROOT_DIR`, which uses the larger data disk.
+
 ### Task containers
 
 Every process in your pipeline must specify a container in order to be executed on Azure Batch.


### PR DESCRIPTION
## Summary
- Adds a documentation tip in the Azure Batch "Task packing" section about relocating Docker/containerd storage to `$AZ_BATCH_NODE_ROOT_DIR` on VMs with attached data disks to avoid OS disk space issues when pulling large container images.
- References: https://github.com/nextflow-io/nextflow/issues/6708#issuecomment-3958969855

## Test plan
- [ ] Verify docs build correctly
- [ ] Confirm the start task link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)