### PR TITLE
Fix LogsCheckpoint thread interrupt race condition

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/LogsCheckpoint.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/LogsCheckpoint.groovy
@@ -68,8 +68,10 @@ class LogsCheckpoint implements TraceObserverV2 {
     protected void run() {
         log.debug "Starting logs checkpoint thread - interval: ${interval}"
         try {
-            while( !Thread.currentThread().isInterrupted() ) {
+            while( true ) {
                 await(interval)
+                if( Thread.currentThread().isInterrupted() )
+                    break
                 handler.saveFiles()
             }
         }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/LogsCheckpoint.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/LogsCheckpoint.groovy
@@ -39,6 +39,7 @@ class LogsCheckpoint implements TraceObserverV2 {
     private Thread thread
     private Duration interval
     private LogsHandler handler
+    private final Object lock = new Object()
 
     @Override
     void onFlowCreate(Session session) {
@@ -55,13 +56,17 @@ class LogsCheckpoint implements TraceObserverV2 {
 
     @Override
     void onFlowComplete() {
-        thread.interrupt()
+        synchronized(lock) {
+            thread.interrupt()
+        }
         thread.join()
     }
 
     @Override
     void onFlowError(TaskEvent event) {
-        thread.interrupt()
+        synchronized(lock) {
+            thread.interrupt()
+        }
         thread.join()
     }
 
@@ -72,7 +77,11 @@ class LogsCheckpoint implements TraceObserverV2 {
                 await(interval)
                 if( Thread.currentThread().isInterrupted() )
                     break
-                handler.saveFiles()
+                synchronized(lock) {
+                    if( Thread.currentThread().isInterrupted() )
+                        break
+                    handler.saveFiles()
+                }
             }
         }
         finally {


### PR DESCRIPTION
## Summary
- Fix race condition in `LogsCheckpoint.run()` where `saveFiles()` was called with the thread interrupt flag already set after `await()` caught an `InterruptedException`
- This caused the AWS SDK to throw `AbortedException` ("Thread was interrupted") during S3 uploads at workflow shutdown
- Move the interrupt check to after `await()` returns and before `saveFiles()`, so the loop exits cleanly on shutdown

## Test plan
- [ ] Verify no `AbortedException` warnings in logs when running workflows with Tower/Seqera platform integration and remote work directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)