### PR TITLE
docs: Add note about oras behavior

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -218,11 +218,17 @@ The following environment variables control the configuration of the Nextflow ru
 
 `NXF_SINGULARITY_CACHEDIR`
 : Directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
+: :::note
+  The `NXF_SINGULARITY_CACHEDIR` variable is not applied when a container image is specified using an `oras://` URI. In that case, the image reference is passed directly to Singularity, independently of Nextflow's caching mechanism.
+  :::
 
 `NXF_SINGULARITY_LIBRARYDIR`
 : :::{versionadded} 21.09.0-edge
   :::
 : Directory where remote Singularity images are retrieved. It should be a directory accessible to all compute nodes.
+: :::note
+  The `NXF_SINGULARITY_LIBRARYDIR` variable is not applied when a container image is specified using an `oras://` URI. In that case, the image reference is passed directly to Singularity, independently of Nextflow's caching mechanism.
+  :::
 
 `NXF_SPACK_CACHEDIR`
 : Directory where Spack environments are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -308,9 +308,17 @@ Defines the path location of the SCM config file .
 
 Directory where remote Singularity images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
 
+:::note
+The `NXF_SINGULARITY_CACHEDIR` variable is not applied when a container image is specified using an `oras://` URI. In that case, the image reference is passed directly to Singularity, independently of Nextflow's caching mechanism.
+:::
+
 ##### `NXF_SINGULARITY_LIBRARYDIR`
 
 Directory where remote Singularity images are retrieved. It should be a directory accessible to all compute nodes.
+
+:::note
+The `NXF_SINGULARITY_LIBRARYDIR` variable is not applied when a container image is specified using an `oras://` URI. In that case, the image reference is passed directly to Singularity, independently of Nextflow's caching mechanism.
+:::
 
 ##### `NXF_SPACK_CACHEDIR`
 


### PR DESCRIPTION
Adds a clarifying note to the Singularity environment variables section of the config docs to resolve an old (Sept 2024) docs request. `NXF_SINGULARITY_CACHEDIR` and `NXF_SINGULARITY_LIBRARYDIR` are not applied when using an `oras://` image URI. Behavior is more similar to Docker, where Singularity downloads and manages the image itself.

May have been resolved since original conversation.