### PR TITLE
Fix security issues due to npr-api dependencies

### DIFF
--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -40,6 +40,10 @@ dependencies {
     api 'com.google.code.gson:gson:2.13.1'
     api 'io.seqera:npr-api:0.22.0-SNAPSHOT'
 
+    // address security vulnerabilities due to npr-api dependencies
+    implementation 'io.netty:netty-bom:4.1.129.Final'
+    implementation 'com.fasterxml.jackson:jackson-bom:2.21.1'
+
     /* testImplementation inherited from top gradle build file */
     testImplementation(testFixtures(project(":nextflow")))
     testFixturesImplementation(project(":nextflow"))

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -71,10 +71,6 @@ dependencies {
     api ('software.amazon.awssdk:apache-client:2.33.2')
     api ('software.amazon.awssdk:aws-crt-client:2.33.2')
 
-    constraints {
-        api 'com.fasterxml.jackson.core:jackson-databind:2.21.1'
-    }
-
     // address security vulnerabilities
     implementation 'io.netty:netty-common:4.1.129.Final'
     implementation 'io.netty:netty-handler:4.1.129.Final'


### PR DESCRIPTION
This pull request addresses security vulnerabilities related to dependencies in `nf-commons`. The main changes involve adding or updating dependency versions to mitigate these vulnerabilities.

**Dependency updates to address security vulnerabilities:**

* Added `io.netty:netty-bom:4.1.129.Final` and `com.fasterxml.jackson:jackson-bom:2.21.1` as implementation dependencies in `modules/nf-commons/build.gradle` to resolve issues caused by transitive dependencies from `npr-api`.

* Removed the `constraints` block for `com.fasterxml.jackson.core:jackson-databind:2.21.1` in `plugins/nf-amazon/build.gradle` to address security concerns.