### PR TITLE
Fix typo in TowerRetryPolicy: maxAttemps -> maxAttempts

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerRetryPolicy.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerRetryPolicy.groovy
@@ -75,7 +75,7 @@ class TowerRetryPolicy implements Retryable.Config, ConfigScope {
     TowerRetryPolicy(Map opts, Map legacy=Map.of()) {
         this.delay = opts.delay as Duration ?: legacy.backOffDelay as Duration ?: RetryConfig.DEFAULT_DELAY
         this.maxDelay = opts.maxDelay as Duration ?: RetryConfig.DEFAULT_MAX_DELAY
-        this.maxAttempts = opts.maxAttemps as Integer ?: legacy.maxRetries as Integer ?: RetryConfig.DEFAULT_MAX_ATTEMPTS
+        this.maxAttempts = opts.maxAttempts as Integer ?: legacy.maxRetries as Integer ?: RetryConfig.DEFAULT_MAX_ATTEMPTS
         this.jitter = opts.jitter as Double ?: RetryConfig.DEFAULT_JITTER
         this.multiplier = opts.multiplier as Double ?: legacy.backOffBase as Double ?: RetryConfig.DEFAULT_MULTIPLIER
     }

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerRetryPolicyTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerRetryPolicyTest.groovy
@@ -44,7 +44,7 @@ class TowerRetryPolicyTest extends Specification {
         def customOptions = [
                 delay: '1s' as nextflow.util.Duration,
                 maxDelay: '60s' as nextflow.util.Duration,
-                maxAttemps: 3,
+                maxAttempts: 3,
                 jitter: 0.5,
                 multiplier: 1.5
         ]


### PR DESCRIPTION
## Summary
- Fix misspelled map key `maxAttemps` → `maxAttempts` in `TowerRetryPolicy`, which caused `tower.retryPolicy.maxAttempts` to be silently ignored
- Update corresponding test to use the correct spelling

Fixes #6948

## Test plan
- [x] Existing unit test updated and passes with correct key spelling

🤖 Generated with [Claude Code](https://claude.com/claude-code)