### PR TITLE
Add consumableResources process directive for AWS Batch

### DIFF
--- a/docs/executor.md
+++ b/docs/executor.md
@@ -24,7 +24,7 @@ Resource requests and other job characteristics can be controlled via the follow
 
 - {ref}`process-accelerator`
 - {ref}`process-arch` (only when using Fargate platform type for AWS Batch)
-- {ref}`process-consumableresources`
+- {ref}`process-hints`
 - {ref}`process-container`
 - {ref}`process-containerOptions`
 - {ref}`process-cpus`

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -24,6 +24,7 @@ Resource requests and other job characteristics can be controlled via the follow
 
 - {ref}`process-accelerator`
 - {ref}`process-arch` (only when using Fargate platform type for AWS Batch)
+- {ref}`process-consumableresources`
 - {ref}`process-container`
 - {ref}`process-containerOptions`
 - {ref}`process-cpus`

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -582,20 +582,24 @@ Containers are a very useful way to execute your scripts in a reproducible self-
 This directive is ignored for processes that are {ref}`executed natively <process-native>`.
 :::
 
-(process-consumableresources)=
+(process-hints)=
 
-### consumableResources
+### hints
 
 :::{versionadded} 25.04.0-edge
 :::
 
-The `consumableResources` directive allows you to specify [AWS Batch consumable resources](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling.html) required by the task. This is useful for managing limited resources such as software license seats — AWS Batch will hold jobs in `RUNNABLE` until the required resources are available, then lock them for the duration of the job.
+The `hints` directive allows you to specify executor-specific scheduling hints using namespaced keys. Executors consume the hints they understand and silently ignore the rest. This directive is repeatable — multiple calls are merged.
+
+Currently supported hint namespaces:
+
+**`consumable-resource:`** — Maps to [AWS Batch consumable resources](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling.html) for managing limited resources such as software license seats. AWS Batch will hold jobs in `RUNNABLE` until the required resources are available, then lock them for the duration of the job.
 
 For example, to require one license seat per task:
 
 ```nextflow
 process runDragen {
-    consumableResources 'my-dragen-license'
+    hints 'consumable-resource:my-dragen-license': 1
     cpus 4
     memory '16 GB'
 
@@ -606,24 +610,11 @@ process runDragen {
 }
 ```
 
-The string shorthand above implies a quantity of 1. To specify an explicit quantity, use the map syntax:
-
-```nextflow
-process runLicensedTool {
-    consumableResources 'seat-license': 2
-
-    script:
-    """
-    licensed-tool ...
-    """
-}
-```
-
-This directive is repeatable — multiple calls accumulate, and multiple resources can be specified in a single call:
+Multiple hints can be specified in a single call or across multiple calls:
 
 ```nextflow
 process runMultiLicense {
-    consumableResources 'license-a': 1, 'license-b': 3
+    hints 'consumable-resource:license-a': 1, 'consumable-resource:license-b': 3
 
     script:
     """
@@ -633,15 +624,11 @@ process runMultiLicense {
 ```
 
 :::{note}
-The consumable resources must be created in your AWS account before using this directive. See the [AWS Batch documentation](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling-how-to-create.html) for details.
+Consumable resources must be created in your AWS account before using this hint. See the [AWS Batch documentation](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling-how-to-create.html) for details.
 :::
 
 :::{warning}
 AWS Batch job queues use FIFO ordering by default. A job waiting for a consumable resource will block all subsequent jobs in the same queue — even those that don't require the resource. To avoid this, use a dedicated job queue (via the `queue` directive) for processes that require consumable resources, or use a fair-share scheduling policy on the job queue.
-:::
-
-:::{note}
-This directive is only supported by the {ref}`awsbatch-executor` executor.
 :::
 
 (process-containeroptions)=

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -582,6 +582,68 @@ Containers are a very useful way to execute your scripts in a reproducible self-
 This directive is ignored for processes that are {ref}`executed natively <process-native>`.
 :::
 
+(process-consumableresources)=
+
+### consumableResources
+
+:::{versionadded} 25.04.0-edge
+:::
+
+The `consumableResources` directive allows you to specify [AWS Batch consumable resources](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling.html) required by the task. This is useful for managing limited resources such as software license seats — AWS Batch will hold jobs in `RUNNABLE` until the required resources are available, then lock them for the duration of the job.
+
+For example, to require one license seat per task:
+
+```nextflow
+process runDragen {
+    consumableResources 'my-dragen-license'
+    cpus 4
+    memory '16 GB'
+
+    script:
+    """
+    dragen --ref-dir /ref ...
+    """
+}
+```
+
+The string shorthand above implies a quantity of 1. To specify an explicit quantity, use the map syntax:
+
+```nextflow
+process runLicensedTool {
+    consumableResources 'seat-license': 2
+
+    script:
+    """
+    licensed-tool ...
+    """
+}
+```
+
+This directive is repeatable — multiple calls accumulate, and multiple resources can be specified in a single call:
+
+```nextflow
+process runMultiLicense {
+    consumableResources 'license-a': 1, 'license-b': 3
+
+    script:
+    """
+    multi-tool ...
+    """
+}
+```
+
+:::{note}
+The consumable resources must be created in your AWS account before using this directive. See the [AWS Batch documentation](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling-how-to-create.html) for details.
+:::
+
+:::{warning}
+AWS Batch job queues use FIFO ordering by default. A job waiting for a consumable resource will block all subsequent jobs in the same queue — even those that don't require the resource. To avoid this, use a dedicated job queue (via the `queue` directive) for processes that require consumable resources, or use a fair-share scheduling policy on the job queue.
+:::
+
+:::{note}
+This directive is only supported by the {ref}`awsbatch-executor` executor.
+:::
+
 (process-containeroptions)=
 
 ### containerOptions

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -529,6 +529,17 @@ class TaskConfig extends LazyMap implements Cloneable {
         return CmdLineOptionMap.emptyOption()
     }
 
+    List<List> getConsumableResources() {
+        def value = get('consumableResources')
+        if( value instanceof Map )
+            return (value as Map).collect { k, v -> [k.toString(), v as int] }
+        if( value instanceof List )
+            return (List<List>) value
+        if( value != null )
+            throw new IllegalArgumentException("Invalid `consumableResources` directive value: $value [${value.getClass().getName()}]")
+        return null
+    }
+
     Map<String, String> getResourceLabels() {
         return get('resourceLabels') as Map<String, String> ?: Collections.<String,String>emptyMap()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -531,6 +531,8 @@ class TaskConfig extends LazyMap implements Cloneable {
 
     List<List> getConsumableResources() {
         def value = get('consumableResources')
+        if( value instanceof CharSequence )
+            return [[value.toString(), 1]]
         if( value instanceof Map )
             return (value as Map).collect { k, v -> [k.toString(), v as int] }
         if( value instanceof List )

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -529,16 +529,12 @@ class TaskConfig extends LazyMap implements Cloneable {
         return CmdLineOptionMap.emptyOption()
     }
 
-    List<List> getConsumableResources() {
-        def value = get('consumableResources')
-        if( value instanceof CharSequence )
-            return [[value.toString(), 1]]
+    Map<String, Object> getHints() {
+        def value = get('hints')
         if( value instanceof Map )
-            return (value as Map).collect { k, v -> [k.toString(), v as int] }
-        if( value instanceof List )
-            return (List<List>) value
+            return (Map<String, Object>) value
         if( value != null )
-            throw new IllegalArgumentException("Invalid `consumableResources` directive value: $value [${value.getClass().getName()}]")
+            throw new IllegalArgumentException("Invalid `hints` directive value: $value [${value.getClass().getName()}]")
         return null
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
@@ -50,7 +50,7 @@ class ProcessBuilder {
             'cache',
             'clusterOptions',
             'conda',
-            'consumableResources',
+            'hints',
             'container',
             'containerOptions',
             'cpus',
@@ -418,39 +418,24 @@ class ProcessBuilder {
     }
 
     /**
-     * Implements the {@code consumableResources} directive with string shorthand.
+     * Implements the {@code hints} directive.
      *
-     * Example: consumableResources 'my-license'
-     * Implies quantity of 1.
-     *
-     * @param value The consumable resource name
-     */
-    void consumableResources(String value) {
-        if( !value ) return
-        consumableResources([(value): 1])
-    }
-
-    /**
-     * Implements the {@code consumableResources} directive with a map.
-     *
-     * Example: consumableResources 'license-a': 1, 'license-b': 2
+     * Example: hints 'consumable-resource:my-license': 1, 'consumable-resource:other': 2
      *
      * This directive can be specified (invoked) multiple times in
-     * the process definition.
+     * the process definition. Multiple calls are merged.
      *
-     * @param value A map of resource name to quantity
+     * @param map A map of namespaced hint keys to values
      */
-    void consumableResources(Map value) {
-        if( !value ) return
+    void hints(Map<String, Object> map) {
+        if( !map ) return
 
-        def current = (List) config.get('consumableResources')
-        if( current == null ) {
-            current = new ConfigList()
-            config.put('consumableResources', current)
+        def allHints = (Map)config.get('hints')
+        if( !allHints ) {
+            allHints = [:]
         }
-        value.each { name, quantity ->
-            current << [name.toString(), quantity as int]
-        }
+        allHints += map
+        config.put('hints', allHints)
     }
 
     /// SCRIPT

--- a/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
@@ -50,6 +50,7 @@ class ProcessBuilder {
             'cache',
             'clusterOptions',
             'conda',
+            'consumableResources',
             'container',
             'containerOptions',
             'cpus',
@@ -414,6 +415,42 @@ class ProcessBuilder {
         // -- avoid duplicates
         if( !allSecrets.contains(name) )
             allSecrets.add(name)
+    }
+
+    /**
+     * Implements the {@code consumableResources} directive with string shorthand.
+     *
+     * Example: consumableResources 'my-license'
+     * Implies quantity of 1.
+     *
+     * @param value The consumable resource name
+     */
+    void consumableResources(String value) {
+        if( !value ) return
+        consumableResources([(value): 1])
+    }
+
+    /**
+     * Implements the {@code consumableResources} directive with a map.
+     *
+     * Example: consumableResources 'license-a': 1, 'license-b': 2
+     *
+     * This directive can be specified (invoked) multiple times in
+     * the process definition.
+     *
+     * @param value A map of resource name to quantity
+     */
+    void consumableResources(Map value) {
+        if( !value ) return
+
+        def current = (List) config.get('consumableResources')
+        if( current == null ) {
+            current = new ConfigList()
+            config.put('consumableResources', current)
+        }
+        value.each { name, quantity ->
+            current << [name.toString(), quantity as int]
+        }
     }
 
     /// SCRIPT

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -617,6 +617,14 @@ class TaskConfigTest extends Specification {
         then:
         res == [['my-license', 1], ['other', 4]]
 
+        // from config: string shorthand (e.g. process.consumableResources = 'my-license')
+        when:
+        config = new TaskConfig()
+        config.put('consumableResources', 'my-license')
+        res = config.getConsumableResources()
+        then:
+        res == [['my-license', 1]]
+
         // absent directive returns null
         when:
         config = new TaskConfig()

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -586,6 +586,45 @@ class TaskConfigTest extends Specification {
         res.type == 'nvidia'
     }
 
+    def 'should get consumable resources'() {
+        given:
+        def script = Mock(BaseScript)
+
+        // from DSL: accumulated ConfigList of [name, quantity] pairs
+        when:
+        def process = new ProcessConfig(script)
+        def dsl = new ProcessBuilder(process)
+        dsl.consumableResources 'my-license'
+        def res = process.createTaskConfig().getConsumableResources()
+        then:
+        res == [['my-license', 1]]
+
+        // from DSL: multiple resources
+        when:
+        process = new ProcessConfig(script)
+        dsl = new ProcessBuilder(process)
+        dsl.consumableResources 'license-a': 2
+        dsl.consumableResources 'license-b': 3
+        res = process.createTaskConfig().getConsumableResources()
+        then:
+        res == [['license-a', 2], ['license-b', 3]]
+
+        // from config: map syntax
+        when:
+        def config = new TaskConfig()
+        config.put('consumableResources', ['my-license': 1, 'other': 4])
+        res = config.getConsumableResources()
+        then:
+        res == [['my-license', 1], ['other', 4]]
+
+        // absent directive returns null
+        when:
+        config = new TaskConfig()
+        res = config.getConsumableResources()
+        then:
+        res == null
+    }
+
     def 'should configure secrets'()  {
         given:
         def script = Mock(BaseScript)

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -586,49 +586,41 @@ class TaskConfigTest extends Specification {
         res.type == 'nvidia'
     }
 
-    def 'should get consumable resources'() {
+    def 'should get hints'() {
         given:
         def script = Mock(BaseScript)
 
-        // from DSL: accumulated ConfigList of [name, quantity] pairs
+        // from DSL: merged map
         when:
         def process = new ProcessConfig(script)
         def dsl = new ProcessBuilder(process)
-        dsl.consumableResources 'my-license'
-        def res = process.createTaskConfig().getConsumableResources()
+        dsl.hints 'consumable-resource:my-license': 1
+        def res = process.createTaskConfig().getHints()
         then:
-        res == [['my-license', 1]]
+        res == ['consumable-resource:my-license': 1]
 
-        // from DSL: multiple resources
+        // from DSL: multiple calls merge
         when:
         process = new ProcessConfig(script)
         dsl = new ProcessBuilder(process)
-        dsl.consumableResources 'license-a': 2
-        dsl.consumableResources 'license-b': 3
-        res = process.createTaskConfig().getConsumableResources()
+        dsl.hints 'consumable-resource:license-a': 2
+        dsl.hints 'consumable-resource:license-b': 3
+        res = process.createTaskConfig().getHints()
         then:
-        res == [['license-a', 2], ['license-b', 3]]
+        res == ['consumable-resource:license-a': 2, 'consumable-resource:license-b': 3]
 
         // from config: map syntax
         when:
         def config = new TaskConfig()
-        config.put('consumableResources', ['my-license': 1, 'other': 4])
-        res = config.getConsumableResources()
+        config.put('hints', ['consumable-resource:my-license': 1, 'other-hint': 'value'])
+        res = config.getHints()
         then:
-        res == [['my-license', 1], ['other', 4]]
-
-        // from config: string shorthand (e.g. process.consumableResources = 'my-license')
-        when:
-        config = new TaskConfig()
-        config.put('consumableResources', 'my-license')
-        res = config.getConsumableResources()
-        then:
-        res == [['my-license', 1]]
+        res == ['consumable-resource:my-license': 1, 'other-hint': 'value']
 
         // absent directive returns null
         when:
         config = new TaskConfig()
-        res = config.getConsumableResources()
+        res = config.getHints()
         then:
         res == null
     }

--- a/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessBuilderTest.groovy
@@ -134,6 +134,32 @@ class ProcessBuilderTest extends Specification {
         config.getSecret() == ['foo', 'bar']
     }
 
+    def 'should set consumableResources'() {
+        when:
+        def builder = createBuilder()
+        def config = builder.getConfig()
+        then:
+        config.get('consumableResources') == null
+
+        // string shorthand implies quantity 1
+        when:
+        builder.consumableResources 'my-license'
+        then:
+        config.get('consumableResources') == [['my-license', 1]]
+
+        // map syntax with explicit quantity
+        when:
+        builder.consumableResources 'other-license': 3
+        then:
+        config.get('consumableResources') == [['my-license', 1], ['other-license', 3]]
+
+        // multi-resource map in one call
+        when:
+        builder.consumableResources 'license-a': 2, 'license-b': 5
+        then:
+        config.get('consumableResources') == [['my-license', 1], ['other-license', 3], ['license-a', 2], ['license-b', 5]]
+    }
+
     def 'should set process labels'() {
         when:
         def builder = createBuilder()

--- a/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessBuilderTest.groovy
@@ -134,30 +134,29 @@ class ProcessBuilderTest extends Specification {
         config.getSecret() == ['foo', 'bar']
     }
 
-    def 'should set consumableResources'() {
-        when:
+    def 'should set hints'() {
+        given:
         def builder = createBuilder()
         def config = builder.getConfig()
-        then:
-        config.get('consumableResources') == null
+        expect:
+        config.get('hints') == null
 
-        // string shorthand implies quantity 1
         when:
-        builder.consumableResources 'my-license'
+        builder.hints 'consumable-resource:my-license': 1
         then:
-        config.get('consumableResources') == [['my-license', 1]]
+        config.get('hints') == ['consumable-resource:my-license': 1]
 
-        // map syntax with explicit quantity
+        // multiple calls merge
         when:
-        builder.consumableResources 'other-license': 3
+        builder.hints 'consumable-resource:other-license': 3
         then:
-        config.get('consumableResources') == [['my-license', 1], ['other-license', 3]]
+        config.get('hints') == ['consumable-resource:my-license': 1, 'consumable-resource:other-license': 3]
 
-        // multi-resource map in one call
+        // multi-key map in one call
         when:
-        builder.consumableResources 'license-a': 2, 'license-b': 5
+        builder.hints 'consumable-resource:license-a': 2, 'some-other-hint': 'value'
         then:
-        config.get('consumableResources') == [['my-license', 1], ['other-license', 3], ['license-a', 2], ['license-b', 5]]
+        config.get('hints') == ['consumable-resource:my-license': 1, 'consumable-resource:other-license': 3, 'consumable-resource:license-a': 2, 'some-other-hint': 'value']
     }
 
     def 'should set process labels'() {

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -123,12 +123,11 @@ public interface ProcessDsl extends DslScope {
         void conda(String value);
 
         @Description("""
-            The `consumableResources` directive allows you to specify AWS Batch consumable resources required by the task, such as software license seats.
+            The `hints` directive allows you to specify executor-specific scheduling hints using namespaced keys. Executors consume the hints they understand and ignore the rest.
 
-            [Read more](https://nextflow.io/docs/latest/reference/process.html#consumableresources)
+            [Read more](https://nextflow.io/docs/latest/reference/process.html#hints)
         """)
-        void consumableResources(Map<String,Integer> value);
-        void consumableResources(String value);
+        void hints(Map<String,?> value);
 
         @Description("""
             The `container` directive allows you to execute the process script in a container.

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -123,6 +123,14 @@ public interface ProcessDsl extends DslScope {
         void conda(String value);
 
         @Description("""
+            The `consumableResources` directive allows you to specify AWS Batch consumable resources required by the task, such as software license seats.
+
+            [Read more](https://nextflow.io/docs/latest/reference/process.html#consumableresources)
+        """)
+        void consumableResources(Map<String,Integer> value);
+        void consumableResources(String value);
+
+        @Description("""
             The `container` directive allows you to execute the process script in a container.
 
             [Read more](https://nextflow.io/docs/latest/reference/process.html#container)

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -625,23 +625,29 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         // finally set the container options
         result.containerProperties(container)
 
-        // set consumable resource properties
-        final List<List> consumable = task.config.getConsumableResources()
-        if( consumable ) {
-            final List<ConsumableResourceRequirement> resourceList = new ArrayList<>(consumable.size())
-            for( List entry : consumable ) {
-                resourceList.add(
-                    ConsumableResourceRequirement.builder()
-                        .consumableResource(entry[0] as String)
-                        .quantity(entry[1] as Long)
+        // set consumable resource properties from hints
+        final hints = task.config.getHints()
+        final consumablePrefix = 'consumable-resource:'
+        if( hints ) {
+            final List<ConsumableResourceRequirement> resourceList = new ArrayList<>()
+            for( Map.Entry<String, Object> entry : hints.entrySet() ) {
+                if( entry.key.startsWith(consumablePrefix) ) {
+                    final resourceName = entry.key.substring(consumablePrefix.length())
+                    resourceList.add(
+                        ConsumableResourceRequirement.builder()
+                            .consumableResource(resourceName)
+                            .quantity(entry.value as Long)
+                            .build()
+                    )
+                }
+            }
+            if( resourceList ) {
+                result.consumableResourceProperties(
+                    ConsumableResourceProperties.builder()
+                        .consumableResourceList(resourceList)
                         .build()
                 )
             }
-            result.consumableResourceProperties(
-                ConsumableResourceProperties.builder()
-                    .consumableResourceList(resourceList)
-                    .build()
-            )
         }
 
         // add to this list all values that has to contribute to the
@@ -650,8 +656,8 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         hashingTokens.add(container.toString())
         if( containerOpts )
             hashingTokens.add(containerOpts)
-        if( consumable )
-            hashingTokens.add(consumable.toString())
+        if( hints )
+            hashingTokens.add(hints.toString())
 
         return result
     }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -82,6 +82,8 @@ import software.amazon.awssdk.services.batch.model.SubmitJobRequest
 import software.amazon.awssdk.services.batch.model.SubmitJobResponse
 import software.amazon.awssdk.services.batch.model.TerminateJobRequest
 import software.amazon.awssdk.services.batch.model.Volume
+import software.amazon.awssdk.services.batch.model.ConsumableResourceProperties
+import software.amazon.awssdk.services.batch.model.ConsumableResourceRequirement
 /**
  * Implements a task handler for AWS Batch jobs
  */
@@ -623,12 +625,33 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         // finally set the container options
         result.containerProperties(container)
 
+        // set consumable resource properties
+        final List<List> consumable = task.config.getConsumableResources()
+        if( consumable ) {
+            final List<ConsumableResourceRequirement> resourceList = new ArrayList<>(consumable.size())
+            for( List entry : consumable ) {
+                resourceList.add(
+                    ConsumableResourceRequirement.builder()
+                        .consumableResource(entry[0] as String)
+                        .quantity(entry[1] as Long)
+                        .build()
+                )
+            }
+            result.consumableResourceProperties(
+                ConsumableResourceProperties.builder()
+                    .consumableResourceList(resourceList)
+                    .build()
+            )
+        }
+
         // add to this list all values that has to contribute to the
         // job definition unique name creation
         hashingTokens.add(name)
         hashingTokens.add(container.toString())
         if( containerOpts )
             hashingTokens.add(containerOpts)
+        if( consumable )
+            hashingTokens.add(consumable.toString())
 
         return result
     }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/model/RegisterJobDefinitionModel.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/model/RegisterJobDefinitionModel.groovy
@@ -20,6 +20,7 @@ package nextflow.cloud.aws.batch.model
 import groovy.transform.CompileStatic
 import software.amazon.awssdk.services.batch.model.JobDefinitionType
 import software.amazon.awssdk.services.batch.model.PlatformCapability
+import software.amazon.awssdk.services.batch.model.ConsumableResourceProperties
 import software.amazon.awssdk.services.batch.model.RegisterJobDefinitionRequest
 
 /**
@@ -44,6 +45,8 @@ class RegisterJobDefinitionModel {
     private Map<String,String> parameters
 
     private Map<String,String> tags
+
+    private ConsumableResourceProperties consumableResourceProperties
 
     RegisterJobDefinitionModel jobDefinitionName(String value) {
         this.jobDefinitionName = value
@@ -82,6 +85,11 @@ class RegisterJobDefinitionModel {
         return this
     }
 
+    RegisterJobDefinitionModel consumableResourceProperties(ConsumableResourceProperties value) {
+        this.consumableResourceProperties = value
+        return this
+    }
+
     String getJobDefinitionName() {
         return jobDefinitionName
     }
@@ -106,6 +114,10 @@ class RegisterJobDefinitionModel {
         return tags
     }
 
+    ConsumableResourceProperties getConsumableResourceProperties() {
+        return consumableResourceProperties
+    }
+
     RegisterJobDefinitionRequest toBatchRequest() {
         final builder = RegisterJobDefinitionRequest.builder()
 
@@ -121,6 +133,8 @@ class RegisterJobDefinitionModel {
             builder.parameters(parameters)
         if (tags)
             builder.tags(tags)
+        if (consumableResourceProperties)
+            builder.consumableResourceProperties(consumableResourceProperties)
 
         return (RegisterJobDefinitionRequest) builder.build()
     }
@@ -134,6 +148,7 @@ class RegisterJobDefinitionModel {
             ", containerProperties=" + containerProperties +
             ", parameters=" + parameters +
             ", tags=" + tags +
+            ", consumableResourceProperties=" + consumableResourceProperties +
             '}';
     }
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -602,15 +602,15 @@ class AwsBatchTaskHandlerTest extends Specification {
         result.containerProperties.volumes[0].name() == 'aws-cli'
     }
 
-    def 'should create a job definition with consumable resources' () {
+    def 'should create a job definition with consumable resource hints' () {
         given:
         def IMAGE = 'foo/bar:1.0'
         def JOB_NAME = 'nf-foo-bar-1-0'
-        def CONSUMABLE = [['my-license', 1]]
+        def HINTS = ['consumable-resource:my-license': 1]
         def task = Mock(TaskRun) {
             getContainer() >> IMAGE
             getConfig() >> Mock(TaskConfig) {
-                getConsumableResources() >> CONSUMABLE
+                getHints() >> HINTS
             }
         }
         def handler = Spy(AwsBatchTaskHandler) {
@@ -630,15 +630,15 @@ class AwsBatchTaskHandlerTest extends Specification {
         result.consumableResourceProperties.consumableResourceList()[0].quantity() == 1
     }
 
-    def 'should create a job definition with multiple consumable resources' () {
+    def 'should create a job definition with multiple consumable resource hints' () {
         given:
         def IMAGE = 'foo/bar:1.0'
         def JOB_NAME = 'nf-foo-bar-1-0'
-        def CONSUMABLE = [['license-a', 2], ['license-b', 3]]
+        def HINTS = ['consumable-resource:license-a': 2, 'consumable-resource:license-b': 3]
         def task = Mock(TaskRun) {
             getContainer() >> IMAGE
             getConfig() >> Mock(TaskConfig) {
-                getConsumableResources() >> CONSUMABLE
+                getHints() >> HINTS
             }
         }
         def handler = Spy(AwsBatchTaskHandler) {
@@ -660,14 +660,39 @@ class AwsBatchTaskHandlerTest extends Specification {
         result.consumableResourceProperties.consumableResourceList()[1].quantity() == 3
     }
 
-    def 'should not set consumable resources when directive is absent' () {
+    def 'should ignore non-consumable hints in job definition' () {
+        given:
+        def IMAGE = 'foo/bar:1.0'
+        def JOB_NAME = 'nf-foo-bar-1-0'
+        def HINTS = ['some-other-hint': 'value']
+        def task = Mock(TaskRun) {
+            getContainer() >> IMAGE
+            getConfig() >> Mock(TaskConfig) {
+                getHints() >> HINTS
+            }
+        }
+        def handler = Spy(AwsBatchTaskHandler) {
+            getTask() >> task
+            fusionEnabled() >> false
+        }
+        handler.@executor = Mock(AwsBatchExecutor)
+
+        when:
+        def result = handler.makeJobDefRequest(task)
+        then:
+        1 * handler.normalizeJobDefinitionName(IMAGE) >> JOB_NAME
+        1 * handler.getAwsOptions() >> new AwsOptions()
+        result.consumableResourceProperties == null
+    }
+
+    def 'should not set consumable resources when hints absent' () {
         given:
         def IMAGE = 'foo/bar:1.0'
         def JOB_NAME = 'nf-foo-bar-1-0'
         def task = Mock(TaskRun) {
             getContainer() >> IMAGE
             getConfig() >> Mock(TaskConfig) {
-                getConsumableResources() >> null
+                getHints() >> null
             }
         }
         def handler = Spy(AwsBatchTaskHandler) {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -61,6 +61,8 @@ import software.amazon.awssdk.services.batch.model.ResourceType
 import software.amazon.awssdk.services.batch.model.RetryStrategy
 import software.amazon.awssdk.services.batch.model.SubmitJobRequest
 import software.amazon.awssdk.services.batch.model.SubmitJobResponse
+import software.amazon.awssdk.services.batch.model.ConsumableResourceProperties
+import software.amazon.awssdk.services.batch.model.ConsumableResourceRequirement
 import spock.lang.Specification
 import spock.lang.Unroll
 /**
@@ -598,6 +600,88 @@ class AwsBatchTaskHandlerTest extends Specification {
         result.containerProperties.mountPoints[0].readOnly()
         result.containerProperties.volumes[0].host().sourcePath() == '/home/conda'
         result.containerProperties.volumes[0].name() == 'aws-cli'
+    }
+
+    def 'should create a job definition with consumable resources' () {
+        given:
+        def IMAGE = 'foo/bar:1.0'
+        def JOB_NAME = 'nf-foo-bar-1-0'
+        def CONSUMABLE = [['my-license', 1]]
+        def task = Mock(TaskRun) {
+            getContainer() >> IMAGE
+            getConfig() >> Mock(TaskConfig) {
+                getConsumableResources() >> CONSUMABLE
+            }
+        }
+        def handler = Spy(AwsBatchTaskHandler) {
+            getTask() >> task
+            fusionEnabled() >> false
+        }
+        handler.@executor = Mock(AwsBatchExecutor)
+
+        when:
+        def result = handler.makeJobDefRequest(task)
+        then:
+        1 * handler.normalizeJobDefinitionName(IMAGE) >> JOB_NAME
+        1 * handler.getAwsOptions() >> new AwsOptions()
+        result.consumableResourceProperties != null
+        result.consumableResourceProperties.consumableResourceList().size() == 1
+        result.consumableResourceProperties.consumableResourceList()[0].consumableResource() == 'my-license'
+        result.consumableResourceProperties.consumableResourceList()[0].quantity() == 1
+    }
+
+    def 'should create a job definition with multiple consumable resources' () {
+        given:
+        def IMAGE = 'foo/bar:1.0'
+        def JOB_NAME = 'nf-foo-bar-1-0'
+        def CONSUMABLE = [['license-a', 2], ['license-b', 3]]
+        def task = Mock(TaskRun) {
+            getContainer() >> IMAGE
+            getConfig() >> Mock(TaskConfig) {
+                getConsumableResources() >> CONSUMABLE
+            }
+        }
+        def handler = Spy(AwsBatchTaskHandler) {
+            getTask() >> task
+            fusionEnabled() >> false
+        }
+        handler.@executor = Mock(AwsBatchExecutor)
+
+        when:
+        def result = handler.makeJobDefRequest(task)
+        then:
+        1 * handler.normalizeJobDefinitionName(IMAGE) >> JOB_NAME
+        1 * handler.getAwsOptions() >> new AwsOptions()
+        result.consumableResourceProperties != null
+        result.consumableResourceProperties.consumableResourceList().size() == 2
+        result.consumableResourceProperties.consumableResourceList()[0].consumableResource() == 'license-a'
+        result.consumableResourceProperties.consumableResourceList()[0].quantity() == 2
+        result.consumableResourceProperties.consumableResourceList()[1].consumableResource() == 'license-b'
+        result.consumableResourceProperties.consumableResourceList()[1].quantity() == 3
+    }
+
+    def 'should not set consumable resources when directive is absent' () {
+        given:
+        def IMAGE = 'foo/bar:1.0'
+        def JOB_NAME = 'nf-foo-bar-1-0'
+        def task = Mock(TaskRun) {
+            getContainer() >> IMAGE
+            getConfig() >> Mock(TaskConfig) {
+                getConsumableResources() >> null
+            }
+        }
+        def handler = Spy(AwsBatchTaskHandler) {
+            getTask() >> task
+            fusionEnabled() >> false
+        }
+        handler.@executor = Mock(AwsBatchExecutor)
+
+        when:
+        def result = handler.makeJobDefRequest(task)
+        then:
+        1 * handler.normalizeJobDefinitionName(IMAGE) >> JOB_NAME
+        1 * handler.getAwsOptions() >> new AwsOptions()
+        result.consumableResourceProperties == null
     }
 
     def 'should create a fargate job definition' () {


### PR DESCRIPTION
## Summary

- Add `consumableResources` process directive that maps to [AWS Batch resource-aware scheduling](https://docs.aws.amazon.com/batch/latest/userguide/resource-aware-scheduling.html)
- Enables license-seat-aware job scheduling — AWS Batch holds jobs in RUNNABLE until consumable resources are available
- Supports string shorthand (`consumableResources 'my-license'` implies quantity 1), map syntax (`consumableResources 'lic': 2`), and is repeatable across multiple calls

### Usage

```nextflow
process runDragen {
    consumableResources 'my-dragen-license'
    cpus 4
    memory '16 GB'

    script:
    """
    dragen --ref-dir /ref ...
    """
}
```

### Implementation

- **Core module**: Directive registered in `ProcessBuilder.DIRECTIVES`, handler methods for string/map syntax with `ConfigList` accumulation, `TaskConfig.getConsumableResources()` getter normalizing all input forms
- **nf-lang**: `ProcessDsl.DirectiveDsl` updated for config validation
- **nf-amazon plugin**: `AwsBatchTaskHandler.configJobDefRequest()` maps directive to `ConsumableResourceProperties` on `RegisterJobDefinitionRequest` via `RegisterJobDefinitionModel`; included in job definition hash
- **Docs**: Full directive documentation in `docs/reference/process.md` with FIFO queue ordering caveat; added to AWS Batch executor's supported directives list

Closes #5917

## Test plan

- [x] `ProcessBuilderTest` — string shorthand, map syntax, multi-resource, repeatable accumulation
- [x] `TaskConfigTest` — Map normalization, List passthrough, String shorthand, null handling
- [x] `AwsBatchTaskHandlerTest` — single resource, multiple resources, absent directive, hashing, no regression on existing tests
- [x] Full nf-amazon plugin test suite passes
- [x] Core module smoke tests pass (3 pre-existing failures unrelated to this change)
- [x] Live validation with AWS Batch consumable resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)