### PR TITLE
Fix AgentLogObserver printing [SUCCESS] on failed runs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/AgentLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/AgentLogObserver.groovy
@@ -220,7 +220,8 @@ class AgentLogObserver implements TraceObserverV2, LogObserver {
         def cached = stats?.cachedCount ?: 0
         def completed = succeeded + failed
 
-        def status = failed > 0 ? 'FAILED' : 'SUCCESS'
+        def hasSessionError = session && !session.isSuccess()
+        def status = (failed > 0 || hasSessionError) ? 'FAILED' : 'SUCCESS'
         printLine("\n[${status}] completed=${completed} failed=${failed} cached=${cached}")
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/trace/AgentLogObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/AgentLogObserverTest.groovy
@@ -103,8 +103,12 @@ class AgentLogObserverTest extends Specification {
         def statsObserver = Stub(WorkflowStatsObserver) {
             getStats() >> stats
         }
+        def session = Stub(Session) {
+            isSuccess() >> true
+        }
         def observer = new TestAgentLogObserver(output)
         observer.setStatsObserver(statsObserver)
+        observer.onFlowCreate(session)
 
         when:
         observer.onFlowComplete()
@@ -123,14 +127,42 @@ class AgentLogObserverTest extends Specification {
         def statsObserver = Stub(WorkflowStatsObserver) {
             getStats() >> stats
         }
+        def session = Stub(Session) {
+            isSuccess() >> false
+        }
         def observer = new TestAgentLogObserver(output)
         observer.setStatsObserver(statsObserver)
+        observer.onFlowCreate(session)
 
         when:
         observer.onFlowComplete()
 
         then:
         output[0] == '\n[FAILED] completed=7 failed=2 cached=0'
+    }
+
+    def 'should output failed summary when session has error but no task failures'() {
+        given:
+        def output = []
+        def stats = new WorkflowStats()
+        stats.succeededCount = 0
+        stats.failedCount = 0
+        stats.cachedCount = 0
+        def statsObserver = Stub(WorkflowStatsObserver) {
+            getStats() >> stats
+        }
+        def session = Stub(Session) {
+            isSuccess() >> false
+        }
+        def observer = new TestAgentLogObserver(output)
+        observer.setStatsObserver(statsObserver)
+        observer.onFlowCreate(session)
+
+        when:
+        observer.onFlowComplete()
+
+        then:
+        output[0] == '\n[FAILED] completed=0 failed=0 cached=0'
     }
 
     def 'should handle task complete for failed task'() {


### PR DESCRIPTION
## Summary
- Check `session.isSuccess()` in `AgentLogObserver.printSummary()` so that session-level errors (aborted, cancelled, failOnIgnore) correctly produce a `[FAILED]` summary line
- Previously only task-level `failedCount` was checked, causing `[SUCCESS]` to be printed even when the session exited with code 1

Fixes #6959

## Test plan
- [x] Existing tests updated to provide session stub
- [x] New test: `[FAILED]` is printed when session has error but zero task failures
- [ ] Manual: run `nextflow module run` with missing params and verify `[FAILED]` in summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)