### PR TITLE
Add support for Java 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [17, 24]
+        java_version: [17, 25]
 
     steps:
       - name: Checkout
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [17, 24]
+        java_version: [17, 25]
         test_mode: ["test_integration", "test_parser_v2", "test_docs", "test_aws", "test_azure", "test_google", "test_wave"]
     steps:
       - name: Checkout

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,7 +12,7 @@ New versions of Nextflow are released regularly. See {ref}`updating-nextflow-pag
 
 ## Requirements
 
-Nextflow requires Bash 3.2 (or later) and [Java 17 (or later, up to 25)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to be installed. To see which version of Java you have, run the following command:
+Nextflow requires Bash 3.2 (or later) and [Java 17 (or later, up to 26)](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to be installed. To see which version of Java you have, run the following command:
 
 ```{code-block} bash
 :class: copyable

--- a/launch.sh
+++ b/launch.sh
@@ -67,14 +67,14 @@ fi
 JAVA_VER=$(echo "$JAVA_VER" | awk '/version/ {gsub(/"/, "", $3); print $3}')
 major=${BASH_REMATCH[1]}
 minor=${BASH_REMATCH[2]}
-version_check="^(17|18|19|20|21|23|24|25)"
+version_check="^(17|18|19|20|21|22|23|24|25|26)"
 if [[ ! $JAVA_VER =~ $version_check ]]; then
     echo "Error: cannot find Java or it's a wrong version -- please make sure that Java 17 or higher is installed"
     exit 1
 fi
 JVM_ARGS+=" -Dfile.encoding=UTF-8 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
 JVM_ARGS+=" --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio.file.spi=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED"
-[[ "$JAVA_VER" =~ ^(24|25) ]]&& JVM_ARGS+=" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+[[ "$JAVA_VER" =~ ^(24|25|26) ]]&& JVM_ARGS+=" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 [[ $NXF_ENABLE_VIRTUAL_THREADS == 'true' ]] && [[ "$JAVA_VER" =~ ^(19|20) ]] && JVM_ARGS+=" --enable-preview"
 [[ "$JAVA_VER" =~ ^(21) ]] && [[ ! "$NXF_ENABLE_VIRTUAL_THREADS" ]] && NXF_ENABLE_VIRTUAL_THREADS=true
 

--- a/nextflow
+++ b/nextflow
@@ -345,8 +345,8 @@ else
   fi
   major=${BASH_REMATCH[1]}
   minor=${BASH_REMATCH[2]}
-  version_check="^(17|18|19|20|21|22|23|24|25)"
-  version_message="Java 17 or later (up to 25)"
+  version_check="^(17|18|19|20|21|22|23|24|25|26)"
+  version_message="Java 17 or later (up to 26)"
   if [[ ! $JAVA_VER =~ $version_check ]]; then
       echo_red "ERROR: Cannot find Java or it's a wrong version -- please make sure that $version_message is installed"
       if [[ "$NXF_JAVA_HOME" ]]; then
@@ -470,13 +470,13 @@ else
     launcher+=(--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED)
     launcher+=(--add-opens=java.base/jdk.internal.vm=ALL-UNNAMED)
     launcher+=(--add-opens=java.base/java.util.regex=ALL-UNNAMED)
-    if [[ "$JAVA_VER" =~ ^(24|25) ]]; then
+    if [[ "$JAVA_VER" =~ ^(24|25|26) ]]; then
         launcher+=(--enable-native-access=ALL-UNNAMED)
         launcher+=(--sun-misc-unsafe-memory-access=allow)
     fi
     if [[ "$NXF_ENABLE_VIRTUAL_THREADS" == 'true' ]]; then
       if [[ "$JAVA_VER" =~ ^(19|20) ]]; then launcher+=(--enable-preview)
-      elif [[ ! "$JAVA_VER" =~ ^(21|22|23|24|25) ]]; then die "Virtual threads require Java 19 or later - current version $JAVA_VER"
+      elif [[ ! "$JAVA_VER" =~ ^(21|22|23|24|25|26) ]]; then die "Virtual threads require Java 19 or later - current version $JAVA_VER"
       fi
     fi
     launcher+=("${cmd_tail[@]}")


### PR DESCRIPTION
## Summary
- Add Java 26 to the supported versions in the `nextflow` launcher script and `launch.sh`
- Enable `--enable-native-access` and `--sun-misc-unsafe-memory-access` JVM flags for Java 26
- Add Java 26 to the virtual threads version check
- Fix missing Java 22 in `launch.sh` version check
- Update docs to reflect Java 26 support

Note: CI build matrix updated to Java 25 (not 26) because Java 26 is not yet available as a Temurin distribution in GitHub Actions `setup-java`.

## Test plan
- [ ] Verify CI passes with Java 17 and Java 25
- [ ] Test Nextflow launcher with Java 26 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)