### PR TITLE
Fix Google Batch exit code after spot preemption retry

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -559,6 +559,13 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - terminated job=$jobId; task=$taskId; state=$state"
             // finalize the task
             task.exitStatus = getExitCode()
+            // When the Batch job succeeded but the API-reported exit code reflects a failed
+            // intermediate attempt (e.g. spot preemption with exit code 50001 that was retried),
+            // fall back to the .exitcode file written by the final successful attempt
+            if( state == 'SUCCEEDED' && task.exitStatus != 0 ) {
+                log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - job SUCCEEDED but API reported exit code ${task.exitStatus}; falling back to .exitcode file"
+                task.exitStatus = readExitFile()
+            }
             if( state == 'FAILED' ) {
                 // When no exit code or 500XX codes, get the jobError reason from events
                 if( task.exitStatus == Integer.MAX_VALUE || task.exitStatus >= 50000)

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -773,5 +773,36 @@ class GoogleBatchTaskHandlerTest extends Specification {
         TaskStatus.State.FAILED | 'Task failed due to Spot VM preemption with exit code 50001.' | 50001     | false          | nextflow.processor.TaskStatus.COMPLETED   | 50001             | true      | 'Task failed due to Spot VM preemption with exit code 50001.'
     }
 
+    def 'should use exitcode file when job succeeded after spot preemption retry' () {
+        given:
+        def jobId = '1'
+        def taskId = '1'
+        // Simulate: job SUCCEEDED but API status events only contain the failed preemption attempt's exit code (50001)
+        // The SUCCEEDED event from Google Batch does not carry a TaskExecution, so getExitCode() finds only 50001
+        def client = Mock(BatchClient){
+            getTaskInArrayStatus(jobId, taskId) >> makeTaskStatus(TaskStatus.State.SUCCEEDED, '', 50001)
+            getTaskStatus(jobId, taskId) >> makeTaskStatus(TaskStatus.State.SUCCEEDED, '', 50001)
+            getJobStatus(jobId) >> makeJobStatus(JobStatus.State.SUCCEEDED, '')
+        }
+        def logging = Mock(BatchLogging)
+        def executor = Mock(GoogleBatchExecutor){
+            getLogging() >> logging
+        }
+        def task = new TaskRun()
+        task.name = 'hello'
+        def handler = Spy(new GoogleBatchTaskHandler(jobId: jobId, taskId: taskId, client: client, task: task, isArrayChild: ARRAY_CHILD, status: nextflow.processor.TaskStatus.RUNNING, executor: executor))
+        when:
+        def result = handler.checkIfCompleted()
+        then:
+        1 * handler.readExitFile() >> 0
+        handler.status == nextflow.processor.TaskStatus.COMPLETED
+        handler.task.exitStatus == 0
+        handler.task.error == null
+        result == true
+
+        where:
+        ARRAY_CHILD << [true, false]
+    }
+
 
 }


### PR DESCRIPTION
When using `google.batch.maxSpotAttempts > 0`, Google Batch will automatically retry the task with the same job ID right after a 50001 exit is returned. When a Google Batch job succeeds after an internal spot preemption retry (via `lifecyclePolicy` with `RETRY_TASK` on exit code 50001), `GoogleBatchTaskHandler` reports the exit code from the **first failed attempt** (50001) instead of the **final successful attempt** (0). This causes Nextflow to terminate the pipeline even though the Batch job completed successfully. 

This can be mitigated by including something like:
```
    process.errorStrategy = {
        if (task.exitStatus == 50001) {
            return 'ignore'
        }
 }
```
But if a user forgets, jobs will appear to have failed even when a preemption has been retried and the task succeeds.         

### Root cause

`getExitCode()` filters task status events for those with a `TaskExecution` and picks the latest by timestamp. The problem: Google Batch's `SUCCEEDED` status event does **not** carry a `TaskExecution` object; only the `FAILED` preemption event does. So the method always returns 50001 from the failed attempt, even when the job state is `SUCCEEDED`.

### Fix

In `checkIfCompleted()`, when the Batch job state is `SUCCEEDED` but the Batch API-derived exit code is non-zero, fall back to the `.exitcode` file written by the final successful attempt.

- This affects every pipeline using `google.batch.maxSpotAttempts` on spot VMs
- Without fix: any spot preemption that Batch successfully retries still terminates the pipeline
- With fix: exit code correctly resolves to 0 from the `.exitcode` file

### Test plan

- [x] Added Spock test for spot preemption retry scenario (array and non-array tasks)
- [x] All existing `GoogleBatchTaskHandlerTest` tests pass
