### PR TITLE
Send module resources as build context for container builds

### DIFF
--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/SubmitContainerTokenRequest.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/SubmitContainerTokenRequest.groovy
@@ -158,4 +158,12 @@ class SubmitContainerTokenRequest {
      */
     String buildTemplate
 
+    /**
+     * A layer holding the build context for this container request.
+     * When a container file (Dockerfile) is provided, module resources
+     * are sent as build context so they are available to COPY/ADD instructions
+     * during the image build.
+     */
+    ContainerLayer buildContext
+
 }

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -203,9 +203,17 @@ class WaveClient {
 
     SubmitContainerTokenRequest makeRequest(WaveAssets assets) {
         ContainerConfig containerConfig = assets.containerConfig ?: new ContainerConfig()
-        // prepend the bundle layer
+        ContainerLayer buildContext = null
+        // when a container file is provided, send module resources as build context
+        // so that they are available to COPY/ADD instructions during the image build;
+        // otherwise prepend them as container config layers for runtime overlay
         if( assets.moduleResources!=null && assets.moduleResources.hasEntries() ) {
-            containerConfig.prependLayer(makeLayer(assets.moduleResources))
+            if( assets.containerFile ) {
+                buildContext = makeLayer(assets.moduleResources)
+            }
+            else {
+                containerConfig.prependLayer(makeLayer(assets.moduleResources))
+            }
         }
         // prepend project resources bundle
         if( assets.projectResources!=null && assets.projectResources.hasEntries() ) {
@@ -255,7 +263,8 @@ class WaveClient {
                 scanMode: config.scanMode(),
                 scanLevels: config.scanAllowedLevels(),
                 buildCompression: config.buildCompression(),
-                buildTemplate: config.buildTemplate()
+                buildTemplate: config.buildTemplate(),
+                buildContext: buildContext
         )
     }
 

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -463,6 +463,50 @@ class WaveClientTest extends Specification {
     }
 
 
+    def 'should create request with module resources as build context when containerFile is provided' () {
+        given:
+        def DOCKERFILE = 'FROM foo:latest\nCOPY bin/ /usr/local/bin/'
+        def MODULE_RES = Mock(ResourcesBundle) { hasEntries() >> true }
+        def MODULE_LAYER = Mock(ContainerLayer)
+        and:
+        def session = Mock(Session) { getConfig() >> [:]}
+        WaveClient wave = Spy(WaveClient, constructorArgs: [session])
+
+        when:
+        def assets = new WaveAssets(null, null, MODULE_RES, null, DOCKERFILE)
+        def req = wave.makeRequest(assets)
+        then:
+        1 * wave.makeLayer(MODULE_RES) >> MODULE_LAYER
+        and:
+        new String(req.containerFile.decodeBase64()) == DOCKERFILE
+        req.buildContext == MODULE_LAYER
+        !req.containerConfig.layers
+    }
+
+    def 'should create request with module as build context and project as layer' () {
+        given:
+        def DOCKERFILE = 'FROM foo:latest\nCOPY bin/ /usr/local/bin/'
+        def MODULE_RES = Mock(ResourcesBundle) { hasEntries() >> true }
+        def MODULE_LAYER = Mock(ContainerLayer)
+        and:
+        def PROJECT_RES = Mock(ResourcesBundle) { hasEntries() >> true }
+        def PROJECT_LAYER = Mock(ContainerLayer)
+        and:
+        def session = Mock(Session) { getConfig() >> [:]}
+        WaveClient wave = Spy(WaveClient, constructorArgs: [session])
+
+        when:
+        def assets = new WaveAssets(null, null, MODULE_RES, null, DOCKERFILE, null, PROJECT_RES)
+        def req = wave.makeRequest(assets)
+        then:
+        1 * wave.makeLayer(MODULE_RES) >> MODULE_LAYER
+        1 * wave.makeLayer(PROJECT_RES) >> PROJECT_LAYER
+        and:
+        req.buildContext == MODULE_LAYER
+        req.containerConfig.layers.size() == 1
+        req.containerConfig.layers[0] == PROJECT_LAYER
+    }
+
     def 'should create asset with image' () {
         given:
         def session = Mock(Session) { getConfig() >> [:]}


### PR DESCRIPTION
## Summary
- When a `containerFile` (Dockerfile) is provided alongside module resources, send the module resources as `buildContext` instead of `containerConfig.layers`
- This makes module `bin/` and `lib/` files available to `COPY`/`ADD` instructions during the image build, rather than overlaying them as opaque layers at runtime
- When no `containerFile` is present (image-only requests), existing behavior is preserved — module resources remain as `containerConfig.layers`

## Motivation
Enable support for Dockerfile `COPY` and `ADD` commands using module resources as build context. Currently module resources are sent as `containerConfig.layers`, which are overlaid at runtime and not accessible during the image build. By sending them as `buildContext` when a `containerFile` is present, module-provided files become available to `COPY`/`ADD` instructions in the Dockerfile.

## Test plan
- [x] Existing test: module resources as layers when no containerFile (unchanged behavior)
- [x] New test: module resources sent as `buildContext` when containerFile is present
- [x] New test: module resources as `buildContext` + project resources as layer with containerFile
- [x] All nf-wave plugin tests pass