### PR TITLE
Bump org.apache.groovy from 4.0.30 to 4.0.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,8 @@ allprojects {
 
         // Documentation required libraries
         groovyDoc 'org.fusesource.jansi:jansi:2.4.0'
-        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.30"
-        groovyDoc "org.apache.groovy:groovy-ant:4.0.30"
+        groovyDoc "org.apache.groovy:groovy-groovydoc:4.0.31"
+        groovyDoc "org.apache.groovy:groovy-ant:4.0.31"
     }
 
     test {

--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -41,12 +41,12 @@ dependencies {
     api(project(':nf-commons'))
     api(project(':nf-httpfs'))
     api(project(':nf-lang'))
-    api "org.apache.groovy:groovy:4.0.30"
-    api "org.apache.groovy:groovy-nio:4.0.30"
-    api "org.apache.groovy:groovy-xml:4.0.30"
-    api "org.apache.groovy:groovy-json:4.0.30"
-    api "org.apache.groovy:groovy-templates:4.0.30"
-    api "org.apache.groovy:groovy-yaml:4.0.30"
+    api "org.apache.groovy:groovy:4.0.31"
+    api "org.apache.groovy:groovy-nio:4.0.31"
+    api "org.apache.groovy:groovy-xml:4.0.31"
+    api "org.apache.groovy:groovy-json:4.0.31"
+    api "org.apache.groovy:groovy-templates:4.0.31"
+    api "org.apache.groovy:groovy-yaml:4.0.31"
     api "org.slf4j:jcl-over-slf4j:2.0.17"
     api "org.slf4j:jul-to-slf4j:2.0.17"
     api "org.slf4j:log4j-over-slf4j:2.0.17"
@@ -78,7 +78,7 @@ dependencies {
     testImplementation (project(':nf-lineage'))
     testImplementation 'org.wiremock:wiremock:3.13.1'
     // test configuration
-    testFixturesApi ("org.apache.groovy:groovy-test:4.0.30") { exclude group: 'org.apache.groovy' }
+    testFixturesApi ("org.apache.groovy:groovy-test:4.0.31") { exclude group: 'org.apache.groovy' }
     testFixturesApi ("org.objenesis:objenesis:3.4")
     testFixturesApi ("net.bytebuddy:byte-buddy:1.14.17")
     testFixturesApi ("org.spockframework:spock-core:2.4-groovy-4.0") { exclude group: 'org.apache.groovy' }

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -27,8 +27,8 @@ sourceSets {
 dependencies {
     api(project(':nf-lang'))
     api "ch.qos.logback:logback-classic:1.5.26"
-    api "org.apache.groovy:groovy:4.0.30"
-    api "org.apache.groovy:groovy-nio:4.0.30"
+    api "org.apache.groovy:groovy:4.0.31"
+    api "org.apache.groovy:groovy-nio:4.0.31"
     api "org.apache.commons:commons-lang3:3.18.0"
     api 'com.google.guava:guava:33.0.0-jre'
     api 'org.pf4j:pf4j:3.12.0'
@@ -44,7 +44,7 @@ dependencies {
     testImplementation(testFixtures(project(":nextflow")))
     testFixturesImplementation(project(":nextflow"))
 
-    testImplementation "org.apache.groovy:groovy-json:4.0.30" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.31" // needed by wiremock
     testImplementation ('org.wiremock:wiremock:3.13.1') { exclude module: 'groovy-all' }
 }
 

--- a/modules/nf-httpfs/build.gradle
+++ b/modules/nf-httpfs/build.gradle
@@ -30,12 +30,12 @@ sourceSets {
 dependencies {
     api project(':nf-commons')
     api "ch.qos.logback:logback-classic:1.5.26"
-    api "org.apache.groovy:groovy:4.0.30"
-    api "org.apache.groovy:groovy-nio:4.0.30"
+    api "org.apache.groovy:groovy:4.0.31"
+    api "org.apache.groovy:groovy-nio:4.0.31"
     api("com.esotericsoftware.kryo:kryo:2.24.0") { exclude group: 'com.esotericsoftware.minlog', module: 'minlog' }
 
     /* testImplementation inherited from top gradle build file */
-    testImplementation "org.apache.groovy:groovy-json:4.0.30" // needed by wiremock
+    testImplementation "org.apache.groovy:groovy-json:4.0.31" // needed by wiremock
     testImplementation ('org.wiremock:wiremock:3.13.1') { exclude module: 'groovy-all' }
 
     testImplementation(testFixtures(project(":nextflow")))

--- a/modules/nf-lang/build.gradle
+++ b/modules/nf-lang/build.gradle
@@ -23,7 +23,7 @@ compileJava {
 
 dependencies {
   antlr 'me.sunlan:antlr4:4.13.2.6'
-  api 'org.apache.groovy:groovy:4.0.30'
+  api 'org.apache.groovy:groovy:4.0.31'
   api 'org.pf4j:pf4j:3.12.0'
 
   testFixturesApi 'com.google.jimfs:jimfs:1.2'

--- a/modules/nf-lineage/build.gradle
+++ b/modules/nf-lineage/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':nextflow')
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }
 

--- a/plugins/nf-amazon/build.gradle
+++ b/plugins/nf-amazon/build.gradle
@@ -78,6 +78,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }

--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -69,6 +69,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }

--- a/plugins/nf-cloudcache/build.gradle
+++ b/plugins/nf-cloudcache/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }
 

--- a/plugins/nf-codecommit/build.gradle
+++ b/plugins/nf-codecommit/build.gradle
@@ -60,6 +60,6 @@ dependencies {
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }

--- a/plugins/nf-console/build.gradle
+++ b/plugins/nf-console/build.gradle
@@ -51,13 +51,13 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     api("org.apache.groovy:groovy-console:4.0.21-patch.2") { transitive=false }
-    api("org.apache.groovy:groovy-swing:4.0.30")  { transitive=false }
+    api("org.apache.groovy:groovy-swing:4.0.31")  { transitive=false }
     // this is required by 'groovy-console'
     api("com.github.javaparser:javaparser-core:3.25.8")
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }
 

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -65,8 +65,8 @@ dependencies {
     runtimeOnly 'com.fasterxml.jackson.core:jackson-core:2.18.6'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }
 
 test {

--- a/plugins/nf-k8s/build.gradle
+++ b/plugins/nf-k8s/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     api 'org.bouncycastle:bcpkix-jdk18on:1.79'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }
 
 test {

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -54,6 +54,6 @@ dependencies {
     api 'io.seqera:sched-client:0.41.0-SNAPSHOT'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.21.1"
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
-    testImplementation "org.apache.groovy:groovy-json:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy-json:4.0.31"
     // wiremock required by TowerFusionEnvTest
     testImplementation "org.wiremock:wiremock:3.13.1"
     // Address security vulnerabilities CVE-2022-45688 and CVE-2023-5072

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -66,6 +66,6 @@ dependencies {
     api 'io.seqera:wave-utils:1.31.1'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.30"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.30"
+    testImplementation "org.apache.groovy:groovy:4.0.31"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
 }


### PR DESCRIPTION
## Summary
- Bump Apache Groovy from 4.0.30 to 4.0.31 across all modules and plugins (16 build.gradle files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)