### PR TITLE
[codex] Add local plugin registry guidance for air-gapped setups

### DIFF
--- a/docs/plugins/plugin-registry.md
+++ b/docs/plugins/plugin-registry.md
@@ -12,6 +12,39 @@ The Nextflow plugin registry is currently available as a public preview. Plugin 
 
 See {ref}`gradle-plugin-publish` for instructions on how to publish plugins to the registry, including the {ref}`README.md requirement <gradle-plugin-readme>`.
 
+## Using a custom or local registry
+
+If your environment can't reach the public registry directly, you can point Nextflow to a custom plugin registry endpoint:
+
+```bash
+export NXF_PLUGINS_REGISTRY_URL="https://plugins.myorg.internal/api"
+```
+
+This is useful for restricted or air-gapped environments where plugin metadata and plugin archives are mirrored behind an internal URL.
+
+To reduce or eliminate runtime downloads, pre-populate the local plugin cache and point Nextflow at that directory:
+
+```bash
+export NXF_PLUGINS_DIR="/shared/nextflow/plugins"
+```
+
+In fully offline environments, enable offline mode only after the required plugin versions have already been staged in `NXF_PLUGINS_DIR`:
+
+```bash
+export NXF_OFFLINE=true
+```
+
+In offline mode, Nextflow does not contact remote project or plugin endpoints, and plugin versions must be specified explicitly.
+
+For practical air-gapped setups:
+
+1. Mirror the plugin registry behind an approved internal URL.
+2. Set `NXF_PLUGINS_REGISTRY_URL` to that internal registry.
+3. Pre-stage approved plugin versions in `NXF_PLUGINS_DIR` for the execution environment.
+4. Use `NXF_OFFLINE=true` only when workflows and required plugins are already available locally.
+
+If you continue to use the public registry, allow outbound access to `registry.nextflow.io`. If you use a custom registry URL instead, only that internal endpoint needs to be reachable for plugin metadata and downloads.
+
 (plugin-registry-claim)=
 
 ## Claiming a plugin


### PR DESCRIPTION
## Summary
This draft adds practical guidance for running Nextflow plugins with a custom or local registry in restricted or air-gapped environments.

## Source context
- Slack source: https://seqera.slack.com/archives/C0APYR2A3A8/p1775081447163959
- Jira: https://seqera.atlassian.net/browse/EDU-1115

## Doc target
- `docs/plugins/plugin-registry.md`

## Rationale
The EDU ticket called out a missing doc path for air-gapped plugin usage. The existing docs already describe the registry itself and the relevant environment variables separately, so this change adds the minimum connective guidance in the plugin registry page: custom registry URL, local cache directory, offline mode, and when `registry.nextflow.io` still needs outbound access.

## Validation
- Reviewed the edited page directly
- Confirmed the new guidance matches existing Nextflow environment variable docs and current plugin-registry behavior in code
- Did not run a full docs build in the temp automation clone

## Follow-up
If we want a more complete air-gapped operations guide later, this section can link out to a dedicated admin-oriented page.