### PR TITLE
[codex] Clarify self-update guidance for sudo installs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -94,6 +94,8 @@ To install Nextflow with the self-installing package:
 
     :::{warning}
     Nextflow updates its executable during the self-install process, therefore the update can fail if the executable is placed in a directory with restricted permissions.
+
+    Avoid installing the `nextflow` executable into a root-owned location such as `/usr/local/bin` with `sudo` if you plan to use `nextflow self-update`. If the executable is not writable by your normal user account, self-updates can fail and may leave the installation in a broken state. Prefer a user-writable location such as `$HOME/.local/bin`.
     :::
 
 4. Confirm Nextflow is installed correctly:

--- a/docs/updating-nextflow.md
+++ b/docs/updating-nextflow.md
@@ -34,7 +34,16 @@ When updating from an edge release to a stable release, you must explicitly set 
 
 :::{warning}
 Nextflow will update its executable during the self-update process. The update can fail if the Nextflow executable is in a directory with restricted permissions.
+
+Do not run `nextflow self-update` with `sudo`. If the executable or framework directory becomes owned by `root`, subsequent Nextflow commands can fail with `Permission denied` errors for your normal user account.
 :::
+
+If `self-update` fails after a `sudo` install or update, recover the installation with the following steps:
+
+1. Remove the root-owned framework directory for the affected version, for example `sudo rm -rf ~/.nextflow/framework/<version>`.
+2. If needed, remove or replace a root-owned `nextflow` executable that was installed into a protected location such as `/usr/local/bin`.
+3. Reinstall Nextflow in a user-writable location such as `$HOME/.local/bin`.
+4. Run `nextflow info` or `nextflow -v` to confirm the installation works again.
 
 ## Version selection
 


### PR DESCRIPTION
## Summary
This draft adds a targeted warning for `nextflow self-update` installs that were done with `sudo` or into root-owned locations, plus recovery steps if that leaves the installation unusable.

## Source context
- Slack source: https://seqera.slack.com/archives/C0APYR2A3A8/p1775254519687639
- Jira: https://seqera.atlassian.net/browse/EDU-1119
- Related product discussion: https://seqera.slack.com/archives/CUTDS6JE9/p1770300590508689

## Doc target
- `docs/install.md`
- `docs/updating-nextflow.md`

## Rationale
The EDU ticket called out a docs gap around users breaking local Nextflow installs after running `self-update` with elevated permissions. The existing docs already warn that restricted permissions can break self-install and self-update, so this draft keeps the change narrow: it makes the `sudo` / root-owned path explicit, recommends a user-writable install location, and adds a short recovery sequence for the broken-install case.

## Validation
- Reviewed the edited docs diff directly
- Attempted `python3 -m sphinx -b dummy . /tmp/nextflow-docs-dummy` from `docs/`, but this environment does not have `sphinx` installed

## Follow-up
If we see more cases like this, the install and update docs may also benefit from a short troubleshooting section for common local permission mistakes.
