### PR TITLE
Fix NPE in GitLab/Gitea getGitCredentials when token set but password null

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GiteaRepositoryProvider.groovy
@@ -20,6 +20,8 @@ package nextflow.scm
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 
 import java.nio.charset.StandardCharsets
 
@@ -63,6 +65,12 @@ final class GiteaRepositoryProvider extends RepositoryProvider {
         return getToken()
             ? true
             : super.hasCredentials()
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    CredentialsProvider getGitCredentials() {
+        return new UsernamePasswordCredentialsProvider(getUser(), getToken() ?: getPassword())
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -18,6 +18,8 @@ package nextflow.scm
 
 import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 
 import java.nio.charset.StandardCharsets
 
@@ -60,6 +62,12 @@ class GitlabRepositoryProvider extends RepositoryProvider {
         return getToken()
             ? true
             : super.hasCredentials()
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    CredentialsProvider getGitCredentials() {
+        return new UsernamePasswordCredentialsProvider(getUser(), getToken() ?: getPassword())
     }
 
     @Override

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GiteaRepositoryProviderTest.groovy
@@ -76,6 +76,24 @@ class GiteaRepositoryProviderTest extends Specification {
         true        | new ProviderConfig('gitea').setToken('xyz')
     }
 
+    @Unroll
+    def 'should return git credentials' () {
+        given:
+        def provider = new GiteaRepositoryProvider('pditommaso/tutorial', CONFIG)
+
+        when:
+        def credentials = provider.getGitCredentials()
+
+        then:
+        credentials != null
+
+        where:
+        CONFIG                                                                  | _
+        new ProviderConfig('gitea').setUser('foo').setPassword('bar')           | _
+        new ProviderConfig('gitea').setUser('foo').setToken('xyz')              | _
+        new ProviderConfig('gitea').setUser('foo').setPassword('bar').setToken('xyz') | _
+    }
+
     @IgnoreIf({System.getenv('NXF_SMOKE')})
     @Requires({System.getenv('NXF_GITEA_ACCESS_TOKEN')})
     def 'should read file content'() {

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
@@ -54,6 +54,24 @@ class GitlabRepositoryProviderTest extends Specification {
         true        | new ProviderConfig('gitlab').setToken('xyz')
     }
 
+    @Unroll
+    def 'should return git credentials' () {
+        given:
+        def provider = new GitlabRepositoryProvider('pditommaso/tutorial', CONFIG)
+
+        when:
+        def credentials = provider.getGitCredentials()
+
+        then:
+        credentials != null
+
+        where:
+        CONFIG                                                                    | _
+        new ProviderConfig('gitlab').setUser('foo').setPassword('bar')            | _
+        new ProviderConfig('gitlab').setUser('foo').setToken('xyz')               | _
+        new ProviderConfig('gitlab').setUser('foo').setPassword('bar').setToken('xyz') | _
+    }
+
     @Requires({System.getenv('NXF_GITLAB_ACCESS_TOKEN')})
     def 'should return clone url'() {
         given:


### PR DESCRIPTION
## Summary
- Override `getGitCredentials()` in `GitlabRepositoryProvider` and `GiteaRepositoryProvider` to fall back to the token when password is not provided, using `getToken() ?: getPassword()`
- Matches the existing pattern in `BitbucketRepositoryProvider` (line 64-66)
- Fixes the `NullPointerException: Cannot invoke "String.toCharArray()" because "password" is null` when SCM config has `user` and `token` but no `password`

Fixes #7006

## Test plan
- [x] Added parameterized `'should return git credentials'` tests for both GitlabRepositoryProvider and GiteaRepositoryProvider covering password-only, token-only, and both configurations
- [x] All SCM unit tests pass (`NXF_SMOKE=1 ./gradlew :nextflow:test --tests "nextflow.scm.*"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)