### PR TITLE
Add option to disable printing workflow outputs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1614,7 +1614,7 @@ The `run` command is used to execute a local pipeline script or remote pipeline 
 `-output-format`
 : :::{versionadded} 26.04.0
   :::
-: Output format for printing workflow outputs. Options: `text` (default), `json`.
+: Output format for printing workflow outputs. Options: `text` (default), `json`, `none`.
 
 `-params-file`
 : Load script parameters from a JSON/YAML file.

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -116,7 +116,7 @@ class CmdRun extends CmdBase implements HubOptions {
     @Parameter(names=['-o', '-output-dir'], description = 'Directory where workflow outputs are stored')
     String outputDir
 
-    @Parameter(names=['-output-format'], description = 'Output format for printing workflow outputs. Options: `text` (default), `json`')
+    @Parameter(names=['-output-format'], description = 'Output format for printing workflow outputs. Options: `text` (default), `json`, `none`')
     String outputFormat = 'text'
 
     @Parameter(names=['-w', '-work-dir'], description = 'Directory where intermediate result files are stored')
@@ -324,8 +324,8 @@ class CmdRun extends CmdBase implements HubOptions {
         if( offline && latest )
             throw new AbortOperationException("Command line options `-latest` and `-offline` cannot be specified at the same time")
 
-        if( outputFormat !in ['json', 'text'] )
-            throw new AbortOperationException("Command line option `-output-format` should be either `json` or `text`")
+        if( outputFormat !in ['text', 'json', 'none'] )
+            throw new AbortOperationException("Command line option `-output-format` should be either `text`, `json`, or `none`")
 
         checkRunName()
 

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -934,16 +934,10 @@ class ConfigBuilder {
 
         // strip secrets
         SecretHelper.hideSecrets(config)
-        // strip command line options
-        stripCliOptions(config)
         // compute config
         final result = toCanonicalString(config, false)
         // dump config for debugging
         log.trace "Resolved config:\n${result.indent('\t')}"
         return result
-    }
-
-    private static void stripCliOptions(Map config) {
-        config.remove('outputFormat')
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -76,11 +76,13 @@ class OutputDsl {
         }
 
         // print workflow outputs on run completion
-        session.addIgniter {
+        session.workflowMetadata.onComplete {
+            if( !session.isSuccess() )
+                return
             final output = getOutput()
             if( session.outputFormat == 'json' )
                 session.printConsole(DumpHelper.prettyPrintJson(output), true)
-            else
+            else if( session.outputFormat == 'text' )
                 printOutput(session, output)
         }
     }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -2383,6 +2383,7 @@ class ConfigBuilderTest extends Specification {
                executor = { 'local' }
             }
 
+            outputFormat = 'text'
             workDir = 'work'
 
             tower {

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -26,13 +26,20 @@ import nextflow.exception.ScriptRuntimeException
 import nextflow.trace.event.FilePublishEvent
 import nextflow.trace.event.WorkflowOutputEvent
 import spock.lang.Specification
-
-import static test.ScriptHelper.runDataflow
 /**
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
 class OutputDslTest extends Specification {
+
+    Session createSession(Map config) {
+        def session = new Session(config) {
+            @Override
+            void abort(Throwable cause) { throw cause }
+        }
+        session.init(null)
+        return session
+    }
 
     def 'should publish workflow outputs'() {
         given:
@@ -58,7 +65,7 @@ class OutputDslTest extends Specification {
         SysEnv.push(NXF_FILE_ROOT: root.toString())
 
         when:
-        def session = Spy(new Session(config))
+        def session = Spy(createSession(config))
 
         session.outputs.put('foo', Channel.of(file1))
         session.outputs.put('bar', Channel.of(file2))
@@ -77,6 +84,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         outputDir.resolve('foo/file1.txt').text == 'Hello'
@@ -112,7 +120,7 @@ class OutputDslTest extends Specification {
         SysEnv.push(NXF_FILE_ROOT: root.toString())
 
         when:
-        def session = Spy(new Session(config))
+        def session = Spy(createSession(config))
 
         session.outputs.put('foo', Channel.of(file1))
 
@@ -121,6 +129,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         outputDir.resolve('file1.txt').text == 'Hello'
@@ -151,7 +160,7 @@ class OutputDslTest extends Specification {
         SysEnv.push(NXF_FILE_ROOT: root.toString())
 
         when:
-        def session = Spy(new Session(config))
+        def session = Spy(createSession(config))
 
         session.outputs.put('foo', Channel.of(record))
 
@@ -160,6 +169,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         0 * session.notifyFilePublish(_)
@@ -220,9 +230,7 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid path directive' () {
         when:
-        def session = new Session(outputDir: Path.of('results')) {
-            void abort(Throwable cause) { throw cause }
-        }
+        def session = createSession(outputDir: Path.of('results'))
 
         session.outputs.put('foo', Channel.of(1, 2, 3))
 
@@ -232,6 +240,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -241,9 +250,7 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid publish target' () {
         when:
-        def session = new Session(outputDir: Path.of('results')) {
-            void abort(Throwable cause) { throw cause }
-        }
+        def session = createSession(outputDir: Path.of('results'))
         def file = Path.of('output.txt')
 
         session.outputs.put('foo', Channel.of([file, file, file]))
@@ -254,6 +261,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -262,9 +270,7 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid publish source' () {
         when:
-        def session = new Session(outputDir: Path.of('results')) {
-            void abort(Throwable cause) { throw cause }
-        }
+        def session = createSession(outputDir: Path.of('results'))
 
         session.outputs.put('foo', Channel.of(42))
 
@@ -274,6 +280,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -283,9 +290,7 @@ class OutputDslTest extends Specification {
 
     def 'should report error for invalid index file extension' () {
         when:
-        def session = new Session(outputDir: Path.of('results')) {
-            void abort(Throwable cause) { throw cause }
-        }
+        def session = createSession(outputDir: Path.of('results'))
 
         session.outputs.put('foo', Channel.empty())
 
@@ -297,6 +302,7 @@ class OutputDslTest extends Specification {
         }
         dsl.apply(session)
         session.fireDataflowNetwork()
+        dsl.getOutput()
 
         then:
         def e = thrown(ScriptRuntimeException)


### PR DESCRIPTION
This PR adds the ability to disable printing workflow outputs by specifying `-output-format none`

It also improves the workflow output printing logic by (1) using an onComplete handler instead of an igniter and (2) not printing in the event of a pipeline error