### PR TITLE
Make plugin metadata prefetch failure non-fatal

### DIFF
--- a/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
@@ -88,7 +88,6 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
             }
             catch (Exception e) {
                 log.warn "Failed to prefetch plugin metadata - ${e.message}"
-                log.debug "Plugin metadata prefetch error details", e
                 this.plugins = new HashMap<>()
             }
         }

--- a/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
@@ -83,7 +83,14 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
     @Override
     void prefetch(List<PluginRef> plugins) {
         if (plugins && !plugins.isEmpty()) {
-            this.plugins = fetchMetadata(plugins)
+            try {
+                this.plugins = fetchMetadata(plugins)
+            }
+            catch (Exception e) {
+                log.warn "Failed to prefetch plugin metadata - ${e.message}"
+                log.debug "Plugin metadata prefetch error details", e
+                this.plugins = new HashMap<>()
+            }
         }
     }
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -36,6 +36,7 @@ import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.file.FileMutex
 import org.pf4j.InvalidPluginDescriptorException
+import org.pf4j.ManifestPluginDescriptorFinder
 import org.pf4j.PluginDependency
 import org.pf4j.PluginRuntimeException
 import org.pf4j.PluginState
@@ -155,6 +156,11 @@ class PluginUpdater extends UpdateManager {
                 log.trace "Prefetching plugin metadata from repository: ${repo.getClass().getSimpleName()} [${repo.id}]; plugins=${plugins}"
                 repo.prefetch(plugins)
             }
+        }
+        // When remote registry an no plugins detected after prefetch, add local repo to work with downloaded plugins
+        if( !offline && getPluginsMap().isEmpty() ){
+            final localRepo = new LocalUpdateRepository('downloaded', pluginsStore)
+            this.addRepository(localRepo)
         }
     }
 

--- a/modules/nf-commons/src/test/nextflow/plugin/HttpPluginRepositoryTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/HttpPluginRepositoryTest.groovy
@@ -104,14 +104,26 @@ class HttpPluginRepositoryTest extends Specification {
         r1.requires == ">=24.10.0"
     }
 
-    // ------------------------------------------------------------------------
-
-    def 'handle prefetch error when metadata service is unavailable'() {
+    def 'catch prefetch exceptions'() {
         setup:
         wiremock.stop()
 
         when:
         unit.prefetch([new PluginRef("nf-fake")])
+
+        then:
+        noExceptionThrown()
+        unit.getPlugins() == [:]
+    }
+
+    // ------------------------------------------------------------------------
+
+    def 'handle fetchMetadata error when metadata service is unavailable'() {
+        setup:
+        wiremock.stop()
+
+        when:
+        unit.fetchMetadata([new PluginRef("nf-fake")])
 
         then:
         def err = thrown PluginRuntimeException
@@ -120,7 +132,7 @@ class HttpPluginRepositoryTest extends Specification {
 
     // ------------------------------------------------------------------------
 
-    def 'handle prefetch error with percent chars in error message'() {
+    def 'handle fetchMetadata error with percent chars in error message'() {
         given:
         // Test that URLs containing '%' characters (like URL-encoded values) are handled
         // correctly when an exception occurs. The '%' must be escaped to '%%' to avoid
@@ -129,7 +141,7 @@ class HttpPluginRepositoryTest extends Specification {
         wiremock.stop()
 
         when:
-        repoWithEncodedUrl.prefetch([new PluginRef("nf-fake")])
+        repoWithEncodedUrl.fetchMetadata([new PluginRef("nf-fake")])
 
         then:
         def err = thrown PluginRuntimeException
@@ -140,7 +152,7 @@ class HttpPluginRepositoryTest extends Specification {
 
     // ------------------------------------------------------------------------
 
-    def 'handle prefetch error when metadata service returns an error response'() {
+    def 'handle fetchMetadata error when metadata service returns an error response'() {
         given:
         wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
             .willReturn(aResponse()
@@ -148,7 +160,7 @@ class HttpPluginRepositoryTest extends Specification {
                 .withBody("Server error!")))
 
         when:
-        unit.prefetch([new PluginRef("nf-fake")])
+        unit.fetchMetadata([new PluginRef("nf-fake")])
 
         then:
         def err = thrown PluginRuntimeException
@@ -177,7 +189,7 @@ class HttpPluginRepositoryTest extends Specification {
 
     // ------------------------------------------------------------------------
 
-    def 'handle prefetch error caused by nextflow sending a bad request to metadata service'() {
+    def 'handle fetchMetadata error caused by nextflow sending a bad request to metadata service'() {
         given:
         wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
             .willReturn(aResponse()
@@ -188,7 +200,7 @@ class HttpPluginRepositoryTest extends Specification {
                 }""")))
 
         when:
-        unit.prefetch([new PluginRef("nf-fake")])
+        unit.fetchMetadata([new PluginRef("nf-fake")])
 
         then:
         def err = thrown PluginRuntimeException


### PR DESCRIPTION
## Summary

Fixes #7013

- Make `HttpPluginRepository.prefetch()` catch exceptions and log a warning instead of aborting startup
- Initialize the plugins map to an empty `HashMap` on failure so that `getPlugin()` can still attempt on-demand lazy fetches later
- Refactor tests to verify prefetch error tolerance while still testing `fetchMetadata()` error behavior directly

## Context

When all plugins are pinned to exact versions and pre-installed locally, Nextflow unconditionally calls the plugin registry API at startup. If the registry is unreachable, the run aborts even though the fetched metadata would never be used.

This affects users in airlocked/firewalled environments who pre-install plugins into container images. `NXF_OFFLINE=true` works around it but also blocks remote pipeline cloning, making it unusable for environments that need to fetch pipelines from a Git server.

With this fix, the prefetch error is deferred — it only surfaces later if something genuinely needs the metadata (version resolution for unpinned plugins, download URLs for missing plugins).

## Test plan

- [x] `HttpPluginRepositoryTest` — all 9 tests pass
- [x] All `nextflow.plugin.*` tests pass
- [x] Manual: pre-install a plugin, block registry access, verify `nextflow run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)