### PR TITLE
Fix resolution of config profiles with strict syntax parser

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
@@ -33,13 +33,6 @@ interface ConfigParser {
     ConfigParser setIgnoreIncludes(boolean value)
 
     /**
-     * Toggle whether to strip secrets when rendering the config.
-     *
-     * @param value
-     */
-    ConfigParser setStripSecrets(boolean value)
-
-    /**
      * Toggle whether to render the source code of closures.
      *
      * @param value
@@ -52,6 +45,13 @@ interface ConfigParser {
      * @param value
      */
     ConfigParser setStrict(boolean value)
+
+    /**
+     * Toggle whether to strip secrets when rendering the config.
+     *
+     * @param value
+     */
+    ConfigParser setStripSecrets(boolean value)
 
     /**
      * Define variables which will be made available to the config script.
@@ -80,13 +80,13 @@ interface ConfigParser {
     ConfigObject parse(Path path)
 
     /**
-     * Get the set of declared profiles.
-     */
-    Set<String> getDeclaredProfiles()
-
-    /**
      * Get the map of declared params.
      */
     Map<String,Object> getDeclaredParams()
+
+    /**
+     * Get the set of declared profiles.
+     */
+    Set<String> getDeclaredProfiles()
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -22,6 +22,7 @@ import java.nio.file.Path
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
+import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.SysEnv
 import nextflow.exception.ConfigParseException
@@ -49,13 +50,13 @@ class ConfigDsl extends Script {
 
     private Map cliParams
 
-    private List<String> profiles
+    private List<String> enabledProfiles
 
     private Map target = [params: [:]]
 
-    private Set<String> declaredProfiles = []
-
     private Map<String,Object> declaredParams = [:]
+
+    private Map<String,Closure> declaredProfiles = [:]
 
     void setIgnoreIncludes(boolean value) {
         this.ignoreIncludes = value
@@ -86,24 +87,24 @@ class ConfigDsl extends Script {
         (target.params as Map).putAll(params)
     }
 
-    void setProfiles(List<String> profiles) {
-        this.profiles = profiles
-    }
-
-    void declareProfile(String profile) {
-        declaredProfiles.add(profile)
-    }
-
-    Set<String> getDeclaredProfiles() {
-        return declaredProfiles
+    void setProfiles(List<String> enabledProfiles) {
+        this.enabledProfiles = enabledProfiles
     }
 
     void declareParam(String name, Object value) {
         declaredParams.put(name, value)
     }
 
+    void declareProfile(String profile, Closure closure) {
+        declaredProfiles.put(profile, closure)
+    }
+
     Map<String,Object> getDeclaredParams() {
         return declaredParams
+    }
+
+    Set<String> getDeclaredProfiles() {
+        return declaredProfiles.keySet()
     }
 
     Map getTarget() {
@@ -204,7 +205,6 @@ class ConfigDsl extends Script {
         cl.setResolveStrategy(Closure.DELEGATE_FIRST)
         cl.setDelegate(dsl)
         cl.call()
-        dsl.apply()
     }
 
     private ConfigBlockDsl blockDsl(List<String> names) {
@@ -219,7 +219,7 @@ class ConfigDsl extends Script {
             return new ProcessDsl(this, names)
 
         if( names.size() == 1 && names.first() == 'profiles' )
-            return new ProfilesDsl(this, profiles)
+            return new ProfilesDsl(this)
 
         return new ConfigBlockDsl(this, names)
     }
@@ -258,10 +258,11 @@ class ConfigDsl extends Script {
                 .setBinding(binding.getVariables())
                 .setParams(cliParams)
                 .setConfigParams(target.params as Map)
-                .setProfiles(profiles)
+                .setProfiles(enabledProfiles)
         final config = parser.parse(configText, includePath)
-        declaredProfiles.addAll(parser.getDeclaredProfiles())
         declaredParams.putAll(parser.getDeclaredParams())
+        for( final profile : parser.getDeclaredProfiles() )
+            declaredProfiles.put(profile, null)
 
         final ctx = navigate(names)
         ctx.putAll(Bolts.deepMerge(ctx, config))
@@ -284,6 +285,29 @@ class ConfigDsl extends Script {
         }
         catch (IOException e) {
             throw new IOException("Cannot read config file include: ${includePath.toUriString()}", e)
+        }
+    }
+
+    /**
+     * Apply profiles to the config.
+     */
+    @PackageScope
+    void applyProfiles() {
+        if( enabledProfiles != null ) {
+            // apply profiles in the order they were specified
+            for( final name : enabledProfiles ) {
+                final closure = declaredProfiles[name]
+                if( closure )
+                    block(Collections.emptyList(), closure)
+            }
+        }
+        else {
+            // append all profiles to the config map
+            for( final name : declaredProfiles.keySet() ) {
+                final closure = declaredProfiles[name]
+                if( closure )
+                    block(['profiles', name], closure)
+            }
         }
     }
 
@@ -314,9 +338,6 @@ class ConfigDsl extends Script {
 
         void includeConfig(String includeFile) {
             dsl.includeConfig(scope, includeFile)
-        }
-
-        void apply() {
         }
     }
 
@@ -349,12 +370,8 @@ class ConfigDsl extends Script {
     }
 
     private static class ProfilesDsl extends ConfigBlockDsl {
-        private List<String> profiles
-        private Map<String,Closure> blocks = [:]
-
-        ProfilesDsl(ConfigDsl dsl, List<String> profiles) {
+        ProfilesDsl(ConfigDsl dsl) {
             super(dsl, Collections.<String>emptyList())
-            this.profiles = profiles
         }
 
         @Override
@@ -364,32 +381,12 @@ class ConfigDsl extends Script {
 
         @Override
         void block(String name, Closure closure) {
-            blocks[name] = closure
-            dsl.declareProfile(name)
+            dsl.declareProfile(name, closure)
         }
 
         @Override
         void includeConfig(String includeFile) {
             throw new ConfigParseException("Only profile blocks are allowed in the `profiles` scope")
-        }
-
-        @Override
-        void apply() {
-            if( profiles != null ) {
-                // apply profiles in the order they were specified
-                for( final name : profiles ) {
-                    final closure = blocks[name]
-                    if( closure )
-                        dsl.block(scope, closure)
-                }
-            }
-            else {
-                // append all profiles to the config map
-                for( final name : blocks.keySet() ) {
-                    final closure = blocks[name]
-                    dsl.block(['profiles', name], closure)
-                }
-            }
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
@@ -49,17 +49,15 @@ class ConfigParserV2 implements ConfigParser {
 
     private boolean stripSecrets
 
-    private List<String> appliedProfiles
-
-    private Set<String> declaredProfiles = []
+    private List<String> enabledProfiles
 
     private Map<String,Object> declaredParams = [:]
 
-    private GroovyShell groovyShell
+    private Set<String> declaredProfiles = []
 
     @Override
     ConfigParserV2 setProfiles(List<String> profiles) {
-        this.appliedProfiles = profiles
+        this.enabledProfiles = profiles
         return this
     }
 
@@ -107,13 +105,13 @@ class ConfigParserV2 implements ConfigParser {
     }
 
     @Override
-    Set<String> getDeclaredProfiles() {
-        return declaredProfiles
+    Map<String,Object> getDeclaredParams() {
+        return declaredParams
     }
 
     @Override
-    Map<String,Object> getDeclaredParams() {
-        return declaredParams
+    Set<String> getDeclaredProfiles() {
+        return declaredProfiles
     }
 
     /**
@@ -140,12 +138,13 @@ class ConfigParserV2 implements ConfigParser {
             script.setStripSecrets(stripSecrets)
             script.setParams(cliParams)
             script.setConfigParams(configParams)
-            script.setProfiles(appliedProfiles)
+            script.setProfiles(enabledProfiles)
             script.run()
+            script.applyProfiles()
 
             final target = script.getTarget()
-            declaredProfiles.addAll(script.getDeclaredProfiles())
             declaredParams.putAll(script.getDeclaredParams())
+            declaredProfiles.addAll(script.getDeclaredProfiles())
             return Bolts.toConfigObject(target)
         }
         catch( CompilationFailedException e ) {

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -348,6 +348,59 @@ class ConfigParserV2Test extends Specification {
 
     }
 
+    def 'should apply profiles after config parsing' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def main = folder.resolve('nextflow.config')
+        def snippet = folder.resolve('snippet.config')
+
+        main.text = """\
+            profiles {
+                special {
+                    process {
+                        cpus = 8
+                        ext.args = "special"
+
+                        withLabel: example {
+                            memory = '16 GB'
+                        }
+                    }
+                }
+            }
+
+            includeConfig "$snippet"
+            """.stripIndent()
+
+        snippet.text = """\
+            process {
+                cpus = 2
+                ext.args = ""
+
+                withLabel: example {
+                    memory = '4 GB'
+                }
+            }
+            """.stripIndent()
+
+        when:
+        def config = new ConfigParserV2().parse(main)
+        then:
+        config.process.cpus == 2
+        config.process.ext.args == ''
+        config.process.'withLabel:example'.memory == '4 GB'
+
+        when:
+        config = new ConfigParserV2().setProfiles(['special']).parse(main)
+        then:
+        config.process.cpus == 8
+        config.process.ext.args == 'special'
+        config.process.'withLabel:example'.memory == '16 GB'
+
+        cleanup:
+        folder.deleteDir()
+    }
+
     def 'should return the set of declared profiles' () {
 
         given:


### PR DESCRIPTION
Fix #4960 

This PR fixes the v2 config parser to apply profiles only after the entire config file is parsed, so that profiles are not overridden by subsequent config blocks. This behavior is consistent with the v1 config parser.