### PR TITLE
Apply socket timeout to S3 CRT connections

### DIFF
--- a/docs/guides/aws-java-sdk-v2.md
+++ b/docs/guides/aws-java-sdk-v2.md
@@ -16,6 +16,12 @@ The HTTP client in SDK v2 does not support overriding certain advanced HTTP opti
 - `aws.client.socketSendBufferSizeHint`
 - `aws.client.userAgent`
 
+## Connection timeouts
+
+The `aws.client.connectionTimeout` option continues to work as before, controlling the timeout for establishing new connections.
+
+The `aws.client.socketTimeout` option behaves differently depending on the HTTP client. For synchronous connections, it applies directly as a socket timeout with a default of `30000` ms. For S3 transfers using the CRT client, no default is applied; when explicitly set, this value is translated into a CRT connection health check that enforces a minimum throughput of 1 byte per second within the specified timeout period. This allows Nextflow to detect and close stalled CRT connections that are no longer making progress.
+
 ## Parallel S3 operations
 
 Nextflow manages S3 transfers, including uploads, downloads, and S3-to-S3 copies, separately from other S3 API calls such as listing a directory or retrieving object metadata.

--- a/docs/guides/aws-java-sdk-v2.md
+++ b/docs/guides/aws-java-sdk-v2.md
@@ -20,7 +20,7 @@ The HTTP client in SDK v2 does not support overriding certain advanced HTTP opti
 
 The `aws.client.connectionTimeout` option continues to work as before, controlling the timeout for establishing new connections.
 
-The `aws.client.socketTimeout` option behaves differently depending on the HTTP client. For synchronous connections, it applies directly as a socket timeout with a default of `30000` ms. For S3 transfers using the CRT client, no default is applied; when explicitly set, this value is translated into a CRT connection health check that enforces a minimum throughput of 1 byte per second within the specified timeout period. This allows Nextflow to detect and close stalled CRT connections that are no longer making progress.
+The `aws.client.socketTimeout` option behaves differently depending on the HTTP client. For synchronous connections, it applies directly as a socket timeout. For S3 transfers using the CRT client, no default is applied; when explicitly set, this value is translated into a CRT connection health check that enforces a minimum throughput of 1 byte per second within the specified timeout period. This allows Nextflow to detect and close stalled CRT connections that are no longer making progress.
 
 ## Parallel S3 operations
 

--- a/docs/guides/aws-java-sdk-v2.md
+++ b/docs/guides/aws-java-sdk-v2.md
@@ -16,12 +16,6 @@ The HTTP client in SDK v2 does not support overriding certain advanced HTTP opti
 - `aws.client.socketSendBufferSizeHint`
 - `aws.client.userAgent`
 
-## Connection timeouts
-
-The `aws.client.connectionTimeout` option continues to work as before, controlling the timeout for establishing new connections.
-
-The `aws.client.socketTimeout` option behaves differently depending on the HTTP client. For synchronous connections, it applies directly as a socket timeout. For S3 transfers using the CRT client, no default is applied; when explicitly set, this value is translated into a CRT connection health check that enforces a minimum throughput of 1 byte per second within the specified timeout period. This allows Nextflow to detect and close stalled CRT connections that are no longer making progress.
-
 ## Parallel S3 operations
 
 Nextflow manages S3 transfers, including uploads, downloads, and S3-to-S3 copies, separately from other S3 API calls such as listing a directory or retrieving object metadata.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -245,7 +245,7 @@ The following settings are available:
 : The Size hint (in bytes) for the low level TCP receive buffer (default: `0`).
 
 `aws.client.socketTimeout`
-: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out (default: `50000`).
+: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out. The default value of `30000` only applies to synchronous HTTP connections. For S3 transfers using the CRT client, no default is applied; when explicitly set, this value is translated into a connection health check that requires a minimum throughput of 1 byte per second within the specified timeout, allowing stalled CRT connections to be detected and closed.
 
 `aws.client.storageClass`
 : The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -245,7 +245,10 @@ The following settings are available:
 : The Size hint (in bytes) for the low level TCP receive buffer (default: `0`).
 
 `aws.client.socketTimeout`
-: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out (default: `30000`). For synchronous connections, it applies directly as a socket timeout. For S3 transfers using the CRT client, this value is translated into a connection health check that requires a minimum throughput of 1 byte per second within the specified timeout, allowing stalled CRT connections to be detected and closed.
+: :::{versionchanged} 25.10.0
+  The default socket timeout changed from `50000` to `30000`.
+  :::
+: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out (default: `30000`).
 
 `aws.client.storageClass`
 : The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -245,7 +245,7 @@ The following settings are available:
 : The Size hint (in bytes) for the low level TCP receive buffer (default: `0`).
 
 `aws.client.socketTimeout`
-: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out. The default value of `30000` only applies to synchronous HTTP connections. For S3 transfers using the CRT client, no default is applied; when explicitly set, this value is translated into a connection health check that requires a minimum throughput of 1 byte per second within the specified timeout, allowing stalled CRT connections to be detected and closed.
+: The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out (default: `30000`). For synchronous connections, it applies directly as a socket timeout. For S3 transfers using the CRT client, this value is translated into a connection health check that requires a minimum throughput of 1 byte per second within the specified timeout, allowing stalled CRT connections to be detected and closed.
 
 `aws.client.storageClass`
 : The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/config/AwsS3Config.groovy
@@ -152,7 +152,7 @@ class AwsS3Config implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out (default: `50000`).
+        The amount of time to wait (in milliseconds) for data to be transferred over an established, open connection before the connection is timed out (default: `30000`).
     """)
     final Integer socketTimeout
 

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3AsyncClientConfiguration.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3AsyncClientConfiguration.java
@@ -32,6 +32,8 @@ import java.util.Properties;
  */
 public class S3AsyncClientConfiguration extends S3ClientConfiguration{
 
+    private static final long DEFAULT_SOCKET_TIMEOUT_MS = 30_000L;
+
     private S3CrtHttpConfiguration.Builder crtHttpConfiguration;
     private MultipartConfiguration.Builder multiPartBuilder;
     private S3CrtRetryConfiguration crtRetryConfiguration;
@@ -120,15 +122,16 @@ public class S3AsyncClientConfiguration extends S3ClientConfiguration{
             crtHttpConfiguration().connectionTimeout(Duration.ofMillis(Long.parseLong(props.getProperty("connection_timeout"))));
         }
 
-        if( props.containsKey("socket_timeout")) {
-            log.debug("AWS client config - 'socket_timeout' doesn't exist in CRT connection. Setting CRT health configuration with minimum throughput 1bps and timeout with value {}",props.getProperty("socket_timeout"));
-            crtHttpConfiguration().connectionHealthConfiguration(
-                S3CrtConnectionHealthConfiguration.builder()
-                    .minimumThroughputInBps(1L)
-                    .minimumThroughputTimeout(Duration.ofMillis(Long.parseLong(props.getProperty("socket_timeout"))))
-                    .build()
-            );
-        }
+        final long socketTimeoutMs = props.containsKey("socket_timeout")
+            ? Long.parseLong(props.getProperty("socket_timeout"))
+            : DEFAULT_SOCKET_TIMEOUT_MS;
+        log.debug("AWS client config - setting CRT health configuration with minimum throughput 1bps and timeout {}", socketTimeoutMs);
+        crtHttpConfiguration().connectionHealthConfiguration(
+            S3CrtConnectionHealthConfiguration.builder()
+                .minimumThroughputInBps(1L)
+                .minimumThroughputTimeout(Duration.ofMillis(socketTimeoutMs))
+                .build()
+        );
 
         if( props.containsKey("proxy_host")) {
             final String host = props.getProperty("proxy_host");

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3AsyncClientConfiguration.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3AsyncClientConfiguration.java
@@ -125,7 +125,7 @@ public class S3AsyncClientConfiguration extends S3ClientConfiguration{
         final long socketTimeoutMs = props.containsKey("socket_timeout")
             ? Long.parseLong(props.getProperty("socket_timeout"))
             : DEFAULT_SOCKET_TIMEOUT_MS;
-        log.debug("AWS client config - setting CRT health configuration with minimum throughput 1bps and timeout {}", socketTimeoutMs);
+        log.trace("AWS client config - socket_timeout: {} (using CRT health configuration with minimum throughput 1bps)", socketTimeoutMs);
         crtHttpConfiguration().connectionHealthConfiguration(
             S3CrtConnectionHealthConfiguration.builder()
                 .minimumThroughputInBps(1L)

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3AsyncClientConfiguration.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/S3AsyncClientConfiguration.java
@@ -15,6 +15,7 @@
  */
 package nextflow.cloud.aws.nio.util;
 
+import software.amazon.awssdk.services.s3.crt.S3CrtConnectionHealthConfiguration;
 import software.amazon.awssdk.services.s3.crt.S3CrtProxyConfiguration;
 import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
 import software.amazon.awssdk.services.s3.crt.S3CrtRetryConfiguration;
@@ -120,7 +121,13 @@ public class S3AsyncClientConfiguration extends S3ClientConfiguration{
         }
 
         if( props.containsKey("socket_timeout")) {
-            log.warn("AWS client config - 'socket_timeout' doesn't exist in AWS SDK V2 Async Client");
+            log.debug("AWS client config - 'socket_timeout' doesn't exist in CRT connection. Setting CRT health configuration with minimum throughput 1bps and timeout with value {}",props.getProperty("socket_timeout"));
+            crtHttpConfiguration().connectionHealthConfiguration(
+                S3CrtConnectionHealthConfiguration.builder()
+                    .minimumThroughputInBps(1L)
+                    .minimumThroughputTimeout(Duration.ofMillis(Long.parseLong(props.getProperty("socket_timeout"))))
+                    .build()
+            );
         }
 
         if( props.containsKey("proxy_host")) {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/S3ClientConfigurationTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/S3ClientConfigurationTest.groovy
@@ -16,8 +16,6 @@
 package nextflow.cloud.aws.nio.util
 
 import nextflow.cloud.aws.config.AwsConfig
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption
 import software.amazon.awssdk.http.SdkHttpConfigurationOption
 import spock.lang.Specification
 
@@ -72,6 +70,9 @@ class S3ClientConfigurationTest extends Specification{
         httpConfiguration.proxyConfiguration().scheme() == 'https'
         httpConfiguration.proxyConfiguration().username() == 'user'
         httpConfiguration.proxyConfiguration().password() == 'pass'
+        //Check Timeout
+        httpConfiguration.healthConfiguration().minimumThroughputInBps() == 1
+        httpConfiguration.healthConfiguration().minimumThroughputTimeout().toMillis() == 20000
         //Check Crt Retry Configuration
         def retryConfig = clientConfig.getCrtRetryConfiguration()
         retryConfig.numRetries() == 3

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/S3ClientConfigurationTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/S3ClientConfigurationTest.groovy
@@ -42,6 +42,19 @@ class S3ClientConfigurationTest extends Specification{
         httpClientbuilder.standardOptions.get(SdkHttpConfigurationOption.MAX_CONNECTIONS) == 100
     }
 
+    def 'create S3 asynchronous client configuration with default socket timeout' (){
+        given:
+        def props = new Properties()
+        def config = new AwsConfig([client: [:]])
+        props.putAll(config.getS3LegacyProperties())
+        when:
+        def clientConfig = S3AsyncClientConfiguration.create(props)
+        then:
+        def httpConfiguration = clientConfig.getCrtHttpConfiguration()
+        httpConfiguration.healthConfiguration().minimumThroughputInBps() == 1
+        httpConfiguration.healthConfiguration().minimumThroughputTimeout().toMillis() == 30000
+    }
+
     def 'create S3 asynchronous client configuration' (){
         given:
         def props = new Properties()


### PR DESCRIPTION
This pull request updates how the `socket_timeout` configuration is handled for AWS S3 transfers using the CRT client in the SDK v2 integration. The main improvement is that when `socket_timeout` is set, it is now translated into a CRT connection health check, allowing the detection and closure of stalled S3 connections. The documentation and tests have also been updated to reflect this new behavior.

**AWS S3 CRT Client Timeout Handling:**
- The `socket_timeout` property for S3 transfers using the CRT client is now mapped to a connection health check that enforces a minimum throughput of 1 byte per second within the specified timeout period, instead of being ignored. This helps detect and close stalled CRT connections.

**Documentation Updates:**
- The user guide (`aws-java-sdk-v2.md`) and configuration reference (`config.md`) have been updated to clarify the new behavior of the `aws.client.socketTimeout` option for CRT-based S3 transfers, including the lack of a default and the new health check mechanism. [[1]](diffhunk://#diff-8dc76da53116aee8da6debfb02777d7ca4c4281195cf1a07ba1c60b343b482e7R19-R24) [[2]](diffhunk://#diff-9ae244d0598c1cc7efc9875baf25a5f8b4bc13aabad4fbe17dd4bc5cfe856909L248-R248)

**Testing Enhancements:**
- The test suite for S3 client configuration now verifies that the CRT health configuration is set with the correct minimum throughput and timeout values when `socket_timeout` is specified.

**Dependency and Import Adjustments:**
- Added the necessary import for `S3CrtConnectionHealthConfiguration` to support the new health check configuration.
- Cleaned up unused imports in the S3 client configuration test file.