### PR TITLE
Exclude params from resolved config text

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -932,6 +932,8 @@ class ConfigBuilder {
                 .setBaseDir(baseDir)
                 .buildConfigObject()
 
+        // strip params
+        config.remove('params')
         // strip secrets
         SecretHelper.hideSecrets(config)
         // compute config

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -2352,17 +2352,18 @@ class ConfigBuilderTest extends Specification {
 
     def 'should return parsed config' () {
         given:
-        def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: new Launcher())
-        def base = Files.createTempDirectory('test')
-        base.resolve('nextflow.config').text = '''
+        def folder = Files.createTempDirectory('test')
+        def configFile = folder.resolve('nextflow.config')
+        configFile.text = '''
         profiles {
             first {
                 params {
-                  foo = 'Hello world'
-                  awsKey = 'xyz'
+                    foo = 'Hello world'
+                    awsKey = 'xyz'
                 }
                 process {
-                    executor = { 'local' }
+                    executor = 'local'
+                    cpus = { 4 }
                 }
             }
             second {
@@ -2370,17 +2371,17 @@ class ConfigBuilderTest extends Specification {
             }
         }
         '''
-        when:
-        def txt = ConfigBuilder.resolveConfig(base, cmd)
-        then:
-        txt == '''\
-            params {
-               foo = 'Hello world'
-               awsKey = '[secret]'
-            }
+        and:
+        def launcher = new Launcher(options: new CliOptions(config: [configFile.toFile().canonicalPath]))
+        def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: launcher)
 
+        when:
+        def result = ConfigBuilder.resolveConfig(folder, cmd)
+        then:
+        result == '''\
             process {
-               executor = { 'local' }
+               executor = 'local'
+               cpus = { 4 }
             }
 
             outputFormat = 'text'
@@ -2393,7 +2394,7 @@ class ConfigBuilderTest extends Specification {
             '''.stripIndent()
 
         cleanup:
-        base?.deleteDir()
+        folder?.deleteDir()
     }
 
     def 'should merge profiles with conditions' () {
@@ -2428,7 +2429,7 @@ class ConfigBuilderTest extends Specification {
                 ext.args = '--quiet'
             }
         }
-        params{
+        params {
             another = true
         }
         '''


### PR DESCRIPTION
This PR removes the `params` scope from the resolved config text that is sent to Seqera Platform

The params do not need to be shown in the resolved config because they are already sent separately in `makeBeginReq()`.

Also, the params in the resolved config can differ from the actual params if the script defines params with default values, which will not be reflected in the resolved config. Removing the params from the resolved config text removes this potential source of confusion