### PR TITLE
Fix formatting issues with complex expressions

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
@@ -27,6 +27,7 @@ import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.Variable;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.BitwiseNegationExpression;
+import org.codehaus.groovy.ast.expr.BooleanExpression;
 import org.codehaus.groovy.ast.expr.CastExpression;
 import org.codehaus.groovy.ast.expr.ClassExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
@@ -152,9 +153,9 @@ public class Formatter extends CodeVisitorSupport {
         appendLeadingComments(node);
         if( preIndent )
             appendIndent();
-        append("if (");
+        append("if ");
         visit(node.getBooleanExpression());
-        append(") {\n");
+        append(" {\n");
         incIndent();
         visit(node.getIfBlock());
         decIndent();
@@ -366,8 +367,6 @@ public class Formatter extends CodeVisitorSupport {
 
     private boolean inVariableDeclaration;
 
-    private boolean inWrappedPipeChain;
-
     @Override
     public void visitBinaryExpression(BinaryExpression node) {
         if( node instanceof DeclarationExpression ) {
@@ -394,25 +393,12 @@ public class Formatter extends CodeVisitorSupport {
             return;
         }
 
-        var beginWrappedPipeChain = shouldWrapPipeExpression(node);
-        if( beginWrappedPipeChain )
-            inWrappedPipeChain = true;
-
         visit(node.getLeftExpression());
 
-        if( inWrappedPipeChain ) {
-            appendNewLine();
-            incIndent();
-            appendIndent();
-        }
-        else {
-            append(' ');
-        }
+        append(' ');
         append(node.getOperation().getText());
         append(' ');
 
-        var iwpc = inWrappedPipeChain;
-        inWrappedPipeChain = false;
         if( node.getOperation().isA(Types.ASSIGNMENT_OPERATOR) ) {
             var source = node.getRightExpression();
             var cre = currentRootExpr;
@@ -423,13 +409,6 @@ public class Formatter extends CodeVisitorSupport {
         else {
             visit(node.getRightExpression());
         }
-        inWrappedPipeChain = iwpc;
-
-        if( inWrappedPipeChain )
-            decIndent();
-
-        if( beginWrappedPipeChain )
-            inWrappedPipeChain = false;
     }
 
     @Override
@@ -461,6 +440,11 @@ public class Formatter extends CodeVisitorSupport {
         visit(node.getTrueExpression());
         append(" ?: ");
         visit(node.getFalseExpression());
+    }
+
+    @Override
+    public void visitBooleanExpression(BooleanExpression node) {
+        visit(node.getExpression());
     }
 
     @Override
@@ -751,10 +735,6 @@ public class Formatter extends CodeVisitorSupport {
         return shouldWrapExpression(root)
             ? false
             : depth >= 2;
-    }
-
-    private boolean shouldWrapPipeExpression(BinaryExpression node) {
-        return currentRootExpr == node && node.getOperation().isA(Types.PIPE) && shouldWrapExpression(node);
     }
 
     private static final String SLASH_STR = "/";

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -771,11 +771,13 @@ class ScriptFormatterTest extends Specification {
             !(2+2==4)
             (1+2)*3
             x%2==0?'x is even!':'x is odd!'
+            (false?'foo':true)?'bar':'baz'
             ''',
             '''\
             !(2 + 2 == 4)
             (1 + 2) * 3
             x % 2 == 0 ? 'x is even!' : 'x is odd!'
+            (false ? 'foo' : true) ? 'bar' : 'baz'
             '''
         )
     }


### PR DESCRIPTION
This PR fixes two issues with formatting complex expressions:

- Nested ternaries -- when the condition of a ternary is wrapped in parens, the parens were not being preserved by the formatter, which can cause a semantic change

- Pipe chains -- the formatter previously tried to wrap pipe chains across multiple lines, but this code was brittle and untested, and had some negative side effects such as #6971 . This code has been removed since pipes are effectively deprecated (not supported in typed workflows)