### PR TITLE
Fix module info formatting separator

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleInfo.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleInfo.groovy
@@ -161,7 +161,7 @@ class CmdModuleInfo extends CmdBase {
         // Generate and display usage template
         println ""
         println "Usage Template:"
-        println "-" * 80
+        println "---------------"
         println generateUsageTemplate(reference, metadata).join(" \\\n    ")
         println ""
     }


### PR DESCRIPTION
## Summary

- Fix separator line formatting in `module info` command output

## Test plan
- [x] Verified formatting change in `CmdModuleInfo.groovy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)