### PR TITLE
Feature: Allow cloning from local Git repositories when `--offline`

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -620,10 +620,11 @@ class CmdRun extends CmdBase implements HubOptions {
             if( revision )
                 manager.setRevision(revision)
             def repo = manager.getProjectWithRevision()
+            final localScm = manager.isLocalScmSource()
 
             boolean checkForUpdate = true
             if( !manager.isRunnable() || latest ) {
-                if( offline )
+                if( offline && !localScm )
                     throw new AbortOperationException("Unknown project `$repo` -- NOTE: automatic download from remote repositories is disabled")
                 log.info "Pulling $repo ..."
                 def result = manager.download(revision,deep)
@@ -641,7 +642,7 @@ class CmdRun extends CmdBase implements HubOptions {
                 manager.checkout(revision)
                 manager.updateModules()
                 final scriptFile = manager.getScriptFile(mainScript)
-                if( checkForUpdate && !offline )
+                if( checkForUpdate && (!offline || localScm) )
                     manager.checkRemoteStatus(scriptFile.revisionInfo)
                 // return the script file
                 return scriptFile

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -589,7 +589,7 @@ class CmdRun extends CmdBase implements HubOptions {
          * read from the stdin
          */
         if( pipelineName == '-' ) {
-            def file = tryReadFromStdin()
+            final file = tryReadFromStdin()
             if( !file )
                 throw new AbortOperationException("Cannot access `stdin` stream")
 
@@ -603,7 +603,7 @@ class CmdRun extends CmdBase implements HubOptions {
          * look for a file with the specified pipeline name
          */
         def script = new File(pipelineName)
-        if( script.isDirectory()  ) {
+        if( script.isDirectory() ) {
             script = mainScript ? new File(mainScript) : new AssetManager().setLocalPath(script).getMainScriptFile()
         }
 
@@ -616,24 +616,24 @@ class CmdRun extends CmdBase implements HubOptions {
         /*
          * try to look for a pipeline in the repository
          */
-        try (def manager = new AssetManager(pipelineName, this)) {
+        try( final manager = new AssetManager(pipelineName, this) ) {
             if( revision )
                 manager.setRevision(revision)
-            def repo = manager.getProjectWithRevision()
-            final localScm = manager.isLocalScmSource()
+            final repo = manager.getProjectWithRevision()
+            final remoteSource = !manager.isLocalScmSource()
 
             boolean checkForUpdate = true
             if( !manager.isRunnable() || latest ) {
-                if( offline && !localScm )
+                if( offline && remoteSource )
                     throw new AbortOperationException("Unknown project `$repo` -- NOTE: automatic download from remote repositories is disabled")
                 log.info "Pulling $repo ..."
-                def result = manager.download(revision,deep)
+                final result = manager.download(revision,deep)
                 if( result )
                     log.info " $result"
                 checkForUpdate = false
             }
             // Warn if using legacy
-            if( manager.isUsingLegacyStrategy() ){
+            if( manager.isUsingLegacyStrategy() ) {
                 log.warn1 "This Nextflow version supports a new Multi-revision strategy for managing the SCM repositories, " +
                     "but '${repo}' is single-revision legacy strategy - Please consider to update the repository with the 'nextflow pull -migrate' command."
             }
@@ -642,7 +642,7 @@ class CmdRun extends CmdBase implements HubOptions {
                 manager.checkout(revision)
                 manager.updateModules()
                 final scriptFile = manager.getScriptFile(mainScript)
-                if( checkForUpdate && (!offline || localScm) )
+                if( checkForUpdate && !(offline && remoteSource) )
                     manager.checkRemoteStatus(scriptFile.revisionInfo)
                 // return the script file
                 return scriptFile

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -532,15 +532,6 @@ class AssetManager implements Closeable {
         return strategy?.getGitRepositoryUrl() ?: provider.getCloneUrl()
     }
 
-    /**
-     * @return {@code true} when the SCM source points to a local file-system repository.
-     */
-    boolean isLocalScmSource() {
-        if( provider instanceof LocalRepositoryProvider )
-            return true
-        return false
-    }
-
     File getLocalPath() {
         return strategy?.getLocalPath()
     }
@@ -655,6 +646,13 @@ class AssetManager implements Closeable {
 
     boolean isLocal() {
         return localPath && localPath.exists()
+    }
+
+    /**
+     * @return {@code true} when the SCM source points to a local file-system repository.
+     */
+    boolean isLocalScmSource() {
+        return provider instanceof LocalRepositoryProvider
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -539,7 +539,7 @@ class AssetManager implements Closeable {
         if( provider instanceof LocalRepositoryProvider )
             return true
 
-        final repoUrl = provider?.getRepositoryUrl()
+        final repoUrl = provider?.getRepositoryUrl() ?: provider?.getCloneUrl()
         if( !repoUrl )
             return false
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -536,15 +536,17 @@ class AssetManager implements Closeable {
      * @return {@code true} when the SCM source points to a local file-system repository.
      */
     boolean isLocalScmSource() {
-        final repoUrl = getGitRepositoryUrl()
+        if( provider instanceof LocalRepositoryProvider )
+            return true
+
+        final repoUrl = provider?.getRepositoryUrl()
         if( !repoUrl )
             return false
-        try {
-            return new GitUrl(repoUrl).protocol == 'file'
-        }
-        catch( IllegalArgumentException e ) {
-            return false
-        }
+
+        if( repoUrl.startsWith('file:') )
+            return true
+
+        return new File(repoUrl).isAbsolute()
     }
 
     File getLocalPath() {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -532,6 +532,21 @@ class AssetManager implements Closeable {
         return strategy?.getGitRepositoryUrl() ?: provider.getCloneUrl()
     }
 
+    /**
+     * @return {@code true} when the SCM source points to a local file-system repository.
+     */
+    boolean isLocalScmSource() {
+        final repoUrl = getGitRepositoryUrl()
+        if( !repoUrl )
+            return false
+        try {
+            return new GitUrl(repoUrl).protocol == 'file'
+        }
+        catch( IllegalArgumentException e ) {
+            return false
+        }
+    }
+
     File getLocalPath() {
         return strategy?.getLocalPath()
     }

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -538,15 +538,7 @@ class AssetManager implements Closeable {
     boolean isLocalScmSource() {
         if( provider instanceof LocalRepositoryProvider )
             return true
-
-        final repoUrl = provider?.getRepositoryUrl() ?: provider?.getCloneUrl()
-        if( !repoUrl )
-            return false
-
-        if( repoUrl.startsWith('file:') )
-            return true
-
-        return new File(repoUrl).isAbsolute()
+        return false
     }
 
     File getLocalPath() {

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdRunTest.groovy
@@ -18,20 +18,38 @@ package nextflow.cli
 
 
 import java.nio.file.Files
+import java.nio.file.Path
 
 import nextflow.NextflowMeta
 import nextflow.SysEnv
 import nextflow.config.ConfigMap
 import nextflow.exception.AbortOperationException
+import nextflow.scm.AssetManager
 import nextflow.util.VersionNumber
+import org.eclipse.jgit.api.Git
+import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
+import test.TemporaryPath
 
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class CmdRunTest extends Specification {
+
+    @Rule
+    TemporaryPath tempDir = new TemporaryPath()
+
+    private File savedRoot
+
+    def setup() {
+        savedRoot = AssetManager.root
+    }
+
+    def cleanup() {
+        AssetManager.root = savedRoot
+    }
 
     @Unroll
     def 'should parse cmd param=#STR' () {
@@ -414,6 +432,52 @@ class CmdRunTest extends Specification {
         0 * cmd.getCurrentVersion()
         0 * cmd.showVersionWarning(_)
         0 * cmd.showVersionError(_)
+    }
+
+    def 'should allow local scm clone in offline mode' () {
+        given: 'a source git repo with a main.nf'
+        def folder = tempDir.getRoot()
+        def sourceDir = folder.resolve('source-repo')
+        Files.createDirectories(sourceDir)
+        sourceDir.resolve('main.nf').text = "println 'Hello'"
+        def git = Git.init().setDirectory(sourceDir.toFile()).call()
+        git.add().addFilepattern('.').call()
+        git.commit().setSign(false).setMessage('init').call()
+        git.close()
+
+        and: 'a bare clone of it'
+        def bareDir = folder.resolve('my-pipeline.git')
+        Git.cloneRepository()
+            .setURI(sourceDir.toUri().toString())
+            .setDirectory(bareDir.toFile())
+            .setBare(true)
+            .call()
+            .close()
+
+        and: 'AssetManager root points to a temp directory'
+        AssetManager.root = folder.resolve('assets').toFile()
+
+        when: 'running in offline mode with a file: URL'
+        def cmd = new CmdRun(offline: true)
+        def scriptFile = cmd.getScriptFile0("file:${bareDir}")
+
+        then: 'the pipeline is cloned and returned successfully'
+        scriptFile != null
+        scriptFile.main.text.contains("println 'Hello'")
+    }
+
+    def 'should block remote repo clone in offline mode' () {
+        given:
+        def folder = tempDir.getRoot()
+        AssetManager.root = folder.resolve('assets').toFile()
+
+        when: 'running in offline mode with a remote repo name'
+        def cmd = new CmdRun(offline: true)
+        cmd.getScriptFile0('nextflow-io/hello')
+
+        then: 'an AbortOperationException is thrown'
+        def e = thrown(AbortOperationException)
+        e.message.contains('automatic download from remote repositories is disabled')
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -25,6 +25,7 @@ import static nextflow.scm.MultiRevisionRepositoryStrategy.REPOS_SUBDIR
 
 import spock.lang.IgnoreIf
 
+import nextflow.cli.HubOptions
 import nextflow.exception.AbortOperationException
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Config
@@ -690,6 +691,62 @@ class AssetManagerTest extends Specification {
         })
         then:
         !manager.isLocalScmSource()
+    }
+
+    def 'should detect local scm source for LocalRepositoryProvider' () {
+        given:
+        def config = new ProviderConfig('local', [path: '/tmp/workflows'])
+        def localProvider = new LocalRepositoryProvider('socks', config)
+
+        when:
+        def manager = new AssetManager(provider: localProvider)
+
+        then:
+        manager.isLocalScmSource()
+    }
+
+    def 'should return false for local scm when provider is null' () {
+        when:
+        def manager = new AssetManager()
+
+        then:
+        !manager.isLocalScmSource()
+    }
+
+    def 'should return false for local scm when urls are null' () {
+        when:
+        def manager = new AssetManager(provider: Mock(RepositoryProvider) {
+            getRepositoryUrl() >> null
+            getCloneUrl() >> null
+        })
+
+        then:
+        !manager.isLocalScmSource()
+    }
+
+    def 'should detect local scm for pipelineNames' () {
+        when:
+        def manager = new AssetManager('my-repo', Mock(HubOptions))
+        then:
+        !manager.isLocalScmSource()
+
+        when:
+        manager = new AssetManager('my-project/repo',  Mock(HubOptions))
+
+        then:
+        !manager.isLocalScmSource()
+
+        when:
+        manager = new AssetManager('https://github.com/nextflow-io/socks.git',  Mock(HubOptions))
+
+        then:
+        !manager.isLocalScmSource()
+
+        when:
+        manager = new AssetManager( 'file:/path/my-project/repo.git', Mock(HubOptions))
+
+        then:
+        manager.isLocalScmSource()
     }
 
     @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -696,19 +696,16 @@ class AssetManagerTest extends Specification {
 
         when:
         manager = new AssetManager('my-project/repo',  Mock(HubOptions))
-
         then:
         !manager.isLocalScmSource()
 
         when:
         manager = new AssetManager('https://github.com/nextflow-io/socks.git',  Mock(HubOptions))
-
         then:
         !manager.isLocalScmSource()
 
         when:
         manager = new AssetManager( 'file:/path/my-project/repo.git', Mock(HubOptions))
-
         then:
         manager.isLocalScmSource()
     }

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -669,6 +669,29 @@ class AssetManagerTest extends Specification {
 
     }
 
+    def 'should detect local scm source from repository url' () {
+        when:
+        def manager = new AssetManager(provider: Mock(RepositoryProvider) {
+            getCloneUrl() >> 'file:///tmp/workflows/nextflow-io-socks.git'
+        })
+        then:
+        manager.isLocalScmSource()
+
+        when:
+        manager = new AssetManager(provider: Mock(RepositoryProvider) {
+            getCloneUrl() >> '/tmp/workflows/nextflow-io-socks.git'
+        })
+        then:
+        manager.isLocalScmSource()
+
+        when:
+        manager = new AssetManager(provider: Mock(RepositoryProvider) {
+            getCloneUrl() >> 'https://github.com/nextflow-io/socks.git'
+        })
+        then:
+        !manager.isLocalScmSource()
+    }
+
     @Requires({System.getenv('NXF_GITHUB_ACCESS_TOKEN')})
     def 'should download branch specified legacy'() {
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -670,56 +670,20 @@ class AssetManagerTest extends Specification {
 
     }
 
-    def 'should detect local scm source from repository url' () {
-        when:
-        def manager = new AssetManager(provider: Mock(RepositoryProvider) {
-            getCloneUrl() >> 'file:///tmp/workflows/nextflow-io-socks.git'
-        })
-        then:
-        manager.isLocalScmSource()
-
-        when:
-        manager = new AssetManager(provider: Mock(RepositoryProvider) {
-            getCloneUrl() >> '/tmp/workflows/nextflow-io-socks.git'
-        })
-        then:
-        manager.isLocalScmSource()
-
-        when:
-        manager = new AssetManager(provider: Mock(RepositoryProvider) {
-            getCloneUrl() >> 'https://github.com/nextflow-io/socks.git'
-        })
-        then:
-        !manager.isLocalScmSource()
-    }
-
-    def 'should detect local scm source for LocalRepositoryProvider' () {
-        given:
+    def 'should detect local scm source' () {
+        when: 'provider is a LocalRepositoryProvider'
         def config = new ProviderConfig('local', [path: '/tmp/workflows'])
-        def localProvider = new LocalRepositoryProvider('socks', config)
-
-        when:
-        def manager = new AssetManager(provider: localProvider)
-
+        def manager = new AssetManager(provider: new LocalRepositoryProvider('socks', config))
         then:
         manager.isLocalScmSource()
-    }
 
-    def 'should return false for local scm when provider is null' () {
-        when:
-        def manager = new AssetManager()
-
+        when: 'provider is a remote RepositoryProvider'
+        manager = new AssetManager(provider: Mock(RepositoryProvider))
         then:
         !manager.isLocalScmSource()
-    }
 
-    def 'should return false for local scm when urls are null' () {
-        when:
-        def manager = new AssetManager(provider: Mock(RepositoryProvider) {
-            getRepositoryUrl() >> null
-            getCloneUrl() >> null
-        })
-
+        when: 'provider is null'
+        manager = new AssetManager()
         then:
         !manager.isLocalScmSource()
     }


### PR DESCRIPTION
close #6988

This pull requests suggests a change to the `AssetManager` to allow cloning from local SCM repositories even when `NXF_OFFLINE=true`. 

Feel free to choose a different implementation, since I am unfamiliar with the codebase of Nextflow and Groovy in general and relied heavily on AI to propose this contribution. 

Furthermore, I requested to generate extended tests for this functionality, but ultimately refrained from including them in this PR, because without Groovy knowledge, I was unsure if those tests are meaningful at all. You can find the extended tests in [this commit](https://github.com/nextflow-io/nextflow/commit/f800abd847df39f78618cb76b22e1619899873d6). Let me know if I should cherry-pick that commit and add it to this  PRs branch as well.