### PR TITLE
Fix NIO contract violations in Seqera filesystem

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -314,7 +314,7 @@ class TowerClient {
             throw new ForbiddenException("Forbidden — check permissions")
         if( status == 404 )
             throw new NotFoundException("Resource $url not found")
-        throw new Exception("Seqera API error: HTTP ${status} for ${url}")
+        throw new IOException("Seqera API error: HTTP ${status} for ${url}")
     }
 
     protected HttpRequest makeRequest(String url, String payload, String verb) {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/dataset/SeqeraDatasetClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/dataset/SeqeraDatasetClient.groovy
@@ -58,7 +58,10 @@ class SeqeraDatasetClient {
      */
     Long getUserId() {
         try {
-             return towerClient.getUserInfo()?.id as long
+             final info = towerClient.getUserInfo()
+             if( info?.id == null )
+                 throw new AbortOperationException("Unable to retrieve user ID from Seqera Platform — check your access token")
+             return info.id as long
         }catch( UnauthorizedException e ){
             throw new AbortOperationException(e.getMessage())
         }catch( ForbiddenException e){
@@ -93,7 +96,7 @@ class SeqeraDatasetClient {
         final url = "${endpoint}/datasets?workspaceId=${workspaceId}"
         log.debug "SeqeraDatasetClient GET $url"
         final resp = towerClient.sendApiRequest(url)
-        checkResponse(resp, url)
+        checkFsResponse(resp, url)
         final json = new JsonSlurper().parseText(resp.message) as Map
         final list = json.datasets as List<Map>
         return list ? list.collect { m -> mapDataset(m) } : Collections.<DatasetDto>emptyList()
@@ -107,7 +110,7 @@ class SeqeraDatasetClient {
         final url = "${endpoint}/datasets?workspaceId=${workspaceId}"
         log.debug "SeqeraDatasetClient POST $url name=$name"
         final resp = towerClient.sendApiRequest(url, [name: name], 'POST')
-        checkResponse(resp, url)
+        checkFsResponse(resp, url)
         final json = new JsonSlurper().parseText(resp.message) as Map
         return mapDataset(json.dataset as Map)
     }
@@ -119,7 +122,7 @@ class SeqeraDatasetClient {
         final url = "${endpoint}/datasets/${datasetId}/versions?workspaceId=${workspaceId}"
         log.debug "SeqeraDatasetClient GET $url"
         final resp = towerClient.sendApiRequest(url)
-        checkResponse(resp, url)
+        checkFsResponse(resp, url)
         final json = new JsonSlurper().parseText(resp.message) as Map
         final list = json.versions as List<Map>
         return list ? list.collect { m -> mapVersion(m) } : Collections.<DatasetVersionDto>emptyList()
@@ -150,7 +153,7 @@ class SeqeraDatasetClient {
 
     // ---- private helpers ----
 
-    private static void checkResponse(TowerClient.Response resp, String url) {
+    private static void checkFsResponse(TowerClient.Response resp, String url) {
         if (!resp.error) return
         final code = resp.code
         if (code == 401)

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/fs/DatasetInputStream.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/fs/DatasetInputStream.groovy
@@ -17,6 +17,7 @@
 package io.seqera.tower.plugin.fs
 
 import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
 import java.nio.channels.SeekableByteChannel
 
 import groovy.transform.CompileStatic
@@ -40,6 +41,8 @@ class DatasetInputStream implements SeekableByteChannel {
 
     @Override
     int read(ByteBuffer dst) throws IOException {
+        if( !open )
+            throw new ClosedChannelException()
         final len = dst.remaining()
         if (buf.length < len)
             buf = new byte[len]

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/fs/SeqeraFileSystemProvider.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/fs/SeqeraFileSystemProvider.groovy
@@ -27,6 +27,7 @@ import java.nio.file.FileSystemAlreadyExistsException
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.Files
 import java.nio.file.LinkOption
+import java.nio.file.DirectoryIteratorException
 import java.nio.file.NoSuchFileException
 import java.nio.file.NotDirectoryException
 import java.nio.file.OpenOption
@@ -207,7 +208,8 @@ class SeqeraFileSystemProvider extends FileSystemProvider {
         }
 
         final filtered = filter ? entries.findAll { Path p ->
-            try { filter.accept(p) } catch (IOException e) { false }
+            try { filter.accept(p) }
+            catch (IOException e) { throw new DirectoryIteratorException(e) }
         } : entries
 
         return new DirectoryStream<Path>() {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/fs/SeqeraPath.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/fs/SeqeraPath.groovy
@@ -360,12 +360,14 @@ class SeqeraPath implements Path {
 
     @Override
     Path resolveSibling(Path other) {
-        return getParent().resolve(other)
+        final parent = getParent()
+        return parent != null ? parent.resolve(other) : other
     }
 
     @Override
     Path resolveSibling(String other) {
-        return getParent().resolve(other)
+        final parent = getParent()
+        return parent != null ? parent.resolve(other) : new SeqeraPath(fs, other)
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes 6 issues found during code review of #6946:

- **resolveSibling NPE**: SeqeraPath.resolveSibling() called getParent().resolve() without null-checking. NIO contract says return other when parent is null.
- **read-after-close**: DatasetInputStream.read() did not check the open flag. Now throws ClosedChannelException.
- **raw Exception**: TowerClient.sendStreamingRequest() threw raw Exception for unknown HTTP status codes. Changed to IOException.
- **getUserId NPE**: SeqeraDatasetClient.getUserId() did getUserInfo()?.id as long which NPEs when info or id is null. Added explicit null guard.
- **filter IOException swallowed**: newDirectoryStream caught filter IOException and returned false. NIO spec requires throwing DirectoryIteratorException. Fixed.
- **ambiguous checkResponse**: Renamed SeqeraDatasetClient.checkResponse to checkFsResponse to disambiguate from TowerClient.checkResponse.

## Test plan

- [x] ./gradlew :plugins:nf-tower:test -- all tests pass