### PR TITLE
Fix resolution of `-with-tower` with `TOWER_API_ENDPOINT`

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -718,8 +718,6 @@ class ConfigBuilder {
             config.tower.enabled = true
             if( cmdRun.withTower != '-' )
                 config.tower.endpoint = cmdRun.withTower
-            else if( !config.tower.endpoint )
-                config.tower.endpoint = 'https://api.cloud.seqera.io'
         }
 
         // -- set wave options
@@ -729,8 +727,6 @@ class ConfigBuilder {
             config.wave.enabled = true
             if( cmdRun.withWave != '-' )
                 config.wave.endpoint = cmdRun.withWave
-            else if( !config.wave.endpoint )
-                config.wave.endpoint = 'https://wave.seqera.io'
         }
 
         // -- set fusion options

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -854,6 +854,7 @@ class ConfigBuilderTest extends Specification {
         then: // command line should override the config file
         config.trace instanceof Map
         config.trace.enabled
+        !config.trace.file
     }
 
     def 'should set session report options' () {
@@ -909,6 +910,7 @@ class ConfigBuilderTest extends Specification {
         then:
         config.report instanceof Map
         config.report.enabled
+        !config.report.file
     }
 
 
@@ -965,6 +967,7 @@ class ConfigBuilderTest extends Specification {
         then:
         config.dag instanceof Map
         config.dag.enabled
+        !config.dag.file
     }
 
     def 'should set session weblog options' () {
@@ -1083,6 +1086,7 @@ class ConfigBuilderTest extends Specification {
         then:
         config.timeline instanceof Map
         config.timeline.enabled
+        !config.timeline.file
     }
 
     def 'should set tower options' () {
@@ -1129,7 +1133,7 @@ class ConfigBuilderTest extends Specification {
         then:
         config.tower instanceof Map
         config.tower.enabled
-        config.tower.endpoint == 'https://api.cloud.seqera.io'
+        !config.tower.endpoint
     }
 
     def 'should set wave options' () {
@@ -1176,7 +1180,7 @@ class ConfigBuilderTest extends Specification {
         then:
         config.wave instanceof Map
         config.wave.enabled
-        config.wave.endpoint == 'https://wave.seqera.io'
+        !config.wave.endpoint
     }
 
     def 'should set cloudcache options' () {
@@ -2352,9 +2356,9 @@ class ConfigBuilderTest extends Specification {
 
     def 'should return parsed config' () {
         given:
-        def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: new Launcher())
         def base = Files.createTempDirectory('test')
-        base.resolve('nextflow.config').text = '''
+        def configFile = base.resolve('nextflow.config')
+        configFile.text = '''
         profiles {
             first {
                 params {
@@ -2371,6 +2375,8 @@ class ConfigBuilderTest extends Specification {
         }
         '''
         when:
+        def opt = new CliOptions(config: [configFile.toFile().canonicalPath])
+        def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: new Launcher(options: opt))
         def txt = ConfigBuilder.resolveConfig(base, cmd)
         then:
         txt == '''\

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerConfigTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerConfigTest.groovy
@@ -24,6 +24,18 @@ import spock.lang.Specification
  */
 class TowerConfigTest extends Specification {
 
+    def 'should use default endpoint when not specified'() {
+        when:
+        def config = new TowerConfig([:], [TOWER_API_ENDPOINT: 'https://example.com'])
+        then:
+        config.endpoint == 'https://example.com'
+
+        when:
+        config = new TowerConfig([:], [:])
+        then:
+        config.endpoint == 'https://api.cloud.seqera.io'
+    }
+
     def 'should use default timeout values when not specified'() {
         when:
         def config = new TowerConfig([:], [:])

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/config/WaveConfig.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/config/WaveConfig.groovy
@@ -42,7 +42,9 @@ import nextflow.util.Duration
 @ToString(includeNames = true, includePackage = false, includeFields = true, useGetters = false)
 @CompileStatic
 class WaveConfig implements ConfigScope {
+
     final private static String DEF_ENDPOINT = 'https://wave.seqera.io'
+
     final private static List<String> DEF_STRATEGIES = List.of('container','dockerfile','conda')
 
     final BuildOpts build


### PR DESCRIPTION
Close #7044 

Previously, the `ConfigBuilder` assigned defaults for all of the `-with-*` CLI options. Now that these config settings are accessed through config classes like `TowerConfig` and `WaveConfig`, default values should only be assigned there instead of `ConfigBuilder`

The report options like `-with-report` were already corrected. This PR applies the same refactor to `-with-tower` and `-with-wave`