### PR TITLE
Simplify demo module README template

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleCreate.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleCreate.groovy
@@ -191,21 +191,7 @@ class CmdModuleCreate extends CmdBase {
         include { ${name.replaceAll('[^a-zA-Z0-9_]', '_').toUpperCase()} } from '${namespace}/${name}'
         ```
 
-        ## Input / Output / Dependencies
-
-        ### Input
-
-        | Name       | Type   | Description       |
-        |------------|--------|-------------------|
-        | greeting   | string | A greeting string |
-
-        ### Output
-
-        | Name   | Type   | Description          |
-        |--------|--------|----------------------|
-        | stdout | string | The greeting message |
-
-        ### Dependencies
+        ## Dependencies
 
         None.
 

--- a/modules/nextflow/src/test/groovy/nextflow/cli/module/CmdModuleCreateTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/module/CmdModuleCreateTest.groovy
@@ -115,7 +115,7 @@ class CmdModuleCreateTest extends Specification {
         content.contains('# myorg/hello')
         content.contains('## Summary')
         content.contains('## Get started')
-        content.contains('## Input / Output / Dependencies')
+        content.contains('## Dependencies')
         content.contains('## License')
         content.contains("include { HELLO } from 'myorg/hello'")
     }


### PR DESCRIPTION
## Summary
- Drop the placeholder Input/Output tables from the README generated by `nf module create`
- Keep only the Dependencies section, matching the simpler hello-world demo module scope

## Test plan
- [x] `./gradlew :nextflow:test --tests CmdModuleCreateTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)