### PR TITLE
Allow `-with-docker` to be used without a default container image

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -798,32 +798,6 @@ class ConfigBuilder {
         else if( containerConfig.image ) {
             config.process.container = containerConfig.image
         }
-
-        if( !hasContainerDirective(config.process) )
-            throw new AbortOperationException("You have requested to run with ${engine.capitalize()} but no image was specified")
-
-    }
-
-    /**
-     * Verify that configuration for process contains at last one `container` directive
-     *
-     * @param process
-     * @return {@code true} when a `container` is defined or {@code false} otherwise
-     */
-    protected boolean hasContainerDirective(process)  {
-
-        if( process instanceof Map ) {
-            if( process.container )
-                return true
-
-            def result = process
-                    .findAll { String name, value -> (name.startsWith('withName:') || name.startsWith('$')) && value instanceof Map }
-                    .find { String name, Map value -> value.container as boolean }  // the first non-empty `container` string
-
-            return result as boolean
-        }
-
-        return false
     }
 
     ConfigObject buildConfigObject() {

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -727,10 +727,10 @@ class ConfigBuilderTest extends Specification {
         when:
         opt = new CliOptions()
         run = new CmdRun(withDocker: '-')
-        new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
+        config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
         then:
-        def e = thrown(AbortOperationException)
-        e.message == 'You have requested to run with Docker but no image was specified'
+        config.docker.enabled
+        !config.process.container
 
         when:
         file.text =
@@ -739,10 +739,10 @@ class ConfigBuilderTest extends Specification {
                 '''
         opt = new CliOptions(config: [file.toFile().canonicalPath])
         run = new CmdRun(withDocker: '-')
-        new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
+        config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
         then:
-        e = thrown(AbortOperationException)
-        e.message == 'You have requested to run with Docker but no image was specified'
+        config.docker.enabled
+        !config.process.container
 
     }
 
@@ -788,22 +788,6 @@ class ConfigBuilderTest extends Specification {
         config.cluster.slots == 10
         config.cluster.tcp.alpha == 'uno'
         config.cluster.tcp.beta == 'due'
-
-    }
-
-    def 'has container directive' () {
-        when:
-        def config = new ConfigBuilder()
-
-        then:
-        !config.hasContainerDirective(null)
-        !config.hasContainerDirective([:])
-        !config.hasContainerDirective([foo: true])
-        config.hasContainerDirective([container: 'hello/world'])
-        !config.hasContainerDirective([foo: 1, bar: 2])
-        !config.hasContainerDirective([foo: 1, bar: 2, baz: [container: 'user/repo']])
-        config.hasContainerDirective([foo: 1, bar: 2, $baz: [container: 'user/repo']])
-        config.hasContainerDirective([foo: 1, bar: 2, 'withName:baz': [container: 'user/repo']])
 
     }
 


### PR DESCRIPTION
This PR allows the `-with-docker` option to be used without a default container image.

Particularly useful when running modules directly:
```bash
nextflow module run nf-core/fastqc --meta.id 1 --reads sample.fastq -with-docker
```

The above currently fails because Nextflow currently requires a default container image, even if every process defines its own container.

Whereas `-with-conda` works out of the box, because it doesn't require a default conda environment:
```bash
nextflow module run nf-core/fastqc --meta.id 1 --reads sample.fastq -with-conda
```

The consequence of this PR is that when a process doesn't define a container image, it will implicitly run without containerization. This is consistent with Conda: processes that don't define a conda environment will simply run without conda.