### PR TITLE
Add $schema ref to generated module spec

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/module/ModuleSpec.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/module/ModuleSpec.groovy
@@ -169,6 +169,7 @@ class ModuleSpec {
      */
     Map<String, Object> asMap() {
         final result = new LinkedHashMap<String, Object>()
+        result['$schema'] = 'https://raw.githubusercontent.com/nextflow-io/schemas/refs/heads/main/module/v1/schema.json'
         if( name )
             result['name'] = name
         if( version )

--- a/modules/nextflow/src/test/groovy/nextflow/cli/module/CmdModuleSpecTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/module/CmdModuleSpecTest.groovy
@@ -341,6 +341,7 @@ class CmdModuleSpecTest extends Specification {
         then:
         noExceptionThrown()
         existingMetaYml.text.contains '''\
+            $schema: https://raw.githubusercontent.com/nextflow-io/schemas/refs/heads/main/module/v1/schema.json
             name: test-namespace/fastqc
             input:
             - - name: meta


### PR DESCRIPTION
This PR adds a `$schema` property to the module spec which denotes the module schema

The generated module spec always uses the new schema: https://github.com/nextflow-io/schemas/blob/main/module/v1/schema.json

So if the `$schema` isn't specified, you can assume it is the nf-core schema:
https://github.com/nf-core/modules/blob/master/modules/meta-schema.json