### PR TITLE
Fix error checking in workflow emits

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -312,6 +312,7 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
             var output = es.getExpression();
             VariableExpression target;
             if( output instanceof VariableExpression ve ) {
+                visit(ve);
                 target = ve;
             }
             else if( output instanceof AssignmentExpression assign ) {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -312,7 +312,11 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
             var output = es.getExpression();
             VariableExpression target;
             if( output instanceof VariableExpression ve ) {
-                visit(ve);
+                // a bare name without a type (e.g. `x`) is an output expression
+                // and should be resolved as a variable reference; a name with a type
+                // (e.g. `x: String`) declares a named output and should not be visited
+                if( ClassHelper.isDynamicTyped(ve.getOriginType()) )
+                    visit(ve);
                 target = ve;
             }
             else if( output instanceof AssignmentExpression assign ) {

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -886,8 +886,6 @@ public class ScriptAstBuilder {
         var hasEmitExpression = statements.stream().anyMatch(this::isEmitExpression);
         if( hasEmitExpression && statements.size() > 1 )
             collectSyntaxError(new SyntaxException("Every emit must be assigned to a name when there are multiple emits", result));
-        if( !hasEmitExpression && statements.size() == 1 )
-            collectWarning("Emit name should be omitted when there is only one emit", ctx.workflowEmit(0).getText(), result);
         return result;
     }
 

--- a/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
@@ -182,6 +182,75 @@ class ScriptResolveTest extends Specification {
         errors[0].getStartLine() == 3
         errors[0].getStartColumn() == 9
         errors[0].getOriginalMessage() == 'Variables in a closure should be declared with `def`'
+
+        when:
+        errors = check(
+            '''\
+            workflow hello {
+                emit:
+                x
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 3
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == '`x` is not defined'
+
+        when:
+        errors = check(
+            '''\
+            workflow hello {
+                emit:
+                x = y
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 3
+        errors[0].getStartColumn() == 9
+        errors[0].getOriginalMessage() == '`y` is not defined'
+
+        when:
+        errors = check(
+            '''\
+            workflow hello {
+                emit:
+                x + y
+            }
+            '''
+        )
+        then:
+        errors.size() == 2
+        errors[0].getStartLine() == 3
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == '`x` is not defined'
+        errors[1].getStartLine() == 3
+        errors[1].getStartColumn() == 9
+        errors[1].getOriginalMessage() == '`y` is not defined'
+    }
+
+    def 'should not warn when a workflow emits a channel by name' () {
+        given:
+        def source = '''\
+            workflow example {
+                main:
+                output = channel.value('hi')
+
+                emit:
+                output
+            }
+            '''
+        when:
+        def result = scriptParser.parse('main.nf', source.stripIndent())
+        scriptParser.analyze()
+        def errors = TestUtils.getErrors(result)
+        def warnings = TestUtils.getWarnings(result)
+        then:
+        errors.size() == 0
+        warnings.size() == 0
     }
 
     def 'should report an error for an undefined function' () {

--- a/modules/nf-lang/src/testFixtures/groovy/test/TestUtils.groovy
+++ b/modules/nf-lang/src/testFixtures/groovy/test/TestUtils.groovy
@@ -108,6 +108,20 @@ class TestUtils {
             .toList()
     }
 
+    /**
+     * Get the list of compiler warnings for a source file.
+     *
+     * @param source
+     */
+    static List<String> getWarnings(SourceUnit source) {
+        final errorCollector = source.getErrorCollector()
+        if( !errorCollector.hasWarnings() )
+            return Collections.emptyList()
+        return errorCollector.getWarnings().stream()
+            .map(w -> w.getMessage())
+            .toList()
+    }
+
     static boolean hasSyntaxErrors(SourceUnit source) {
         return getErrors(source).stream()
             .filter(error -> error instanceof PhaseAware ? error.getPhase() == Phases.SYNTAX : true)


### PR DESCRIPTION
This PR adds proper name checking for workflow emits that are just a name:

```groovy
workflow hello {
  x = channel.of(...)

  emit:
  // shorthand for `x = x`
  x
}
```

- Report error if an emit expression references an undefined variable
- Mark the emitted variable as used in order to not report an "unused variable" warning
- Remove the "emit name should be omitted" warning as it causes too much confusion for users who haven't migrated to static typing