### PR TITLE
Add submit-time check to avoid submitting task with container engine enabled without contaner image

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1895,6 +1895,13 @@ class TaskProcessor {
     final protected void submitTask( TaskRun task, HashCode hash, Path folder ) {
         log.trace "[${safeTaskName(task)}] actual run folder: ${folder}"
 
+        // validate that a container image is defined when a container engine is enabled
+        final containerConfig = task.getContainerConfig()
+        if( containerConfig?.isEnabled() && !task.getContainer() )
+            throw new ProcessUnrecoverableException(
+                "Process `${safeTaskName(task)}` requires a container image but none was specified -- add a `container` directive or disable the ${containerConfig.getEngine()} engine"
+            )
+
         // set name, hash, and working directory
         task.hash = hash
         task.workDir = folder

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService
 import com.google.common.hash.HashCode
 import groovyx.gpars.agent.Agent
 import nextflow.Session
+import nextflow.container.ContainerConfig
 import nextflow.exception.IllegalArityException
 import nextflow.exception.ProcessException
 import nextflow.exception.ProcessUnrecoverableException
@@ -616,6 +617,58 @@ class TaskProcessorTest extends Specification {
         task.getConfig() >> new TaskConfig(attempt: 2)
         and:
         0 * collector.collect(task)
+        1 * exec.submit(task)
+    }
+
+    def 'should fail submit when container engine is enabled but no container is defined'() {
+        given:
+        def exec = Mock(Executor)
+        def proc = Spy(new TaskProcessor(executor: exec))
+        and:
+        def containerCfg = Mock(ContainerConfig) {
+            isEnabled() >> true
+            getEngine() >> 'docker'
+        }
+        def task = Mock(TaskRun) {
+            lazyName() >> 'FOO'
+            getContainerConfig() >> containerCfg
+            getContainer() >> null
+        }
+        def hash = HashCode.fromString('0123456789abcdef')
+        def workDir = Path.of('/work')
+
+        when:
+        proc.submitTask(task, hash, workDir)
+
+        then:
+        def e = thrown(ProcessUnrecoverableException)
+        e.message.contains('FOO')
+        e.message.contains('docker')
+        and:
+        0 * exec.submit(task)
+    }
+
+    def 'should submit when container engine is enabled and a container image is defined'() {
+        given:
+        def exec = Mock(Executor)
+        def proc = Spy(new TaskProcessor(executor: exec))
+        and:
+        def containerCfg = Mock(ContainerConfig) {
+            isEnabled() >> true
+            getEngine() >> 'docker'
+        }
+        def task = Mock(TaskRun) {
+            getConfig() >> new TaskConfig()
+            getContainerConfig() >> containerCfg
+            getContainer() >> 'ubuntu:22.04'
+        }
+        def hash = HashCode.fromString('0123456789abcdef')
+        def workDir = Path.of('/work')
+
+        when:
+        proc.submitTask(task, hash, workDir)
+
+        then:
         1 * exec.submit(task)
     }
 }


### PR DESCRIPTION
This pull request adds validation to ensure that when a container engine is enabled for a process, a container image must be specified. If no container image is defined, the process submission will now fail with a clear error message. The changes also include new tests to verify this behavior.

**Container validation improvements:**

* Added a check in `TaskProcessor.submitTask` to throw a `ProcessUnrecoverableException` if a container engine (e.g., Docker) is enabled but no container image is specified for the task, with an informative error message.

**Testing enhancements:**

* Added a unit test to `TaskProcessorTest` to verify that submitting a task without a container image when a container engine is enabled results in a failure with the correct error message.
* Added a unit test to ensure that submitting a task with both a container engine enabled and a container image defined proceeds

Error message example:
```
ERROR ~ Error executing process > 'TEST (1)'

Caused by:
  Process `TEST (1)` requires a container image but none was specified -- add a `container` directive or disable the docker engine
```
