### PR TITLE
Remove arch config option from Seqera MachineRequirement

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1418,9 +1418,6 @@ The following settings are available:
 `seqera.executor.autoLabels`
 : When `true`, automatically adds workflow metadata labels to the session with the `nextflow.io/` prefix (default: `false`). The following labels are added: `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`. A `seqera.io/runId` label is also added, computed as a SipHash of the session ID and run name.
 
-`seqera.executor.machineRequirement.arch`
-: The CPU architecture for task execution, e.g. `'x86_64'` or `'arm64'`.
-
 `seqera.executor.machineRequirement.provisioning`
 : The instance provisioning mode. Can be `'spot'`, `'ondemand'`, or `'spotFirst'`.
 

--- a/plugins/nf-seqera/src/main/io/seqera/config/MachineRequirementOpts.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/config/MachineRequirementOpts.groovy
@@ -32,12 +32,6 @@ class MachineRequirementOpts implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        The CPU architecture for task execution (e.g., `x86_64`, `arm64`).
-    """)
-    final String arch
-
-    @ConfigOption
-    @Description("""
         The instance provisioning mode: `spot`, `ondemand`, or `spotFirst`.
     """)
     final String provisioning
@@ -116,7 +110,6 @@ class MachineRequirementOpts implements ConfigScope {
     MachineRequirementOpts() {}
 
     MachineRequirementOpts(Map opts) {
-        this.arch = opts.arch as String
         this.provisioning = opts.provisioning as String
         this.maxSpotAttempts = opts.maxSpotAttempts as Integer
         this.machineTypes = (opts.machineTypes ?: opts.machineFamilies) as List<String>
@@ -130,10 +123,6 @@ class MachineRequirementOpts implements ConfigScope {
             ? opts.diskSize as MemoryUnit
             : (opts.diskSize ? MemoryUnit.of(opts.diskSize as String) : null)
         this.capacityMode = opts.capacityMode as String
-    }
-
-    String getArch() {
-        return arch
     }
 
     String getProvisioning() {

--- a/plugins/nf-seqera/src/main/io/seqera/util/SchemaMapperUtil.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/util/SchemaMapperUtil.groovy
@@ -63,10 +63,9 @@ class SchemaMapperUtil {
             return null
         final diskReq = toDiskRequirement(opts.diskSize, opts)
         final capacityMode = toEcsCapacityMode(opts.capacityMode)
-        if (!opts.arch && !opts.provisioning && !opts.maxSpotAttempts && !opts.machineTypes && !diskReq && !capacityMode)
+        if (!opts.provisioning && !opts.maxSpotAttempts && !opts.machineTypes && !diskReq && !capacityMode)
             return null
         new MachineRequirement()
-            .arch(opts.arch)
             .provisioning(toProvisioningModel(opts.provisioning))
             .maxSpotAttempts(opts.maxSpotAttempts)
             .machineTypes(opts.machineTypes)
@@ -76,7 +75,6 @@ class SchemaMapperUtil {
 
     /**
      * Maps MachineRequirementOpts to MachineRequirement API object, merging with task arch.
-     * Task arch overrides config arch if specified.
      *
      * @param opts the config options (can be null)
      * @param taskArch the task container platform/arch (can be null)
@@ -88,7 +86,6 @@ class SchemaMapperUtil {
 
     /**
      * Maps MachineRequirementOpts to MachineRequirement API object, merging with task arch, disk, and snapshots.
-     * Task arch overrides config arch if specified.
      *
      * @param opts the config options (can be null)
      * @param taskArch the task container platform/arch (can be null)
@@ -97,7 +94,7 @@ class SchemaMapperUtil {
      * @return the MachineRequirement API object, or null if no settings
      */
     static MachineRequirement toMachineRequirement(MachineRequirementOpts opts, String taskArch, MemoryUnit diskSize, boolean snapshotEnabled) {
-        final arch = taskArch ?: opts?.arch
+        final arch = taskArch
         final provisioning = opts?.provisioning
         final maxSpotAttempts = opts?.maxSpotAttempts
             ?: (snapshotEnabled ? FusionConfig.DEFAULT_SNAPSHOT_MAX_SPOT_ATTEMPTS : null)

--- a/plugins/nf-seqera/src/test/io/seqera/config/ExecutorOptsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/config/ExecutorOptsTest.groovy
@@ -46,7 +46,6 @@ class ExecutorOptsTest extends Specification {
         config.keyPairName == null
         config.batchFlushInterval == Duration.of('1 sec')
         config.machineRequirement != null
-        config.machineRequirement.arch == null
         config.machineRequirement.provisioning == null
         !config.autoLabels
     }
@@ -79,7 +78,6 @@ class ExecutorOptsTest extends Specification {
         def config = new ExecutorOpts([
             endpoint: 'https://sched.example.com',
             machineRequirement: [
-                arch: 'arm64',
                 provisioning: 'spotFirst',
                 maxSpotAttempts: 3,
                 machineTypes: ['m6g', 'c6g']
@@ -88,7 +86,6 @@ class ExecutorOptsTest extends Specification {
 
         then:
         config.machineRequirement != null
-        config.machineRequirement.arch == 'arm64'
         config.machineRequirement.provisioning == 'spotFirst'
         config.machineRequirement.maxSpotAttempts == 3
         config.machineRequirement.machineTypes == ['m6g', 'c6g']
@@ -114,7 +111,6 @@ class ExecutorOptsTest extends Specification {
             keyPairName: 'my-key',
             batchFlushInterval: '2 sec',
             machineRequirement: [
-                arch: 'x86_64',
                 provisioning: 'spot'
             ]
         ])
@@ -124,7 +120,6 @@ class ExecutorOptsTest extends Specification {
         config.region == 'eu-west-1'
         config.keyPairName == 'my-key'
         config.batchFlushInterval == Duration.of('2 sec')
-        config.machineRequirement.arch == 'x86_64'
         config.machineRequirement.provisioning == 'spot'
     }
 

--- a/plugins/nf-seqera/src/test/io/seqera/config/MachineRequirementOptsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/config/MachineRequirementOptsTest.groovy
@@ -30,7 +30,6 @@ class MachineRequirementOptsTest extends Specification {
         def opts = new MachineRequirementOpts([:])
 
         then:
-        opts.arch == null
         opts.provisioning == null
         opts.maxSpotAttempts == null
         opts.machineTypes == null
@@ -39,14 +38,12 @@ class MachineRequirementOptsTest extends Specification {
     def 'should create with all settings' () {
         when:
         def opts = new MachineRequirementOpts([
-            arch: 'arm64',
             provisioning: 'spotFirst',
             maxSpotAttempts: 3,
             machineTypes: ['m5', 'c5', 'r5']
         ])
 
         then:
-        opts.arch == 'arm64'
         opts.provisioning == 'spotFirst'
         opts.maxSpotAttempts == 3
         opts.machineTypes == ['m5', 'c5', 'r5']
@@ -54,10 +51,9 @@ class MachineRequirementOptsTest extends Specification {
 
     def 'should create with partial settings' () {
         when:
-        def opts = new MachineRequirementOpts([arch: 'x86_64', provisioning: 'spot'])
+        def opts = new MachineRequirementOpts([provisioning: 'spot'])
 
         then:
-        opts.arch == 'x86_64'
         opts.provisioning == 'spot'
         opts.maxSpotAttempts == null
         opts.machineTypes == null

--- a/plugins/nf-seqera/src/test/io/seqera/config/SeqeraConfigTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/config/SeqeraConfigTest.groovy
@@ -58,7 +58,6 @@ class SeqeraConfigTest extends Specification {
                 keyPairName: 'my-key',
                 batchFlushInterval: '2 sec',
                 machineRequirement: [
-                    arch: 'arm64',
                     provisioning: 'spot'
                 ]
             ]
@@ -70,7 +69,6 @@ class SeqeraConfigTest extends Specification {
         config.executor.region == 'eu-west-1'
         config.executor.keyPairName == 'my-key'
         config.executor.batchFlushInterval == Duration.of('2 sec')
-        config.executor.machineRequirement.arch == 'arm64'
         config.executor.machineRequirement.provisioning == 'spot'
     }
 

--- a/plugins/nf-seqera/src/test/io/seqera/util/MapperUtilTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/util/MapperUtilTest.groovy
@@ -43,28 +43,15 @@ class MapperUtilTest extends Specification {
         SchemaMapperUtil.toMachineRequirement(new MachineRequirementOpts([:])) == null
     }
 
-    def 'should map arch only' () {
-        when:
-        def result = SchemaMapperUtil.toMachineRequirement(new MachineRequirementOpts([arch: 'arm64']))
-
-        then:
-        result.arch == 'arm64'
-        result.provisioning == null
-        result.maxSpotAttempts == null
-        result.machineTypes == null
-    }
-
     def 'should map all fields' () {
         when:
         def result = SchemaMapperUtil.toMachineRequirement(new MachineRequirementOpts([
-            arch: 'x86_64',
             provisioning: 'spotFirst',
             maxSpotAttempts: 3,
             machineTypes: ['m5', 'c5']
         ]))
 
         then:
-        result.arch == 'x86_64'
         result.provisioning == ProvisioningModel.SPOT_FIRST
         result.maxSpotAttempts == 3
         result.machineTypes == ['m5', 'c5']
@@ -101,10 +88,10 @@ class MapperUtilTest extends Specification {
         result.provisioning == null
     }
 
-    def 'should use taskArch over config arch' () {
+    def 'should use taskArch with config settings' () {
         when:
         def result = SchemaMapperUtil.toMachineRequirement(
-            new MachineRequirementOpts([arch: 'x86_64', provisioning: 'spot']),
+            new MachineRequirementOpts([provisioning: 'spot']),
             'arm64'
         )
 
@@ -113,15 +100,15 @@ class MapperUtilTest extends Specification {
         result.provisioning == ProvisioningModel.SPOT
     }
 
-    def 'should use config arch when taskArch is null' () {
+    def 'should have null arch when taskArch is null' () {
         when:
         def result = SchemaMapperUtil.toMachineRequirement(
-            new MachineRequirementOpts([arch: 'x86_64', provisioning: 'spot']),
+            new MachineRequirementOpts([provisioning: 'spot']),
             null
         )
 
         then:
-        result.arch == 'x86_64'
+        result.arch == null
         result.provisioning == ProvisioningModel.SPOT
     }
 
@@ -181,8 +168,8 @@ class MapperUtilTest extends Specification {
     def 'should include disk in machine requirement' () {
         when:
         def result = SchemaMapperUtil.toMachineRequirement(
-            new MachineRequirementOpts([arch: 'x86_64']),
-            null,
+            new MachineRequirementOpts([:]),
+            'x86_64',
             MemoryUnit.of('200 GB'),
             false
         )
@@ -204,7 +191,7 @@ class MapperUtilTest extends Specification {
         result.disk.sizeGiB == 100
     }
 
-    def 'should return null when no arch, no opts, and no disk' () {
+    def 'should return null when no taskArch, no opts, and no disk' () {
         expect:
         SchemaMapperUtil.toMachineRequirement(null, null, null, false) == null
     }
@@ -289,7 +276,6 @@ class MapperUtilTest extends Specification {
     def 'should pass disk options through machine requirement' () {
         given:
         def opts = new MachineRequirementOpts([
-            arch: 'arm64',
             diskAllocation: 'task',
             diskType: 'ebs/io2',
             diskIops: 15000,
@@ -297,7 +283,7 @@ class MapperUtilTest extends Specification {
         ])
 
         when:
-        def result = SchemaMapperUtil.toMachineRequirement(opts, null, MemoryUnit.of('500 GB'), false)
+        def result = SchemaMapperUtil.toMachineRequirement(opts, 'arm64', MemoryUnit.of('500 GB'), false)
 
         then:
         result.arch == 'arm64'
@@ -365,12 +351,11 @@ class MapperUtilTest extends Specification {
     def 'should include disk allocation in machine requirement' () {
         given:
         def opts = new MachineRequirementOpts([
-            arch: 'x86_64',
             diskAllocation: 'node'
         ])
 
         when:
-        def result = SchemaMapperUtil.toMachineRequirement(opts, null, MemoryUnit.of('200 GB'), false)
+        def result = SchemaMapperUtil.toMachineRequirement(opts, 'x86_64', MemoryUnit.of('200 GB'), false)
 
         then:
         result.arch == 'x86_64'
@@ -483,7 +468,7 @@ class MapperUtilTest extends Specification {
 
     def 'should not default maxSpotAttempts when snapshot disabled' () {
         when:
-        def result = SchemaMapperUtil.toMachineRequirement(new MachineRequirementOpts([arch: 'x86_64']), null, null, false)
+        def result = SchemaMapperUtil.toMachineRequirement(new MachineRequirementOpts([:]), 'x86_64', null, false)
 
         then:
         result.snapshotEnabled == null
@@ -519,8 +504,8 @@ class MapperUtilTest extends Specification {
     def 'should include capacity mode in machine requirement with task arch' () {
         when:
         def result = SchemaMapperUtil.toMachineRequirement(
-            new MachineRequirementOpts([capacityMode: 'managed', arch: 'arm64']),
-            null,
+            new MachineRequirementOpts([capacityMode: 'managed']),
+            'arm64',
             null,
             false
         )
@@ -533,8 +518,8 @@ class MapperUtilTest extends Specification {
     def 'should combine snapshot with other machine requirement settings' () {
         when:
         def result = SchemaMapperUtil.toMachineRequirement(
-            new MachineRequirementOpts([arch: 'arm64', provisioning: 'spot']),
-            null,
+            new MachineRequirementOpts([provisioning: 'spot']),
+            'arm64',
             MemoryUnit.of('100 GB'),
             true
         )
@@ -581,10 +566,10 @@ class MapperUtilTest extends Specification {
 
     def 'should include nvme disk in machine requirement' () {
         given:
-        def opts = new MachineRequirementOpts([arch: 'x86_64', diskAllocation: 'nvme', capacityMode: 'asg'])
+        def opts = new MachineRequirementOpts([diskAllocation: 'nvme', capacityMode: 'asg'])
 
         when:
-        def result = SchemaMapperUtil.toMachineRequirement(opts)
+        def result = SchemaMapperUtil.toMachineRequirement(opts, 'x86_64', null, false)
 
         then:
         result != null


### PR DESCRIPTION
## Summary
- Remove the redundant `arch` option under `seqera.executor.machineRequirement`.
- Architecture is now sourced exclusively from the process `arch` directive via `task.getContainerPlatform()` (already passed as `taskArch` to `SchemaMapperUtil.toMachineRequirement`).
- Update related unit tests.

## Test plan
- [x] `./gradlew :plugins:nf-seqera:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)