### PR TITLE
Replace current cloud info url call by Cloud Info client

### DIFF
--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     api 'com.google.cloud:google-cloud-logging:3.23.5'
     api 'com.google.cloud:google-cloud-nio:0.128.5'
     api 'com.google.cloud:google-cloud-storage:2.58.0'
-
+    api 'io.seqera:lib-cloudinfo:1.0.0'
     // Force patched version to address CVE-2025-55163 (MadeYouReset HTTP/2 DDoS vulnerability)
     runtimeOnly 'io.grpc:grpc-netty-shaded:1.75.0'
     // Force patched version to address GHSA-72hv-8253-57qq (jackson-core Number Length Constraint Bypass DoS)

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchMachineTypeSelector.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchMachineTypeSelector.groovy
@@ -15,9 +15,11 @@
  */
 package nextflow.cloud.google.batch
 
+import io.seqera.cloudinfo.api.CloudPrice
+import io.seqera.cloudinfo.client.CloudInfoClient
+
 import java.math.RoundingMode
 
-import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
 import groovy.transform.Memoized
@@ -41,8 +43,6 @@ import nextflow.util.MemoryUnit
 class GoogleBatchMachineTypeSelector {
 
     static GoogleBatchMachineTypeSelector INSTANCE = new GoogleBatchMachineTypeSelector()
-
-    private static final CLOUD_INFO_API = "https://cloudinfo.seqera.io/api/v1"
 
     /*
      * Some families CPUs are faster so this is a cost correction factor
@@ -100,6 +100,12 @@ class GoogleBatchMachineTypeSelector {
      * Families that support local SSD with 'lssd' suffix
      */
     private static final List<String> PARTIAL_LOCAL_SSD_SUPPORT_FAMILIES = ['c3-*', 'c3a-*', 'c3d-*', 'c4-*', 'c4a-*', 'c4d-*', 'h4d-*', 'z3-*']
+
+    private CloudInfoClient cloudInfo
+
+    GoogleBatchMachineTypeSelector(){
+        cloudInfo = CloudInfoClient.create()
+    }
 
     @Immutable
     static class MachineType {
@@ -170,16 +176,14 @@ class GoogleBatchMachineTypeSelector {
     @Memoized
     protected List<MachineType> getAvailableMachineTypes(String region, boolean spot) {
         final priceModel = spot ? PriceModel.spot : PriceModel.standard
-        final json = "${CLOUD_INFO_API}/providers/google/services/compute/regions/${region}/products".toURL().text
-        final data = new JsonSlurper().parseText(json)
-        final products = data['products'] as List<Map>
-        final averageSpotPrice = (List<Map> prices) -> prices ? prices.collect{it.price as float}.average() as float : 0.0f
+        final products = cloudInfo.getProducts('google', region)
+        final averageSpotPrice = (List<CloudPrice> prices) -> prices ? prices.collect{it.price as float}.average() as float : 0.0f
 
         products.collect {
             new MachineType(
                     type: it.type,
                     family: it.type.toString().split('-')[0],
-                    spotPrice: averageSpotPrice(it.spotPrice as List<Map>),
+                    spotPrice: averageSpotPrice(it.spotPrice as List<CloudPrice>),
                     onDemandPrice: it.onDemandPrice as float,
                     cpusPerVm: it.cpusPerVm as int,
                     memPerVm: it.memPerVm as int,


### PR DESCRIPTION
This pull request updates the Google Batch machine type selection logic to use the new `lib-cloudinfo` client library instead of manual HTTP requests and JSON parsing. This contains default retries as well as connection and request timeouts.

**Dependency update:**

* Added `io.seqera:lib-cloudinfo:1.0.0` as an API dependency in `build.gradle` to enable use of the CloudInfo client library.

**Refactoring to use CloudInfo client:**

* Replaced manual HTTP requests and JSON parsing in `GoogleBatchMachineTypeSelector.groovy` with the `CloudInfoClient` API for retrieving product and pricing information.
* Imported `CloudPrice` and `CloudInfoClient` from the new library and initialized a `CloudInfoClient` instance in the selector class. [[1]](diffhunk://#diff-0f651a8bc13f65b635fae5eaca24bac94174df5abbc836fa4952b1c5ee6aa489R18-L20) [[2]](diffhunk://#diff-0f651a8bc13f65b635fae5eaca24bac94174df5abbc836fa4952b1c5ee6aa489R104-R109)
* Removed the hardcoded `CLOUD_INFO_API` URL, as the client library now handles API endpoint management.