### PR TITLE
Fix IllegalArgumentException when process.resourceLabels is a closure

### DIFF
--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
@@ -214,7 +214,13 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
     @PackageScope
     void computeRunResourceLabels() {
         final processMap = session.config.process as Map
-        this.runResourceLabels = Labels.toStringMap(processMap?.get('resourceLabels'))
+        final value = processMap?.get('resourceLabels')
+        if( value instanceof Closure ) {
+            log.debug "Skipping run-level process.resourceLabels: dynamic (closure) values are only resolved per-task"
+            this.runResourceLabels = Collections.<String,String>emptyMap()
+            return
+        }
+        this.runResourceLabels = Labels.toStringMap(value)
     }
 
     SeqeraBatchSubmitter getBatchSubmitter() {

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
@@ -175,6 +175,23 @@ class SeqeraExecutorTest extends Specification {
         executor.runResourceLabels == [:]
     }
 
+    def 'should skip run resource labels when process.resourceLabels is a closure'() {
+        given:
+        SysEnv.push([:])
+        def executor = new SeqeraExecutor()
+        def dynamic = { [team: 'a', priority: 7] }
+        executor.session = Mock(Session) {
+            getConfig() >> [process: [resourceLabels: dynamic]]
+        }
+
+        when:
+        executor.computeRunResourceLabels()
+
+        then:
+        noExceptionThrown()
+        executor.runResourceLabels == [:]
+    }
+
     def 'createRun populates CreateRunRequest.labels with config-level resourceLabels merged with auto-labels'() {
         given:
         SysEnv.push([:])


### PR DESCRIPTION
## Summary

- `SeqeraExecutor.computeRunResourceLabels` (introduced in #7048) reads the raw `process.resourceLabels` value from the session config and passes it to `Labels.toStringMap`. When the directive is defined dynamically (as a closure), the value is not a `Map` and execution aborts with `IllegalArgumentException: Invalid value for 'resourceLabels' directive - expected a map of key/value pairs, got '..._closure...'`.
- Closure-based `resourceLabels` typically reference task-scoped bindings (`task.process`, `task.hash`, ...) and cannot be meaningfully evaluated at the run level. Skip them at run level with a debug log; per-task resolution via `TaskConfig.getResourceLabels` continues to resolve the closure with the task binding as before.

## Test plan

- [x] New Spock test `should skip run resource labels when process.resourceLabels is a closure` fails before the fix and passes after.
- [x] Existing `SeqeraExecutorTest` suite still green.
- [ ] Manual run of a pipeline with `process { resourceLabels = { [...] } }` against the Seqera executor.

Generated with Claude Code
