### PR TITLE
Default NXF_FUSION_TRACE to false

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -126,7 +126,7 @@ The following environment variables control the configuration of the Nextflow ru
 `NXF_FUSION_TRACE`
 : :::{versionadded} 26.04.0
   :::
-: When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fusion trace file (`.fusion/trace.json`) produced in the task work directory, replacing the metrics collected by the default bash command-trace wrapper. Requires Fusion to be enabled. GPU metrics from Fusion are always collected regardless of this setting.
+: When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fusion trace file (`.fusion/trace.json`) produced in the task work directory, replacing the metrics collected by the default bash command-trace wrapper. Requires Fusion to be enabled. GPU metrics from Fusion are always collected regardless of this setting. Defaults to `false`.
 
 `NXF_HOME`
 : Nextflow home directory (default: `$HOME/.nextflow`).

--- a/modules/nf-commons/src/main/nextflow/Global.groovy
+++ b/modules/nf-commons/src/main/nextflow/Global.groovy
@@ -38,7 +38,7 @@ class Global {
      * When {@code true}, Fusion trace metrics replace the bash command-trace wrapper
      */
     static boolean isFusionTraceEnabled() {
-        return SysEnv.get('NXF_FUSION_TRACE', 'true') == 'true'
+        return SysEnv.get('NXF_FUSION_TRACE', 'false') == 'true'
     }
 
     /**


### PR DESCRIPTION
## Summary

- Change the default for `NXF_FUSION_TRACE` from `true` to `false` so that Fusion trace-based resource metrics (CPU, memory, I/O) are opt-in rather than on by default.
- Document the default in `docs/reference/env-vars.md`.

## Test plan

- [ ] Existing `TaskHandlerTest` / `BashWrapperBuilderTest` suites (which set the variable explicitly) still pass.
- [ ] With the variable unset, the bash command-trace wrapper is used as before.
