### PR TITLE
Fix generation of resolvedConfig when params included in the configuration 

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -418,7 +418,7 @@ class CmdRun extends CmdBase implements HubOptions {
         final isTowerEnabled = config.navigate('tower.enabled') as Boolean
         final isDataEnabled = config.navigate("lineage.enabled") as Boolean
         if( isTowerEnabled || isDataEnabled || log.isTraceEnabled() )
-            runner.session.resolvedConfig = ConfigBuilder.resolveConfig(scriptFile.parent, this)
+            runner.session.resolvedConfig = ConfigBuilder.resolveConfig(scriptFile.parent, this, cliParams)
         // note config files are collected during the build process
         // this line should be after `ConfigBuilder#build`
         runner.session.configFiles = builder.parsedConfigFiles

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -892,13 +892,14 @@ class ConfigBuilder {
         }
     }
 
-    static String resolveConfig(Path baseDir, CmdRun cmdRun) {
+    static String resolveConfig(Path baseDir, CmdRun cmdRun, Map cliParams) {
 
         final config = new ConfigBuilder()
                 .setShowClosures(true)
                 .setStripSecrets(true)
                 .setOptions(cmdRun.launcher.options)
                 .setCmdRun(cmdRun)
+                .setCliParams(cliParams)
                 .setBaseDir(baseDir)
                 .buildConfigObject()
 

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -2352,6 +2352,7 @@ class ConfigBuilderTest extends Specification {
                 process {
                     executor = { 'local' }
                 }
+                outputDir = params.outdir
             }
             second {
                 params.none = 'Blah'
@@ -2361,11 +2362,13 @@ class ConfigBuilderTest extends Specification {
         when:
         def opt = new CliOptions(config: [configFile.toFile().canonicalPath])
         def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: new Launcher(options: opt))
-        def txt = ConfigBuilder.resolveConfig(base, cmd)
+        def cliParams = [foo: 'Hola', outdir: 'output_folder']
+        def txt = ConfigBuilder.resolveConfig(base, cmd, cliParams)
         then:
         txt == '''\
             params {
-               foo = 'Hello world'
+               foo = 'Hola'
+               outdir = 'output_folder'
                awsKey = '[secret]'
             }
 
@@ -2373,6 +2376,7 @@ class ConfigBuilderTest extends Specification {
                executor = { 'local' }
             }
 
+            outputDir = 'output_folder'
             outputFormat = 'text'
             workDir = 'work'
 


### PR DESCRIPTION
close #7002

This pull request updates the configuration resolution in the Nextflow CLI to allow command-line parameters to be passed and correctly injected into the resolved configuration. This ensures that parameters provided via the CLI are reflected in the generated config and adds a corresponding test to verify this behavior.

**Enhancements to configuration resolution:**

* Updated `ConfigBuilder.resolveConfig` to accept a `cliParams` map, allowing command-line parameters to be injected into the resolved configuration (`ConfigBuilder.groovy`, `CmdRun.groovy`). [[1]](diffhunk://#diff-06c5c01a6a87bb8d43db5f4132f1c562b768da582ae3b969d7b8d29d92687373L895-R902) [[2]](diffhunk://#diff-ffcdda4a2bee87145991cf936cc717025b8d72da48e757b5a632e741abe53580L421-R421)

**Testing improvements:**

* Enhanced the test in `ConfigBuilderTest.groovy` to verify that CLI parameters override config values and are correctly reflected in the resolved configuration output. [[1]](diffhunk://#diff-715888fadf65476a5e143dc4bc89299a6722bd94905a9b56b562c7d6213b606dR2355) [[2]](diffhunk://#diff-715888fadf65476a5e143dc4bc89299a6722bd94905a9b56b562c7d6213b606dL2364-R2379)