### PR TITLE
Propagate task.containerPlatform through Fusion

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -223,7 +223,7 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
         final launcher = fusionLauncher()
         final config = task.getContainerConfig()
         final containerOpts = task.config.getContainerOptions()
-        final cmd = FusionHelper.runWithContainer(launcher, config, task.getContainer(), containerOpts, submit)
+        final cmd = FusionHelper.runWithContainer(launcher, config, task.getContainer(), containerOpts, submit, task.getContainerPlatform())
         // create an inline script to launch the job execution
         return '#!/bin/bash\n' + submitDirective(task) + cmd + '\n'
     }

--- a/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/local/LocalTaskHandler.groovy
@@ -156,7 +156,7 @@ class LocalTaskHandler extends TaskHandler implements FusionAwareTask {
         final launcher = fusionLauncher()
         final config = task.getContainerConfig()
         final containerOpts = task.config.getContainerOptions()
-        final cmd = FusionHelper.runWithContainer(launcher, config, task.getContainer(), containerOpts, submit)
+        final cmd = FusionHelper.runWithContainer(launcher, config, task.getContainer(), containerOpts, submit, task.getContainerPlatform())
         log.debug "Launch cmd line: ${cmd}"
 
         final logPath = Files.createTempFile('nf-task','.log')

--- a/modules/nextflow/src/main/groovy/nextflow/fusion/FusionHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/fusion/FusionHelper.groovy
@@ -43,13 +43,16 @@ class FusionHelper {
         return result!=null ? result.toString()=='true' : false
     }
 
-    static String runWithContainer(FusionScriptLauncher launcher, ContainerConfig containerConfig, String containerName, String containerOpts, List<String> runCmd) {
+    static String runWithContainer(FusionScriptLauncher launcher, ContainerConfig containerConfig, String containerName, String containerOpts, List<String> runCmd, String containerPlatform = null) {
         if( !containerName )
             throw new IllegalArgumentException("Missing task container -- Fusion requires the task to be executed by a container process")
         final containerBuilder = ContainerBuilder.create(containerConfig, containerName)
                 .addMountWorkDir(false)
                 .addRunOptions(containerOpts)
                 .addRunOptions(containerConfig.getFusionOptions())
+
+        if( containerPlatform )
+            containerBuilder.setPlatform(containerPlatform)
 
         // add fusion env vars
         for(Map.Entry<String,String> it : launcher.fusionEnv()) {

--- a/modules/nextflow/src/test/groovy/nextflow/fusion/FusionHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/fusion/FusionHelperTest.groovy
@@ -47,6 +47,19 @@ class FusionHelperTest extends Specification {
 
     }
 
+    def 'should include container platform in fusion command' () {
+        given:
+        def launcher = Mock(FusionScriptLauncher)
+        def config = new DockerConfig([:])
+
+        when:
+        def result = FusionHelper.runWithContainer(launcher, config, 'image:1', null, ['echo', 'hello'], 'linux/amd64')
+        then:
+        1 * launcher.fusionEnv() >> [:]
+        and:
+        result == "docker run -i --platform linux/amd64 --rm --privileged image:1 echo 'hello'"
+    }
+
     def 'should return fusion container command' () {
         given:
         def launcher = Mock(FusionScriptLauncher) {


### PR DESCRIPTION
## Summary

The Fusion code path in `FusionHelper.runWithContainer` bypassed `setPlatform` on the container builder, so `process.arch` was silently dropped when Fusion was enabled.

Thread `task.getContainerPlatform()` through `FusionHelper.runWithContainer` and apply it on the builder when present. The non-Fusion path already calls `setPlatform` in `BashWrapperBuilder`; this aligns the two.

Affects every container engine under Fusion (docker, podman, sarus, apple-container, ...).

## Test plan

- [x] New unit test in `FusionHelperTest` asserts `--platform linux/amd64` appears in the emitted docker command when the platform is passed.
- [x] Existing `FusionHelperTest` cases (no platform) still pass — the new parameter defaults to `null`.
- [x] `./gradlew :nextflow:test --tests "nextflow.fusion.*" --tests "nextflow.container.*" --tests "nextflow.executor.local.*"` passes.