### PR TITLE
Use toUriString for paths in work-dir and FilesEx error messages

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -54,6 +54,7 @@ import nextflow.exception.MissingLibraryException
 import nextflow.exception.ScriptCompilationException
 import nextflow.executor.ExecutorFactory
 import nextflow.extension.CH
+import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.file.FilePorter
 import nextflow.plugin.Plugins
@@ -82,7 +83,6 @@ import nextflow.trace.event.TaskEvent
 import nextflow.trace.event.WorkflowOutputEvent
 import nextflow.util.Barrier
 import nextflow.util.ClassLoaderFactory
-import nextflow.util.Duration
 import nextflow.util.HistoryFile
 import nextflow.util.LoggerHelper
 import nextflow.util.NameGenerator
@@ -445,7 +445,8 @@ class Session implements ISession {
      */
     Session init( ScriptFile scriptFile, List<String> args=null, Map<String,?> cliParams=null, Map<String,?> configParams=null ) {
 
-        if(!workDir.mkdirs()) throw new AbortOperationException("Cannot create work-dir: $workDir -- Make sure you have write permissions or specify a different directory by using the `-w` command line option")
+        if(!workDir.mkdirs())
+            throw new AbortOperationException("Cannot create work-dir '${FilesEx.toUriString(workDir)}' -- Make sure you have write permissions or specify a different directory by using the `-w` command line option")
         log.debug "Work-dir: ${workDir.toUriString()} [${FileHelper.getPathFsType(workDir)}]"
 
         if( config.bucketDir ) {

--- a/modules/nf-commons/src/main/nextflow/extension/FilesEx.groovy
+++ b/modules/nf-commons/src/main/nextflow/extension/FilesEx.groovy
@@ -495,7 +495,7 @@ class FilesEx {
             return true
         }
         catch(IOException e) {
-            log.debug "Failed to create directory '$self'", e
+            log.debug "Failed to create directory '${toUriString(self)}'", e
             return false
         }
     }
@@ -515,7 +515,7 @@ class FilesEx {
             Files.isReadable(self)
         }
         catch( IOException e ) {
-            log.trace("Cannot get read permission on file: $self -- Cause: ${e.getMessage()}")
+            log.trace("Cannot get read permission on file '${toUriString(self)}' -- Cause: ${e.getMessage()}")
             return false
         }
     }
@@ -536,7 +536,7 @@ class FilesEx {
             Files.isWritable(self)
         }
         catch( IOException e ) {
-            log.trace("Cannot get write permission on file: $self -- Cause: ${e.getMessage()}")
+            log.trace("Cannot get write permission on file '${toUriString(self)}' -- Cause: ${e.getMessage()}")
             return false
         }
     }
@@ -560,7 +560,7 @@ class FilesEx {
             Files.isExecutable(self)
         }
         catch( IOException e ) {
-            log.trace("Cannot get execute permission on file: $self -- Cause: ${e.getMessage()}")
+            log.trace("Cannot get execute permission on file '${toUriString(self)}' -- Cause: ${e.getMessage()}")
             return false
         }
     }
@@ -590,7 +590,7 @@ class FilesEx {
             Files.getLastModifiedTime(self,options).toMillis()
         }
         catch( IOException e ) {
-            log.trace "Cannot get lastModified time on file: $self -- Cause: ${e.getMessage()}"
+            log.trace "Cannot get lastModified time on file '${toUriString(self)}' -- Cause: ${e.getMessage()}"
             return 0
         }
     }


### PR DESCRIPTION
## Summary

Paths backed by non-default filesystems (S3, Azure Blob, etc.) render as opaque provider objects when interpolated directly into a GString, producing unhelpful messages like `Cannot get read permission on file: nextflow.file.http.XPath@...`.

Wrap the offending paths with `toUriString(...)` in:
- `Session.init` — the "Cannot create work-dir" abort message now shows the work-dir URI.
- `FilesEx` — the `mkdirs`/`canRead`/`canWrite`/`canExecute`/`lastModified` debug/trace logs now include a usable URI.

Also splits the long single-line `if(!workDir.mkdirs()) throw ...` in `Session.init` onto two lines for readability.

## Test plan

- [x] `./gradlew :nextflow:compileGroovy :nf-commons:compileGroovy` passes
- [ ] Trigger a non-writable work-dir and confirm the error message shows the URI