### PR TITLE
Add WorkflowInterceptor extension point for named-workflow plugins

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
@@ -24,6 +24,8 @@ import nextflow.exception.MissingProcessException
 import nextflow.exception.MissingValueException
 import nextflow.exception.ScriptRuntimeException
 import nextflow.extension.CH
+import nextflow.plugin.Plugins
+import nextflow.plugin.WorkflowInterceptor
 import nextflow.util.TestOnly
 /**
  * Models a script workflow component
@@ -181,6 +183,17 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
     }
 
     Object run(Object[] args) {
+        final interceptor = name != null ? Plugins.getExtension(WorkflowInterceptor) : null
+        if( interceptor != null ) {
+            final result = interceptor.intercept(this, args, { runDefault(args) })
+            if( result instanceof ChannelOut )
+                this.output = result
+            return result
+        }
+        return runDefault(args)
+    }
+
+    private Object runDefault(Object[] args) {
         binding = new WorkflowBinding(owner)
         ExecutionStack.push(this)
         try {

--- a/modules/nf-commons/src/main/nextflow/plugin/WorkflowInterceptor.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/WorkflowInterceptor.groovy
@@ -1,0 +1,32 @@
+package nextflow.plugin
+
+import org.pf4j.ExtensionPoint
+
+/**
+ * Extension point for intercepting named workflow execution.
+ *
+ * Plugins implement this interface to gain control before
+ * each named workflow runs. The interceptor uses the
+ * {@code proceed} callback to decide whether to execute
+ * the original workflow logic:
+ * - Call {@code proceed()} to execute normally, optionally
+ *   post-processing the result (e.g. archiving)
+ * - Return without calling {@code proceed()} to skip
+ *   execution (e.g. restore from archive)
+ *
+ * Entry workflows (name is null) are never intercepted.
+ *
+ * @author Zhibo Huang
+ */
+interface WorkflowInterceptor extends ExtensionPoint {
+
+    /**
+     * Intercept the execution of a named workflow.
+     *
+     * @param workflow the named workflow definition (WorkflowDef)
+     * @param args the arguments passed to the workflow
+     * @param proceed callback that executes the original workflow logic
+     * @return the workflow execution result (ChannelOut)
+     */
+    Object intercept(Object workflow, Object[] args, Closure proceed)
+}


### PR DESCRIPTION
## Context

Relates to #5589 (checkpoint / skip-forward discussion).

Adds a minimal `pf4j` `ExtensionPoint` — `nextflow.plugin.WorkflowInterceptor` — that lets a plugin wrap the execution of *named* workflows. The core change is tiny; the actual stage-archiving / reuse logic lives in a separate plugin, [`nf-stage`](https://github.com/huangzhibo/nf-stage), which is the first consumer.

## What changes

- New interface `WorkflowInterceptor` in `nf-commons` (32 lines)
- `WorkflowDef.run()` looks up an interceptor via `Plugins.getExtension(WorkflowInterceptor)`; if one is registered, delegates to it with a `proceed` closure that runs the original body (13 lines, extracted into `runDefault()`)
- Entry workflows (`name == null`) are never intercepted
- Behavior is unchanged when no plugin is installed

Total: +45 / -0 across 2 files.

## API

```groovy
interface WorkflowInterceptor extends ExtensionPoint {
    Object intercept(Object workflow, Object[] args, Closure proceed)
}
```

The interceptor owns the invocation: it may mutate `args` (e.g. clone channel inputs in place) before calling `proceed()`, and post-process the returned `ChannelOut`. Whether and when `proceed()` is invoked, and how the result channels are driven, is the plugin's responsibility.

## Why an extension point

Issue #5589 surfaces two positions: users want stage-level skip-forward semantics; core maintainers want `-resume` left alone and prefer pipeline authors prototype the pattern first. An extension point sidesteps the tension — it doesn't add any user-facing semantics to core, but unblocks plugin-side experimentation. If a pattern proves out in a plugin, promoting it to core remains an option later.

## Consumer: `nf-stage`

`nf-stage` uses this hook to archive each named workflow's `emit:` outputs on first run and, on reruns, replay them from a content-addressed archive when a SHA-256 digest over `(stage name, static args, channel input contents)` matches — no `work/` dependency, no per-task hash. The mechanics (clone channel args into `args[]`, let `proceed()` wire processes onto the clones, decide after digest compute whether to feed clones or STOP them) rely on the interceptor controlling args mutation and post-proceed channel flow, which is why the hook signature includes `args[]` and a `proceed` closure rather than simple before/after callbacks.

## Test plan

- [x] Existing `WorkflowDef` tests pass (no behavior change without a plugin)
- [x] Validated in `nf-stage` end-to-end: named sub-workflows intercepted, entry workflow not intercepted, `proceed()` round-trips `ChannelOut` correctly
- [ ] Happy to add a core-side test with a mock interceptor if reviewers prefer