### PR TITLE
Update warning in migration docs, now that 26.04 is released

### DIFF
--- a/docs/migrations/26-04.md
+++ b/docs/migrations/26-04.md
@@ -1,12 +1,8 @@
 (migrating-26-04-page)=
 
-# Migrating to 26.04 (preview)
+# Migrating to 26.04
 
-This page summarizes the upcoming changes in Nextflow 26.04, which will be released in April 2026.
-
-:::{note}
-This page is a work in progress and will be updated as features are finalized. It should not be considered complete until the 26.04 release.
-:::
+[Nextflow 26.04](https://github.com/nextflow-io/nextflow/releases/tag/v26.04.0) was released on April 29, 2026.
 
 ## New features
 
@@ -164,19 +160,37 @@ Breaking changes from the {ref}`first preview <static-typing-first-preview>`:
 
 - The syntax for process tuple inputs has been updated:
 
-  ```nextflow
-  // 25.10
-  input:
-  (id, fastq_1, fastq_2): Tuple<String,Path,Path>
+    ```nextflow
+    // 25.10
+    input:
+    (id, fastq_1, fastq_2): Tuple<String,Path,Path>
 
-  // 26.04
-  input:
-  tuple(id: String, fastq_1: Path, fastq_2: Path)
-  ```
+    // 26.04
+    input:
+    tuple(id: String, fastq_1: Path, fastq_2: Path)
+    ```
 
 - The method signature for the `stageAs` directive was changed from `(filePattern, value)` to `(value, filePattern)`.
 
 See {ref}`migrating-static-types` for more information about migrating to static typing. See {ref}`migrating-static-types-operators` for best practices on using operators with static typing.
+
+<h3>Process <code>hints</code> directive</h3>
+
+The `hints` process directive allows you to specify executor-specific hints for individual processes.
+
+For example, the AWS Batch executor uses the `consumableReources` hint for [resource-aware scheduling](https://aws.amazon.com/about-aws/whats-new/2025/02/aws-batch-resource-aware-scheduling/):
+
+```nextflow
+process hello {
+    hints 'awsbatch/consumableResources': ['my-license': 1]
+
+    // ...
+}
+```
+
+Custom executors can use hints to control scheduling behavior in a fine-grained manner over configuration options.
+
+See {ref}`process-hints` for details.
 
 ## Enhancements
 
@@ -217,10 +231,6 @@ Nextflow now checks out pipelines separately by revision when running remote pip
 Nextflow uses the default branch specified by the Git repository when no revision is specified, rather than defaulting to `master`. Since each revision is checked out separately, using a specific revision doesn't prevent the default branch from being used on subsequent runs.
 
 The `manifest.defaultBranch` config option is no longer needed because of this update.
-
-<h3>Load collection-type params automatically from files</h3>
-
-When using the `params` block, collection-type parameters such as `List<Record>` can be loaded automatically from a CSV, JSON, or YAML file. This feature simplifies the loading of samplesheet inputs and allows a pipeline to support multiple structured data formats.
 
 See {ref}`workflow-typed-params` for details. See {ref}`migrating-static-types` for a migration example.
 
@@ -338,6 +348,33 @@ workflow RNASEQ {
 ```
 
 See the {ref}`cli-lint` command reference for details.
+
+<h3>Apple container support</h3>
+
+Nextflow can run containers on macOS using [Apple container](https://github.com/apple/container), a lightweight container runtime for Apple silicon machines:
+
+```groovy
+process.container = 'nextflow/examples:latest'
+appleContainer.enabled = true
+```
+
+See {ref}`container-apple` for details.
+
+<h3>Seqera filesystem for datasets</h3>
+
+Nextflow can download [Seqera Platform datasets](https://docs.seqera.io/platform-cloud/data/datasets) using the `seqera` URI scheme.
+
+Seqera dataset URIs are specified as `seqera://<organization>/<workspace>/datasets/<name>[@version]`. For example:
+
+```nextflow
+params.dataset = 'seqera://seqeralabs/showcase/datasets/sarek_samples'
+
+workflow {
+    println file(params.dataset).text
+}
+```
+
+A Platform access token with appropriate permissions is required to download non-public datasets. It can be specified using the `TOWER_ACCESS_TOKEN` environment variable or the `tower.accessToken` config option.
 
 ## Breaking changes
 


### PR DESCRIPTION
<img width="1424" height="620" alt="CleanShot 2026-04-29 at 08 16 26@2x" src="https://github.com/user-attachments/assets/56ce4c8c-959a-4b47-9471-2080b0d824a9" />
