### PR TITLE
Fix module binaries on `nextflow module run` via session flag (#7087)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -902,6 +902,23 @@ class Session implements ISession {
         NF.isModuleBinariesEnabled()
     }
 
+    /**
+     * Whether the entry script was launched directly as a module via
+     * `nextflow module run`. Used to decide whether the entry script's
+     * `resources/` bundle (and module bin paths) should be picked up
+     * even though the script is not being loaded via `include`.
+     */
+    private volatile boolean moduleRun
+
+    boolean isModuleRun() {
+        return moduleRun
+    }
+
+    Session setModuleRun(boolean value) {
+        this.moduleRun = value
+        return this
+    }
+
     boolean failOnIgnore() {
         config.navigate('workflow.failOnIgnore', false) as boolean
     }

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -914,9 +914,8 @@ class Session implements ISession {
         return moduleRun
     }
 
-    Session setModuleRun(boolean value) {
+    void setModuleRun(boolean value) {
         this.moduleRun = value
-        return this
     }
 
     boolean failOnIgnore() {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -414,6 +414,7 @@ class CmdRun extends CmdBase implements HubOptions {
         runner.session.agentLog = SysEnv.isAgentMode()
         runner.session.debug = launcher.options.remoteDebug
         runner.session.disableJobsCancellation = getDisableJobsCancellation()
+        runner.session.setModuleRun(isModuleRun())
 
         final isTowerEnabled = config.navigate('tower.enabled') as Boolean
         final isDataEnabled = config.navigate("lineage.enabled") as Boolean
@@ -490,6 +491,12 @@ class CmdRun extends CmdBase implements HubOptions {
             : scriptFile.getScriptId()?.substring(0,10)
         printLaunchInfo(repo, head, revision)
     }
+
+    /**
+     * @return {@code true} when the entry script is being launched directly as a
+     * module via `nextflow module run`. Overridden by {@link nextflow.cli.module.CmdModuleRun}.
+     */
+    protected boolean isModuleRun() { false }
 
     static void detectModuleBinaryFeature(ConfigMap config) {
         final moduleBinaries = config.navigate('nextflow.enable.moduleBinaries', false)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleRun.groovy
@@ -55,6 +55,9 @@ class CmdModuleRun extends CmdRun {
     }
 
     @Override
+    protected boolean isModuleRun() { true }
+
+    @Override
     void run() {
         if( !args ) {
             throw new AbortOperationException("Module name/path not provided")

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1569,11 +1569,10 @@ class TaskProcessor {
     ResourcesBundle getModuleBundle() {
         final script = this.getOwnerScript()
         final meta = ScriptMeta.get(script)
-        if( meta?.scriptPath == null )
+        if( meta == null )
             return null
-        // The bundle is resolved when the owner script is either an included
-        // module, or it is the entry script of a `nextflow module run`
-        // invocation -- see #7087
+        // Resolve the bundle when the owner script is either an included module,
+        // or the entry script of a `nextflow module run` invocation (see #7087).
         return (meta.isModule() || session.isModuleRun()) ? meta.getModuleBundle() : null
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1569,6 +1569,7 @@ class TaskProcessor {
     ResourcesBundle getModuleBundle() {
         final script = this.getOwnerScript()
         final meta = ScriptMeta.get(script)
+        // No script meta registered (e.g. processors not tied to a loaded script): nothing to resolve.
         if( meta == null )
             return null
         // Resolve the bundle when the owner script is either an included module,

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1569,7 +1569,12 @@ class TaskProcessor {
     ResourcesBundle getModuleBundle() {
         final script = this.getOwnerScript()
         final meta = ScriptMeta.get(script)
-        return meta?.isModule() ? meta.getModuleBundle() : null
+        if( meta?.scriptPath == null )
+            return null
+        // The bundle is resolved when the owner script is either an included
+        // module, or it is the entry script of a `nextflow module run`
+        // invocation -- see #7087
+        return (meta.isModule() || session.isModuleRun()) ? meta.getModuleBundle() : null
     }
 
     @Memoized

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -35,6 +35,7 @@ import nextflow.script.BaseScript
 import nextflow.script.BodyDef
 import nextflow.script.ProcessConfig
 import nextflow.script.ProcessConfigV1
+import nextflow.script.ScriptMeta
 import nextflow.script.ScriptType
 import nextflow.script.bundle.ResourcesBundle
 import nextflow.script.params.FileInParam
@@ -98,6 +99,49 @@ class TaskProcessorTest extends Specification {
         cleanup:
         home.deleteDir()
 
+    }
+
+    @Unroll
+    def 'should resolve module bundle for entry script when running as module #desc' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def mod = folder.resolve('mod1'); mod.mkdir()
+        def bin = mod.resolve('resources/usr/bin'); bin.mkdirs()
+        def scriptPath = mod.resolve('main.nf'); Files.createFile(scriptPath)
+        Files.createFile(bin.resolve('echo.sh'))
+        and:
+        def script = Mock(BaseScript)
+        def meta = Mock(ScriptMeta) {
+            getScriptPath() >> scriptPath
+            isModule() >> IS_MODULE
+            getModuleBundle() >> ResourcesBundle.scan(mod.resolve('resources'))
+        }
+        and:
+        def session = Mock(Session) {
+            getConfig() >> [:]
+            isModuleRun() >> IS_MODULE_RUN
+        }
+        def executor = Mock(Executor) {}
+        def processor = Spy(TaskProcessor, constructorArgs: [[session:session, executor:executor]])
+        processor.getOwnerScript() >> script
+
+        when:
+        ResourcesBundle bundle
+        GroovyMock(ScriptMeta, global: true)
+        ScriptMeta.get(script) >> meta
+        bundle = processor.getModuleBundle()
+
+        then:
+        (bundle != null) == EXPECTED
+
+        cleanup:
+        folder?.deleteDir()
+
+        where:
+        desc                                | IS_MODULE | IS_MODULE_RUN | EXPECTED
+        '(included module)'                 | true      | false         | true
+        '(nextflow module run entry)'       | false     | true          | true
+        '(plain entry, no module run flag)' | false     | false         | false
     }
 
     @Unroll


### PR DESCRIPTION
## Summary

Fixes #7087 — alternative to #7088.

When a module is launched directly via `nextflow module run <scope>/<name>`, the module's `main.nf` is loaded as the **entry** script, not as an *included* module. As a result `ScriptMeta.isModule()` returns `false` for the script that owns the process, and `TaskProcessor.getModuleBundle()` returned `null`, so the `resources/usr/bin` directory was never injected into the task `PATH` -- even with `nextflow.enable.moduleBinaries = true`.

### Approach

Track the "running as a module" state explicitly on the `Session` (run-scoped, not global), instead of widening the bundle gate:

- `CmdRun` exposes a `protected boolean isModuleRun()` hook (default `false`).
- `CmdModuleRun` overrides it to return `true`.
- `CmdRun.run()` propagates the value to the runner's session: `runner.session.setModuleRun(isModuleRun())`.
- `TaskProcessor.getModuleBundle()` now resolves the bundle when the owner script is either an included module (`meta.isModule()`) **or** the entry script of a module-run invocation (`session.isModuleRun()`).

```groovy
// TaskProcessor.getModuleBundle()
if( meta?.scriptPath == null )
    return null
return (meta.isModule() || session.isModuleRun()) ? meta.getModuleBundle() : null
```

The feature remains opt-in via `nextflow.enable.moduleBinaries`.

### How this differs from #7088

| | #7088 (drop the gate) | This PR (session flag) |
|---|---|---|
| Change footprint | 1 file, 1-line gate change | 5 files: `Session`, `CmdRun`, `CmdModuleRun`, `TaskProcessor`, test |
| Gate semantics | Bundle resolved whenever the owner script has a known path | Bundle resolved only for included modules **or** module-run entry scripts |
| Behavior for plain `nextflow run pipeline.nf` with a sibling `resources/` | New: bundle picked up if `moduleBinaries=true` | Unchanged: bundle still ignored (exactly preserves previous behavior) |
| Risk of accidental bundle pickup | Low (still gated by feature flag), but the surface is broader | None: the new path is only reachable via `nextflow module run` |
| Plumbing | None | Adds `Session.moduleRun` + `CmdRun.isModuleRun()` hook |

This variation is more conservative: it fixes the reported issue without changing what counts as a module-bundle source for any existing invocation other than `nextflow module run`. The trade-off is more plumbing (one new flag threaded from CLI to Session).

## Possible side-effects and implications

- **No effect when the feature flag is off.** `TaskProcessor.getBinDirs()` still gates the call on `session.enableModuleBinaries()`, so default behavior is unchanged.
- **No effect on `nextflow run` (with or without `include`).** `session.isModuleRun()` is `false` for every CLI subcommand other than `nextflow module run`, so the gate behaves exactly as before for those invocations.
- **No effect when there is no `resources/` directory.** `ResourcesBundle.scan()` returns an empty bundle when the directory does not exist, so `getBinDirs()` produces an empty list.
- **Defensive guard added.** A `meta?.scriptPath == null` early-return preserves robustness — `ScriptMeta.getModuleBundle()` would otherwise throw `IllegalStateException` if `scriptPath` were not yet set.
- **API surface change.** `Session` gains `isModuleRun()` / `setModuleRun(boolean)` and `CmdRun` gains a `protected boolean isModuleRun()` hook. These are minor additions but worth noting for downstream code that subclasses `CmdRun`.

## Test plan

- [x] `./gradlew :nextflow:test --tests "nextflow.processor.TaskProcessorTest"` — new parameterized test `should resolve module bundle for entry script when running as module …` covers all three combinations:
  - included module (`isModule=true`, `isModuleRun=false`) → bundle resolved
  - module-run entry (`isModule=false`, `isModuleRun=true`) → bundle resolved (the fix)
  - plain entry (`isModule=false`, `isModuleRun=false`) → bundle NOT resolved (unchanged)
- [x] `./gradlew :nextflow:test --tests "nextflow.SessionTest" --tests "nextflow.cli.CmdRunTest"` passes.
- [ ] End-to-end repro from the issue (`nextflow -c test.config module run cellgeni/failexample --greeting 'Hello world!'`) succeeds with this change applied — recommended manual verification before merge.
