### PR TITLE
docs: document ConfigScope discovery rules

### DIFF
--- a/docs/developer/config-scopes.mdx
+++ b/docs/developer/config-scopes.mdx
@@ -43,16 +43,16 @@ The fully-qualified class name (in this case, `nextflow.hello.HelloConfig`) must
 
 A *config option* is defined as a field with the `@ConfigOption` annotation. The field name determines the name of the config option.
 
-:::note
-Config options are collected with `Class.getDeclaredFields()`, which does not include inherited fields. Each scope class must declare its options directly, even if a shared parent class provides common logic.
-:::
-
 For example:
 
 ```groovy
     @ConfigOption
     String createMessage
 ```
+
+:::note
+Inherited fields are not included. Each scope class must declare its options directly.
+:::
 
 The `@ConfigOption` annotation can specify an optional set of types that are valid in addition to the field type. For example, the `fusion.tags` option, which accepts either a String or Boolean, is declared as follows:
 
@@ -63,17 +63,39 @@ The `@ConfigOption` annotation can specify an optional set of types that are val
 
 The field type and any additional types are included in the config spec, allowing them to be used for validation.
 
-The field type can be any Java or Groovy class, but in practice it should be a class that can be constructed from primitive values (numbers, booleans, strings). For example, `Duration` and `MemoryUnit` are standard Nextflow types that can each be constructed from an integer or string.
-
-:::note
-The field type and the `types` attribute should only refer to [standard types][stdlib-types]. Runtime classes such as `GString`, `Number`, and `Map` do not correspond to configurable types and may produce confusing errors in the language server.
-:::
+The field type can be any Java or Groovy class, but in practice it should be a [standard Nextflow type][stdlib-types] that can be constructed from primitive values (numbers, booleans, strings). For example, `Duration` and `MemoryUnit` are standard types that can each be constructed from an integer or string.
 
 ### Nested scopes
 
-A *nested scope* is defined as a field whose type is an implementation of `ConfigScope`. The field name determines the name of the nested scope.
+A *nested scope* is defined as a field whose type is an implementation of `ConfigScope`. The field name determines the name of the nested scope. It does not need the `@ConfigOption` annotation.
 
 The scope class referenced by the field type defines config options and scopes in the same manner as top-level scope classes. Unlike top-level scopes, nested scope classes do not need to use the `@ScopeName` annotation or provide a default constructor.
+
+For example:
+
+```groovy
+@ScopeName('hello')
+class HelloConfig implements ConfigScope {
+
+    ReportConfig report
+
+    HelloConfig() {}
+
+    HelloConfig(Map opts) {
+        this.report = new ReportConfig(opts.report as Map ?: [:])
+    }
+}
+
+class ReportConfig implements ConfigScope {
+
+    @ConfigOption
+    String file
+
+    ReportConfig(Map opts) {
+        this.file = opts.file
+    }
+}
+```
 
 See `ExecutorConfig` and `ExecutorRetryConfig` for an example of how a nested scope is defined and constructed.
 

--- a/docs/developer/config-scopes.mdx
+++ b/docs/developer/config-scopes.mdx
@@ -43,6 +43,10 @@ The fully-qualified class name (in this case, `nextflow.hello.HelloConfig`) must
 
 A *config option* is defined as a field with the `@ConfigOption` annotation. The field name determines the name of the config option.
 
+:::note
+Config options are collected with `Class.getDeclaredFields()`, which does not include fields inherited from a parent class. Each scope class must therefore declare its options directly. A shared parent class can still provide common logic, such as helper methods that compute default values.
+:::
+
 For example:
 
 ```groovy
@@ -60,6 +64,10 @@ The `@ConfigOption` annotation can specify an optional set of types that are val
 The field type and any additional types are included in the config spec, allowing them to be used for validation.
 
 The field type can be any Java or Groovy class, but in practice it should be a class that can be constructed from primitive values (numbers, booleans, strings). For example, `Duration` and `MemoryUnit` are standard Nextflow types that can each be constructed from an integer or string.
+
+:::note
+The field type and the `types` attribute should only refer to [standard types][stdlib-types]. Runtime classes such as `GString`, `Number`, and `Map` do not correspond to configurable types and may produce confusing errors in the language server.
+:::
 
 ### Nested scopes
 
@@ -174,3 +182,4 @@ The config spec described above can be rendered to Markdown using the `MarkdownR
 This approach to docs generation is not yet complete, and has not been incorporated into the build process yet. However, it can be used to check for discrepancies between the source code and docs when making changes. The documentation should match the `@Description` annotations as closely as possible, but may contain additional details such as version notes and extra paragraphs.
 
 [config-options]: ../reference/config
+[stdlib-types]: ../reference/stdlib-types

--- a/docs/developer/config-scopes.mdx
+++ b/docs/developer/config-scopes.mdx
@@ -44,7 +44,7 @@ The fully-qualified class name (in this case, `nextflow.hello.HelloConfig`) must
 A *config option* is defined as a field with the `@ConfigOption` annotation. The field name determines the name of the config option.
 
 :::note
-Config options are collected with `Class.getDeclaredFields()`, which does not include fields inherited from a parent class. Each scope class must therefore declare its options directly. A shared parent class can still provide common logic, such as helper methods that compute default values.
+Config options are collected with `Class.getDeclaredFields()`, which does not include inherited fields. Each scope class must declare its options directly, even if a shared parent class provides common logic.
 :::
 
 For example:

--- a/docs/plugins/developing-plugins.mdx
+++ b/docs/plugins/developing-plugins.mdx
@@ -129,6 +129,18 @@ Runs plugin unit tests. See [Test a plugin][gradle-plugin-test] for more informa
 
 Nextflow’s plugin system exposes various extension points. This section gives examples of typical extension points and how to use them.
 
+Each extension point must be registered in `build.gradle`, so that Nextflow can discover it:
+
+```groovy
+nextflowPlugin {
+    // ...
+    extensionPoints = [
+        'nextflow.myplugin.MyPluginConfig',
+        // other extension points...
+    ]
+}
+```
+
 ### Commands
 
 Plugins can define custom CLI commands that are executable with the `nextflow plugin` command.
@@ -231,6 +243,60 @@ class MyPluginConfig implements ConfigScope {
 
     MyPluginConfig(Map opts) {
         this.createMessage = opts.createMessage
+    }
+}
+```
+
+Configuration options can be grouped by adding a nested `ConfigScope` as a field on the parent scope. Nextflow discovers nested scopes by walking fields whose declared type implements `ConfigScope`, so the field itself does not need a `@ConfigOption` annotation. Only the top-level scope needs `@ScopeName`, a no-arg constructor, and an entry in `extensionPoints`.
+
+```groovy
+import java.nio.file.Path
+
+import nextflow.config.spec.ConfigOption
+import nextflow.config.spec.ConfigScope
+import nextflow.config.spec.ScopeName
+import nextflow.script.dsl.Description
+
+@ScopeName('myplugin')
+@Description('''
+    The `myplugin` scope allows you to configure the `nf-myplugin` plugin.
+''')
+class MyPluginConfig implements ConfigScope {
+
+    @Description('''
+        Configuration for the report file.
+    ''')
+    final ReportConfig report
+
+    // no-arg constructor is required to enable validation of config options
+    MyPluginConfig() {
+    }
+
+    MyPluginConfig(Map opts) {
+        this.report = new ReportConfig(opts.report as Map ?: [:])
+    }
+}
+
+@Description('''
+    The `myplugin.report` scope allows you to configure the report file.
+''')
+class ReportConfig implements ConfigScope {
+
+    @ConfigOption
+    @Description('''
+        Path to the report file.
+    ''')
+    final Path file
+
+    @ConfigOption
+    @Description('''
+        Whether report generation is enabled.
+    ''')
+    final Boolean enabled
+
+    ReportConfig(Map opts) {
+        this.file = opts.file as Path
+        this.enabled = opts.enabled as Boolean ?: true
     }
 }
 ```

--- a/docs/plugins/developing-plugins.mdx
+++ b/docs/plugins/developing-plugins.mdx
@@ -288,15 +288,8 @@ class ReportConfig implements ConfigScope {
     ''')
     final Path file
 
-    @ConfigOption
-    @Description('''
-        Whether report generation is enabled.
-    ''')
-    final Boolean enabled
-
     ReportConfig(Map opts) {
         this.file = opts.file as Path
-        this.enabled = opts.enabled as Boolean ?: true
     }
 }
 ```

--- a/docs/plugins/developing-plugins.mdx
+++ b/docs/plugins/developing-plugins.mdx
@@ -247,53 +247,6 @@ class MyPluginConfig implements ConfigScope {
 }
 ```
 
-Configuration options can be grouped by adding a nested `ConfigScope` as a field on the parent scope. Nextflow discovers nested scopes by walking fields whose declared type implements `ConfigScope`. The field itself does not need a `@ConfigOption` annotation. Only the top-level scope needs `@ScopeName`, a no-arg constructor, and an entry in `extensionPoints`.
-
-```groovy
-import java.nio.file.Path
-
-import nextflow.config.spec.ConfigOption
-import nextflow.config.spec.ConfigScope
-import nextflow.config.spec.ScopeName
-import nextflow.script.dsl.Description
-
-@ScopeName('myplugin')
-@Description('''
-    The `myplugin` scope allows you to configure the `nf-myplugin` plugin.
-''')
-class MyPluginConfig implements ConfigScope {
-
-    @Description('''
-        Configuration for the report file.
-    ''')
-    final ReportConfig report
-
-    // no-arg constructor is required to enable validation of config options
-    MyPluginConfig() {
-    }
-
-    MyPluginConfig(Map opts) {
-        this.report = new ReportConfig(opts.report as Map ?: [:])
-    }
-}
-
-@Description('''
-    The `myplugin.report` scope allows you to configure the report file.
-''')
-class ReportConfig implements ConfigScope {
-
-    @ConfigOption
-    @Description('''
-        Path to the report file.
-    ''')
-    final Path file
-
-    ReportConfig(Map opts) {
-        this.file = opts.file as Path
-    }
-}
-```
-
 This approach is not required to support plugin config options. However, it allows Nextflow to recognize plugin definitions when validating the configuration. See [Configuration scopes][config-scopes-page] for more information.
 
 ### Executors

--- a/docs/plugins/developing-plugins.mdx
+++ b/docs/plugins/developing-plugins.mdx
@@ -247,7 +247,7 @@ class MyPluginConfig implements ConfigScope {
 }
 ```
 
-Configuration options can be grouped by adding a nested `ConfigScope` as a field on the parent scope. Nextflow discovers nested scopes by walking fields whose declared type implements `ConfigScope`, so the field itself does not need a `@ConfigOption` annotation. Only the top-level scope needs `@ScopeName`, a no-arg constructor, and an entry in `extensionPoints`.
+Configuration options can be grouped by adding a nested `ConfigScope` as a field on the parent scope. Nextflow discovers nested scopes by walking fields whose declared type implements `ConfigScope`. The field itself does not need a `@ConfigOption` annotation. Only the top-level scope needs `@ScopeName`, a no-arg constructor, and an entry in `extensionPoints`.
 
 ```groovy
 import java.nio.file.Path


### PR DESCRIPTION
## Summary

The plugin developer guide currently shows a single-option `ConfigScope` example with `@ScopeName` and a no-arg constructor, but does not mention registering the scope in `build.gradle` `extensionPoints`. Following the example as written does not eliminate `Unrecognized config option` warnings under the v2 syntax parser, because the scope is never discovered.

This PR fills four related gaps:

- Documents the `extensionPoints` registration step required for the top-level scope to be discovered
- Adds a nested-scope example, showing that fields whose declared type implements `ConfigScope` are auto-discovered and do not need a `@ConfigOption` annotation
- Notes that `@ConfigOption` fields are not inherited (the validator uses `Class.getDeclaredFields()`), so each `ConfigScope` class must declare its options directly
- Notes that the `types` attribute on `@ConfigOption` should only list [standard Nextflow types](https://docs.seqera.io/nextflow/reference/stdlib-types), not runtime classes like `GString`, `Number` or `Map`

These rules are derivable from `SpecNode.java` and `ConfigValidator.groovy`, but were not surfaced for plugin authors. Context for the gap: nextflow-io/nf-co2footprint#362 and the related upstream issue #6974.

## Style

The new content is additive; the existing single-option example is left intact. Triple-quoted `@Description` strings, `:::{note}` admonitions and prose voice match the surrounding section.