### PR TITLE
Pin netty deps in nf-azure to 4.1.133.Final

### DIFF
--- a/plugins/nf-azure/build.gradle
+++ b/plugins/nf-azure/build.gradle
@@ -68,6 +68,14 @@ dependencies {
     // Force patched version to address GHSA-72hv-8253-57qq (jackson-core Number Length Constraint Bypass DoS)
     runtimeOnly 'com.fasterxml.jackson.core:jackson-core:2.18.6'
 
+    // Pin patched netty versions to address security vulnerabilities
+    implementation 'io.netty:netty-common:4.1.133.Final'
+    implementation 'io.netty:netty-handler:4.1.133.Final'
+    implementation 'io.netty:netty-handler-proxy:4.1.133.Final'
+    implementation 'io.netty:netty-codec-http:4.1.133.Final'
+    implementation 'io.netty:netty-codec-http2:4.1.133.Final'
+    implementation 'io.netty:netty-codec-dns:4.1.133.Final'
+
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation project(':nextflow')
     testImplementation "org.apache.groovy:groovy:4.0.31"


### PR DESCRIPTION
## Summary

- Pin several netty artifacts to `4.1.133.Final` in `plugins/nf-azure/build.gradle` to clear open Dependabot security alerts that affect the Azure plugin's transitive netty graph.
- Modules pinned: `netty-common`, `netty-handler`, `netty-handler-proxy`, `netty-codec-http`, `netty-codec-http2`, `netty-codec-dns`.

## Why pinning (and not bumping Azure SDK)

The latest `com.azure:azure-storage-blob` / `azure-compute-batch` / `azure-identity` releases still pull netty `4.1.131.Final`–`4.1.132.Final` transitively — they have not been re-released against the patched `4.1.133.Final` line. Bumping the Azure SDK is therefore not sufficient on its own; the netty versions have to be forced at the plugin level.

## Dependabot alerts addressed

- `#168 / #176 / #178 / #182 / #184 / #187` — `netty-codec-http` (CVE smuggling / decompression bomb / desync)
- `#188` — `netty-codec-http2` (decompression bomb DoS)
- `#180` — `netty-codec` (Lz4FrameDecoder resource exhaustion) — picked up transitively via the `netty-codec-http` pin
- `#174` — `netty-codec-dns` (DNS codec input validation bypass)
- `#172` — `netty-handler-proxy` (HTTP header injection)

`#171` (`netty-transport-native-epoll`) is left as-is: the advisory text scopes the bug to the `4.2.x` branch only, while the project resolves `4.1.x`, so it appears to be a Dependabot range-matching false positive. Recommend dismissing in the UI.

## Test plan

- [x] `./gradlew :plugins:nf-azure:test` passes
- [x] `./gradlew :plugins:nf-azure:dependencies --configuration runtimeClasspath` shows the six pinned modules resolving to `4.1.133.Final`
- [ ] Dependabot re-scan clears alerts #168, #172, #174, #176, #178, #180, #182, #184, #187, #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)