### PR TITLE
Update guidelines for strict parser

### DIFF
--- a/docs/cache-and-resume.md
+++ b/docs/cache-and-resume.md
@@ -141,7 +141,7 @@ channel.of(1,2,3).map { v -> def X=v; X+=2 }.view { v -> "ch1 = $v" }
 ```
 
 :::{versionadded} 25.04.0
-The {ref}`strict syntax <strict-syntax-page>` does not allow global variables to be declared in closures.
+The {ref}`strict parser <strict-syntax-page>` does not allow global variables to be declared in closures.
 :::
 
 (cache-nondeterministic-inputs)=

--- a/docs/config.md
+++ b/docs/config.md
@@ -320,7 +320,7 @@ nextflow run main.nf -profile standard,cloud
 Nextflow applies config profiles in the order in which they were defined in the config, regardless of the order you specify them on the command line.
 
 :::{versionadded} 25.04.0
-When using the {ref}`strict syntax <strict-syntax-page>`, Nextflow applies profiles in the order you specify them on the command line.
+When using the {ref}`strict parser <strict-syntax-page>`, Nextflow applies profiles in the order you specify them on the command line.
 :::
 
 (config-workflow-handlers)=

--- a/docs/migrations/25-04.md
+++ b/docs/migrations/25-04.md
@@ -8,13 +8,13 @@
 
 <h3>Strict syntax</h3>
 
-The *strict syntax* is a strict parser for Nextflow DSL2 that implements the {ref}`Nextflow language specification <syntax-page>`. Originally introduced by the [Nextflow language server](https://github.com/nextflow-io/language-server) alongside Nextflow 24.10, the strict syntax is now available in the Nextflow CLI.
+The *strict syntax parser* is a strict implementation of Nextflow DSL2 based on the {ref}`Nextflow language specification <syntax-page>`. Originally introduced by the [Nextflow language server](https://github.com/nextflow-io/language-server) alongside Nextflow 24.10, the strict parser is now available in the Nextflow CLI.
 
-The strict syntax is disabled by default. Enable it by setting the environment variable `NXF_SYNTAX_PARSER=v2`. See {ref}`strict-syntax-page` for details.
+The strict parser is disabled by default. Enable it by setting the environment variable `NXF_SYNTAX_PARSER=v2`. See {ref}`strict-syntax-page` for details.
 
 <h3>Linting and formatting</h3>
 
-The `nextflow lint` command checks Nextflow scripts and config files for errors using the {ref}`strict syntax <strict-syntax-page>`. It can also format Nextflow files using the same formatter as the Nextflow language server. See {ref}`cli-lint` for details.
+The `nextflow lint` command checks Nextflow scripts and config files for errors using the {ref}`strict parser <strict-syntax-page>`. It can also format Nextflow files using the same formatter as the Nextflow language server. See {ref}`cli-lint` for details.
 
 (workflow-outputs-third-preview)=
 

--- a/docs/migrations/25-10.md
+++ b/docs/migrations/25-10.md
@@ -9,7 +9,7 @@
 <h3>Workflow params</h3>
 
 :::{note}
-Typed parameters require the {ref}`strict syntax <strict-syntax-page>`. Set the `NXF_SYNTAX_PARSER` environment variable to `v2` to enable:
+Typed parameters require the {ref}`strict parser <strict-syntax-page>`. Set the `NXF_SYNTAX_PARSER` environment variable to `v2` to enable:
 
 ```bash
 export NXF_SYNTAX_PARSER=v2
@@ -73,7 +73,7 @@ See {ref}`migrating-workflow-outputs` to get started.
 <h3>Static typing (preview)</h3>
 
 :::{note}
-Static typing requires the {ref}`strict syntax <strict-syntax-page>`. Set the `NXF_SYNTAX_PARSER` environment variable to `v2` to enable:
+Static typing requires the {ref}`strict parser <strict-syntax-page>`. Set the `NXF_SYNTAX_PARSER` environment variable to `v2` to enable:
 
 ```bash
 export NXF_SYNTAX_PARSER=v2
@@ -209,7 +209,7 @@ Plugins should be updated to publish to the Nextflow plugin registry using the {
 <h3>New syntax for workflow handlers</h3>
 
 :::{note}
-The new syntax for workflow handlers require the {ref}`strict syntax <strict-syntax-page>`. Set the `NXF_SYNTAX_PARSER` environment variable to `v2` to enable:
+The new syntax for workflow handlers requires the {ref}`strict parser <strict-syntax-page>`. Set the `NXF_SYNTAX_PARSER` environment variable to `v2` to enable:
 
 ```bash
 export NXF_SYNTAX_PARSER=v2
@@ -231,11 +231,11 @@ workflow {
 }
 ```
 
-This syntax is simpler and easier to use with the {ref}`strict syntax <strict-syntax-page>`. See {ref}`workflow-handlers` for details.
+This syntax is simpler and easier to use with the {ref}`strict parser <strict-syntax-page>`. See {ref}`workflow-handlers` for details.
 
 <h3>Simpler syntax for dynamic directives</h3>
 
-The {ref}`strict syntax <strict-syntax-page>` allows dynamic process directives to be specified without a closure:
+The {ref}`strict parser <strict-syntax-page>` allows dynamic process directives to be specified without a closure:
 
 ```nextflow
 process hello {
@@ -284,11 +284,11 @@ This feature addresses previous inconsistencies in timestamp representations.
 
 ## Deprecations
 
-- The legacy type detection of CLI parameters is disabled when using the strict syntax (`NXF_SYNTAX_PARSER=v2`). {ref}`Legacy parameters <workflow-params-legacy>` in the strict syntax should not rely on legacy type detection. Alternatively, use the new `params` block to convert CLI parameters based on their type annotations. Legacy type detection can be disabled globally by setting the environment variable `NXF_DISABLE_PARAMS_TYPE_DETECTION=true`.
+- The legacy type detection of CLI parameters is disabled when using the strict parser (`NXF_SYNTAX_PARSER=v2`). {ref}`Legacy parameters <workflow-params-legacy>` should not rely on legacy type detection. Alternatively, use the new `params` block to convert CLI parameters based on their type annotations. Legacy type detection can be disabled globally by setting the environment variable `NXF_DISABLE_PARAMS_TYPE_DETECTION=true`.
 
 - The use of workflow handlers in the configuration file has been deprecated. You should define workflow handlers in the pipeline script or a plugin instead. See {ref}`config-workflow-handlers` for details.
 
-- The `nextflow.enable.configProcessNamesValidation` feature flag is deprecated. It was originally introduced to suppress false warnings for process selectors targeting conditional processes. The {ref}`strict syntax <strict-syntax-page>` now validates process selectors without producing false warnings.
+- The `nextflow.enable.configProcessNamesValidation` feature flag is deprecated. It was originally introduced to suppress false warnings for process selectors targeting conditional processes. The {ref}`strict parser <strict-syntax-page>` now validates process selectors without producing false warnings.
 
 ## Miscellaneous
 

--- a/docs/migrations/26-04.md
+++ b/docs/migrations/26-04.md
@@ -382,7 +382,7 @@ A Platform access token with appropriate permissions is required to download non
 
 ## Deprecations
 
-- The `nextflow.enable.strict` feature flag is deprecated. It is not needed when {ref}`strict syntax <strict-syntax-page>` is enabled.
+- The `nextflow.enable.strict` feature flag is deprecated. It is not needed when usiung the {ref}`strict parser <strict-syntax-page>`.
 
 - The `manifest.defaultBranch` config option is deprecated. Nextflow can automatically detect the default branch when using a remote pipeline.
 

--- a/docs/process-typed.md
+++ b/docs/process-typed.md
@@ -30,7 +30,7 @@ process hello {
 
 To use this feature:
 
-1. Enable the {ref}`strict syntax <strict-syntax-page>` by setting the `NXF_SYNTAX_PARSER` environment variable to `v2`:
+1. Enable the {ref}`strict parser <strict-syntax-page>` by setting the `NXF_SYNTAX_PARSER` environment variable to `v2`:
 
     ```bash
     export NXF_SYNTAX_PARSER=v2

--- a/docs/process.md
+++ b/docs/process.md
@@ -211,8 +211,8 @@ Template scripts are generally discouraged due to the caveats described above. T
 
 ### Shell
 
-:::{deprecated} 24.11.0-edge
-Use the `script` section instead. Consider using the {ref}`strict syntax <strict-syntax-page>`, which provides error checking to help distinguish between Nextflow variables and Bash variables in the process script.
+:::{deprecated} 25.04.0
+Use the `script` section instead.
 :::
 
 The `shell` section is a string expression that defines the script that is executed by the process. It is an alternative to the {ref}`process-script` definition with one important difference: it uses the exclamation mark `!` character, instead of the usual dollar `$` character, to denote Nextflow variables.
@@ -1036,8 +1036,7 @@ The `tuple` qualifier outputs multiple values in a single output as a {ref}`tupl
 ```nextflow
 process blast {
   input:
-    val species
-    path query
+    tuple val(species), path(query)
 
   output:
     tuple val(species), path('result')
@@ -1052,7 +1051,7 @@ workflow {
   ch_species = channel.of('human', 'cow', 'horse')
   ch_query = channel.fromPath('*.fa')
 
-  blast(ch_species, ch_query)
+  blast(ch_species.combine(ch_query))
 }
 ```
 
@@ -1257,7 +1256,7 @@ All directives can be assigned a dynamic value except the following:
 :::{versionadded} 25.10
 :::
 
-Dynamic directives can be specified without a closure when using the {ref}`strict syntax <strict-syntax-page>`:
+Dynamic directives can be specified without a closure when using the {ref}`strict parser <strict-syntax-page>`:
 
 ```nextflow
 queue (entries > 100 ? 'long' : 'short')

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -238,9 +238,13 @@ The following environment variables control the configuration of the Nextflow ru
 : Enable the use of Spack recipes defined by using the {ref}`process-spack` directive. (default: `false`).
 
 `NXF_SYNTAX_PARSER`
-: :::{versionadded} 25.02.0-edge
+: :::{versionadded} 25.04.0
+  The strict parser is disabled by default.
   :::
-: Set to `'v2'` to use the {ref}`strict syntax <strict-syntax-page>` for Nextflow scripts and config files (default: `'v1'`).
+: :::{versionchanged} 26.04.0
+  The strict parser is enabled by default.
+  :::
+: Set to `'v2'` to use the {ref}`strict syntax parser <strict-syntax-page>` for Nextflow code. Set to `'v1'` to fall back to the legacy parser.
 
 `NXF_TEMP`
 : Directory where temporary files are stored

--- a/docs/reference/feature-flags.md
+++ b/docs/reference/feature-flags.md
@@ -10,7 +10,7 @@ Feature flags marked as *preview* can cause pipelines run with newer versions of
 
 `nextflow.enable.configProcessNamesValidation`
 : :::{deprecated} 25.10.0
-  Use the {ref}`strict syntax <strict-syntax-page>` instead. It validates process selectors without producing false warnings.
+  Use the {ref}`strict parser <strict-syntax-page>` instead. It validates process selectors without producing false warnings.
   :::
 : When `true`, prints a warning for every `withName:` process selector that doesn't match a process in the pipeline (default: `true`).
 

--- a/docs/strict-syntax.md
+++ b/docs/strict-syntax.md
@@ -2,31 +2,33 @@
 
 # Preparing for strict syntax
 
-This page explains how to update Nextflow scripts and config files to adhere to the {ref}`Nextflow language specification <syntax-page>`, also known as the _strict syntax_.
+This page explains how to update Nextflow scripts and config files to adhere to the {ref}`Nextflow language specification <syntax-page>`, which is enforced by the _strict syntax parser_.
 
 :::{note}
 If you are still using DSL1, see {ref}`dsl1-page` to learn how to migrate your Nextflow pipelines to DSL2 before consulting this guide.
 :::
 
-:::{versionadded} 25.04.0
-To enable strict syntax, set the `NXF_SYNTAX_PARSER` environment variable to `v2`:
+## Overview
+
+The strict syntax parser is a strict implementation of DSL2. While the legacy DSL2 parser allows any Groovy syntax, the strict parser allows only a subset of Groovy syntax for Nextflow scripts and config files. It is used by the language server and `nextflow lint` to provide more specific error messages when checking Nextflow code.
+
+In Nextflow 25.04 and 25.10, the strict parser is disabled by default when running Nextflow code. You can enable it by setting the `NXF_SYNTAX_PARSER` environment variable to `v2`:
 
 ```bash
 export NXF_SYNTAX_PARSER=v2
 ```
-:::
 
-:::{versionchanged} 26.04.0
-The strict syntax is enabled by default. You can disable it by setting the environment variable `NXF_SYNTAX_PARSER=v1`.
-:::
+In Nextflow 26.04 and later, the strict parser is enabled by default. You can disable it by setting `NXF_SYNTAX_PARSER` to `v1`:
 
-## Overview
+```bash
+export NXF_SYNTAX_PARSER=v1
+```
 
-The strict syntax is a subset of DSL2. While DSL2 allows any Groovy syntax, the strict syntax allows only a subset of Groovy syntax for Nextflow scripts and config files. This new specification enables more specific error reporting, ensures more consistent code, and will allow the Nextflow language to evolve independently of Groovy.
+In the future, the legacy parser will be removed and the strict parser will become the only way to run Nextflow code. You can prepare for the strict parser by rewriting unsupported code with supported patterns -- code that runs with the strict parser will also run with the legacy parser.
 
-The strict syntax will eventually become the only way to write Nextflow code, and new language features will be implemented only in the strict syntax, with few exceptions. Therefore, it is important to prepare for the strict syntax in order to maintain compatibility with future versions of Nextflow and be able to use new language features.
+Starting in Nextflow 25.10, new language features can only be used with the strict parser. Therefore, it is also important to prepare for the strict parser in order to use new language features (e.g., static typing).
 
-This page outlines the key differences between DSL2 and the strict syntax. The extent of required changes will vary depending on the amount of custom Groovy code used within your scripts and config files.
+This page describes how to migrate the most common unsupported patterns to comply with the strict parser. The extent of required changes will vary depending on the amount of custom Groovy code used within your scripts and config files.
 
 ## Removed syntax
 
@@ -40,7 +42,7 @@ import groovy.json.JsonSlurper
 def json = new JsonSlurper().parseText(json_file.text)
 ```
 
-In the strict syntax, use the fully qualified name to reference the class:
+In Nextflow, use the fully qualified name to reference the class:
 
 ```nextflow
 def json = new groovy.json.JsonSlurper().parseText(json_file.text)
@@ -75,7 +77,7 @@ record FastqPair {
 
 ### Mixing script declarations and statements
 
-In the strict syntax, a script may contain any of the following top-level declarations:
+A Nextflow script may contain any of the following top-level declarations:
 
 - Feature flags
 - Include declarations
@@ -83,6 +85,7 @@ In the strict syntax, a script may contain any of the following top-level declar
 - Workflows
 - Processes
 - Functions
+- Type definitions
 - Output block
 
 Alternatively, a script may contain only statements, also known as a _code snippet_:
@@ -116,7 +119,7 @@ workflow {
 ```
 
 :::{note}
-Mixing statements and script declarations was necessary in DSL1 and optional in DSL2. However, it is no longer supported in the strict syntax in order to simplify the language and to ensure that top-level statements are not executed when the script is included as a module.
+Mixing statements and script declarations was necessary in DSL1 and optional in DSL2. However, this pattern is not supported by the strict parser in order to ensure that top-level statements are not executed when the script is included as a module.
 :::
 
 ### Assignment expressions
@@ -127,7 +130,7 @@ In Groovy, variables can be assigned in an expression:
 hello(x = 1, y = 2)
 ```
 
-In the strict syntax, assignments are allowed only as statements:
+In Nextflow, assignments are allowed only as statements:
 
 ```nextflow
 x = 1
@@ -141,7 +144,7 @@ In Groovy, variables can be incremented and decremented in an expression:
 hello(x++, y--)
 ```
 
-In the strict syntax, use `+=` and `-=` instead:
+In Nextflow, use `+=` and `-=` instead:
 
 ```nextflow
 x += 1
@@ -160,7 +163,7 @@ for (rseqc_module in ['read_distribution', 'inner_distance', 'tin']) {
 }
 ```
 
-In the strict syntax, use higher-order functions, such as the `each` method, instead:
+In Nextflow, use higher-order functions, such as the `each` method, instead:
 
 ```nextflow
 ['read_distribution', 'inner_distance', 'tin'].each { rseqc_module ->
@@ -194,7 +197,7 @@ default:
 }
 ```
 
-In the strict syntax, use if-else statements instead:
+In Nextflow, use if-else statements instead:
 
 ```nextflow
 if (aligner == 'bowtie2') {
@@ -218,9 +221,9 @@ In Groovy, the _spread_ operator can be used to flatten a nested list:
 ch.map { meta, bambai -> [meta, *bambai] }
 ```
 
-In the strict syntax, enumerate the list elements explicitly:
+In Nextflow, enumerate the list elements explicitly:
 
-```groovy
+```nextflow
 // alternative 1
 ch.map { meta, bambai -> [meta, bambai[0], bambai[1]] }
 
@@ -239,7 +242,7 @@ In Nextflow DSL1 and DSL2, environment variables can be referenced directly in s
 println "PWD = ${PWD}"
 ```
 
-In the strict syntax, use `System.getenv()` instead:
+Use `System.getenv()` instead:
 
 ```nextflow
 println "PWD = ${System.getenv('PWD')}"
@@ -273,7 +276,7 @@ workflow {
 }
 ```
 
-In the strict syntax, these clauses are no longer supported. Params should be passed to workflows, processes, and functions as explicit inputs:
+These clauses are no longer supported by the strict parser. Params should be passed to workflows, processes, and functions as explicit inputs:
 
 ```nextflow
 include { sayHello } from './some/module'
@@ -312,7 +315,7 @@ String str = 'hello'
 def Map meta = [:]
 ```
 
-In the strict syntax, variables must be declared with `def` and must not specify a type:
+In Nextflow, variables must be declared with `def` and must not specify a type:
 
 ```nextflow
 def a = 1
@@ -343,7 +346,7 @@ Groovy-style type annotations are still supported. However, the language server 
 
 Groovy supports a wide variety of strings, including multi-line strings, dynamic strings, slashy strings, multi-line dynamic slashy strings, and more.
 
-The strict syntax supports single- and double-quoted strings, multi-line strings, and slashy strings.
+Nextflow supports single- and double-quoted strings, multi-line strings, and slashy strings.
 
 Slashy strings cannot be interpolated:
 
@@ -404,7 +407,7 @@ def map = (Map) readJson(json)  // soft cast
 def map = readJson(json) as Map // hard cast
 ```
 
-In the strict syntax, only hard casts are supported. Use an explicit method to cast a value to a different type if one is available. For example, to parse a string as a number:
+In Nextflow, only hard casts are supported. Use an explicit method to cast a value to a different type if one is available. For example, to parse a string as a number:
 
 ```groovy
 def x = '42' as Integer
@@ -425,7 +428,7 @@ process my_task {
 }
 ```
 
-In the strict syntax, the name must be specified with quotes:
+The strict parser requires the name to be specified with quotes:
 
 ```nextflow
 process my_task {
@@ -452,7 +455,7 @@ process greet {
 }
 ```
 
-In the strict syntax, the `script:` label can be omitted only if there are no other sections:
+The strict parser requires the `script:` label to be specified unless there are no other sections:
 
 ```nextflow
 process hello {
@@ -483,7 +486,7 @@ workflow.onComplete {
 }
 ```
 
-The strict syntax does not allow statements to be mixed with script declarations, so workflow handlers must be defined in the entry workflow:
+The strict parser does not allow statements to be mixed with script declarations, so workflow handlers must be defined in the entry workflow:
 
 ```nextflow
 workflow {
@@ -518,7 +521,7 @@ See {ref}`workflow-handlers` for details.
 
 ## Deprecated syntax
 
-The following patterns are deprecated, and the strict syntax reports warnings for them. These warnings will become errors in the future.
+The following patterns are deprecated, and the strict parser reports warnings for them. These warnings will become errors in the future.
 
 ### `channel` vs `Channel`
 
@@ -535,11 +538,11 @@ See {ref}`stdlib-namespaces-channel` and {ref}`stdlib-types-channel` for more in
 
 In Groovy, a closure with no parameters is assumed to have a single parameter named `it`:
 
-```nextflow
+```groovy
 ch.map { it * 2 }
 ```
 
-In the strict syntax, the closure parameter should be explicitly declared:
+In Nextflow, the closure parameter should be explicitly declared:
 
 ```nextflow
 ch.map { v -> v * 2 }   // correct
@@ -548,13 +551,69 @@ ch.map { it -> it * 2 } // also correct
 
 ### Process shell section
 
-The process `shell` section is deprecated. Use the `script` section instead. The strict syntax provides error checking to help distinguish between Nextflow variables and Bash variables.
+The process `shell` section is deprecated. Use the `script` section instead. The strict parser provides error checking to help distinguish between Nextflow variables and Bash variables.
 
 ## Best practices
 
 The following patterns are discouraged and may become warnings or errors in future Nextflow versions. The language server can detect these patterns, but does not report them by default.
 
 To enable these checks, set **Nextflow > Error reporting mode** to **paranoid** in the extension settings.
+
+### Using legacy parameter declarations
+
+:::{versionadded} 25.10.0
+:::
+
+{ref}`Legacy parameters <workflow-params-legacy>` can automatically cast CLI parameters to numbers and booleans:
+
+```nextflow
+params.save_intermeds = true
+
+workflow {
+    println "save_intermeds = ${params.save_intermeds ? 'true' : 'false'}"
+}
+```
+
+```console
+$ NXF_SYNTAX_PARSER=v1 nextflow run main.nf --save_intermeds false
+save_intermeds = false
+```
+
+However, this type detection is disabled when using the strict parser. In the above example, `params.save_intermeds` will be set to `'false'` instead of `false`, causing it to be truthy:
+
+```console
+$ NXF_SYNTAX_PARSER=v2 nextflow run main.nf --save_intermeds false
+save_intermeds = true
+```
+
+Legacy parameters should not rely on CLI type detection when using the strict parser. Parameters that may be supplied on the command line should be treated as strings:
+
+```nextflow
+params.save_intermeds = 'true'
+
+workflow {
+    println "save_intermeds = ${params.save_intermeds.toBoolean() ? 'true' : 'false'}"
+}
+```
+
+```console
+$ NXF_SYNTAX_PARSER=v2 nextflow run main.nf --save_intermeds false
+save_intermeds = false
+```
+
+Alternatively, use the `params` block to convert CLI parameters based on their type annotations:
+
+```nextflow
+params {
+    save_intermeds: Booean = true
+}
+
+workflow {
+    println "save_intermeds = ${params.save_intermeds ? 'true' : 'false'}"
+}
+```
+
+See {ref}`workflow-typed-params` for details.
 
 ### Using params outside the entry workflow
 
@@ -591,19 +650,11 @@ The process {ref}`process-when` section is discouraged. As a best practice, cond
 
 ## Configuration syntax
 
-:::{versionadded} 25.04.0
-To enable the {ref}`strict syntax <strict-syntax-page>`, set the `NXF_SYNTAX_PARSER` environment variable to `v2`:
-
-```bash
-export NXF_SYNTAX_PARSER=v2
-```
-:::
-
 See {ref}`Configuration <config-syntax>` for a comprehensive description of the configuration language.
 
 ### Mixing config statements and scripting statements
 
-Currently, Nextflow parses config files as Groovy scripts, allowing the use of scripting constructs like variables, helper functions, try-catch blocks, and conditional logic for dynamic configuration:
+The legacy parser treats config files as Groovy scripts, allowing the use of scripting constructs like variables, helper functions, try-catch blocks, and conditional logic for dynamic configuration:
 
 ```groovy
 def getHostname() {
@@ -621,7 +672,7 @@ else if (hostname == 'large') {
 }
 ```
 
-The strict config syntax does not support functions, and only allows statements (e.g., variables and if statements) within closures. The same dynamic configuration can be achieved by using a dynamic include:
+The strict parser only allows config assignments, config blocks, and config includes. Function declarations are not supported. Statements (e.g., variables and if statements) can only be used within closures. The same dynamic configuration can be achieved using a dynamic include:
 
 ```groovy
 includeConfig ({
@@ -660,7 +711,7 @@ google.location = "us-west1"
 google.batch.subnetwork = "regions/${google.location}/subnetworks/default"
 ```
 
-The strict config syntax does not support this. Only params can be referenced as variables:
+The strict parser does not support this. Only params can be referenced as variables:
 
 ```groovy
 params.location = "us-west1"

--- a/docs/tutorials/static-types.md
+++ b/docs/tutorials/static-types.md
@@ -42,7 +42,7 @@ Automatic migration is an experimental feature and may not be able to convert an
 
 ## Example: rnaseq-nf
 
-This section demonstrates how to migrate a pipeline to static typing using [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf) as an example. See {ref}`rnaseq-nf-page` for an introduction to the pipeline.
+This section demonstrates how to migrate a pipeline to static typing using [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf/tree/v2.4) (v2.4) as an example. See {ref}`rnaseq-nf-page` for an introduction to the pipeline.
 
 The approach is as follows:
 
@@ -139,10 +139,10 @@ Create the following samplesheet to represent the test data:
 **`data/allreads.csv`**
 ```
 id,fastq_1,fastq_2
-gut,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_2.fq
-liver,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_2.fq
-lung,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_2.fq
-spleen,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_2.fq
+ggal_gut,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_gut_2.fq
+ggal_liver,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_liver_2.fq
+ggal_lung,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_lung_2.fq
+ggal_spleen,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_1.fq,https://raw.githubusercontent.com/nextflow-io/rnaseq-nf/refs/heads/master/data/ggal/ggal_spleen_2.fq
 ```
 
 Refactor `params.reads` to refer to the samplesheet file path instead of a glob pattern:
@@ -329,7 +329,7 @@ process MULTIQC {
     // ...
 
     input:
-    logs: Set<Path>
+    logs: Bag<Path>
     config: Path
 
     // stage:
@@ -344,14 +344,10 @@ process MULTIQC {
 
 In a typed process, file patterns for `path` inputs must be declared using a *stage directive*. In this example, the first input uses the variable name `logs`, and the `stageAs` directive stages the input using the glob pattern `*`.
 
-In this case, you can omit the stage directive because `*` matches Nextflow's default staging behavior. Inputs of type `Path` or a `Path` collection (e.g., `Set<Path>`) are staged by default using the pattern `'*'`.
+In this case, you can omit the stage directive because `*` matches Nextflow's default staging behavior. Inputs of type `Path` or a `Path` collection (e.g., `Bag<Path>`) are staged by default using the pattern `'*'`.
 
 :::{note}
-In a legacy process, you can use the `arity` option to specify whether a `path` qualifier expects a single file or collection of files. When using typed inputs and outputs, the type determines this behavior, i.e., `Path` vs `Set<Path>`.
-:::
-
-:::{note}
-While `List<Path>` and `Bag<Path>` are also valid path collection types, `Set<Path>` is preferred in this case because it represents an unordered collection of files. You should only use `List<Path>` when you want the collection to be ordered.
+In a legacy process, you can use the `arity` option to specify whether a `path` qualifier expects a single file or collection of files. When using typed inputs and outputs, the type determines this behavior, i.e., `Path` vs `Bag<Path>`.
 :::
 
 <h4>INDEX</h4>
@@ -564,15 +560,15 @@ The `RNASEQ` workflow now returns a single combined channel, so the `mix` operat
 
 While static typing can be adopted progressively with existing code, many coding patterns are not compatible with static typing. Following best practices and avoiding anti-patterns beforehand will make it easier to adopt static typing.
 
-### Use the strict syntax
+### Use the strict syntax parser
 
-The {ref}`strict syntax <strict-syntax-page>` is required to use static typing. It is enabled by default in Nextflow 26.04.
+The {ref}`strict syntax parser <strict-syntax-page>` is required to use static typing. It is enabled by default in Nextflow 26.04.
 
-Before you migrate to static typing, ensure your code adheres to the strict syntax using `nextflow lint` or the language server.
+Before you migrate to static typing, ensure your code complies with the strict parser using `nextflow lint` or the language server.
 
 ### Avoid deprecated patterns
 
-When preparing for the strict syntax, try to address {ref}`deprecation warnings <strict-syntax-deprecated>` as much as possible. For example:
+When preparing for the strict parser, try to address {ref}`deprecation warnings <strict-syntax-deprecated>` as much as possible. For example:
 
 ```nextflow
 Channel.from(1, 2, 3).map { it * 2 }        // deprecated

--- a/docs/tutorials/workflow-outputs.md
+++ b/docs/tutorials/workflow-outputs.md
@@ -42,7 +42,7 @@ The `publishDir` directive will continue to be supported, but will be deprecated
 
 ## Example: rnaseq-nf
 
-This section describes how to migrate from `publishDir` to workflow outputs using the [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf) pipeline as an example. To view the completed migration, see the [`preview-25-10`](https://github.com/nextflow-io/rnaseq-nf/tree/preview-25-10) branch of the rnaseq-nf repository.
+This section describes how to migrate from `publishDir` to workflow outputs using the [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf/tree/v2.4) pipeline (v2.4) as an example. To view the completed migration, see the [`preview-25-10`](https://github.com/nextflow-io/rnaseq-nf/tree/preview-25-10) branch of the rnaseq-nf repository.
 
 See {ref}`rnaseq-nf-page` for an introduction to the rnaseq-nf pipeline.
 

--- a/docs/workflow-typed.md
+++ b/docs/workflow-typed.md
@@ -6,7 +6,7 @@ Typed workflows use a new syntax for inputs and outputs that supports static typ
 
 To use this feature:
 
-1. Enable the {ref}`strict syntax <strict-syntax-page>` by setting the `NXF_SYNTAX_PARSER` environment variable to `v2`:
+1. Enable the {ref}`strict parser <strict-syntax-page>` by setting the `NXF_SYNTAX_PARSER` environment variable to `v2`:
 
     ```bash
     export NXF_SYNTAX_PARSER=v2

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -385,6 +385,26 @@ The `emit:` section declares the outputs of a named workflow:
 
 ```nextflow
 workflow my_workflow {
+    main:
+    ch_hello = hello(data)
+    ch_bye = bye(ch_hello)
+
+    emit:
+    hello = ch_hello
+    bye = ch_bye
+}
+
+workflow {
+    result = my_workflow()
+    result.hello.view()
+    result.bye.view()
+}
+```
+
+The name should be omitted when only one output is declared:
+
+```nextflow
+workflow my_workflow {
     take:
     data
 
@@ -394,29 +414,12 @@ workflow my_workflow {
     emit:
     ch_bye
 }
-```
-
-If an output is assigned to a name, the name can be used to reference the output from the calling workflow. For example:
-
-```nextflow
-workflow my_workflow {
-    main:
-    ch_hello = hello(data)
-    ch_bye = bye(ch_hello)
-
-    emit:
-    my_data = ch_bye
-}
 
 workflow {
     result = my_workflow()
-    result.my_data.view()
+    result.view()
 }
 ```
-
-:::{note}
-Every output must be assigned to a name when multiple outputs are declared.
-:::
 
 (dataflow-page)=
 
@@ -581,6 +584,7 @@ workflow hello_bye {
     bye_out = bye(hello_out.txt)
 
     emit:
+    hello = hello_out.txt
     bye = bye_out.txt
 }
 
@@ -603,6 +607,7 @@ workflow hello_bye {
     bye(hello.out)
 
     emit:
+    hello = hello.out
     bye = bye.out
 }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/IncludeDef.groovy
@@ -124,7 +124,7 @@ class IncludeDef {
     Path getOwnerPath() { getMeta().getScriptPath() }
 
     /**
-     * When using the strict syntax, the included script will already
+     * When using the strict parser, the included script will already
      * have been compiled, so simply execute it to load its definitions.
      *
      * @param path    The included script path
@@ -143,7 +143,7 @@ class IncludeDef {
     }
 
     /**
-     * When not using the strict syntax, compile and execute the
+     * When using the legacy parser, compile and execute the
      * included script to load its definitions.
      *
      * @param path    The included script path

--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
@@ -29,7 +29,7 @@ import org.codehaus.groovy.control.CompilationFailedException
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.runtime.InvokerHelper
 /**
- * Script parser/loader that uses the strict syntax.
+ * Script loader that uses the strict syntax parser.
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
@@ -51,7 +51,7 @@ class ScriptLoaderV2 implements ScriptLoader {
     @Override
     ScriptLoaderV2 setEntryName(String name) {
         if( name )
-            throw new IllegalArgumentException("The `-entry` option is not supported with the strict syntax -- use a param to run a named workflow from the entry workflow")
+            throw new IllegalArgumentException("The `-entry` option is not supported with the strict parser -- use a param to run a named workflow from the entry workflow")
         return this
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
@@ -1009,6 +1009,9 @@ class ScriptIncludesTest extends Dsl2Spec {
                 test2: String = "test2"
             }
 
+            workflow {
+            }
+
             def test2() {
             }
             '''

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -29,6 +29,7 @@ import nextflow.script.ast.IncludeNode;
 import nextflow.script.ast.OutputBlockNode;
 import nextflow.script.ast.OutputNode;
 import nextflow.script.ast.ParamBlockNode;
+import nextflow.script.ast.ParamNodeV1;
 import nextflow.script.ast.ProcessNode;
 import nextflow.script.ast.ProcessNodeV1;
 import nextflow.script.ast.ProcessNodeV2;
@@ -248,6 +249,11 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         }
     }
 
+    @Override
+    public void visitParamV1(ParamNodeV1 node) {
+        vsc.addParanoidWarning("Legacy parameter declarations are discouraged -- use the `params` block instead", "params", node);
+    }
+
     private boolean inWorkflowEmit;
 
     @Override
@@ -344,7 +350,8 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         visitDirectives(node.stagers, "stage directive", false);
         vsc.popScope();
 
-        // deprecation warning reported during ast construction
+        if( !(node.when instanceof EmptyExpression) )
+            vsc.addWarning("Process `when` section will not be supported in a future version", "", node.when);
         visit(node.when);
 
         visit(node.exec);

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -240,6 +240,12 @@ public class ScriptAstBuilder {
             }
         }
 
+        if( moduleNode.getEntry() == null && moduleNode.getParams() != null )
+            collectSyntaxError(new SyntaxException("Params block cannot be defined without an entry workflow", moduleNode.getParams()));
+
+        if( moduleNode.getEntry() == null && moduleNode.getOutputs() != null )
+            collectSyntaxError(new SyntaxException("Output block cannot be defined without an entry workflow", moduleNode.getOutputs()));
+
         if( !statements.isEmpty() ) {
             var main = block(new VariableScope(), statements);
             ast( main, statements.get(0), statements.get(statements.size() - 1) );
@@ -880,6 +886,8 @@ public class ScriptAstBuilder {
         var hasEmitExpression = statements.stream().anyMatch(this::isEmitExpression);
         if( hasEmitExpression && statements.size() > 1 )
             collectSyntaxError(new SyntaxException("Every emit must be assigned to a name when there are multiple emits", result));
+        if( !hasEmitExpression && statements.size() == 1 )
+            collectWarning("Emit name should be omitted when there is only one emit", ctx.workflowEmit(0).getText(), result);
         return result;
     }
 

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -343,12 +343,17 @@ class ScriptFormatterTest extends Specification {
         expect:
         checkFormat(
             '''\
+            workflow{}
+
             output{
             foo{path'foo'}
             bar{path'bar';index{path'index.csv'}}
             }
             ''',
             '''\
+            workflow {
+            }
+
             output {
                 foo {
                     path 'foo'
@@ -364,12 +369,17 @@ class ScriptFormatterTest extends Specification {
         )
         checkFormat(
             '''\
+            workflow{}
+
             output{
             foo:Path{path'foo'}
             bar:Channel<Path>{path'bar';index{path'index.csv'}}
             }
             ''',
             '''\
+            workflow {
+            }
+
             output {
                 foo: Path {
                     path 'foo'

--- a/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
@@ -152,6 +152,64 @@ class ScriptAstBuilderTest extends Specification {
         errors[0].getOriginalMessage().contains "Statements cannot be mixed with script declarations"
     }
 
+    def 'should report an error for params block without an entry workflow' () {
+        when:
+        def errors = check(
+            '''\
+            params {
+                greeting: String
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 1
+        errors[0].getOriginalMessage() == "Params block cannot be defined without an entry workflow"
+
+        when:
+        errors = check(
+            '''\
+            params {
+                greeting: String
+            }
+
+            workflow {
+            }
+            '''
+        )
+        then:
+        errors.size() == 0
+    }
+
+    def 'should report an error for output block without an entry workflow' () {
+        when:
+        def errors = check(
+            '''\
+            output {
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 1
+        errors[0].getOriginalMessage() == "Output block cannot be defined without an entry workflow"
+
+        when:
+        errors = check(
+            '''\
+            workflow {
+            }
+
+            output {
+            }
+            '''
+        )
+        then:
+        errors.size() == 0
+    }
+
     def 'should report an error for implicit process script section' () {
         when:
         def errors = check(

--- a/validation/test.sh
+++ b/validation/test.sh
@@ -46,7 +46,7 @@ test_e2e() {
 }
 
 #
-# Integration tests
+# Integration tests (legacy parser)
 #
 if [[ $TEST_MODE == 'test_integration' ]]; then
   export NXF_SYNTAX_PARSER=v1
@@ -56,7 +56,7 @@ if [[ $TEST_MODE == 'test_integration' ]]; then
 fi
 
 #
-# Integration tests (strict syntax)
+# Integration tests (strict parser)
 #
 if [[ $TEST_MODE == 'test_parser_v2' ]]; then
   export NXF_SYNTAX_PARSER=v2


### PR DESCRIPTION
This PR updates the "Preparing for strict syntax" page to reflect the current state of Nextflow 26.04 (strict parser enabled by default)

- Remove uses of "strict syntax" where possible in favor of "strict parser" or just "Nextflow", to reflect the fact that the strict parser is a strict implementation of Nextflow, not a new language or syntax version

- Add a section on legacy CLI type casting with suggested workarounds

- Fix inconsistencies in other related syntax guidelines

- Add linter warnings that were missing