### PR TITLE
Fix azure rnaseq-nf test

### DIFF
--- a/validation/azure.sh
+++ b/validation/azure.sh
@@ -55,7 +55,7 @@ $NXF_CMD -C ./azure.config \
 [[ `grep -c 'Using Nextflow cache factory: nextflow.cache.CloudCacheFactory' .nextflow.log` == 1 ]] || false
 
 NXF_CLOUDCACHE_PATH=az://my-data/cache \
-$NXF_CMD -C ./azure.config \
+$NXF_CMD -c ./azure.config \
     run nextflow-io/rnaseq-nf \
     -with-report \
     -with-trace $OPTS \

--- a/validation/azure.sh
+++ b/validation/azure.sh
@@ -47,7 +47,7 @@ $NXF_CMD -C ./azure.config run ./test-complexpaths.nf -resume
 $NXF_CMD -C ./azure.config run ./test-subdirs.nf
 
 NXF_CLOUDCACHE_PATH=az://my-data/cache \
-$NXF_CMD -C ./azure.config \
+$NXF_CMD -c ./azure.config \
     run nextflow-io/rnaseq-nf \
     -with-report \
     -with-trace $OPTS \


### PR DESCRIPTION
rnaseq-nf was recently updated to define test input data only in config and not in the main script

However, the azure e2e test currently runs rnaseq-nf with a full config override (`-C`) instead of a config append (`-c`).  As a result, the e2e fails because no input data is specified

This PR updates the azure e2e test to use `-c` instead of `-C` for rnaseq-nf so that the default project config is still used