### PR TITLE
Honor COLUMNS when determining ANSI output width

### DIFF
--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -359,6 +359,16 @@ The Seqera Platform workspace ID. Can also be configured using the `tower.worksp
 
 Defines a proxy server used as a fallback for any protocol (HTTP, HTTPS, FTP) that does not have a scheme-specific proxy variable set. A scheme-specific variable (e.g. `HTTPS_PROXY`) takes precedence over `ALL_PROXY`. Proxy authentication is supported by providing the credentials in the proxy URL.
 
+##### `COLUMNS`
+
+<AddedInVersion version="26.10" />
+
+Sets the terminal width of ANSI-formatted log output when `TERMINAL_WIDTH` is not set to a positive integer.
+
+:::note
+Bash sets `COLUMNS` in interactive shells but does not export it, so it is not visible to Nextflow unless you export it explicitly, e.g. `export COLUMNS=100`, or set it for the command, e.g. `COLUMNS=100 nextflow run <pipeline>`. In non-interactive contexts such as a batch job script, `COLUMNS` is not set at all — use `TERMINAL_WIDTH` to force a width there.
+:::
+
 ##### `FTP_PROXY`
 
 Defines the FTP proxy server. Proxy authentication is supported by providing the credentials in the proxy URL, e.g. `ftp://user:password@proxy-host.com:port`. Credentials containing special characters must be URL-encoded (percent-encoded).
@@ -375,10 +385,6 @@ Defines the HTTPS proxy server. Proxy authentication is supported by providing t
 When connecting to HTTPS targets through an authenticating proxy, the JDK strips proxy credentials from the `CONNECT` request for the schemes listed in `jdk.http.auth.tunneling.disabledSchemes` (default `Basic`), which can cause a `407` error. Nextflow clears this property automatically when the proxy URL carries credentials. If you set the property yourself, Nextflow does not override it — clear it explicitly to allow Basic proxy authentication over HTTPS with `NXF_OPTS='-Djdk.http.auth.tunneling.disabledSchemes='`.
 :::
 
-##### `COLUMNS`
-
-Sets the terminal width of ANSI-formatted log output when `TERMINAL_WIDTH` is not set to a valid positive integer.
-
 ##### `NO_COLOR`
 
 Disables ANSI color codes in Nextflow log output. When this variable is set, Nextflow prints plain text logs following the [NO_COLOR standard](https://no-color.org/).
@@ -391,7 +397,7 @@ Defines one or more host names that should not use the proxy server. Separate mu
 
 ##### `TERMINAL_WIDTH`
 
-Forces the terminal width of ANSI-formatted log output. Overrides automatic terminal width detection and uses the specified width for line wrapping when set to an integer value.
+Forces the terminal width of ANSI-formatted log output. Overrides automatic terminal width detection and uses the specified width for line wrapping when set to a positive integer. Values that are not positive integers are ignored, in which case Nextflow falls back to `COLUMNS` and then to automatic detection.
 
 [process-conda]: ./process#conda
 [process-publishdir]: ./process#publishdir

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -375,6 +375,10 @@ Defines the HTTPS proxy server. Proxy authentication is supported by providing t
 When connecting to HTTPS targets through an authenticating proxy, the JDK strips proxy credentials from the `CONNECT` request for the schemes listed in `jdk.http.auth.tunneling.disabledSchemes` (default `Basic`), which can cause a `407` error. Nextflow clears this property automatically when the proxy URL carries credentials. If you set the property yourself, Nextflow does not override it — clear it explicitly to allow Basic proxy authentication over HTTPS with `NXF_OPTS='-Djdk.http.auth.tunneling.disabledSchemes='`.
 :::
 
+##### `COLUMNS`
+
+Sets the terminal width of ANSI-formatted log output when `TERMINAL_WIDTH` is not set to a valid positive integer.
+
 ##### `NO_COLOR`
 
 Disables ANSI color codes in Nextflow log output. When this variable is set, Nextflow prints plain text logs following the [NO_COLOR standard](https://no-color.org/).

--- a/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/AnsiLogObserver.groovy
@@ -102,12 +102,17 @@ class AnsiLogObserver implements TraceObserverV2, LogObserver {
 
     private WorkflowStatsObserver statsObserver
 
-    private static Integer getEnvTerminalWidth() {
-        final env = SysEnv.get('TERMINAL_WIDTH')
+    protected static Integer getEnvTerminalWidth() {
+        return parseEnvTerminalWidth('TERMINAL_WIDTH') ?: parseEnvTerminalWidth('COLUMNS')
+    }
+
+    private static Integer parseEnvTerminalWidth(String name) {
+        final env = SysEnv.get(name)
         if( !env )
             return null
         try {
-            return Integer.parseInt(env)
+            final result = Integer.parseInt(env)
+            return result>0 ? result : null
         }
         catch( NumberFormatException e ) {
             // do not log error to avoid catch-22 logging event (this class renders logging events)

--- a/modules/nextflow/src/test/groovy/nextflow/trace/AnsiLogObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/AnsiLogObserverTest.groovy
@@ -17,6 +17,7 @@
 package nextflow.trace
 
 import nextflow.Session
+import nextflow.SysEnv
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -25,6 +26,32 @@ import spock.lang.Unroll
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class AnsiLogObserverTest extends Specification {
+
+    @Unroll
+    def 'should resolve terminal width from environment' () {
+        given:
+        SysEnv.push(ENV)
+
+        expect:
+        AnsiLogObserver.getEnvTerminalWidth() == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        ENV                                             | EXPECTED
+        [COLUMNS: '50']                                | 50
+        [COLUMNS: '']                                  | null
+        [COLUMNS: 'abc']                               | null
+        [COLUMNS: '0']                                 | null
+        [COLUMNS: '-10']                               | null
+        [COLUMNS: '2147483648']                        | null
+        [:]                                            | null
+        [TERMINAL_WIDTH: '60', COLUMNS: '50']          | 60
+        [TERMINAL_WIDTH: 'invalid', COLUMNS: '50']     | 50
+        [TERMINAL_WIDTH: '0', COLUMNS: '50']           | 50
+        [TERMINAL_WIDTH: '-1', COLUMNS: '50']          | 50
+    }
 
     @Unroll
     def 'should render a process line' () {

--- a/modules/nextflow/src/test/groovy/nextflow/trace/AnsiLogObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/AnsiLogObserverTest.groovy
@@ -39,18 +39,19 @@ class AnsiLogObserverTest extends Specification {
         SysEnv.pop()
 
         where:
-        ENV                                             | EXPECTED
-        [COLUMNS: '50']                                | 50
-        [COLUMNS: '']                                  | null
-        [COLUMNS: 'abc']                               | null
-        [COLUMNS: '0']                                 | null
-        [COLUMNS: '-10']                               | null
-        [COLUMNS: '2147483648']                        | null
-        [:]                                            | null
-        [TERMINAL_WIDTH: '60', COLUMNS: '50']          | 60
-        [TERMINAL_WIDTH: 'invalid', COLUMNS: '50']     | 50
-        [TERMINAL_WIDTH: '0', COLUMNS: '50']           | 50
-        [TERMINAL_WIDTH: '-1', COLUMNS: '50']          | 50
+        ENV                                         | EXPECTED
+        [:]                                         | null
+        [COLUMNS: '50']                             | 50
+        [COLUMNS: '']                               | null
+        [COLUMNS: 'abc']                            | null
+        [COLUMNS: '0']                              | null
+        [COLUMNS: '-10']                            | null
+        [COLUMNS: '2147483648']                     | null
+        [TERMINAL_WIDTH: '60']                      | 60
+        [TERMINAL_WIDTH: '60', COLUMNS: '50']       | 60
+        [TERMINAL_WIDTH: 'invalid', COLUMNS: '50']  | 50
+        [TERMINAL_WIDTH: '0', COLUMNS: '50']        | 50
+        [TERMINAL_WIDTH: '-1', COLUMNS: '50']       | 50
     }
 
     @Unroll


### PR DESCRIPTION
Fixes #6274

## Summary

- Use `COLUMNS` as the ANSI log width fallback when `TERMINAL_WIDTH` is not set to a valid positive integer.
- Preserve the existing `TERMINAL_WIDTH` override and existing terminal-width fallback behavior for absent or invalid values.
- Add isolated coverage for valid, absent, malformed, zero, negative, and overflow env values.
- Document the `COLUMNS` behavior in the environment variable reference.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew :nextflow:test --tests nextflow.trace.AnsiLogObserverTest --no-daemon` - passed after code changes; build successful in 5m 25s.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew :nextflow:test --tests nextflow.trace.AnsiLogObserverTest --no-daemon` - passed after the docs edit; Gradle reported tasks up-to-date and build successful in 13s.
- `git diff --check` - passed.

## Notes

- Docs HTML build was not run locally because Sphinx/MyST are not installed in this Python environment (`ModuleNotFoundError: No module named 'sphinx'`).
- Full `make test` / full CI matrix was not run locally.
- Manual `COLUMNS=50 nextflow run ...` smoke was not run; the env-width fallback is covered by `AnsiLogObserverTest`.
