### PR TITLE
Expose workflow lineage id on WorkflowMetadata

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -224,6 +224,13 @@ class WorkflowMetadata {
     PlatformMetadata platform
 
     /**
+     * Workflow lineage identifier in {@code lid://<hash>} URI form,
+     * set by the lineage observer when the {@code nf-lineage} plugin is active.
+     * Null when lineage tracking is not enabled.
+     */
+    String lineageId
+
+    /**
      * The list of files that concurred to create the config object
      */
     List<Path> configFiles

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -113,10 +113,13 @@ class LinObserver implements TraceObserverV2 {
     String setNormalizer(PathNormalizer normalizer){  this.normalizer = normalizer }
 
     @Override
-    void onFlowBegin() {
+    void onFlowCreate(Session session) {
         normalizer = new PathNormalizer(session.workflowMetadata)
         executionHash = storeWorkflowRun(normalizer)
         final executionUri = asUriString(executionHash)
+        // expose the lineage id on workflowMetadata so other observers (e.g. nf-tower)
+        // can read it before their onFlowBegin fires
+        session.workflowMetadata.lineageId = executionUri
         workflowOutput = new WorkflowOutput(
             OffsetDateTime.now(),
             executionUri,

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
@@ -204,6 +204,7 @@ class LinObserverTest extends Specification {
         observer.onFlowBegin()
         then:
         folder.resolve("${observer.executionHash}/.data.json").text == new LinEncoder().encode(workflowRun)
+        1 * metadata.setLineageId({ String it -> it.startsWith('lid://') })
 
         cleanup:
         folder?.deleteDir()


### PR DESCRIPTION
## Summary

Expose the workflow's lineage identifier as a first-class property on `WorkflowMetadata`, populated by `LinObserver` at flow-create time. Other observers (notably the Tower observer) can now read `session.workflowMetadata.lineageId` and forward it to downstream systems without computing it themselves or making a secondary API round-trip to resolve it.

Concretely:

- `WorkflowMetadata` gains a public `String lineageId` field. Reflective `toMap()` picks it up automatically.
- The LID computation that used to live in `LinObserver.onFlowBegin()` moves to `LinObserver.onFlowCreate(Session)`. Lifecycle in `nextflow.Session`: `init()` constructs observers, then `workflowMetadata`; `start()` then calls `notifyFlowCreate()` (fires `onFlowCreate` on every observer) before `fireDataflowNetwork()` calls `notifyFlowBegin()`. Computing the hash in `onFlowCreate` therefore (a) has `session.workflowMetadata` available, and (b) completes before any observer's `onFlowBegin` runs — regardless of plugin discovery order.
- The store save of the `WorkflowRun` value, the history log write, and the in-memory `WorkflowOutput` initialisation move with it.
- Value is the canonical `lid://<hash>` URI; null when the `nf-lineage` plugin is not active.

This is a building block for a Seqera Platform-side change (PLAT-5235) that will persist `Workflow.lineageId` on the workflow entity at trace-begin time, replacing the current secondary `GET /lineage/resolve?sessionId=…` lookup. That PR will land separately.

## Test plan

- [x] `./gradlew :nf-lineage:test` — full module suite green, including an added assertion in `LinObserverTest."should save workflow"` that verifies `setLineageId(_)` is invoked on the metadata with a `lid://`-prefixed URI.
- [x] `./gradlew :plugins:nf-tower:test` — green (no source changes there; just verifying the moved lifecycle hook doesn't regress the consumer that reads `workflowMetadata.toMap()`).
- [x] `./gradlew :nextflow:test --tests "*WorkflowMetadata*"` — green.

## Draft

Marked as **draft** because the matching Seqera Platform change (PR to follow, tracked under PLAT-5235) hasn't landed yet. The Nextflow side is forward-compatible on its own — older Platform versions just ignore the extra field — so this can merge independently once reviewed.
