### PR TITLE
ADR: TaskReadinessGate plugin extension point

### DIFF
--- a/adr/20260516-task-readiness-gate.md
+++ b/adr/20260516-task-readiness-gate.md
@@ -1,14 +1,14 @@
 # `TaskReadinessGate` plugin extension point for deferred task submission
 
 - Authors: Rob Syme
-- Status: draft
+- Status: accepted
 - Deciders: Paolo Di Tommaso, Ben Sherman, Rob Syme
-- Date: 2026-05-16
+- Date: 2026-05-20
 - Tags: plugin, extension-point, scheduler, task-submission
 
 ## Summary
 
-Introduce a `TaskReadinessGate` plugin extension point that lets a plugin defer task submission until an external precondition is met (e.g. an S3 object has been restored from Glacier), removing the need for plugins to subclass an executor and its task handler.
+Introduce a `TaskReadinessGate` plugin extension point that lets a plugin defer task submission until an external precondition is met (e.g. an S3 object has been restored from Glacier), removing the need for plugins to subclass an executor and its task handler. Plugins implement a blocking `void prepare(TaskHandler)` method; core runs each gate on a managed virtual-thread executor via a new `TaskGateManager`, and the standard `TaskPollingMonitor` delegates to the manager from `schedule`, `canSubmit`, and `evict`.
 
 ## Problem Statement
 
@@ -30,19 +30,21 @@ A generic extension point — "consult these plugins before submitting any task"
 
 - Work uniformly across every executor that submits tasks via `TaskPollingMonitor` (i.e. all existing executors).
 
-- Be safe-by-default: a plugin that ships a gate cannot accidentally stall the scheduler thread for the rest of the run.
+- Keep the plugin-author surface minimal — gate authors write straightforward blocking code, not an async state machine.
 
-- Allow gates to kick off async preparation work the moment a task is queued, not when an executor slot frees up — cold-storage restores can take hours and must not wait for capacity.
+- Allow gates to kick off preparation work the moment a task is queued, not when an executor slot frees up — cold-storage restores can take hours and must not wait for capacity.
 
-- Allow plugins to signal permanent task failure cleanly, integrating with the standard `errorStrategy` machinery.
+- Allow plugins to signal permanent task failure cleanly, integrating with the standard `errorStrategy` machinery (including retry routing through `ProcessRetryableException`).
 
 ## Non-goals
 
-- **Per-process gate scoping.** A gate is consulted for every task. Selectors that restrict a gate to specific processes are a config-layer concern that can be added later.
+- **Per-process gate scoping as a new directive.** A gate is consulted for every task. Plugins implement per-process opt-out by reading the existing `hints` directive (e.g. `hints 'glacier/skip': true`).
 
-- **Gate ordering or priority.** Evaluation order across gates is unspecified. An `int order()` default method can be added non-breakingly if a real use case appears.
+- **An executor-level timeout.** Core does not enforce a wall-clock deadline on `prepare`. The right value depends entirely on which plugin is registered and on the workload (Glacier Standard is hours; Deep Archive Bulk is days). Plugins own timeout policy, typically reading a per-process hint (e.g. `hints 'glacier/maxWait': '5h'`) and throwing when the deadline elapses.
 
-- **An `AbstractAsyncReadinessGate` helper class.** A base class that runs blocking work on a dedicated executor and exposes results via per-task `CompletableFuture`s would lower the cliff for plugin authors. We are deliberately not shipping it in v1: the contract is documented in javadoc, and consumers with their own cross-task state (dedup, rate limiting, batched API calls) typically would not use a per-task-future helper. It can be extracted later when a clear use case appears.
+- **Gate ordering or priority.** Evaluation order across gates is unspecified; all gates run in parallel.
+
+- **An `AbstractAsyncReadinessGate` helper class.** Since the SPI is blocking and core owns the executor, there is no async runtime for a helper to wrap. Plugin authors write blocking code directly.
 
 - **Replacing `TaskHandler.isReady()`.** The existing method stays and is still consulted; gates are AND-combined with it. No flag day for existing subclasses.
 
@@ -51,6 +53,13 @@ A generic extension point — "consult these plugins before submitting any task"
 - **Option A — `TaskReadinessGate` SPI in core (this proposal).**
 - **Option B — Channel operator `glacierRestore()`.**
 - **Option C — `FileSystemProvider` interception in nf-amazon's S3 NIO.**
+
+Within Option A, there was a sub-decision between two contract shapes:
+
+- **A.1 polling** — `boolean isReady(TaskRun)`, called repeatedly on the scheduler thread; plugin manages its own async state.
+- **A.2 blocking** — `void prepare(TaskHandler) throws InterruptedException`, called once per task on a core-managed virtual-thread executor; plugin writes straightforward blocking code.
+
+The blocking variant (A.2) was chosen — see "Why blocking, not polling" below.
 
 ## Pros and Cons of the Options
 
@@ -61,7 +70,7 @@ A new extension point consulted by `TaskPollingMonitor` before admitting a task 
 - Good, because it matches the actual problem ("defer task submission until external state is ready"), which is generic across executors and backends.
 - Good, because users get drop-in behavior — `plugins { id '...' }` is enough; no `process.executor` override.
 - Good, because the plugin stops being tied to a specific executor implementation and works with every executor in a single class.
-- Good, because the change to core is small (one interface plus a few lines in `TaskPollingMonitor`) and behavior is bit-identical when no plugin registers a gate.
+- Good, because the change to core is small (one interface, one manager class, ~14 lines in `TaskPollingMonitor`) and behavior is bit-identical when no plugin registers a gate.
 - Bad, because it requires a coordinated upstream change in Nextflow before the consumer plugin can be refactored.
 
 ### Option B — Channel operator `glacierRestore()`
@@ -84,7 +93,7 @@ Rejected. Documented here to avoid revisiting.
 
 ## Decision
 
-Adopt Option A. Introduce a `TaskReadinessGate` interface in `nextflow.processor` and consult registered implementations from `TaskPollingMonitor`. Option B may be pursued separately by individual plugins as a complementary surface.
+Adopt Option A with the blocking-`prepare` contract (A.2). Introduce a `TaskReadinessGate` interface in `nextflow.processor` and a `TaskGateManager` that orchestrates registered implementations on behalf of `TaskPollingMonitor`. Option B may be pursued separately by individual plugins as a complementary surface.
 
 ## Core capabilities
 
@@ -93,33 +102,30 @@ Adopt Option A. Introduce a `TaskReadinessGate` interface in `nextflow.processor
 ```groovy
 package nextflow.processor
 
-import nextflow.plugin.extension.ExtensionPoint
+import org.pf4j.ExtensionPoint
 
 /**
- * Plugin extension point that defers task submission until external preconditions are met.
+ * Plugin extension point that defers task submission until an external precondition is met.
  *
- * <p>Invoked by the task scheduler:
- * <ul>
- *   <li>Once when a task is added to the pending queue (return value ignored). This lets
- *       the gate kick off any async preparation, e.g. issuing an S3 RestoreObject request.</li>
- *   <li>On every subsequent polling tick (~100ms) until it returns {@code true}.</li>
- * </ul>
+ * <p>Implementations are invoked once per task by the scheduler, on a managed background
+ * thread (virtual thread when available). The task is admitted for submission when this
+ * method returns; throw to mark the task as permanently failed and route the cause through
+ * the task's {@code errorStrategy}.
  *
- * <p><b>Implementations must return promptly.</b> This method runs on the task scheduler
- * thread; blocking it stalls submission for every task in the run, not only the one being
- * gated. Kick off async work on the first call and return {@code false}; report status on
- * subsequent calls.
+ * <p>Implementations may block freely — {@code Thread.sleep}, network calls, long polling.
+ * The scheduler thread is never blocked by this call.
  *
- * <p>Throwing from this method marks the task as permanently failed, with the thrown
- * exception attached as the cause. The standard {@code errorStrategy} applies, so a
- * transient failure can be retried. Returning {@code false} indefinitely keeps the task
- * waiting forever — throw to signal definitive failure.
+ * <p>Implementations must honor {@code Thread.interrupt()} so that task eviction and
+ * workflow abort can unblock {@code prepare} promptly. Core does not enforce a wall-clock
+ * deadline — plugins own timeout policy (see the developer guide for the recommended
+ * {@code hints}-based pattern).
  *
- * <p>When multiple gates are registered, a task is admitted only when every gate returns
- * {@code true}. Evaluation order across gates is unspecified.
+ * <p>When multiple gates are registered, a task is admitted only when every gate's
+ * {@code prepare} method has returned successfully. Evaluation order across gates is
+ * unspecified; all gates start in parallel on the managed executor.
  */
 interface TaskReadinessGate extends ExtensionPoint {
-    boolean isReady(TaskRun task)
+    void prepare(TaskHandler handler) throws InterruptedException
 }
 ```
 
@@ -127,117 +133,173 @@ interface TaskReadinessGate extends ExtensionPoint {
 
 | Aspect | Contract |
 |---|---|
-| Return value | `true` = ready to submit; `false` = not yet, poll again |
-| Permanent failure | Throw an exception; routed through the standard task failure path |
-| Latency | Must return promptly. No blocking I/O on the calling thread. |
-| First-call semantics | Idempotent. Kick off async preparation, return `false` immediately. |
-| Aggregation across gates | Logical AND. Order unspecified. |
-| Per-task identity | `TaskRun.id` is stable for dedup and caching inside the gate |
+| Return | Method returns normally → task is ready to submit |
+| Permanent failure | Throw any `Throwable`; `ProcessException` is canonical |
+| Cancellation | `InterruptedException` propagates as cancellation; gate must honor `Thread.interrupt()` |
+| Threading | Runs on a core-managed virtual-thread executor; blocking I/O is fine |
+| Aggregation across gates | All gates must complete successfully; one failure aborts the task |
+| Order across gates | Unspecified; gates run in parallel |
+| Per-task identity | `handler.task.id` stable for plugin-internal dedup/caching |
+| Per-process opt-out / timeout | Plugin reads `handler.task.config.hints` and enforces its own policy |
 
-### Call site integration
+### Architecture
 
-Three small edits to `nextflow.processor.TaskPollingMonitor`.
+The orchestration lives in a new `TaskGateManager` class that owns:
 
-**Cache the gate list once per session** in `start()`:
+- The registered gates list (resolved once via `Plugins.getExtensions(TaskReadinessGate)`).
+- A managed `ExecutorService` (virtual-thread per task when `Threads.useVirtual()`, cached pool otherwise) created lazily only when at least one gate is registered.
+- A `ConcurrentMap<TaskHandler, List<Future<?>>>` tracking in-flight gate work per handler.
+- The session shutdown hook that drains the executor.
+
+The manager exposes three methods to `TaskPollingMonitor`:
 
 ```groovy
-private List<TaskReadinessGate> readinessGates = Collections.emptyList()
+void submit(TaskHandler handler)   // submit prepare() futures for each gate
+boolean isReady(TaskHandler handler)   // poll futures; throw on failure; true when all done
+void evict(TaskHandler handler)        // cancel any in-flight futures
+```
+
+### Monitor integration
+
+`TaskPollingMonitor` adds one field and four delegation lines. The total diff against upstream is ~14 lines.
+
+```groovy
+@PackageScope
+TaskGateManager gateManager = new TaskGateManager(null, [])   // empty until start()
 
 @Override
 TaskMonitor start() {
-    readinessGates = Plugins.getExtensions(TaskReadinessGate)
+    this.gateManager = new TaskGateManager(session)
     // ... existing start logic
-    return this
 }
-```
 
-**Fire-once on enqueue** so the gate can start async work the moment the task is queued — not when an executor slot frees up:
-
-```groovy
 void schedule(TaskHandler handler) {
-    // ... existing enqueue logic
-    if( readinessGates ) {
-        for( gate in readinessGates ) {
-            try {
-                gate.isReady(handler.task)
-            }
-            catch( Throwable t ) {
-                handleGateFailure(handler, t)
-                return
-            }
-        }
-    }
+    pendingLock.lock()
+    try {
+        pendingQueue << handler
+        gateManager.submit(handler)
+        // ... existing signal/notify
+    } finally { pendingLock.unlock() }
 }
-```
 
-The return value is intentionally discarded — this call exists for the side effect.
-
-**AND-in gates with the existing admission checks** in `canSubmit`:
-
-```groovy
 protected boolean canSubmit(TaskHandler handler) {
-    // The single-threaded scheduler invariant is load-bearing here: TaskReadinessGate
-    // implementations are contractually required to return promptly.
-    (capacity > 0 ? checkQueueCapacity(handler) : true) \
-        && handler.canForkProcess() \
-        && allGatesReady(handler) \
+    gateManager.isReady(handler)
+        && handler.canForkProcess()
         && handler.isReady()
+        && (capacity > 0 ? checkQueueCapacity(handler) : true)
 }
 
-private boolean allGatesReady(TaskHandler handler) {
-    if( !readinessGates ) return true
-    for( gate in readinessGates ) {
-        try {
-            if( !gate.isReady(handler.task) ) return false
-        }
-        catch( Throwable t ) {
-            handleGateFailure(handler, t)
-            return false
-        }
-    }
-    return true
+boolean evict(TaskHandler handler) {
+    if( !handler ) return false
+    gateManager.evict(handler)
+    // ... existing remove/signal
 }
 ```
 
-`handleGateFailure(TaskHandler, Throwable)` routes the exception through the same path used today for submit-time `ProcessException`s: the task transitions to `FAILED` with the gate exception as cause, and the configured `errorStrategy` (`terminate` / `ignore` / `retry`) applies.
+When `gateManager.isReady` throws, the existing catch in `submitPendingTasks` routes the cause through `handleException` → `resumeOrDie`, which dispatches via the task's `errorStrategy`. No new failure path.
+
+### Exception handling
+
+`TaskGateManager.isReady` unwraps `ExecutionException` from the future and preserves cause types so retry routing works:
+
+- `ProcessException` (and subclasses) thrown by `prepare` propagate identity-preserved.
+- Any other throwable is wrapped in `new ProcessException("Task readiness gate failed...", cause)`, so markers like `ProcessRetryableException` carried on a `RuntimeException` reach `TaskProcessor.resumeOrDie` via `error.cause`.
+- When one gate throws, peer futures for the same handler are cancelled so background work does not outlive the failing task.
 
 ### Discovery and lifecycle
 
 - Gates are resolved via `Plugins.getExtensions(TaskReadinessGate)` — the standard PF4J path used by `TraceObserverFactory`, `ContainerResolver`, and other plugin extension points.
 - Instances are constructed once when the monitor starts and reused for the run.
 - No teardown hook on the SPI. Plugins that need cleanup own that via their existing `BasePlugin.start/stop` lifecycle.
-- No config flag. A plugin that ships a gate is automatically consulted for every task; opting out means not installing the plugin.
+- The managed executor is shut down via `session.onShutdown` (`shutdownNow()` interrupts any in-flight gates).
+- No config flag. A plugin that ships a gate is automatically consulted for every task; opting out means not installing the plugin (or using `hints` for per-process opt-out).
+
+### Per-process opt-out and timeout via `hints`
+
+Plugins read process-level overrides from the existing `hints` directive — no new core directive required. Namespaced keys (`<plugin>/<name>`) avoid collisions across plugins.
+
+```nextflow
+process FAST_PATH {
+    hints 'glacier/skip': true
+    // ...
+}
+
+process LONG_RESTORE {
+    hints 'glacier/maxWait': '48h'
+    // ...
+}
+```
+
+Inside the gate:
+
+```groovy
+@Override
+void prepare(TaskHandler handler) throws InterruptedException {
+    final hints = handler.task.config.hints
+    if( hints['glacier/skip'] == true ) return
+
+    final maxWait = (hints['glacier/maxWait'] as Duration) ?: defaultMaxWait
+    final deadline = System.currentTimeMillis() + maxWait.toMillis()
+
+    // ... enforce deadline + interrupts
+}
+```
 
 ### Backward compatibility
 
-- With no gates registered, `canSubmit` evaluates one empty-list check per pending task per tick. `schedule` adds one untaken branch. Behavior is bit-identical to today.
+- With no gates registered, `gateManager.submit` and `gateManager.evict` are no-ops and `gateManager.isReady` returns `true` immediately. No executor is created. Behavior is bit-identical to upstream.
 - `TaskHandler.isReady()` is unchanged and still consulted. Existing executor and task-handler subclasses keep working.
 - The SPI is purely additive: no existing signatures change.
 
 ## Rationale & discussion
 
-**Why polling rather than blocking.** `TaskPollingMonitor` runs a single scheduler thread that walks the pending queue every ~100ms. A blocking gate (one that waits inside `isReady` for the external precondition to be satisfied) would stall submission for every task in the run, not just the one being gated. For the driving use case — Glacier restores that can take up to 12 hours — this is unacceptable. The contract is therefore explicitly polling-based: the first call kicks off async work and returns `false`; subsequent calls cheaply check status. This also matches the AWS RestoreObject API, which is async-by-design (issue `RestoreObject`, then poll `HeadObject` for status).
+### Why blocking, not polling
 
-**Why fire on enqueue, not only on `canSubmit`.** If the gate were only consulted from `canSubmit`, a task waiting behind a full executor queue or a `maxForks` limit would not trigger the gate, so the restore would not begin until capacity frees up. Adding the fire-once call in `schedule()` decouples "start the restore" from "is there a slot." The cost is one extra call per task per gate per run; the call is contractually idempotent so this is safe.
+An earlier iteration of this ADR proposed a polling contract — `boolean isReady(TaskRun)` called repeatedly on the scheduler thread, with the plugin responsible for kicking off async work idempotently on the first call. Review pushed back on three grounds:
 
-**Why exceptions for permanent failure.** Returning `false` indefinitely would keep a task waiting forever in cases where success is impossible (object permanently inaccessible, restore window timed out, AccessDenied). Adding a tri-state return value (`READY`/`WAITING`/`FAILED`) would enlarge the public API for the same effect Java already provides via exceptions. Routing through the existing failure path also means `errorStrategy 'retry'` naturally handles transient failures — a `ThrottlingException` bubbling out of the gate triggers the same retry behavior as a transient executor failure.
+1. **Plugin-author cognitive load.** "Must return promptly, kick off async on first call, idempotent thereafter, manage your own state" is a lot of contract to get right. A blocking method with the standard `Thread.interrupt` cancellation contract is what plugin authors already know how to write.
 
-**Why no helper class.** An `AbstractAsyncReadinessGate` base class that runs blocking work on a dedicated executor and exposes results via per-task `CompletableFuture`s would make safe-by-default gates trivial to write. The reason we are skipping it in v1: realistic consumers (e.g. a Glacier restorer with cross-task dedup, rate limiting, and prefix expansion) tend to have their own async state and would not use a per-task-future helper. Shipping the helper now means designing it for hypothetical consumers whose shape we cannot yet see. Extracting it later is non-breaking.
+2. **`FilePorter` precedent.** The in-tree `FilePorter` already uses a managed-pool + blocking-`Runnable` shape for similar "prepare external resource for a task" work. New extension points should follow.
 
-**Why this lives in `nextflow.processor`, not `nf-commons`.** Other task-scoped extension points (`TaskTipProvider`, the task handler itself) live in `nextflow.processor`. `nf-commons` hosts cross-cutting infrastructure (the `ExtensionPoint` marker itself, plugin loading machinery). Co-locating `TaskReadinessGate` with `TaskRun` and `TaskHandler` matches the existing layering.
+3. **Virtual threads make the blocking cost negligible.** A gate parked on a virtual thread costs about 1 KB. The "blocking gate would stall the scheduler" objection that originally motivated polling no longer applies — the scheduler thread doesn't run the gate; the managed virtual-thread executor does.
+
+The blocking design moves the async management cost from every plugin author into one place in core (`TaskGateManager`), and the plugin-facing API shrinks to a single method with no idempotency reasoning.
+
+### Why no helper class
+
+The earlier proposal noted an `AbstractAsyncReadinessGate` helper as a likely follow-up. With the blocking design, no helper is needed: plugin authors write blocking code directly, and core owns the executor. The `AbstractAsyncReadinessGate` non-goal is now permanent rather than deferred.
+
+### Why no executor-level timeout
+
+An earlier iteration carried an `executor.gateMaxWait` config option as a safety net for stuck gates. It was removed during review:
+
+- The right deadline depends on which plugin is registered (Glacier Standard hours vs Deep Archive Bulk days). A one-size-fits-all executor-level default either fires on every legitimate restore or is functionally "no limit" for buggy gates.
+- The safety net was always partial: a plugin that ignores `Thread.interrupt()` cannot be unblocked by a wall-clock timeout. Such plugins already break eviction, so the safety net never delivered on its premise.
+- Discoverability is better when the knob lives with the plugin that defines what a sensible value is. A user reading `executor.gateMaxWait` in the config reference cannot tell what value is right; a user reading the plugin's docs for `hints 'glacier/maxWait'` can.
+
+Plugins enforce their own deadlines. The hints-based pattern documented above gives natural per-process scoping for free.
+
+### Why fire on `schedule`, not only on `canSubmit`
+
+If gate work only started when `canSubmit` was first reached, a task waiting behind a full executor queue or a `maxForks` limit would not trigger preparation until capacity frees up. The fire-on-`schedule` design decouples "start the restore" from "is there a slot," so a 5-hour Glacier restore overlaps with whatever else is running rather than waiting in line for it.
+
+### Why exceptions for permanent failure
+
+Routing through the existing failure path means `errorStrategy 'retry'` naturally handles transient failures — a `ThrottlingException` bubbling out of the gate triggers the same retry behavior as a transient executor failure. Returning a tri-state value (`READY`/`WAITING`/`FAILED`) would enlarge the public API for the same effect Java already provides via exceptions.
+
+Cause-type preservation is load-bearing: `TaskProcessor.resumeOrDie` checks `error.cause instanceof ProcessRetryableException` (and `CloudSpotTerminationException`) — it inspects the cause, not the thrown exception itself. The manager therefore wraps non-`ProcessException` causes in a `ProcessException` so the marker reaches `resumeOrDie` via `error.cause`.
+
+### Why this lives in `nextflow.processor`
+
+Other task-scoped extension points (`TaskTipProvider`, the task handler itself) live in `nextflow.processor`. `nf-commons` hosts cross-cutting infrastructure (plugin loading machinery). Co-locating `TaskReadinessGate` and `TaskGateManager` with `TaskRun` and `TaskHandler` matches the existing layering.
 
 ## Testing
 
-New Spock specs in `modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy`:
+- `TaskReadinessGateTest` — interface shape: extends `org.pf4j.ExtensionPoint`, declares `prepare(TaskHandler) throws InterruptedException`.
+- `TaskGateManagerTest` — full behavioural coverage targeting the manager directly: no-gates no-op, single-gate happy path, multi-gate all-must-complete, fail-fast peer cancellation, eviction interrupt propagation, `ProcessException` identity preservation, `ProcessRetryableException` routing via cause, `RuntimeException` wrapping, checked-exception wrapping, external cancellation.
+- The standard `TaskPollingMonitorTest` and `ParallelPollingMonitorTest` continue to pass with a one-line stub adjustment for the `canSubmit` AND-chain reorder.
 
-- No gates registered → `canSubmit` matches current behavior; `schedule` does not touch gate code.
-- One gate returning `true` → task admitted as soon as capacity and forks allow.
-- One gate returning `false` then `true` → task waits in pending across ticks; admitted on the tick the gate flips.
-- Gate invoked exactly once on enqueue; return value ignored even when `false`.
-- Multiple gates → AND semantics; one `false` blocks admission.
-- Gate throws on enqueue → task fails with the thrown cause; not added to running queue.
-- Gate throws during poll → task fails with the thrown cause; removed from pending.
-- Gate throws under `errorStrategy 'retry'` → standard retry path.
+## References
 
-Gates are injected through a test double rather than a real PF4J context.
-
+- Implementation PR: [nextflow-io/nextflow#7158](https://github.com/nextflow-io/nextflow/pull/7158).
+- This ADR PR: [nextflow-io/nextflow#7151](https://github.com/nextflow-io/nextflow/pull/7151).

--- a/adr/20260516-task-readiness-gate.md
+++ b/adr/20260516-task-readiness-gate.md
@@ -1,0 +1,243 @@
+# `TaskReadinessGate` plugin extension point for deferred task submission
+
+- Authors: Rob Syme
+- Status: draft
+- Deciders: Paolo Di Tommaso, Ben Sherman, Rob Syme
+- Date: 2026-05-16
+- Tags: plugin, extension-point, scheduler, task-submission
+
+## Summary
+
+Introduce a `TaskReadinessGate` plugin extension point that lets a plugin defer task submission until an external precondition is met (e.g. an S3 object has been restored from Glacier), removing the need for plugins to subclass an executor and its task handler.
+
+## Problem Statement
+
+Some plugins need to hold task submission until an external precondition is satisfied. A concrete example is restoring S3 objects from Glacier: a plugin needs to issue a `RestoreObject` request and wait for the object to be available before an AWS Batch job tries to stage it. The same shape applies to other cold-storage backends and to any "warm-up before run" workflow.
+
+The only existing hook is `TaskHandler.isReady()`, which is consulted by `TaskPollingMonitor.canSubmit()` on every polling tick. To override it, a plugin must subclass both an executor and its task handler. This shape has three problems:
+
+1. **Opt-in cost for users.** Pipelines must set `process.executor = '<plugin-specific-name>'`, instead of the plugin being a drop-in via `plugins { id '...' }`.
+
+2. **Coupling to executor internals.** Subclassing an executor's task handler tangles plugin code with executor implementation details. In practice, plugins that subclass `AwsBatchTaskHandler` cannot use `@CompileStatic` because the parent's proxy dispatch breaks under static compilation — i.e. the subclassing approach is already hitting its limits for a single executor.
+
+3. **Single-cloud lock-in.** The same shape recurs for any executor that stages remote inputs (AWS Batch, Google Batch, Azure Batch, Kubernetes, local) and any cold-storage backend (Glacier, GCS Coldline, on-demand warm-up, lazy datasets). Each combination would need a new executor subclass under the current design.
+
+A generic extension point — "consult these plugins before submitting any task" — addresses all three problems with a small additive change to core.
+
+## Goals
+
+- Provide a way for plugins to defer task submission based on external state, without subclassing executors or task handlers.
+
+- Work uniformly across every executor that submits tasks via `TaskPollingMonitor` (i.e. all existing executors).
+
+- Be safe-by-default: a plugin that ships a gate cannot accidentally stall the scheduler thread for the rest of the run.
+
+- Allow gates to kick off async preparation work the moment a task is queued, not when an executor slot frees up — cold-storage restores can take hours and must not wait for capacity.
+
+- Allow plugins to signal permanent task failure cleanly, integrating with the standard `errorStrategy` machinery.
+
+## Non-goals
+
+- **Per-process gate scoping.** A gate is consulted for every task. Selectors that restrict a gate to specific processes are a config-layer concern that can be added later.
+
+- **Gate ordering or priority.** Evaluation order across gates is unspecified. An `int order()` default method can be added non-breakingly if a real use case appears.
+
+- **An `AbstractAsyncReadinessGate` helper class.** A base class that runs blocking work on a dedicated executor and exposes results via per-task `CompletableFuture`s would lower the cliff for plugin authors. We are deliberately not shipping it in v1: the contract is documented in javadoc, and consumers with their own cross-task state (dedup, rate limiting, batched API calls) typically would not use a per-task-future helper. It can be extracted later when a clear use case appears.
+
+- **Replacing `TaskHandler.isReady()`.** The existing method stays and is still consulted; gates are AND-combined with it. No flag day for existing subclasses.
+
+## Considered Options
+
+- **Option A — `TaskReadinessGate` SPI in core (this proposal).**
+- **Option B — Channel operator `glacierRestore()`.**
+- **Option C — `FileSystemProvider` interception in nf-amazon's S3 NIO.**
+
+## Pros and Cons of the Options
+
+### Option A — `TaskReadinessGate` SPI in core
+
+A new extension point consulted by `TaskPollingMonitor` before admitting a task for submission. Plugins implementing the interface are discovered via PF4J.
+
+- Good, because it matches the actual problem ("defer task submission until external state is ready"), which is generic across executors and backends.
+- Good, because users get drop-in behavior — `plugins { id '...' }` is enough; no `process.executor` override.
+- Good, because the plugin stops being tied to a specific executor implementation and works with every executor in a single class.
+- Good, because the change to core is small (one interface plus a few lines in `TaskPollingMonitor`) and behavior is bit-identical when no plugin registers a gate.
+- Bad, because it requires a coordinated upstream change in Nextflow before the consumer plugin can be refactored.
+
+### Option B — Channel operator `glacierRestore()`
+
+A plugin-provided operator that holds items in a channel until each is verified restored, then emits them: `Channel.fromPath('s3://...') | glacierRestore | MY_PROCESS`.
+
+- Good, because it ships independently of Nextflow with no core changes.
+- Good, because it makes the restore step explicit and visible in the pipeline code.
+- Bad, because it requires pipeline authors to rewrite channel plumbing.
+- Bad, because it does not help users who declare `path('s3://...')` directly as a process input without an explicit upstream channel.
+- Best treated as a complement to Option A, not a replacement.
+
+### Option C — `FileSystemProvider` interception in nf-amazon's S3 NIO
+
+Intercept S3 reads at the NIO layer and trigger restore on demand.
+
+- Bad, because Nextflow never reads input bytes on the head node when using AWS Batch — the Batch worker does, via `aws s3 cp` or Fusion. A filesystem hook only catches head-node access (local executor, head-node `publishDir`, etc.) and cannot gate Batch submissions, which is the core requirement.
+
+Rejected. Documented here to avoid revisiting.
+
+## Decision
+
+Adopt Option A. Introduce a `TaskReadinessGate` interface in `nextflow.processor` and consult registered implementations from `TaskPollingMonitor`. Option B may be pursued separately by individual plugins as a complementary surface.
+
+## Core capabilities
+
+### Interface
+
+```groovy
+package nextflow.processor
+
+import nextflow.plugin.extension.ExtensionPoint
+
+/**
+ * Plugin extension point that defers task submission until external preconditions are met.
+ *
+ * <p>Invoked by the task scheduler:
+ * <ul>
+ *   <li>Once when a task is added to the pending queue (return value ignored). This lets
+ *       the gate kick off any async preparation, e.g. issuing an S3 RestoreObject request.</li>
+ *   <li>On every subsequent polling tick (~100ms) until it returns {@code true}.</li>
+ * </ul>
+ *
+ * <p><b>Implementations must return promptly.</b> This method runs on the task scheduler
+ * thread; blocking it stalls submission for every task in the run, not only the one being
+ * gated. Kick off async work on the first call and return {@code false}; report status on
+ * subsequent calls.
+ *
+ * <p>Throwing from this method marks the task as permanently failed, with the thrown
+ * exception attached as the cause. The standard {@code errorStrategy} applies, so a
+ * transient failure can be retried. Returning {@code false} indefinitely keeps the task
+ * waiting forever — throw to signal definitive failure.
+ *
+ * <p>When multiple gates are registered, a task is admitted only when every gate returns
+ * {@code true}. Evaluation order across gates is unspecified.
+ */
+interface TaskReadinessGate extends ExtensionPoint {
+    boolean isReady(TaskRun task)
+}
+```
+
+### Contract
+
+| Aspect | Contract |
+|---|---|
+| Return value | `true` = ready to submit; `false` = not yet, poll again |
+| Permanent failure | Throw an exception; routed through the standard task failure path |
+| Latency | Must return promptly. No blocking I/O on the calling thread. |
+| First-call semantics | Idempotent. Kick off async preparation, return `false` immediately. |
+| Aggregation across gates | Logical AND. Order unspecified. |
+| Per-task identity | `TaskRun.id` is stable for dedup and caching inside the gate |
+
+### Call site integration
+
+Three small edits to `nextflow.processor.TaskPollingMonitor`.
+
+**Cache the gate list once per session** in `start()`:
+
+```groovy
+private List<TaskReadinessGate> readinessGates = Collections.emptyList()
+
+@Override
+TaskMonitor start() {
+    readinessGates = Plugins.getExtensions(TaskReadinessGate)
+    // ... existing start logic
+    return this
+}
+```
+
+**Fire-once on enqueue** so the gate can start async work the moment the task is queued — not when an executor slot frees up:
+
+```groovy
+void schedule(TaskHandler handler) {
+    // ... existing enqueue logic
+    if( readinessGates ) {
+        for( gate in readinessGates ) {
+            try {
+                gate.isReady(handler.task)
+            }
+            catch( Throwable t ) {
+                handleGateFailure(handler, t)
+                return
+            }
+        }
+    }
+}
+```
+
+The return value is intentionally discarded — this call exists for the side effect.
+
+**AND-in gates with the existing admission checks** in `canSubmit`:
+
+```groovy
+protected boolean canSubmit(TaskHandler handler) {
+    // The single-threaded scheduler invariant is load-bearing here: TaskReadinessGate
+    // implementations are contractually required to return promptly.
+    (capacity > 0 ? checkQueueCapacity(handler) : true) \
+        && handler.canForkProcess() \
+        && allGatesReady(handler) \
+        && handler.isReady()
+}
+
+private boolean allGatesReady(TaskHandler handler) {
+    if( !readinessGates ) return true
+    for( gate in readinessGates ) {
+        try {
+            if( !gate.isReady(handler.task) ) return false
+        }
+        catch( Throwable t ) {
+            handleGateFailure(handler, t)
+            return false
+        }
+    }
+    return true
+}
+```
+
+`handleGateFailure(TaskHandler, Throwable)` routes the exception through the same path used today for submit-time `ProcessException`s: the task transitions to `FAILED` with the gate exception as cause, and the configured `errorStrategy` (`terminate` / `ignore` / `retry`) applies.
+
+### Discovery and lifecycle
+
+- Gates are resolved via `Plugins.getExtensions(TaskReadinessGate)` — the standard PF4J path used by `TraceObserverFactory`, `ContainerResolver`, and other plugin extension points.
+- Instances are constructed once when the monitor starts and reused for the run.
+- No teardown hook on the SPI. Plugins that need cleanup own that via their existing `BasePlugin.start/stop` lifecycle.
+- No config flag. A plugin that ships a gate is automatically consulted for every task; opting out means not installing the plugin.
+
+### Backward compatibility
+
+- With no gates registered, `canSubmit` evaluates one empty-list check per pending task per tick. `schedule` adds one untaken branch. Behavior is bit-identical to today.
+- `TaskHandler.isReady()` is unchanged and still consulted. Existing executor and task-handler subclasses keep working.
+- The SPI is purely additive: no existing signatures change.
+
+## Rationale & discussion
+
+**Why polling rather than blocking.** `TaskPollingMonitor` runs a single scheduler thread that walks the pending queue every ~100ms. A blocking gate (one that waits inside `isReady` for the external precondition to be satisfied) would stall submission for every task in the run, not just the one being gated. For the driving use case — Glacier restores that can take up to 12 hours — this is unacceptable. The contract is therefore explicitly polling-based: the first call kicks off async work and returns `false`; subsequent calls cheaply check status. This also matches the AWS RestoreObject API, which is async-by-design (issue `RestoreObject`, then poll `HeadObject` for status).
+
+**Why fire on enqueue, not only on `canSubmit`.** If the gate were only consulted from `canSubmit`, a task waiting behind a full executor queue or a `maxForks` limit would not trigger the gate, so the restore would not begin until capacity frees up. Adding the fire-once call in `schedule()` decouples "start the restore" from "is there a slot." The cost is one extra call per task per gate per run; the call is contractually idempotent so this is safe.
+
+**Why exceptions for permanent failure.** Returning `false` indefinitely would keep a task waiting forever in cases where success is impossible (object permanently inaccessible, restore window timed out, AccessDenied). Adding a tri-state return value (`READY`/`WAITING`/`FAILED`) would enlarge the public API for the same effect Java already provides via exceptions. Routing through the existing failure path also means `errorStrategy 'retry'` naturally handles transient failures — a `ThrottlingException` bubbling out of the gate triggers the same retry behavior as a transient executor failure.
+
+**Why no helper class.** An `AbstractAsyncReadinessGate` base class that runs blocking work on a dedicated executor and exposes results via per-task `CompletableFuture`s would make safe-by-default gates trivial to write. The reason we are skipping it in v1: realistic consumers (e.g. a Glacier restorer with cross-task dedup, rate limiting, and prefix expansion) tend to have their own async state and would not use a per-task-future helper. Shipping the helper now means designing it for hypothetical consumers whose shape we cannot yet see. Extracting it later is non-breaking.
+
+**Why this lives in `nextflow.processor`, not `nf-commons`.** Other task-scoped extension points (`TaskTipProvider`, the task handler itself) live in `nextflow.processor`. `nf-commons` hosts cross-cutting infrastructure (the `ExtensionPoint` marker itself, plugin loading machinery). Co-locating `TaskReadinessGate` with `TaskRun` and `TaskHandler` matches the existing layering.
+
+## Testing
+
+New Spock specs in `modules/nextflow/src/test/groovy/nextflow/processor/TaskPollingMonitorTest.groovy`:
+
+- No gates registered → `canSubmit` matches current behavior; `schedule` does not touch gate code.
+- One gate returning `true` → task admitted as soon as capacity and forks allow.
+- One gate returning `false` then `true` → task waits in pending across ticks; admitted on the tick the gate flips.
+- Gate invoked exactly once on enqueue; return value ignored even when `false`.
+- Multiple gates → AND semantics; one `false` blocks admission.
+- Gate throws on enqueue → task fails with the thrown cause; not added to running queue.
+- Gate throws during poll → task fails with the thrown cause; removed from pending.
+- Gate throws under `errorStrategy 'retry'` → standard retry path.
+
+Gates are injected through a test double rather than a real PF4J context.
+

--- a/adr/20260516-task-readiness-gate.md
+++ b/adr/20260516-task-readiness-gate.md
@@ -303,3 +303,4 @@ Other task-scoped extension points (`TaskTipProvider`, the task handler itself) 
 
 - Implementation PR: [nextflow-io/nextflow#7158](https://github.com/nextflow-io/nextflow/pull/7158).
 - This ADR PR: [nextflow-io/nextflow#7151](https://github.com/nextflow-io/nextflow/pull/7151).
+- Extended by [20260823-file-readiness-gate](20260823-file-readiness-gate.md), which covers head-node reads (foreign-file staging, content-based cache hashing) that happen before a task is scheduled and are therefore outside this gate's window.

--- a/adr/20260823-file-readiness-gate.md
+++ b/adr/20260823-file-readiness-gate.md
@@ -1,0 +1,231 @@
+# `FileReadinessGate` plugin extension point for head-node file reads
+
+- Authors: Rob Syme
+- Status: proposed
+- Deciders: Paolo Di Tommaso, Ben Sherman, Rob Syme
+- Date: 2026-08-23
+- Tags: plugin, extension-point, file-staging, cold-storage
+
+Technical Story: follow-up to [20260516-task-readiness-gate](20260516-task-readiness-gate.md); see the "doesn't work for staging files into work/stage" finding on [nextflow-io/nextflow#7151](https://github.com/nextflow-io/nextflow/pull/7151).
+
+## Summary
+
+Introduce a `FileReadinessGate` plugin extension point that lets a plugin make remote files readable before Nextflow reads them on the head node. `TaskReadinessGate` gates task submission, but foreign-file staging (`FilePorter`) and content-based cache hashing both read remote objects *before* a task is scheduled, so a cold Glacier input kills the run before any gate is consulted. Plugins implement a blocking `void prepare(Collection<Path>)`; core invokes it from `FilePorter.transfer()` and, for content-hashing cache modes, before `TaskHasher.compute()`.
+
+## Problem Statement
+
+`TaskReadinessGate` covers exactly one window: after a `TaskHandler` is created and scheduled, before the executor submits it. Testing against real Glacier-stored inputs showed that Nextflow reads remote files in two places upstream of that window, both on the head node, in `TaskProcessor.invokeTask()`:
+
+1. **Foreign-file staging.** `resolveTaskInputs()` classifies any input whose scheme differs from the work dir's scheme as foreign (`Executor.isForeignFile`), and `session.filePorter.transfer(foreignFiles)` downloads them synchronously on the processor thread. With an `s3://` input and a local, NFS, `az://`, or `gs://` work dir — i.e. the local executor, every grid/HPC executor, and any cross-cloud run — a cold Glacier object throws `InvalidObjectState` during `GetObject`. The error is non-transient, so `FilePorter`'s retries are futile, and the run dies with a `ProcessStageException` before the `TaskHandler` exists. No `TaskReadinessGate` implementation can help, because staging strictly precedes scheduling.
+
+2. **Content-based cache hashing.** `cache 'deep'` and `cache 'sha256'` read full input content in `TaskHasher.compute()`, which also runs before scheduling. This fails on cold objects even in the otherwise-covered S3-work-dir case. The default cache mode is unaffected (metadata only; `HeadObject` succeeds on Glacier objects).
+
+The covered cases work precisely because the first content read happens on the worker *after* the gate: `nxf_s3_download` at task start with an S3 work dir, or lazy FUSE reads under Fusion. Without a fix for the head-node reads, the Glacier feature works on cloud batch executors but fails on local and HPC runs — a fragmentation of the feature across run types.
+
+A third class of head-node reads exists — channel operators and script-level file APIs (`splitCsv`, `file(...).text`, etc.) that never involve a task at all. It shares the root cause but not the remedy surface; see Non-goals.
+
+## Goals
+
+- Close the foreign-file staging gap: a cold remote input must be restorable before `FilePorter` attempts `GetObject`, on every executor.
+
+- Close the content-hashing gap for `cache 'deep'` / `cache 'sha256'`.
+
+- Reuse the design language of `TaskReadinessGate`: blocking call, interrupt-based cancellation, throw-for-permanent-failure, plugin-owned timeout policy, zero cost when no plugin registers the extension.
+
+- Keep the primitive path-keyed and context-free so future call sites (operator-level reads) can adopt it without interface changes.
+
+## Non-goals
+
+- **Operator-level reads (no task exists).** `splitCsv`, `countLines`, `file('s3://...').text`, a Glacier-stored samplesheet. Gating these means touching many splitter/file-API entry points or intercepting inside the S3 `FileSystemProvider` — both invasive, and severable from this change. The extension point is deliberately shaped so these call sites can be added later. Note this does not reopen the prior ADR's rejection of filesystem-level interception: that rejection was about gating *Batch task submission*, which a head-node filesystem hook cannot see; head-node reads are exactly what such a hook does see.
+
+- **Re-validation of restore expiry.** A restore window can lapse between the gate passing and the worker reading. Accepted lifecycle behavior, unchanged by this ADR.
+
+- **Per-process or per-path opt-out.** The gate receives paths only, no task context. Where staging previously failed fatally, the only useful policy is "restore it"; per-process policy for the scheduler-side gate remains available via `hints` on `TaskReadinessGate`.
+
+- **Replacing or extending `TaskReadinessGate`.** The two extension points coexist and cover disjoint windows (see Rationale).
+
+- **Core-enforced timeouts.** Same position as the prior ADR: plugins own timeout policy.
+
+## Considered Options
+
+- **Option A — proactive path gate invoked by `FilePorter.transfer()` (this proposal).**
+- **Option B — reactive recovery hook on transfer failure.**
+- **Option C — task-level pre-stage hook in `invokeTask()`.**
+- **Option D — reorder `invokeTask()` so staging happens after scheduling.**
+
+Within Option A, a sub-decision on the signature: paths-only vs. paths plus a context object (call site, process name, hints). Paths-only was chosen — see Rationale.
+
+## Pros and Cons of the Options
+
+### Option A — proactive path gate in `FilePorter`
+
+A new extension point, `void prepare(Collection<Path>)`, called synchronously at the top of `FilePorter.transfer(Batch)` with the batch's source paths, before any download is submitted.
+
+- Good, because `FilePorter.transfer()` is the single choke point every foreign staging operation passes through — one call site closes the whole staging gap on every executor.
+- Good, because the plugin sees the whole batch at once: one scan, bulk `RestoreObject`, one poll loop.
+- Good, because no `FilePorter` transfer-pool permits are held while a restore waits — warm downloads for other tasks are unaffected.
+- Good, because the same primitive is callable from the hasher (this ADR) and from operator entry points (future work) without interface changes.
+- Bad, because the processor thread blocks for the restore duration. Mitigated: `transfer()` already blocks that thread for the full download duration today, the task cannot proceed regardless, and the call is interruptible.
+
+### Option B — reactive recovery hook on transfer failure
+
+An extension point consulted when a `FileTransfer` fails: `boolean recover(Path, Exception)`; returning true retries the download.
+
+- Good, because there is no proactive scan — zero cost when nothing is cold.
+- Bad, because a restore-in-progress transfer holds a transfer-pool permit for hours, starving unrelated warm downloads, unless the permit handling is restructured.
+- Bad, because recovery is per-file: the plugin loses batch visibility and must coalesce restores itself.
+- Bad, because it entangles the recovery contract with `FilePorter`'s existing transient-error retry logic.
+
+### Option C — task-level pre-stage hook in `invokeTask()`
+
+A second task-keyed hook before `filePorter.transfer()`, keyed on `TaskRun` (no handler exists yet).
+
+- Good, because gaps 1 and 2 are covered at one call site with task context (hints) available.
+- Bad, because it duplicates the gate concept at a second lifecycle point with a different key type.
+- Bad, because the existing handler-keyed gate must still exist for the non-foreign case — two overlapping task-level extension points.
+- Bad, because it does nothing for operator-level reads, ever.
+
+### Option D — reorder `invokeTask()` so staging happens after scheduling
+
+Move `filePorter.transfer()` past `checkCachedOrLaunchTask()` so the existing `TaskReadinessGate` window covers it.
+
+- Bad, because staging is load-bearing for cache hashing: `resolveTaskInputs` rewrites foreign inputs to their stage targets and the hash is computed over them, so resume semantics depend on the current order.
+- Bad, because it is a large behavioral change to the task lifecycle in exchange for what one added call in `FilePorter` achieves.
+
+Rejected without prototyping. Documented to avoid revisiting.
+
+## Solution or decision outcome
+
+Adopt Option A with a paths-only signature. Introduce a `FileReadinessGate` interface in `nextflow.file`, invoked from `FilePorter.transfer()` (staging) and from `TaskProcessor.invokeTask()` before `TaskHasher.compute()` when the cache mode reads content.
+
+## Core capabilities
+
+### Interface
+
+```groovy
+package nextflow.file
+
+import org.pf4j.ExtensionPoint
+
+/**
+ * Plugin extension point that makes remote files readable before Nextflow
+ * reads them on the head node (foreign-file staging, content-based cache
+ * hashing).
+ *
+ * <p>Implementations are invoked synchronously on the caller's thread and may
+ * block freely; returning normally means every path in the collection is
+ * readable now. Throw to signal permanent failure; the error is routed through
+ * the standard staging failure path ({@code ProcessStageException}).
+ *
+ * <p>Implementations must ignore paths they are not responsible for
+ * (non-matching schemes, already-readable objects) cheaply — every foreign
+ * staging batch in the run flows through this call, most of them needing no work.
+ *
+ * <p>Implementations must honor {@code Thread.interrupt()} so that workflow
+ * abort can unblock {@code prepare} promptly. Core does not enforce a
+ * wall-clock deadline — plugins own timeout policy.
+ */
+interface FileReadinessGate extends ExtensionPoint {
+    void prepare(Collection<Path> paths) throws InterruptedException
+}
+```
+
+### Contract
+
+| Aspect | Contract |
+|---|---|
+| Return | Method returns normally → all paths readable now |
+| Permanent failure | Throw; wrapped in `ProcessStageException` unless already a `ProcessException` |
+| Cancellation | `InterruptedException` propagates; gate must honor `Thread.interrupt()` |
+| Threading | Synchronous on the caller's thread (processor/operator thread); blocking is expected |
+| Irrelevant paths | Must be ignored cheaply (scheme check, no network call) |
+| Aggregation across gates | All gates invoked sequentially; one failure aborts the read |
+| Cross-call dedup | Plugin-internal (e.g. restore state keyed by path) |
+
+### Call site 1 — foreign-file staging
+
+At the top of `FilePorter.transfer(Batch)`, before `submitStagingActions`, the batch's *source* paths (the foreign originals, not the stage targets) are passed to each registered gate. Only then are downloads submitted to the transfer pool.
+
+```groovy
+void transfer(Batch batch) {
+    if( batch.size() ) {
+        prepareForeignFiles(batch)   // invokes each FileReadinessGate with source paths
+        log.trace "Stage foreign files: $batch"
+        submitStagingActions(batch.actions)
+    }
+}
+```
+
+Multiple processor threads call `transfer()` concurrently and the same reference file can appear in many batches. Core does not dedup across calls; a plugin keys restore state by path so the second caller joins the first caller's wait rather than issuing a second restore.
+
+### Call site 2 — content-based cache hashing
+
+In `TaskProcessor.invokeTask()`, between `filePorter.transfer(foreignFiles)` and `new TaskHasher(task).compute()`, guarded on the task's hash mode:
+
+```groovy
+session.filePorter.transfer(foreignFiles)
+
+if( hashModeReadsContent(task) ) {   // DEEP or SHA256 only
+    final remote = task.getInputFilesMap().values().findAll { !it.fileSystem.equals(FileSystems.default) }
+    fileGates.each { it.prepare(remote) }
+}
+final hash = new TaskHasher(task).compute()
+```
+
+The filter matters: foreign inputs were already rewritten to local stage targets by `resolveTaskInputs`, so the remote paths remaining here are exactly the same-scheme case (e.g. S3 work dir) that `transfer()` never sees. The default hash mode skips the call entirely — metadata hashing works on cold objects today and stays zero-cost.
+
+### Error handling
+
+A gate throwing inside `transfer()` propagates like any staging failure: non-`ProcessException` causes are wrapped in `ProcessStageException`, so `invokeTask` routes the error through `errorStrategy` exactly as a failed download does today. The hashing call site wraps the same way. `InterruptedException` propagates untouched — the thread is being torn down on session abort — and core re-asserts the interrupt flag if a gate returns after being interrupted.
+
+### Discovery and lifecycle
+
+- Gates are resolved via `Plugins.getExtensions(FileReadinessGate)` lazily on first use and cached for the run.
+- No manager class, no executor, no future tracking. Unlike `TaskReadinessGate`, the caller's thread is *supposed* to wait here — `transfer()` already blocks it for the full download duration — so the synchronous call is the simple and honest shape.
+- With no gates registered, the cost is an empty-list check per batch. Behavior is bit-identical to upstream.
+
+### Coexistence with `TaskReadinessGate`
+
+The two extension points cover disjoint windows and both remain necessary:
+
+| Window | Read location | Covered by |
+|---|---|---|
+| Foreign staging (work dir scheme differs from input scheme) | Head node, `FilePorter` | `FileReadinessGate` |
+| Content-based cache hashing | Head node, `TaskHasher` | `FileReadinessGate` |
+| Same-scheme inputs, first read at task start | Worker (`nxf_s3_download`, Fusion) | `TaskReadinessGate` |
+
+A cold-storage plugin implements both against a shared restore manager.
+
+## Rationale & discussion
+
+### Why paths-only, no context object
+
+A context parameter (call site, process name, hints) was considered and dropped. Where staging previously failed fatally, per-process opt-out has no useful semantics — the alternative to restoring is a dead run — so the hints machinery has nothing to decide here. Paths-only also makes the primitive trivially reusable from call sites that have no task (the hasher already, operator reads later) without fabricating context. As a side effect, the staging path needs no per-process annotation at all, removing the adoption gap where a missed `hints` line degraded to a fatal staging error.
+
+### Why proactive, not reactive
+
+Restore latency dominates (hours), so proactive scanning and reactive recovery have the same wall-clock cost — the difference is structural. The reactive shape pins a `FilePorter` transfer-pool permit per cold file for the restore duration, starving warm downloads for unrelated tasks, and forces the plugin to coalesce per-file recoveries into bulk restores itself. The proactive shape does its waiting before any permit is acquired and hands the plugin the whole batch.
+
+### Why synchronous, when `TaskReadinessGate` got a managed executor
+
+The prior ADR's executor exists because the *scheduler* thread must never block — it multiplexes every pending task. Here the caller is a processor thread that is already committed to blocking until this specific task's inputs are staged; moving the wait to another thread would add machinery only to have the caller wait on that thread instead. The `FilePorter` precedent cited in the prior ADR's review cuts the same way: blocking work on the thread that needs the result.
+
+### Why the hashing call site is guarded, not unconditional
+
+Only `cache 'deep'` and `cache 'sha256'` read content before scheduling. Guarding on hash mode keeps the default path at zero added calls, and avoids a per-task `HeadObject` scan for the overwhelmingly common metadata-hash case.
+
+### Why operator-level reads are deferred
+
+Their natural interception points are per-operator (many call sites across `nextflow.splitter` and the file APIs) or inside the S3 filesystem provider (an nf-amazon change with its own blast radius). Both are severable: the extension point defined here is the primitive either would call. Shipping staging plus hashing now fixes every run type for task inputs; the samplesheet-in-Glacier case remains a documented limitation until a follow-up.
+
+## Testing
+
+- `FilePorterTest` — a recording stub gate proving gate-before-download ordering, the empty-extension fast path, exception wrapping into `ProcessStageException`, and interrupt propagation.
+- `TaskProcessorTest` — the hash-mode guard: gate invoked for `deep`/`sha256` only; staged-local paths filtered out of the collection.
+- Consumer plugin — unit tests with a mocked S3 client (cold object restored then `prepare` returns; restore failure throws), plus an end-to-end scenario on the local executor with an `s3://` input: the exact configuration that dies with `ProcessStageException` today.
+
+## Links
+
+- Extends [20260516-task-readiness-gate](20260516-task-readiness-gate.md)
+- ADR discussion: [nextflow-io/nextflow#7151](https://github.com/nextflow-io/nextflow/pull/7151)
+- `TaskReadinessGate` implementation: [nextflow-io/nextflow#7158](https://github.com/nextflow-io/nextflow/pull/7158)


### PR DESCRIPTION
## Summary

Adds an architecture decision record proposing a new `TaskReadinessGate` plugin extension point that defers task submission until external preconditions are met (e.g. restoring S3 objects from Glacier before an AWS Batch job tries to stage them).

The motivation is that plugins needing this capability today must subclass an executor and its task handler purely to override `TaskHandler.isReady()`, which:
- forces users to opt in via `process.executor = '<plugin-specific-name>'` instead of a drop-in `plugins { id '...' }`;
- couples plugins to executor internals (e.g. `@CompileStatic` is incompatible with `AwsBatchTaskHandler` subclassing due to its proxy dispatch);
- requires a new executor subclass per (executor × cold-storage backend) combination.

The proposed SPI is consulted by `TaskPollingMonitor` before submitting any task, works uniformly across every executor, and is a small additive change to core (one interface + a handful of lines at the call site). Behavior is bit-identical when no plugin registers a gate.

The ADR documents the contract (polling-based, must return promptly, exceptions signal permanent failure), the call-site integration, considered alternatives (channel operator, S3 NIO interception — both rejected with reasoning), explicit non-goals, and follow-ups left for later (`AbstractAsyncReadinessGate` helper, per-process scoping, gate ordering).

Status in the ADR is `draft` — opening for review and discussion before implementation.

## Test plan

- [ ] Reviewers (Paolo, Ben) read the ADR and confirm the SPI shape, contract, and call-site integration.
- [ ] Confirm the non-goals (no helper class, no scoping, no ordering) are acceptable for v1.
- [ ] Confirm the placement under `nextflow.processor` rather than `nf-commons`.
- [ ] Once accepted, follow-up PR implements the interface, the three edits to `TaskPollingMonitor`, Spock specs, and developer-docs section.