### PR TITLE
PoC: cloud-checksum task hashing for the global cache

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -440,6 +440,21 @@ class Session implements ISession {
         if(!workDir.mkdirs()) throw new AbortOperationException("Cannot create work-dir: $workDir -- Make sure you have write permissions or specify a different directory by using the `-w` command line option")
         log.debug "Work-dir: ${workDir.toUriString()} [${FileHelper.getPathFsType(workDir)}]"
 
+        // Bootstrap the global-cache directory if NXF_GLOBALCACHE_PATH is active.
+        // This runs here (rather than in ConfigBuilder) so cloud path factories
+        // that need the Session config (e.g. nf-azure's AzPathFactory which reads
+        // azure credentials from session.config) can resolve the URI. The
+        // pre-creation prevents CloudCacheStore.openForRead from aborting on the
+        // first run of a fresh global-cache path.
+        if( System.getenv('NXF_GLOBALCACHE_PATH') && cloudCachePath ) {
+            try {
+                cloudCachePath.resolve(uniqueId.toString()).mkdirs()
+            }
+            catch( Exception e ) {
+                log.warn("Unable to bootstrap global-cache directory ${cloudCachePath}: ${e.message}")
+            }
+        }
+
         if( config.bucketDir ) {
             this.bucketDir = config.bucketDir as Path
             log.debug "Bucket-dir: ${bucketDir.toUriString()}"

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -768,8 +768,11 @@ class ConfigBuilder {
 
             log.warn "Enabling global cache. This will enable resume, set the cache path to ${config.cloudcache.path}, and set the work directory to ${config.workDir}"
 
-            final cachePath = FileHelper.asPath(globalCachePath)
-            cachePath.resolve("cache/${sessionId}").mkdirs()
+            // NOTE: the bootstrap mkdirs of "${globalCachePath}/cache/${sessionId}" must
+            // happen AFTER the Session is constructed (Global.session is set), because
+            // some cloud path factories (notably nf-azure's AzPathFactory) read
+            // credentials from session config to resolve URIs. That bootstrap is
+            // performed in Session.init() once the work-dir is created.
         }
 
         // -- set container options

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHasher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHasher.groovy
@@ -46,6 +46,16 @@ class TaskHasher {
         this.session = task.processor.session
     }
 
+    /**
+     * Returns true when this session is running with the global cache feature
+     * enabled (sessionId zeroed by {@code NXF_GLOBALCACHE_PATH}). Hashing
+     * switches to {@link CacheHelper.HashMode#CLOUD_HASH} which is handled in
+     * {@code FileHolder.funnel} via {@link nextflow.file.ChecksumAwareFileSystemProvider}.
+     */
+    private boolean isGlobalCacheActive() {
+        return session != null && session.uniqueId == new UUID(0L, 0L)
+    }
+
     public HashCode compute() {
 
         final keys = new ArrayList<Object>()
@@ -125,8 +135,12 @@ class TaskHasher {
             keys.add('stub-run')
         }
 
-        // compute task hash
-        final mode = task.processor.getConfig().getHashMode()
+        // compute task hash — switch to CLOUD_HASH when the global cache feature
+        // is active so FileHolder.funnel routes through the path's
+        // ChecksumAwareFileSystemProvider (S3 CRC64NVMe etc.) instead of
+        // STANDARD path+size+mtime
+        final configMode = task.processor.getConfig().getHashMode()
+        final mode = isGlobalCacheActive() ? CacheHelper.HashMode.CLOUD_HASH : configMode
         final hash = computeHash(keys, mode)
 
         // log task hash entries if enabled

--- a/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
@@ -87,25 +87,47 @@ class KryoHelper {
         def kryo = new Kryo()
         kryo.setInstantiatorStrategy( InstantiationStrategy.instance )
 
-        // special serializers
+        // Allow Kryo to encode unregistered classes by name on first
+        // encounter instead of failing. Without this, every plugin-
+        // contributed class would need a stable pre-registered numeric
+        // ID, but those IDs are assigned in plugin-load order — so
+        // cross-pipeline cache reuse breaks when different runs load
+        // different plugin sets (e.g. one run with only nf-amazon, the
+        // next with nf-amazon + nf-google). See spec 260514 for context.
+        kryo.setRegistrationRequired(false)
+
+        // Name-encoded classes are resolved via Class.forName at read
+        // time. The default classloader (Kryo's own) sees only system /
+        // application classes — plugin classes like S3Path live in a
+        // pf4j PluginClassLoader and aren't visible. Wire in a delegating
+        // classloader that tries the standard loader first and falls
+        // through to each started plugin's classloader.
+        kryo.setClassLoader(getPluginAwareClassLoader())
+
+        // Built-in JDK collection serializers. These register a fixed
+        // list of classes in a fixed order, so their positional IDs are
+        // stable across all Nextflow processes — safe to keep.
         UnmodifiableCollectionsSerializer.registerSerializers(kryo)
 
-        // users serializers
+        // Plugin-contributed serializers. We attach them as DEFAULT
+        // serializers rather than calling kryo.register(...), so the
+        // serializer mapping is preserved but no positional ID is
+        // pre-assigned. Classes are written by name on first encounter
+        // and Kryo assigns a per-stream dynamic ID — the encoding is
+        // therefore independent of which plugins were loaded when the
+        // blob was written.
         for( Map.Entry entry : serializers ) {
             final k = (Class)entry.key
             final v = entry.value
             if( v instanceof Class )
-                kryo.register(k,(Serializer)v.newInstance())
-
+                kryo.addDefaultSerializer(k, (Class<? extends Serializer>) v)
             else if( v instanceof Closure<Serializer> )
-                kryo.register(k, v.call(kryo))
-
-            else
-                kryo.register(k)
-
+                kryo.addDefaultSerializer(k, (Serializer) v.call(kryo))
+            // else: no serializer specified — Kryo picks a default
+            // (FieldSerializer) on first encounter. Nothing to attach.
         }
 
-        // Register default serializers
+        // Default serializers
         // - there are multiple GString implementation so it
         //   has to be registered the base class as default serializer
         //   See Nextflow issues #12
@@ -114,6 +136,41 @@ class KryoHelper {
         kryo.addDefaultSerializer(Map.Entry, MapEntrySerializer)
 
         return kryo
+    }
+
+    /**
+     * Build a classloader that resolves classes from the standard
+     * application classloader first and, on miss, falls through to each
+     * started plugin's pf4j {@code PluginClassLoader}. Required so Kryo's
+     * name-encoded class lookups can find classes contributed by plugins
+     * (e.g. {@code nextflow.cloud.aws.nio.S3Path} loaded by nf-amazon).
+     *
+     * The composite is lazy-resolved per call so plugins that start
+     * after KryoHelper initialisation are still picked up.
+     */
+    static private ClassLoader getPluginAwareClassLoader() {
+        return new ClassLoader(KryoHelper.classLoader) {
+            @Override
+            protected Class<?> findClass(String name) throws ClassNotFoundException {
+                try {
+                    final manager = Plugins.getManager()
+                    if( manager != null ) {
+                        for( def wrapper : manager.getStartedPlugins() ) {
+                            try {
+                                return wrapper.getPluginClassLoader().loadClass(name)
+                            }
+                            catch( ClassNotFoundException ignored ) {
+                                // try next plugin
+                            }
+                        }
+                    }
+                }
+                catch( Exception e ) {
+                    log.trace "Plugin-aware classloader: error iterating plugins for '${name}': ${e.message}"
+                }
+                throw new ClassNotFoundException(name)
+            }
+        }
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskHasherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskHasherTest.groovy
@@ -142,4 +142,19 @@ class TaskHasherTest extends Specification {
         result1 == result2
         result1 == 'nxf_out_eval_1=echo "value1"\nnxf_out_eval_2=echo "value2"\nnxf_out_eval_3=echo "value3"'
     }
+
+    def 'isGlobalCacheActive returns true only when sessionId is the zero UUID' () {
+        given:
+        def session = Mock(Session) { getUniqueId() >> uniqueId }
+        def processor = Mock(TaskProcessor) { getSession() >> session }
+        def task = Mock(TaskRun) { getProcessor() >> processor }
+
+        expect:
+        new TaskHasher(task).isGlobalCacheActive() == expected
+
+        where:
+        uniqueId                                                   | expected
+        new UUID(0L, 0L)                                           | true
+        UUID.fromString('b69b6eeb-b332-4d2c-9957-c291b15f498c')    | false
+    }
 }

--- a/modules/nf-commons/src/main/nextflow/file/ChecksumAwareFileSystemProvider.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/ChecksumAwareFileSystemProvider.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.file
+
+import java.nio.file.Path
+
+import nextflow.util.checksum.Checksum
+
+/**
+ * Capability interface implemented by cloud-storage filesystem providers that
+ * can return a content-addressable checksum for a path via a single metadata
+ * call (e.g. S3 HEAD with {@code ChecksumMode.ENABLED}).
+ *
+ * Used by {@code FileHolder.funnel} when the active
+ * {@link nextflow.util.CacheHelper.HashMode#CLOUD_HASH} mode is in effect, so
+ * that task hashes contribute the cloud-native checksum (e.g. S3 CRC64NVMe)
+ * instead of {@code path + size + mtime}. Filesystems that cannot provide a
+ * checksum return {@link Optional#empty()} and the caller falls back to the
+ * default hashing path.
+ *
+ * Mirrors the existing {@link FileSystemTransferAware} capability pattern:
+ * checked at runtime via {@code instanceof} on the provider returned by
+ * {@code path.getFileSystem().provider()}.
+ */
+interface ChecksumAwareFileSystemProvider {
+
+    /**
+     * Return the cloud-storage-native checksum for the given path, or
+     * {@link Optional#empty()} when the path has no usable native checksum
+     * (e.g. pre-2025 S3 object with null CRC64NVMe).
+     *
+     * Implementations MUST be cheap (a single HEAD-equivalent metadata call)
+     * and side-effect-free.
+     */
+    Optional<Checksum> headChecksum(Path path)
+}

--- a/modules/nf-commons/src/main/nextflow/file/FileHolder.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/FileHolder.groovy
@@ -76,7 +76,16 @@ class FileHolder implements CacheFunnel {
 
     @Override
     Hasher funnel(Hasher hasher, HashMode mode) {
-        return CacheHelper.hasher(hasher, sourceObj, mode)
+        // For CLOUD_HASH mode, route to the workdir-side staged path
+        // (storePath) where the file actually lives after FilePorter staging,
+        // not the source URI which may be on a different cloud / scheme. For
+        // any other mode, preserve the existing source-identity semantics by
+        // hashing sourceObj.
+        //
+        // HashBuilder.hashFile handles file-vs-directory dispatch and the
+        // CLOUD_HASH FS-provider lookup uniformly for both.
+        final target = (mode == HashMode.CLOUD_HASH) ? storePath : sourceObj
+        return CacheHelper.hasher(hasher, target, mode)
     }
 
     @PackageScope

--- a/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
+++ b/modules/nf-commons/src/main/nextflow/util/CacheHelper.java
@@ -29,7 +29,7 @@ public class CacheHelper {
 
     public enum HashMode {
 
-        STANDARD, DEEP, LENIENT, SHA256;
+        STANDARD, DEEP, LENIENT, SHA256, CLOUD_HASH;
 
         private static HashMode defaultValue;
 
@@ -56,6 +56,8 @@ public class CacheHelper {
                     return DEEP;
                 if( "sha256".equals(obj) )
                     return SHA256;
+                if( "cloud-hash".equals(obj) || "cloud_hash".equals(obj) )
+                    return CLOUD_HASH;
             }
             LoggerFactory.getLogger(HashMode.class).warn("Unknown cache mode: {}", obj.toString());
             return null;

--- a/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
+++ b/modules/nf-commons/src/main/nextflow/util/HashBuilder.java
@@ -45,8 +45,10 @@ import nextflow.Global;
 import nextflow.ISession;
 import nextflow.extension.Bolts;
 import nextflow.extension.FilesEx;
+import nextflow.file.ChecksumAwareFileSystemProvider;
 import nextflow.io.SerializableMarker;
 import nextflow.script.types.Bag;
+import nextflow.util.checksum.Checksum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static nextflow.Const.DEFAULT_ROOT;
@@ -263,7 +265,7 @@ public class HashBuilder {
             log.warn("Unable to get file attributes file: {} -- Cause: {}", FilesEx.toUriString(path), e.toString());
         }
 
-        if( (mode==HashMode.STANDARD || mode==HashMode.LENIENT) && isAssetFile(path, DEFAULT_ROOT) ) {
+        if( (mode==HashMode.STANDARD || mode==HashMode.LENIENT || mode==HashMode.CLOUD_HASH) && isAssetFile(path, DEFAULT_ROOT) ) {
             if( attrs==null ) {
                 // when file attributes are not avail, or it's a directory
                 // hash the file using the file name path and the repository
@@ -287,8 +289,96 @@ public class HashBuilder {
             return hashFileContent(hasher, path);
         if( mode==HashMode.SHA256 && attrs!=null && attrs.isRegularFile() )
             return hashFileSha256(hasher, path, null);
+        if( mode==HashMode.CLOUD_HASH && attrs!=null && attrs.isRegularFile() )
+            return hashFileCloud(hasher, path, attrs, basePath);
+        if( mode==HashMode.CLOUD_HASH && attrs!=null && attrs.isDirectory() )
+            return hashDirCloud(hasher, path, attrs, basePath);
         // default
         return hashFileMetadata(hasher, path, attrs, mode, basePath);
+    }
+
+    /**
+     * Hash a single regular file using the cloud-native checksum (e.g. S3 CRC64NVMe,
+     * Azure MD5, GCS CRC32C). Falls back to {@link #hashFileMetadata} when no
+     * checksum is reachable.
+     */
+    static private Hasher hashFileCloud( Hasher hasher, Path path, BasicFileAttributes attrs, Path basePath ) {
+        final java.util.Optional<Checksum> ck = lookupCloudChecksum(path);
+        if( ck.isPresent() ) {
+            hasher.putUnencodedChars(ck.get().toHashContribution());
+            return hasher;
+        }
+        // Reason already logged inside lookupCloudChecksum().
+        return hashFileMetadata(hasher, path, attrs, HashMode.STANDARD, basePath);
+    }
+
+    /**
+     * Resolve a cloud-native checksum for a single path via the
+     * {@link ChecksumAwareFileSystemProvider} capability on the path's FS
+     * provider (e.g. S3, Azure).
+     *
+     * Returns {@link Optional#empty()} on any miss/error and emits a WARN log
+     * so the operator can see why cross-bucket cache hits aren't materialising.
+     */
+    static private java.util.Optional<Checksum> lookupCloudChecksum( Path path ) {
+        final java.nio.file.spi.FileSystemProvider provider = path.getFileSystem().provider();
+        if( !(provider instanceof ChecksumAwareFileSystemProvider) ) {
+            log.warn("No cloud-checksum support for {} (provider={}) — falling back to default hashing; cross-bucket cache hits not possible for this file", FilesEx.toUriString(path), provider.getClass().getSimpleName());
+            return java.util.Optional.empty();
+        }
+        try {
+            java.util.Optional<Checksum> ck = ((ChecksumAwareFileSystemProvider) provider).headChecksum(path);
+            if( !ck.isPresent() )
+                log.warn("No cloud-native checksum for {} (provider={}) — falling back to default hashing; cross-bucket cache hits not possible for this file", FilesEx.toUriString(path), provider.getClass().getSimpleName());
+            return ck;
+        }
+        catch( Exception e ) {
+            log.warn("Cloud checksum lookup failed for {} via {}: {} — falling back to default hashing", FilesEx.toUriString(path), provider.getClass().getSimpleName(), e.getMessage());
+            return java.util.Optional.empty();
+        }
+    }
+
+    /**
+     * Hash a directory under CLOUD_HASH mode by walking the tree and summing
+     * the per-file cloud checksums commutatively (so traversal order doesn't
+     * matter), mirroring {@link #hashDirSha256}. Files in the directory that
+     * lack a cloud-native checksum fall back to their path+size+mtime
+     * contribution so the directory hash still reflects them.
+     */
+    static private Hasher hashDirCloud( Hasher hasher, Path dir, BasicFileAttributes dirAttrs, Path basePath ) {
+        final byte[] resultBytes = new byte[HASH_BYTES];
+        try {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                public FileVisitResult visitFile(Path p, BasicFileAttributes a) throws IOException {
+                    final String relPath = dir.relativize(p).toString();
+                    String contribution;
+                    try {
+                        java.util.Optional<Checksum> ck = lookupCloudChecksum(p);
+                        contribution = ck.isPresent()
+                                ? ck.get().toHashContribution()
+                                : String.format("%s|%d|%d", relPath, a.size(), a.lastModifiedTime() != null ? a.lastModifiedTime().toMillis() : -1L);
+                    }
+                    catch( Exception e ) {
+                        log.warn("Cloud checksum lookup failed for {}: {} — including path/size/mtime in directory hash instead", FilesEx.toUriString(p), e.getMessage());
+                        contribution = String.format("%s|%d|%d", relPath, a.size(), a.lastModifiedTime() != null ? a.lastModifiedTime().toMillis() : -1L);
+                    }
+                    sumBytes(resultBytes, hashBytes(Map.entry(relPath, contribution), HashMode.STANDARD));
+                    return FileVisitResult.CONTINUE;
+                }
+                public FileVisitResult preVisitDirectory(Path p, BasicFileAttributes a) {
+                    final String relPath = dir.relativize(p).toString();
+                    sumBytes(resultBytes, hashBytes(relPath, HashMode.STANDARD));
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            hasher.putBytes(resultBytes);
+        }
+        catch( IOException t ) {
+            Throwable err = t.getCause()!=null ? t.getCause() : t;
+            String msg = err.getMessage()!=null ? err.getMessage() : err.toString();
+            log.warn("Unable to compute cloud-hash for directory: {} — Cause: {}", FilesEx.toUriString(dir), msg);
+        }
+        return hasher;
     }
 
 

--- a/modules/nf-commons/src/main/nextflow/util/checksum/Checksum.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/checksum/Checksum.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.util.checksum
+
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * Immutable value object representing a content-addressable checksum produced
+ * by a cloud storage provider (e.g. S3 CRC64NVMe, GCS CRC32C, Azure MD5).
+ *
+ * Used by {@link ContentChecksumResolver} as the file-content contribution to
+ * the task hash when {@link nextflow.util.CacheHelper.HashMode#CLOUD_HASH} is
+ * active.
+ */
+@CompileStatic
+@EqualsAndHashCode
+class Checksum {
+
+    final String algo
+    final String value
+
+    Checksum(String algo, String value) {
+        if( !algo )  throw new IllegalArgumentException("Checksum.algo must not be null or blank")
+        if( !value ) throw new IllegalArgumentException("Checksum.value must not be null or blank")
+        this.algo = algo
+        this.value = value
+    }
+
+    String toHashContribution() { "${algo}:${value}" }
+}

--- a/modules/nf-commons/src/test/nextflow/util/checksum/ChecksumTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/checksum/ChecksumTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.util.checksum
+
+import spock.lang.Specification
+
+class ChecksumTest extends Specification {
+
+    def 'should expose algo + value and a canonical hash contribution'() {
+        given:
+        def ck = new Checksum('crc64nvme', 'abc123')
+
+        expect:
+        ck.algo == 'crc64nvme'
+        ck.value == 'abc123'
+        ck.toHashContribution() == 'crc64nvme:abc123'
+    }
+
+    def 'should reject null or blank fields'() {
+        when:
+        new Checksum(algo, value)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        algo        | value
+        null        | 'abc'
+        ''          | 'abc'
+        'crc64nvme' | null
+        'crc64nvme' | ''
+    }
+
+    def 'should implement equals and hashCode based on algo + value'() {
+        expect:
+        new Checksum('crc64nvme', 'abc') == new Checksum('crc64nvme', 'abc')
+        new Checksum('crc64nvme', 'abc').hashCode() == new Checksum('crc64nvme', 'abc').hashCode()
+        new Checksum('crc64nvme', 'abc') != new Checksum('sha256', 'abc')
+        new Checksum('crc64nvme', 'abc') != new Checksum('crc64nvme', 'xyz')
+    }
+}

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchExecutor.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.cloud.aws.batch
 
+import nextflow.cloud.aws.nio.S3Client
+
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
@@ -55,7 +55,8 @@ import software.amazon.awssdk.transfer.s3.model.*;
  */
 public class S3Client {
 
-	private static final Logger log = LoggerFactory.getLogger(S3Client.class);
+	public static ChecksumAlgorithm CHECKSUM_ALGORITH = ChecksumAlgorithm.SHA256;
+    private static final Logger log = LoggerFactory.getLogger(S3Client.class);
 
 	private software.amazon.awssdk.services.s3.S3Client client;
 
@@ -92,6 +93,14 @@ public class S3Client {
 		this.client = factory.getS3Client(clientConfig, global);
 		this.semaphore = Threads.useVirtual() ? new Semaphore(clientConfig.getMaxConnections()) : null;
 		this.callerAccount = fetchCallerAccount();
+	}
+
+	/**
+	 * Test-only constructor that bypasses the {@link AwsClientFactory} so unit
+	 * tests can inject a mocked SDK client. Not intended for production wiring.
+	 */
+	S3Client(software.amazon.awssdk.services.s3.S3Client client) {
+		this.client = client;
 	}
 
 	/**
@@ -164,7 +173,12 @@ public class S3Client {
 	 * @see software.amazon.awssdk.services.s3.S3Client#putObject
 	 */
 	public PutObjectResponse putObject(String bucket, String key, File file) {
-		PutObjectRequest.Builder builder = PutObjectRequest.builder().bucket(bucket).key(key);
+		PutObjectRequest.Builder builder = PutObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				// Request Checksum algorith so the object is reachable via the cloud-hash
+				// task-hash path (see S3FileSystemProvider.headChecksum).
+				.checksumAlgorithm(ChecksumAlgorithm.SHA256);
 		if( cannedAcl != null ) {
 			log.trace("Setting canned ACL={}; bucket={}; key={}", cannedAcl, bucket, key);
 			builder.acl(cannedAcl);
@@ -173,6 +187,11 @@ public class S3Client {
 	}
 
 	private PutObjectRequest preparePutObjectRequest(PutObjectRequest.Builder reqBuilder, List<Tag> tags, String contentType, String storageClass) {
+		// Request checksum on every PUT this helper
+		// builds, so the object is reachable via the cloud-hash task-hash
+		// path. Set unconditionally here because every caller routes through
+		// preparePutObjectRequest.
+		reqBuilder.checksumAlgorithm(CHECKSUM_ALGORITH);
 		if( cannedAcl != null ) {
 			reqBuilder.acl(cannedAcl);
 		}
@@ -200,7 +219,9 @@ public class S3Client {
 	public PutObjectResponse putObject(String bucket, String keyName, InputStream inputStream, List<Tag> tags, String contentType, long contentLength) {
 		PutObjectRequest.Builder reqBuilder = PutObjectRequest.builder()
 			.bucket(bucket)
-			.key(keyName);
+			.key(keyName)
+			// Request additional checksum (cloud-hash task-hash path).
+			.checksumAlgorithm(CHECKSUM_ALGORITH);
 		if( cannedAcl != null ) {
 			reqBuilder.acl(cannedAcl);
 		}
@@ -285,7 +306,14 @@ public class S3Client {
 	 * @see software.amazon.awssdk.services.s3.S3Client#headObject
 	 */
 	public HeadObjectResponse getObjectMetadata(String bucketName, String key) {
-		return runWithPermit(() -> client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()));
+		// Enable ChecksumMode so the response carries x-amz-checksum-* headers
+		// (notably CRC64NVMe, the default since 2025). Required for the
+		// cloud-checksum task hashing path; harmless for existing callers.
+		return runWithPermit(() -> client.headObject(HeadObjectRequest.builder()
+				.bucket(bucketName)
+				.key(key)
+				.checksumMode(ChecksumMode.ENABLED)
+				.build()));
 	}
 
     /**
@@ -470,6 +498,10 @@ public class S3Client {
 
 	private PutObjectRequest.Builder updateBuilder(PutObjectRequest.Builder porBuilder, List<Tag> tags) {
 
+		// Request checksum TransferManager-driven uploads (uploadFile,
+		// uploadDirectory) populate the additional checksum needed by the
+		// cloud-hash task-hash path.
+		porBuilder.checksumAlgorithm(CHECKSUM_ALGORITH);
 		if( cannedAcl != null )
 			porBuilder.acl(cannedAcl);
 		if( storageEncryption != null )
@@ -505,6 +537,9 @@ public class S3Client {
 	}
 
     public void copyFile(CopyObjectRequest.Builder reqBuilder, List<Tag> tags, String contentType, String storageClass) throws IOException {
+		// Request checksum on the destination so a copied object remains
+		// reachable via the cloud-hash task-hash path.
+		reqBuilder.checksumAlgorithm(CHECKSUM_ALGORITH);
 		if( tags !=null && !tags.isEmpty()) {
 			log.debug("Setting tags: {}", tags);
             reqBuilder.taggingDirective(TaggingDirective.REPLACE);

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
@@ -74,9 +74,11 @@ import nextflow.cloud.aws.nio.util.S3MultipartOptions;
 import nextflow.cloud.aws.nio.util.S3ObjectId;
 import nextflow.cloud.aws.nio.util.S3ObjectSummaryLookup;
 import nextflow.extension.FilesEx;
+import nextflow.file.ChecksumAwareFileSystemProvider;
 import nextflow.file.CopyOptions;
 import nextflow.file.FileHelper;
 import nextflow.file.FileSystemTransferAware;
+import nextflow.util.checksum.Checksum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +111,7 @@ import static java.lang.String.format;
  *
  *
  */
-public class S3FileSystemProvider extends FileSystemProvider implements FileSystemTransferAware {
+public class S3FileSystemProvider extends FileSystemProvider implements FileSystemTransferAware, ChecksumAwareFileSystemProvider {
 
 	private static final Logger log = LoggerFactory.getLogger(S3FileSystemProvider.class);
 
@@ -261,6 +263,37 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
 		}
 
 		return createUploaderOutputStream(s3Path, createNew);
+	}
+
+	/**
+	 * Implementation of {@link ChecksumAwareFileSystemProvider#headChecksum} for s3:// paths.
+	 *
+	 * Reads CRC64NVMe via {@code HeadObject} with {@code ChecksumMode.ENABLED}.
+	 * CRC64NVMe has been default on every new S3 PUT/multipart upload since
+	 * early 2025 and is FULL_OBJECT-only on S3, so the value is content-stable
+	 * across single-part vs multipart uploads and across buckets. Returns
+	 * {@link Optional#empty()} when the object lacks CRC64NVMe (e.g. pre-2025
+	 * objects or KMS configurations with additional checksums disabled),
+	 * signalling the caller to fall back to default hashing.
+	 */
+	@Override
+	public Optional<Checksum> headChecksum(Path path) {
+		if( !(path instanceof S3Path) )
+			return Optional.empty();
+		final S3Path s3 = (S3Path) path;
+		final HeadObjectResponse resp = s3.getFileSystem().getClient().getObjectMetadata(s3.getBucket(), s3.getKey());
+		final String base64 = resp.checksumSHA256();
+		if( base64 == null )
+			return Optional.empty();
+		return Optional.of(new Checksum(S3Client.CHECKSUM_ALGORITH.name(), base64ToHex(base64)));
+	}
+
+	private static String base64ToHex(String base64) {
+		final byte[] bytes = java.util.Base64.getDecoder().decode(base64);
+		final StringBuilder sb = new StringBuilder(bytes.length * 2);
+		for( byte b : bytes )
+			sb.append(String.format("%02x", b & 0xFF));
+		return sb.toString();
 	}
 
 	@Override
@@ -544,7 +577,10 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
                 .sourceBucket(s3Source.getBucket())
                 .sourceKey(s3Source.getKey())
                 .destinationBucket(s3Target.getBucket())
-                .destinationKey(s3Target.getKey());
+                .destinationKey(s3Target.getKey())
+                // Ensure copy destination carries checksum so cloud-hash
+                // task hashing can reach it via the FS provider HEAD path.
+                .checksumAlgorithm(S3Client.CHECKSUM_ALGORITH);
 			log.trace("Copy file via copy object - source: source={}, target={}, tags={}, storageClass={}", s3Source, s3Target, tags, storageClass);
 			client.copyFile(reqBuilder, tags, contentType, storageClass);
 	}

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3OutputStream.java
@@ -422,6 +422,14 @@ public final class S3OutputStream extends OutputStream {
         final CreateMultipartUploadRequest.Builder reqBuilder = //
                 CreateMultipartUploadRequest.builder().bucket(objectId.bucket()).key(objectId.key());
 
+        // Request  additional checksum. This algorith should be FULL_OBJECT-only
+        // on S3, so the value is content-stable across single-part vs
+        // multipart vs different part-size uploads — enabling the cloud-hash
+        // task-hash experiment to converge across buckets. The SDK applies
+        // the algorithm to each UploadPart automatically and the completed
+        // object exposes it via x-amz-checksum-x.
+        reqBuilder.checksumAlgorithm(nextflow.cloud.aws.nio.S3Client.CHECKSUM_ALGORITH);
+
         if (storageClass != null) {
             reqBuilder.storageClass(storageClass);
         }
@@ -608,6 +616,10 @@ public final class S3OutputStream extends OutputStream {
         reqBuilder.key(objectId.key());
         reqBuilder.contentLength(contentLength);
         reqBuilder.contentMD5( Base64.getEncoder().encodeToString(checksum) );
+        // Request additional checksum so the object is hashable by
+        // S3FileSystemProvider.headChecksum (the cloud-hash task-hash path).
+        // SDK computes it client-side and sends x-amz-checksum-x.
+        reqBuilder.checksumAlgorithm(nextflow.cloud.aws.nio.S3Client.CHECKSUM_ALGORITH);
         if( cannedAcl!=null ) {
             reqBuilder.acl(cannedAcl);
         }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/util/S3BashLib.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import nextflow.Global
 import nextflow.Session
 import nextflow.cloud.aws.batch.AwsOptions
+import nextflow.cloud.aws.nio.S3Client
 import nextflow.executor.BashFunLib
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 
@@ -39,6 +40,7 @@ class S3BashLib extends BashFunLib<S3BashLib> {
     private String acl = ''
     private String requesterPays = ''
     private String forceGlacierTransfer = ''
+    private String checksum = "--checksum-algorithm ${S3Client.CHECKSUM_ALGORITH.name().toUpperCase()} "
 
     S3BashLib withCliPath(String cliPath) {
         if( cliPath )
@@ -118,11 +120,11 @@ class S3BashLib extends BashFunLib<S3BashLib> {
             local name=\$1
             local s3path=\$2
             if [[ "\$name" == - ]]; then
-              $cli s3 cp --only-show-errors ${debug}${acl}${storageEncryption}${storageKmsKeyId}${requesterPays}--storage-class $storageClass - "\$s3path"
+              $cli s3 cp --only-show-errors ${debug}${acl}${storageEncryption}${storageKmsKeyId}${requesterPays}${checksum}--storage-class $storageClass - "\$s3path"
             elif [[ -d "\$name" ]]; then
-              $cli s3 cp --only-show-errors --recursive ${debug}${acl}${storageEncryption}${storageKmsKeyId}${requesterPays}--storage-class $storageClass "\$name" "\$s3path/\$name"
+              $cli s3 cp --only-show-errors --recursive ${debug}${acl}${storageEncryption}${storageKmsKeyId}${requesterPays}${checksum}--storage-class $storageClass "\$name" "\$s3path/\$name"
             else
-              $cli s3 cp --only-show-errors ${debug}${acl}${storageEncryption}${storageKmsKeyId}${requesterPays}--storage-class $storageClass "\$name" "\$s3path/\$name"
+              $cli s3 cp --only-show-errors ${debug}${acl}${storageEncryption}${storageKmsKeyId}${requesterPays}${checksum}--storage-class $storageClass "\$name" "\$s3path/\$name"
             fi
         }
         

--- a/plugins/nf-amazon/src/test/nextflow/S3SessionTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/S3SessionTest.groovy
@@ -49,12 +49,23 @@ class S3SessionTest extends Specification {
     def 'should error with non-cloud bucket' () {
         given:
         def session = Spy(Session)
+        // NXF_GLOBALCACHE_PATH prototype added 'file' to the accepted scheme
+        // list (alongside s3/az/gs), so a local path no longer triggers the
+        // rejection. Stub the full Path → FileSystem → provider → scheme
+        // chain to produce a foreign scheme that should still be rejected.
+        def provider = Mock(java.nio.file.spi.FileSystemProvider)
+        provider.getScheme() >> 'ftp'
+        def fs = Mock(java.nio.file.FileSystem)
+        fs.provider() >> provider
+        def badWorkDir = Mock(Path)
+        badWorkDir.getFileSystem() >> fs
+        badWorkDir.toString() >> 'ftp://foo/dir'
 
         when:
-        session.cloudCachePath([enabled:true], Path.of('/foo/dir'))
+        session.cloudCachePath([enabled:true], badWorkDir)
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == "Storage path not supported by Cloud-cache - offending value: '/foo/dir'"
+        e.message == "Storage path not supported by Cloud-cache - offending value: 'ftp://foo/dir'"
 
     }
 

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchFileCopyStrategyTest.groovy
@@ -190,11 +190,11 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                         local name=$1
                         local s3path=$2
                         if [[ "$name" == - ]]; then
-                          aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                         elif [[ -d "$name" ]]; then
-                          aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         else
-                          aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         fi
                     }
 
@@ -281,11 +281,11 @@ class AwsBatchFileCopyStrategyTest extends Specification {
                     local name=$1
                     local s3path=$2
                     if [[ "$name" == - ]]; then
-                      /foo/aws s3 cp --only-show-errors --sse AES256 --storage-class STANDARD_IA - "$s3path"
+                      /foo/aws s3 cp --only-show-errors --sse AES256 --checksum-algorithm SHA256 --storage-class STANDARD_IA - "$s3path"
                     elif [[ -d "$name" ]]; then
-                      /foo/aws s3 cp --only-show-errors --recursive --sse AES256 --storage-class STANDARD_IA "$name" "$s3path/$name"
+                      /foo/aws s3 cp --only-show-errors --recursive --sse AES256 --checksum-algorithm SHA256 --storage-class STANDARD_IA "$name" "$s3path/$name"
                     else
-                      /foo/aws s3 cp --only-show-errors --sse AES256 --storage-class STANDARD_IA "$name" "$s3path/$name"
+                      /foo/aws s3 cp --only-show-errors --sse AES256 --checksum-algorithm SHA256 --storage-class STANDARD_IA "$name" "$s3path/$name"
                     fi
                 }
  

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchScriptLauncherTest.groovy
@@ -124,11 +124,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                     local name=$1
                     local s3path=$2
                     if [[ "$name" == - ]]; then
-                      /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                      /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                     elif [[ -d "$name" ]]; then
-                      /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                      /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                     else
-                      /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                      /conda/bin/aws --region eu-west-1 s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                     fi
                 }
                 
@@ -303,11 +303,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                         local name=$1
                         local s3path=$2
                         if [[ "$name" == - ]]; then
-                          aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                         elif [[ -d "$name" ]]; then
-                          aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         else
-                          aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         fi
                     }
                     
@@ -475,11 +475,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                         local name=$1
                         local s3path=$2
                         if [[ "$name" == - ]]; then
-                          aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                         elif [[ -d "$name" ]]; then
-                          aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         else
-                          aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         fi
                     }
                     
@@ -591,11 +591,11 @@ class AwsBatchScriptLauncherTest extends Specification {
                         local name=$1
                         local s3path=$2
                         if [[ "$name" == - ]]; then
-                          aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                         elif [[ -d "$name" ]]; then
-                          aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         else
-                          aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         fi
                     }
                     

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3ClientTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3ClientTest.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.cloud.aws.nio
+
+import software.amazon.awssdk.services.s3.model.ChecksumMode
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse
+import spock.lang.Specification
+
+class S3ClientTest extends Specification {
+
+    def 'getObjectMetadata enables ChecksumMode so x-amz-checksum-* headers are returned'() {
+        given:
+        def aws = Mock(software.amazon.awssdk.services.s3.S3Client)
+        def s3  = new S3Client(aws)
+        HeadObjectRequest captured = null
+
+        when:
+        s3.getObjectMetadata('bucket', 'key')
+
+        then:
+        1 * aws.headObject(_ as HeadObjectRequest) >> { HeadObjectRequest req ->
+            captured = req
+            HeadObjectResponse.builder().build()
+        }
+        captured.checksumMode() == ChecksumMode.ENABLED
+        captured.bucket() == 'bucket'
+        captured.key() == 'key'
+    }
+}

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/util/S3BashLibTest.groovy
@@ -89,11 +89,11 @@ class S3BashLibTest extends Specification {
                         local name=$1
                         local s3path=$2
                         if [[ "$name" == - ]]; then
-                          aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                         elif [[ -d "$name" ]]; then
-                          aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         else
-                          aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                          aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                         fi
                     }
                     
@@ -188,11 +188,11 @@ class S3BashLibTest extends Specification {
                         local name=$1
                         local s3path=$2
                         if [[ "$name" == - ]]; then
-                          /foo/bin/aws s3 cp --only-show-errors --sse S-ENCRYPT --storage-class S-CLAZZ - "$s3path"
+                          /foo/bin/aws s3 cp --only-show-errors --sse S-ENCRYPT --checksum-algorithm SHA256 --storage-class S-CLAZZ - "$s3path"
                         elif [[ -d "$name" ]]; then
-                          /foo/bin/aws s3 cp --only-show-errors --recursive --sse S-ENCRYPT --storage-class S-CLAZZ "$name" "$s3path/$name"
+                          /foo/bin/aws s3 cp --only-show-errors --recursive --sse S-ENCRYPT --checksum-algorithm SHA256 --storage-class S-CLAZZ "$name" "$s3path/$name"
                         else
-                          /foo/bin/aws s3 cp --only-show-errors --sse S-ENCRYPT --storage-class S-CLAZZ "$name" "$s3path/$name"
+                          /foo/bin/aws s3 cp --only-show-errors --sse S-ENCRYPT --checksum-algorithm SHA256 --storage-class S-CLAZZ "$name" "$s3path/$name"
                         fi
                     }
                     
@@ -230,11 +230,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -268,11 +268,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -303,11 +303,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -341,11 +341,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  /some/bin/aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  /some/bin/aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  /some/bin/aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  /some/bin/aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  /some/bin/aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  /some/bin/aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -435,11 +435,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -526,11 +526,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -623,11 +623,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --sse aws:kms --sse-kms-key-id my-kms-key --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --sse aws:kms --sse-kms-key-id my-kms-key --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --sse aws:kms --sse-kms-key-id my-kms-key --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --sse aws:kms --sse-kms-key-id my-kms-key --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --sse aws:kms --sse-kms-key-id my-kms-key --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --sse aws:kms --sse-kms-key-id my-kms-key --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -721,11 +721,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --acl public-read --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --acl public-read --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --acl public-read --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --acl public-read --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --acl public-read --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --acl public-read --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -833,11 +833,11 @@ class S3BashLibTest extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
 

--- a/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/executor/BashWrapperBuilderWithS3Test.groovy
@@ -72,11 +72,11 @@ class BashWrapperBuilderWithS3Test extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             
@@ -192,11 +192,11 @@ class BashWrapperBuilderWithS3Test extends Specification {
                 local name=$1
                 local s3path=$2
                 if [[ "$name" == - ]]; then
-                  aws s3 cp --only-show-errors --storage-class STANDARD - "$s3path"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD - "$s3path"
                 elif [[ -d "$name" ]]; then
-                  aws s3 cp --only-show-errors --recursive --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --recursive --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 else
-                  aws s3 cp --only-show-errors --storage-class STANDARD "$name" "$s3path/$name"
+                  aws s3 cp --only-show-errors --checksum-algorithm SHA256 --storage-class STANDARD "$name" "$s3path/$name"
                 fi
             }
             

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzFileSystemProvider.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzFileSystemProvider.groovy
@@ -43,6 +43,8 @@ import com.azure.storage.blob.models.BlobStorageException
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.cloud.azure.batch.AzHelper
+import nextflow.file.ChecksumAwareFileSystemProvider
+import nextflow.util.checksum.Checksum
 /**
  * Implements NIO File system provider for Azure Blob Storage
  *
@@ -50,7 +52,7 @@ import nextflow.cloud.azure.batch.AzHelper
  */
 @Slf4j
 @CompileStatic
-class AzFileSystemProvider extends FileSystemProvider {
+class AzFileSystemProvider extends FileSystemProvider implements ChecksumAwareFileSystemProvider {
 
     public static final String AZURE_STORAGE_ACCOUNT_NAME = 'AZURE_STORAGE_ACCOUNT_NAME'
     public static final String AZURE_STORAGE_ACCOUNT_KEY = 'AZURE_STORAGE_ACCOUNT_KEY'
@@ -519,6 +521,36 @@ class AzFileSystemProvider extends FileSystemProvider {
     @Override
     void setAttribute(Path path, String attribute, Object value, LinkOption... options) throws IOException {
         throw new UnsupportedOperationException("Operation 'setAttribute' is not supported by AzFileSystem")
+    }
+
+    /**
+     * Implementation of {@link ChecksumAwareFileSystemProvider#headChecksum} for
+     * Azure Blob Storage paths.
+     *
+     * Returns the blob's stored {@code Content-MD5} via a single GET-properties
+     * call. Azure only stores MD5 (no native CRC64NVMe / CRC32C); blobs uploaded
+     * without an MD5 will have a null property and we fall through to default
+     * hashing. The value is content-stable for the same uploader (same upload
+     * method) but, like S3 ETag, can differ when the same content is uploaded
+     * with different chunk sizes — accepted limitation for the experiment.
+     */
+    @Override
+    Optional<Checksum> headChecksum(Path path) {
+        if( !(path instanceof AzPath) )
+            return Optional.<Checksum>empty()
+        final azPath = (AzPath) path
+        final props = azPath.blobClient().getProperties()
+        final md5 = props?.getContentMd5()
+        if( md5 == null || md5.length == 0 )
+            return Optional.<Checksum>empty()
+        return Optional.of(new Checksum('md5', bytesToHex(md5)))
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        final sb = new StringBuilder(bytes.length * 2)
+        for( byte b : bytes )
+            sb.append(String.format('%02x', b & 0xFF))
+        return sb.toString()
     }
 
 }


### PR DESCRIPTION
## Summary

Experimental implementation of cloud-storage-native content checksums as the file-content contribution to the Nextflow task hash, layered on top of the existing global-cache prototype (`NXF_GLOBALCACHE_PATH`). Enables cross-bucket, cross-region task cache reuse without changing the workdir layout.

Builds on extending `nf-cloudcache` as global-cache work. Targets the `global-cache-playground-concurrency` branch.

## Motivation

The existing prototype on `global-cache-playground-concurrency` zeroes `sessionId` and drops `processName` from the task hash, enabling cross-pipeline reuse — but file inputs are still hashed via `HashMode.STANDARD` (path + size + mtime). The same content at two different paths produces two different task hashes, so cross-bucket / cross-region cache reuse never materialises.

This PR replaces the file-content contribution with the cloud-storage-native checksum (S3 SHA256, Azure MD5), making the task hash truly content-addressable for cloud-resident files.

## Design

Capability-interface pattern, mirroring the existing `FileSystemTransferAware`:

- **`nextflow.util.checksum.Checksum`** (nf-commons) — value object `{algo, value}` with a canonical `toHashContribution()` rendering as `"algo:value"`.
- **`nextflow.file.ChecksumAwareFileSystemProvider`** (nf-commons) — capability interface implemented by cloud `FileSystemProvider`s that can return a content-addressable checksum via a single HEAD-style metadata call.
- **`CacheHelper.HashMode.CLOUD_HASH`** — new enum value. Parsed via `"cloud-hash"` / `"cloud_hash"`.
- **`FileHolder.funnel`** — when mode is `CLOUD_HASH`, routes to `storePath` (workdir-side staged location) rather than `sourceObj`, then delegates to `HashBuilder.hashFile`.
- **`HashBuilder.hashFile`** — handles `CLOUD_HASH` for regular files (single HEAD) and directories (walk + commutative sum, mirroring `hashDirSha256`). Files / dirs without a usable native checksum fall back to STANDARD path+size+mtime with a distinct WARN log per cause.
- **`TaskHasher`** — overrides the configured hash mode to `CLOUD_HASH` automatically when global-cache mode is active (`session.uniqueId == 0000…0000`).

Cloud-side implementations:

- **`S3FileSystemProvider`** (nf-amazon) implements `headChecksum`, reading `checksumSHA256()` from a `HeadObject` with `ChecksumMode.ENABLED`.
- **`AzFileSystemProvider`** (nf-azure) implements `headChecksum`, reading `blobClient().getProperties().getContentMd5()`.
- **`S3OutputStream`, `S3Client`, `S3BashLib`** — every Nextflow-initiated S3 upload now requests `ChecksumAlgorithm.SHA256` (centralised via `S3Client.CHECKSUM_ALGORITH`) so objects Nextflow writes are reachable by `headChecksum`. `aws s3 cp` in the task wrapper gains `--checksum-algorithm SHA256`. `s5cmd` is left alone (the binary doesn't accept the flag).

Supporting fixes:

- **`SerializationHelper`** — `kryo.setRegistrationRequired(false)` + plugin-contributed serializers attached via `addDefaultSerializer` instead of positional `register(...)`. Cached `TaskContext` blobs are now plugin-set-independent (previously, switching the loaded plugin set between cache write and read shifted Kryo numeric class IDs and triggered `Encountered unregistered class ID: N`).
- **`SerializationHelper.getPluginAwareClassLoader`** — Kryo classloader that delegates to pf4j `PluginClassLoader`s so name-encoded class lookups can resolve plugin classes (`S3Path`, `AzPath`, etc.).
- **`Session.init` / `ConfigBuilder`** — the bootstrap mkdirs of `${NXF_GLOBALCACHE_PATH}/cache/${sessionId}` moves out of `ConfigBuilder` (too early for Azure: `AzPathFactory.parseUri` reads `session.config.azure`, which isn't set yet) into `Session.init` (after `Global.setSession`).

## Known limitations

- **Pre-existing S3 objects without an `x-amz-checksum-*` header** (e.g. uploaded before SHA256 was the configured default, or uploaded via tools that don't request additional checksums) fall back to STANDARD path+size+mtime. Backfilling them requires a `CopyObject --checksum-algorithm SHA256` pass for buckets you own, or the S3 Batch Operations "Compute checksum" job for read-only public buckets — not implemented here.
- **Default S3 checksum varies by API surface.** The AWS console uses CRC64NVMe by default, the AWS CLI defaults to CRC32, and other SDKs vary. Nextflow now forces SHA256 on every write it controls (SDK uploads, `S3OutputStream`, `aws s3 cp` from `S3BashLib`), so objects Nextflow produces converge on one algorithm. Objects produced **outside** Nextflow (manual uploads, external tools) may carry a different additional-checksum algorithm and won't be reachable by `headChecksum` until backfilled.
- **GCS support is deferred.** GCS uses Google's `CloudStorageFileSystemProvider`, which can't be extended with the capability interface directly. In practice this is currently not a limitation for the global cache: GCS inputs are foreign-scheme and get ported into the workdir by `FilePorter` before `TaskHasher` runs, so they participate in cloud-hash via their workdir-side copy under the workdir's native algorithm.
- **Multi-provider Fusion / direct-cloud-access scenarios** — if Fusion or similar mechanisms let a task read directly from a different cloud without staging through `FilePorter`, the file would not be reachable via the workdir's `ChecksumAwareFileSystemProvider` and would fall back to STANDARD. This is a forward-looking limitation rather than a present one.
- **`s5cmd cp` does not accept `--checksum-algorithm`** — deployments using s5cmd rely on whatever default that binary applies. Documented as a comment in `AwsBatchExecutor.s3Cmd`.
- **Directory inputs** are walked and per-file hashes are summed commutatively. Wide directories (`fastqc/*/`, `multiqc/`) issue one HEAD per file at hash time — acceptable for an experiment, worth memoising on the FS provider if measurements call for it.

## Reviewer notes

- Targets `global-cache-playground-concurrency` (not `master`) — this is experimental, not for direct master merge.
- Each fall-through case in `HashBuilder.lookupCloudChecksum` emits a distinct WARN so it's easy to see in `.nextflow.log` why a particular input isn't getting cross-bucket hits.
- The change to `SerializationHelper` is broader than just the global cache (affects all Kryo use in Nextflow). The behaviour is more permissive: previously-unregistered classes are now name-encoded rather than throwing. This needs careful review before any landing on `master`.
- `S3OutputStream` retains the existing `Content-MD5` integrity header alongside the new `checksumAlgorithm(SHA256)`. They're independent and complementary.