### PR TITLE
Fix destructured record input in `module run`

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -31,6 +31,8 @@ import nextflow.script.params.StdInParam
 import nextflow.script.params.TupleInParam
 import nextflow.script.params.v2.ProcessInput
 import nextflow.script.params.v2.ProcessTupleInput
+import nextflow.script.types.Record
+import nextflow.util.RecordMap
 
 /**
  * Helper class for process entry execution feature.
@@ -357,8 +359,16 @@ class ProcessEntryHandler {
         // Map declared inputs to command-line arguments
         List arguments = []
         for( final param : declaredInputs ) {
-            if( param instanceof ProcessTupleInput ) {
-                List tupleElements = []
+            if( param instanceof ProcessTupleInput && param.getType() == Record.class ) {
+                final Map<String,Object> recordFields = [:]
+                for( final innerParam : param.getComponents() ) {
+                    final value = getValueForInputV2(innerParam, paramValues)
+                    recordFields.put(innerParam.getName(), value)
+                }
+                arguments.add(new RecordMap(recordFields))
+            }
+            else if( param instanceof ProcessTupleInput ) {
+                final List tupleElements = []
                 for( final innerParam : param.getComponents() ) {
                     final value = getValueForInputV2(innerParam, paramValues)
                     tupleElements.add(value)

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -25,6 +25,9 @@ import nextflow.script.params.TupleInParam
 import nextflow.script.params.ValueInParam
 import nextflow.script.params.v2.ProcessInput
 import nextflow.script.params.v2.ProcessInputsDef
+import nextflow.script.params.v2.ProcessTupleInput
+import nextflow.script.types.Record
+import nextflow.util.RecordMap
 import spock.lang.Specification
 
 /**
@@ -248,6 +251,42 @@ class ProcessEntryHandlerTest extends Specification {
         tupleElements[0].other == 'some-value'
         // tupleElements[1] should be a Path object (mocked)
         tupleElements[1].toString().contains('file.fa')
+    }
+
+    def 'should support destructured record input in typed process' () {
+        given:
+        def session = Mock(Session) {
+            getParams() >> ['id': 'abc', 'greeting': 'hello']
+        }
+        def script = Mock(BaseScript)
+        def meta = Mock(ScriptMeta) {
+            getLocalProcessNames() >> ['RECORDS']
+        }
+        def handler = new ProcessEntryHandler(script, session, meta)
+
+        and: 'a ProcessTupleInput representing a record(id: String, greeting: String)'
+        def idInput = new ProcessInput('id', String, false)
+        def greetingInput = new ProcessInput('greeting', String, false)
+        def recordParam = new ProcessTupleInput([idInput, greetingInput], Record)
+
+        and: 'a V2 config declaring that one record input'
+        def inputsDef = new ProcessInputsDef()
+        inputsDef.addTupleParam([idInput, greetingInput], Record)
+        def processConfig = Mock(ProcessConfigV2) {
+            getInputs() >> inputsDef
+        }
+        def processDef = Mock(ProcessDef) {
+            getProcessConfig() >> processConfig
+        }
+
+        when:
+        def args = handler.getProcessArguments(processDef, ['id': 'abc', 'greeting': 'hello'])
+
+        then: 'a single RecordMap is returned'
+        args.size() == 1
+        args[0] instanceof RecordMap
+        args[0].id == 'abc'
+        args[0].greeting == 'hello'
     }
 
     def 'should convert string parameter to type declared in module spec' () {


### PR DESCRIPTION
Close #7162 

This PR fixes a bug in `module run` where destructured record inputs were not constructed correctly from CLI params.