### PR TITLE
Add nextflow lineage validate command (first pass)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -46,6 +46,7 @@ class CmdLineage extends CmdBase implements UsageAware {
         void diff(ConfigMap config, List<String> args)
         void find(ConfigMap config, List<String> args)
         void check(ConfigMap config, List<String> args)
+        void validate(ConfigMap config, List<String> args)
     }
 
     interface SubCmd {
@@ -68,6 +69,7 @@ class CmdLineage extends CmdBase implements UsageAware {
         commands << new CmdDiff()
         commands << new CmdFind()
         commands << new CmdCheck()
+        commands << new CmdValidate()
     }
 
     @Parameter(hidden = true)
@@ -307,6 +309,38 @@ class CmdLineage extends CmdBase implements UsageAware {
         void usage() {
             println description
             println "Usage: nextflow $NAME $name <lid-file>"
+        }
+
+    }
+
+    class CmdValidate implements SubCmd {
+
+        @Override
+        String getName() { 'validate' }
+
+        @Override
+        String getDescription() {
+            return 'Validate that two workflow runs are semantically equivalent'
+        }
+
+        void apply(List<String> args) {
+            if (args.size() < 2) {
+                println("ERROR: Incorrect number of parameters")
+                usage()
+                return
+            }
+            operation.validate(config, args)
+        }
+
+        @Override
+        void usage() {
+            println description
+            println "Usage: nextflow $NAME $name <lid> --against <baseline-lid> [--ignore-fields field1,field2]"
+            println ""
+            println "Options:"
+            println "  --against <lid>         The baseline workflow run to compare against"
+            println "  --ignore-fields <list>  Comma-separated list of additional fields to ignore"
+            println "  --output-base <path>    Base path for relativizing output file paths"
         }
 
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -75,6 +75,15 @@ class CmdLineage extends CmdBase implements UsageAware {
     @Parameter(hidden = true)
     List<String> args
 
+    @Parameter(names = ['-against'], description = 'Baseline lineage ID for the validate sub-command', hidden = true)
+    String validateAgainst
+
+    @Parameter(names = ['-ignore-fields'], description = 'Comma-separated fields to ignore in validate', hidden = true)
+    String validateIgnoreFields
+
+    @Parameter(names = ['-output-base'], description = 'Base path for output relativization in validate', hidden = true)
+    String validateOutputBase
+
     @Override
     String getName() {
         return NAME
@@ -99,8 +108,18 @@ class CmdLineage extends CmdBase implements UsageAware {
         this.operation = Plugins.getExtension(LinCommand)
         if( !operation )
             throw new IllegalStateException("Unable to load lineage extensions.")
-        // consume the first argument
-        getCmd(args).apply(args.drop(1))
+        // forward sub-command-level options consumed by JCommander
+        final subArgs = new ArrayList<String>(args.drop(1))
+        if( validateAgainst != null ) {
+            subArgs.add('--against'); subArgs.add(validateAgainst)
+        }
+        if( validateIgnoreFields != null ) {
+            subArgs.add('--ignore-fields'); subArgs.add(validateIgnoreFields)
+        }
+        if( validateOutputBase != null ) {
+            subArgs.add('--output-base'); subArgs.add(validateOutputBase)
+        }
+        getCmd(args).apply(subArgs)
     }
 
     /**
@@ -335,12 +354,12 @@ class CmdLineage extends CmdBase implements UsageAware {
         @Override
         void usage() {
             println description
-            println "Usage: nextflow $NAME $name <lid> --against <baseline-lid> [--ignore-fields field1,field2]"
+            println "Usage: nextflow $NAME $name <lid> -against <baseline-lid> [-ignore-fields field1,field2]"
             println ""
             println "Options:"
-            println "  --against <lid>         The baseline workflow run to compare against"
-            println "  --ignore-fields <list>  Comma-separated list of additional fields to ignore"
-            println "  --output-base <path>    Base path for relativizing output file paths"
+            println "  -against <lid>         The baseline workflow run to compare against"
+            println "  -ignore-fields <list>  Comma-separated list of additional fields to ignore"
+            println "  -output-base <path>    Base path for relativizing output file paths"
         }
 
     }

--- a/modules/nextflow/src/test/groovy/nextflow/cli/LauncherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/LauncherTest.groovy
@@ -20,7 +20,6 @@ import java.nio.file.Files
 
 import com.beust.jcommander.DynamicParameter
 import com.beust.jcommander.Parameter
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
@@ -119,7 +118,6 @@ class LauncherTest extends Specification {
     }
 
 
-    @PendingFeature(reason = 'CmdLineage does not yet declare -against/-ignore-fields/-output-base; JCommander rejects them')
     def 'should parse `lineage validate` with -against'() {
         when:
         def launcher = new Launcher().parseMainArgs('lineage','validate','lid://aaa','-against','lid://bbb')
@@ -129,7 +127,6 @@ class LauncherTest extends Specification {
         launcher.command.validateAgainst == 'lid://bbb'
     }
 
-    @PendingFeature(reason = 'CmdLineage does not yet declare -against/-ignore-fields/-output-base; JCommander rejects them')
     def 'should parse `lineage validate` with -ignore-fields and -output-base'() {
         when:
         def launcher = new Launcher().parseMainArgs('lineage','validate','lid://aaa','-against','lid://bbb','-ignore-fields','x,y','-output-base','/tmp/out')

--- a/modules/nextflow/src/test/groovy/nextflow/cli/LauncherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/LauncherTest.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Files
 
 import com.beust.jcommander.DynamicParameter
 import com.beust.jcommander.Parameter
+import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
@@ -117,6 +118,27 @@ class LauncherTest extends Specification {
         launcher.command.hubPassword == 'yy'
     }
 
+
+    @PendingFeature(reason = 'CmdLineage does not yet declare -against/-ignore-fields/-output-base; JCommander rejects them')
+    def 'should parse `lineage validate` with -against'() {
+        when:
+        def launcher = new Launcher().parseMainArgs('lineage','validate','lid://aaa','-against','lid://bbb')
+        then:
+        launcher.command instanceof CmdLineage
+        launcher.command.args == ['validate','lid://aaa']
+        launcher.command.validateAgainst == 'lid://bbb'
+    }
+
+    @PendingFeature(reason = 'CmdLineage does not yet declare -against/-ignore-fields/-output-base; JCommander rejects them')
+    def 'should parse `lineage validate` with -ignore-fields and -output-base'() {
+        when:
+        def launcher = new Launcher().parseMainArgs('lineage','validate','lid://aaa','-against','lid://bbb','-ignore-fields','x,y','-output-base','/tmp/out')
+        then:
+        launcher.command instanceof CmdLineage
+        launcher.command.validateAgainst == 'lid://bbb'
+        launcher.command.validateIgnoreFields == 'x,y'
+        launcher.command.validateOutputBase == '/tmp/out'
+    }
 
     def 'should return `run` command'() {
         when:

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinNormalizer.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinNormalizer.groovy
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.lineage
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import nextflow.lineage.model.v1beta1.FileOutput
+import nextflow.lineage.model.v1beta1.TaskRun
+import nextflow.lineage.model.v1beta1.WorkflowOutput
+import nextflow.lineage.model.v1beta1.WorkflowRun
+import nextflow.lineage.serde.LinEncoder
+import nextflow.lineage.serde.LinSerializable
+
+/**
+ * Normalizes lineage data for comparison by stripping ephemeral fields
+ * (timestamps, session IDs, absolute paths) that vary between runs but
+ * don't affect semantic equivalence.
+ *
+ * @author Edmund Miller <edmund.a.miller@gmail.com>
+ */
+@CompileStatic
+class LinNormalizer {
+
+    /**
+     * Fields to remove during normalization as they vary between runs
+     */
+    static final Set<String> EPHEMERAL_FIELDS = [
+        'sessionId',
+        'createdAt', 
+        'modifiedAt',
+        'name',         // workflow run name is auto-generated
+        'source',       // LID reference - varies per run
+        'workflowRun',  // LID reference - varies per run
+        'taskRun',      // LID reference - varies per run
+        'path'          // absolute path - varies between runs, checksum is what matters
+    ] as Set<String>
+
+    /**
+     * Base path for relativizing absolute paths in FileOutput
+     */
+    private Path outputBase
+
+    /**
+     * Additional fields to ignore during comparison
+     */
+    private Set<String> additionalIgnoreFields = [] as Set<String>
+
+    LinNormalizer() {
+    }
+
+    /**
+     * Set the base path for relativizing file paths
+     */
+    LinNormalizer withOutputBase(Path base) {
+        this.outputBase = base
+        return this
+    }
+
+    /**
+     * Set the base path for relativizing file paths
+     */
+    LinNormalizer withOutputBase(String base) {
+        this.outputBase = base ? Paths.get(base) : null
+        return this
+    }
+
+    /**
+     * Add additional fields to ignore during comparison
+     */
+    LinNormalizer withIgnoreFields(Collection<String> fields) {
+        this.additionalIgnoreFields.addAll(fields)
+        return this
+    }
+
+    /**
+     * Normalize a lineage record by removing ephemeral fields
+     * and relativizing paths
+     *
+     * @param record The lineage record to normalize
+     * @return A normalized Map representation
+     */
+    Map<String, Object> normalize(LinSerializable record) {
+        // Encode to JSON and parse back as a mutable Map
+        def encoder = new LinEncoder()
+        def json = encoder.encode(record)
+        def slurper = new JsonSlurper()
+        def map = slurper.parseText(json) as Map<String, Object>
+        
+        return normalizeMap(map, record)
+    }
+
+    /**
+     * Normalize a Map representation of a lineage record
+     */
+    protected Map<String, Object> normalizeMap(Map<String, Object> map, LinSerializable original) {
+        def result = [:] as Map<String, Object>
+        def fieldsToIgnore = EPHEMERAL_FIELDS + additionalIgnoreFields
+        
+        // Get the spec section which contains the actual data
+        def spec = map['spec'] as Map<String, Object>
+        if (!spec) {
+            return map
+        }
+
+        result['version'] = map['version']
+        result['kind'] = map['kind']
+        
+        def normalizedSpec = [:] as Map<String, Object>
+        spec.each { String key, Object value ->
+            if (key in fieldsToIgnore) {
+                return // skip ephemeral fields
+            }
+            
+            if (key == 'path' && original instanceof FileOutput) {
+                normalizedSpec[key] = relativizePath(value as String)
+            } else if (value instanceof Map) {
+                normalizedSpec[key] = normalizeNestedMap(value as Map<String, Object>)
+            } else if (value instanceof List) {
+                normalizedSpec[key] = normalizeList(value as List)
+            } else {
+                normalizedSpec[key] = value
+            }
+        }
+        
+        result['spec'] = normalizedSpec
+        return result
+    }
+
+    /**
+     * Normalize nested maps recursively
+     */
+    protected Map<String, Object> normalizeNestedMap(Map<String, Object> map) {
+        def result = [:] as Map<String, Object>
+        def fieldsToIgnore = EPHEMERAL_FIELDS + additionalIgnoreFields
+        
+        map.each { String key, Object value ->
+            if (key in fieldsToIgnore) {
+                return
+            }
+            if (value instanceof Map) {
+                result[key] = normalizeNestedMap(value as Map<String, Object>)
+            } else if (value instanceof List) {
+                result[key] = normalizeList(value as List)
+            } else {
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    /**
+     * Normalize lists recursively
+     */
+    protected List normalizeList(List list) {
+        return list.collect { item ->
+            if (item instanceof Map) {
+                return normalizeNestedMap(item as Map<String, Object>)
+            } else if (item instanceof List) {
+                return normalizeList(item as List)
+            } else {
+                return item
+            }
+        }
+    }
+
+    /**
+     * Relativize an absolute path to the output base
+     */
+    String relativizePath(String absolutePath) {
+        if (!absolutePath || !outputBase) {
+            return absolutePath
+        }
+        
+        try {
+            def path = Paths.get(absolutePath)
+            if (path.isAbsolute() && path.startsWith(outputBase)) {
+                return outputBase.relativize(path).toString()
+            }
+        } catch (Exception e) {
+            // If path parsing fails, return as-is
+        }
+        return absolutePath
+    }
+
+    /**
+     * Collect and normalize an entire workflow tree including all outputs
+     *
+     * @param store The lineage store
+     * @param workflowLid The LID of the workflow run
+     * @return Normalized representation of the entire workflow tree
+     */
+    Map<String, Object> normalizeWorkflowTree(LinStore store, String workflowLid) {
+        def result = [:] as Map<String, Object>
+        
+        // Strip lid:// prefix if present
+        def key = workflowLid.startsWith('lid://') ? workflowLid.substring(6) : workflowLid
+        
+        // Load and normalize the workflow run
+        def workflowRun = store.load(key)
+        if (!workflowRun) {
+            throw new IllegalArgumentException("Workflow run not found: ${workflowLid}")
+        }
+        
+        result['workflowRun'] = normalize(workflowRun)
+        
+        // Collect all outputs (sub-keys)
+        def outputs = [:] as Map<String, Object>
+        store.getSubKeys(key).each { String subKey ->
+            def record = store.load(subKey)
+            if (record) {
+                // Use relative key for output identification
+                def relativeKey = subKey.startsWith(key) ? subKey.substring(key.length()) : subKey
+                if (relativeKey.startsWith('/')) {
+                    relativeKey = relativeKey.substring(1)
+                }
+                outputs[relativeKey] = normalize(record)
+            }
+        }
+        
+        if (outputs) {
+            result['outputs'] = outputs
+        }
+        
+        return result
+    }
+
+    /**
+     * Compare two normalized workflow trees and return differences
+     *
+     * @param tree1 First normalized tree
+     * @param tree2 Second normalized tree
+     * @return Map of differences, empty if trees are equivalent
+     */
+    static Map<String, Object> compare(Map<String, Object> tree1, Map<String, Object> tree2) {
+        def differences = [:] as Map<String, Object>
+        
+        compareRecursive('', tree1, tree2, differences)
+        
+        return differences
+    }
+
+    /**
+     * Recursively compare two maps and collect differences
+     */
+    protected static void compareRecursive(String path, Object obj1, Object obj2, Map<String, Object> differences) {
+        if (obj1 == obj2) {
+            return
+        }
+        
+        if (obj1 == null || obj2 == null) {
+            differences[path ?: 'root'] = [expected: obj1, actual: obj2]
+            return
+        }
+        
+        if (obj1.class != obj2.class) {
+            differences[path ?: 'root'] = [expected: obj1, actual: obj2]
+            return
+        }
+        
+        if (obj1 instanceof Map) {
+            def map1 = obj1 as Map<String, Object>
+            def map2 = obj2 as Map<String, Object>
+            def allKeys = (map1.keySet() + map2.keySet()) as Set<String>
+            
+            allKeys.each { key ->
+                String newPath = path ? "${path}.${key}".toString() : key
+                compareRecursive(newPath, map1[key], map2[key], differences)
+            }
+        } else if (obj1 instanceof List) {
+            def list1 = obj1 as List
+            def list2 = obj2 as List
+            
+            if (list1.size() != list2.size()) {
+                differences[path] = [expected: list1, actual: list2, reason: 'size mismatch']
+                return
+            }
+            
+            list1.eachWithIndex { item, int idx ->
+                String idxPath = "${path}[${idx}]".toString()
+                compareRecursive(idxPath, item, list2[idx], differences)
+            }
+        } else if (obj1 != obj2) {
+            differences[path] = [expected: obj1, actual: obj2]
+        }
+    }
+}

--- a/modules/nf-lineage/src/main/nextflow/lineage/cli/LinCommandImpl.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/cli/LinCommandImpl.groovy
@@ -21,12 +21,14 @@ import static nextflow.lineage.fs.LinPath.*
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
+import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
 import nextflow.Session
 import nextflow.cli.CmdLineage
 import nextflow.config.ConfigMap
 import nextflow.exception.AbortOperationException
 import nextflow.lineage.LinHistoryRecord
+import nextflow.lineage.LinNormalizer
 import nextflow.lineage.LinPropertyValidator
 import nextflow.lineage.LinStore
 import nextflow.lineage.LinStoreFactory
@@ -223,5 +225,122 @@ class LinCommandImpl implements CmdLineage.LinCommand {
             params[key] << value
         }
         return params
+    }
+
+    @Override
+    void validate(ConfigMap config, List<String> args) {
+        final store = LinStoreFactory.getOrCreate(new Session(config))
+        if (!store) {
+            println ERR_NOT_LOADED
+            return
+        }
+
+        try {
+            // Parse arguments
+            final parsedArgs = parseValidateArgs(args)
+            final String newLid = parsedArgs.newLid as String
+            final String baselineLid = parsedArgs.baselineLid as String
+            final List<String> ignoreFields = parsedArgs.ignoreFields as List<String>
+            final String outputBase = parsedArgs.outputBase as String
+
+            if (!isLidUri(newLid) || !isLidUri(baselineLid)) {
+                throw new AbortOperationException("Both arguments must be lineage URLs (lid://...)")
+            }
+
+            // Create normalizer with configuration
+            final normalizer = new LinNormalizer()
+            if (outputBase) {
+                normalizer.withOutputBase(outputBase)
+            }
+            if (ignoreFields) {
+                normalizer.withIgnoreFields(ignoreFields)
+            }
+
+            // Normalize both workflow trees
+            final newTree = normalizer.normalizeWorkflowTree(store, newLid)
+            final baselineTree = normalizer.normalizeWorkflowTree(store, baselineLid)
+
+            // Compare
+            final differences = LinNormalizer.compare(newTree, baselineTree)
+
+            if (differences.isEmpty()) {
+                println "Workflow runs are semantically equivalent"
+            } else {
+                println "Workflow runs differ:"
+                println ""
+                
+                // Generate a readable diff using JGit
+                final String newJson = JsonOutput.prettyPrint(JsonOutput.toJson(newTree))
+                final String baselineJson = JsonOutput.prettyPrint(JsonOutput.toJson(baselineTree))
+                
+                final String newKey = newLid.substring(LID_PROT.size())
+                final String baselineKey = baselineLid.substring(LID_PROT.size())
+                generateDiff(baselineJson, baselineKey, newJson, newKey)
+                
+                throw new AbortOperationException("Validation failed: workflow runs are not equivalent")
+            }
+        } catch (AbortOperationException e) {
+            throw e
+        } catch (IllegalArgumentException e) {
+            throw new AbortOperationException(e.message)
+        } catch (Throwable e) {
+            throw new AbortOperationException("Error validating workflow runs: ${e.message}")
+        }
+    }
+
+    /**
+     * Parse validate command arguments
+     */
+    private Map parseValidateArgs(List<String> args) {
+        String newLid = null
+        String baselineLid = null
+        List<String> ignoreFields = []
+        String outputBase = null
+
+        def iter = args.iterator()
+        while (iter.hasNext()) {
+            def arg = iter.next()
+            
+            if (arg == '--against') {
+                if (!iter.hasNext()) {
+                    throw new IllegalArgumentException("--against requires a value")
+                }
+                baselineLid = iter.next()
+            } else if (arg.startsWith('--against=')) {
+                baselineLid = arg.substring('--against='.length())
+            } else if (arg == '--ignore-fields') {
+                if (!iter.hasNext()) {
+                    throw new IllegalArgumentException("--ignore-fields requires a value")
+                }
+                ignoreFields = iter.next().split(',').toList()
+            } else if (arg.startsWith('--ignore-fields=')) {
+                ignoreFields = arg.substring('--ignore-fields='.length()).split(',').toList()
+            } else if (arg == '--output-base') {
+                if (!iter.hasNext()) {
+                    throw new IllegalArgumentException("--output-base requires a value")
+                }
+                outputBase = iter.next()
+            } else if (arg.startsWith('--output-base=')) {
+                outputBase = arg.substring('--output-base='.length())
+            } else if (!arg.startsWith('-') && !newLid) {
+                newLid = arg
+            } else if (!arg.startsWith('-')) {
+                throw new IllegalArgumentException("Unexpected argument: ${arg}")
+            }
+        }
+
+        if (!newLid) {
+            throw new IllegalArgumentException("Missing workflow run LID")
+        }
+        if (!baselineLid) {
+            throw new IllegalArgumentException("Missing --against baseline LID")
+        }
+
+        return [
+            newLid: newLid,
+            baselineLid: baselineLid,
+            ignoreFields: ignoreFields,
+            outputBase: outputBase
+        ]
     }
 }

--- a/modules/nf-lineage/src/main/nextflow/lineage/test/LineageSnapshotter.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/test/LineageSnapshotter.groovy
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.lineage.test
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import nextflow.lineage.LinNormalizer
+import nextflow.lineage.LinStore
+
+/**
+ * Spock integration for lineage validation using snapshot testing.
+ * 
+ * This class allows pipeline tests to compare workflow runs against saved
+ * baseline snapshots. On first run (or when UPDATE_SNAPSHOTS=true), the
+ * normalized lineage is saved. On subsequent runs, it's compared against
+ * the saved snapshot.
+ *
+ * Usage in Spock tests:
+ * <pre>
+ * class MyPipelineTest extends Specification {
+ *     @Shared LineageSnapshotter snapshotter
+ *     
+ *     def setupSpec() {
+ *         snapshotter = new LineageSnapshotter(store)
+ *             .withSnapshotDir('src/test/resources/snapshots')
+ *     }
+ *     
+ *     def "pipeline produces expected outputs"() {
+ *         when:
+ *         def lid = runPipeline('main.nf', params)
+ *         
+ *         then:
+ *         snapshotter.assertMatchesSnapshot(lid, 'baseline-v1')
+ *     }
+ * }
+ * </pre>
+ *
+ * Set UPDATE_SNAPSHOTS=true environment variable to update snapshots.
+ *
+ * @author Edmund Miller <edmund.a.miller@gmail.com>
+ */
+@CompileStatic
+class LineageSnapshotter {
+
+    private final LinStore store
+    private final LinNormalizer normalizer
+    private Path snapshotDir
+    private boolean updateSnapshots
+
+    /**
+     * Create a new LineageSnapshotter
+     *
+     * @param store The lineage store to read workflow data from
+     */
+    LineageSnapshotter(LinStore store) {
+        this.store = store
+        this.normalizer = new LinNormalizer()
+        this.updateSnapshots = System.getenv('UPDATE_SNAPSHOTS')?.toLowerCase() in ['true', '1', 'yes']
+    }
+
+    /**
+     * Set the directory where snapshots are stored
+     */
+    LineageSnapshotter withSnapshotDir(String dir) {
+        this.snapshotDir = Paths.get(dir)
+        return this
+    }
+
+    /**
+     * Set the directory where snapshots are stored
+     */
+    LineageSnapshotter withSnapshotDir(Path dir) {
+        this.snapshotDir = dir
+        return this
+    }
+
+    /**
+     * Set the base path for relativizing file paths in outputs
+     */
+    LineageSnapshotter withOutputBase(String base) {
+        this.normalizer.withOutputBase(base)
+        return this
+    }
+
+    /**
+     * Set the base path for relativizing file paths in outputs
+     */
+    LineageSnapshotter withOutputBase(Path base) {
+        this.normalizer.withOutputBase(base)
+        return this
+    }
+
+    /**
+     * Add additional fields to ignore during comparison
+     */
+    LineageSnapshotter withIgnoreFields(Collection<String> fields) {
+        this.normalizer.withIgnoreFields(fields)
+        return this
+    }
+
+    /**
+     * Force update mode (save snapshots instead of comparing)
+     */
+    LineageSnapshotter withUpdateSnapshots(boolean update) {
+        this.updateSnapshots = update
+        return this
+    }
+
+    /**
+     * Assert that a workflow run matches a saved snapshot.
+     * 
+     * On first run (or when UPDATE_SNAPSHOTS=true), saves the normalized
+     * lineage as the snapshot. On subsequent runs, compares against the
+     * saved snapshot and throws AssertionError if they differ.
+     *
+     * @param lid The LID of the workflow run to validate
+     * @param snapshotId Identifier for the snapshot (used as filename)
+     * @throws AssertionError if the workflow run doesn't match the snapshot
+     */
+    void assertMatchesSnapshot(String lid, String snapshotId) {
+        if (!snapshotDir) {
+            throw new IllegalStateException("Snapshot directory not configured. Call withSnapshotDir() first.")
+        }
+
+        // Normalize the workflow tree
+        def normalized = normalizer.normalizeWorkflowTree(store, lid)
+        def actualJson = JsonOutput.prettyPrint(JsonOutput.toJson(normalized))
+
+        // Get snapshot file path
+        def snapshotFile = snapshotDir.resolve("${snapshotId}.json")
+
+        if (updateSnapshots || !Files.exists(snapshotFile)) {
+            // Save snapshot
+            Files.createDirectories(snapshotFile.parent)
+            snapshotFile.text = actualJson
+            
+            if (updateSnapshots) {
+                println "Updated snapshot: ${snapshotFile}"
+            } else {
+                println "Created snapshot: ${snapshotFile}"
+            }
+            return
+        }
+
+        // Compare against saved snapshot
+        def expectedJson = snapshotFile.text
+        def expected = new JsonSlurper().parseText(expectedJson) as Map
+        def actual = new JsonSlurper().parseText(actualJson) as Map
+
+        def differences = LinNormalizer.compare(expected, actual)
+        
+        if (!differences.isEmpty()) {
+            // Save actual output for debugging
+            def actualFile = snapshotDir.resolve("${snapshotId}.actual.json")
+            actualFile.text = actualJson
+            
+            def diffReport = buildDiffReport(differences)
+            throw new AssertionError(
+                "Workflow run does not match snapshot '${snapshotId}'.\n" +
+                "Differences:\n${diffReport}\n" +
+                "Expected: ${snapshotFile}\n" +
+                "Actual:   ${actualFile}\n" +
+                "Set UPDATE_SNAPSHOTS=true to update the snapshot."
+            )
+        }
+    }
+
+    /**
+     * Assert that two workflow runs are semantically equivalent.
+     * 
+     * This compares two runs directly without using saved snapshots.
+     *
+     * @param lid1 LID of the first workflow run
+     * @param lid2 LID of the second workflow run
+     * @throws AssertionError if the workflow runs differ
+     */
+    void assertEquivalent(String lid1, String lid2) {
+        def tree1 = normalizer.normalizeWorkflowTree(store, lid1)
+        def tree2 = normalizer.normalizeWorkflowTree(store, lid2)
+
+        def differences = LinNormalizer.compare(tree1, tree2)
+        
+        if (!differences.isEmpty()) {
+            def diffReport = buildDiffReport(differences)
+            throw new AssertionError(
+                "Workflow runs are not semantically equivalent.\n" +
+                "LID 1: ${lid1}\n" +
+                "LID 2: ${lid2}\n" +
+                "Differences:\n${diffReport}"
+            )
+        }
+    }
+
+    /**
+     * Build a human-readable diff report from differences map
+     */
+    private String buildDiffReport(Map<String, Object> differences) {
+        def sb = new StringBuilder()
+        differences.each { String path, Object diff ->
+            if (diff instanceof Map) {
+                def diffMap = diff as Map
+                sb.append("  ${path}:\n")
+                sb.append("    expected: ${diffMap['expected']}\n")
+                sb.append("    actual:   ${diffMap['actual']}\n")
+                if (diffMap['reason']) {
+                    sb.append("    reason:   ${diffMap['reason']}\n")
+                }
+            } else {
+                sb.append("  ${path}: ${diff}\n")
+            }
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Get the normalized representation of a workflow run.
+     * Useful for debugging or manual inspection.
+     *
+     * @param lid The LID of the workflow run
+     * @return Normalized Map representation
+     */
+    Map<String, Object> getNormalized(String lid) {
+        return normalizer.normalizeWorkflowTree(store, lid)
+    }
+
+    /**
+     * Get the normalized JSON of a workflow run.
+     * Useful for debugging or manual inspection.
+     *
+     * @param lid The LID of the workflow run
+     * @return Pretty-printed JSON string
+     */
+    String getNormalizedJson(String lid) {
+        def normalized = normalizer.normalizeWorkflowTree(store, lid)
+        return JsonOutput.prettyPrint(JsonOutput.toJson(normalized))
+    }
+}

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinNormalizerTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinNormalizerTest.groovy
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.lineage
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+import nextflow.lineage.model.v1beta1.Checksum
+import nextflow.lineage.model.v1beta1.DataPath
+import nextflow.lineage.model.v1beta1.FileOutput
+import nextflow.lineage.model.v1beta1.Parameter
+import nextflow.lineage.model.v1beta1.TaskRun
+import nextflow.lineage.model.v1beta1.Workflow
+import nextflow.lineage.model.v1beta1.WorkflowOutput
+import nextflow.lineage.model.v1beta1.WorkflowRun
+import spock.lang.Specification
+import spock.lang.TempDir
+
+/**
+ * Tests for LinNormalizer
+ *
+ * @author Edmund Miller <edmund.a.miller@gmail.com>
+ */
+class LinNormalizerTest extends Specification {
+
+    @TempDir
+    Path tmpDir
+
+    def 'should strip ephemeral fields from WorkflowRun'() {
+        given:
+        def normalizer = new LinNormalizer()
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "hello-nf", "abc123")
+        def run = new WorkflowRun(wf, "session-123", "crazy_einstein",
+            [new Parameter("String", "input", "test.fastq")])
+
+        when:
+        def normalized = normalizer.normalize(run)
+
+        then:
+        normalized['kind'] == 'WorkflowRun'
+        normalized['spec']['workflow'] != null
+        // sessionId should be stripped
+        !normalized['spec'].containsKey('sessionId')
+        // name should be stripped (auto-generated run name)
+        !normalized['spec'].containsKey('name')
+        // params should be preserved
+        normalized['spec']['params'] != null
+    }
+
+    def 'should strip timestamps from FileOutput'() {
+        given:
+        def normalizer = new LinNormalizer()
+        def time = OffsetDateTime.ofInstant(Instant.ofEpochMilli(123456789), ZoneOffset.UTC)
+        def output = new FileOutput(
+            "/results/sample1/file.bam",
+            new Checksum("abc123", "nextflow", "standard"),
+            "lid://task123/file.bam",
+            "lid://workflow123",
+            "lid://task123",
+            1024,
+            time,
+            time,
+            ["experiment=test"]
+        )
+
+        when:
+        def normalized = normalizer.normalize(output)
+
+        then:
+        normalized['kind'] == 'FileOutput'
+        // createdAt and modifiedAt should be stripped
+        !normalized['spec'].containsKey('createdAt')
+        !normalized['spec'].containsKey('modifiedAt')
+        // checksum should be preserved
+        normalized['spec']['checksum']['value'] == 'abc123'
+        // labels should be preserved
+        normalized['spec']['labels'] == ['experiment=test']
+    }
+
+    def 'should strip path field from FileOutput'() {
+        given:
+        def normalizer = new LinNormalizer()
+        def output = new FileOutput(
+            "/home/user/results/sample1/file.bam",
+            new Checksum("abc123", "nextflow", "standard"),
+            "lid://task123/file.bam",
+            "lid://workflow123",
+            null,
+            1024,
+            null,
+            null,
+            null
+        )
+
+        when:
+        def normalized = normalizer.normalize(output)
+
+        then:
+        // path is stripped because absolute paths vary between runs
+        // checksum is what matters for comparing outputs
+        !normalized['spec'].containsKey('path')
+        normalized['spec']['checksum']['value'] == 'abc123'
+    }
+
+    def 'should strip path regardless of outputBase setting'() {
+        given:
+        def normalizer = new LinNormalizer()
+            .withOutputBase('/home/user/results')
+        def output = new FileOutput(
+            "/other/path/file.bam",
+            new Checksum("abc123", "nextflow", "standard"),
+            "lid://task123/file.bam",
+            "lid://workflow123",
+            null,
+            1024,
+            null,
+            null,
+            null
+        )
+
+        when:
+        def normalized = normalizer.normalize(output)
+
+        then:
+        // path is always stripped as an ephemeral field
+        !normalized['spec'].containsKey('path')
+    }
+
+    def 'should strip sessionId from TaskRun'() {
+        given:
+        def normalizer = new LinNormalizer()
+        def task = new TaskRun(
+            "session-456",
+            "ALIGN",
+            new Checksum("hash123", "nextflow", "standard"),
+            'bwa mem ref.fa reads.fq > out.bam',
+            [new Parameter("path", "reads", "reads.fq")],
+            "docker://biocontainers/bwa",
+            null,
+            null,
+            null,
+            [:],
+            []
+        )
+
+        when:
+        def normalized = normalizer.normalize(task)
+
+        then:
+        normalized['kind'] == 'TaskRun'
+        !normalized['spec'].containsKey('sessionId')
+        normalized['spec']['name'] == null  // name is also stripped
+        normalized['spec']['script'] == 'bwa mem ref.fa reads.fq > out.bam'
+        normalized['spec']['codeChecksum']['value'] == 'hash123'
+    }
+
+    def 'should support additional ignore fields'() {
+        given:
+        def normalizer = new LinNormalizer()
+            .withIgnoreFields(['container', 'conda'])
+        def task = new TaskRun(
+            "session-456",
+            "ALIGN",
+            new Checksum("hash123", "nextflow", "standard"),
+            'script',
+            null,
+            "docker://bwa",
+            "bioconda::bwa",
+            null,
+            null,
+            [:],
+            []
+        )
+
+        when:
+        def normalized = normalizer.normalize(task)
+
+        then:
+        !normalized['spec'].containsKey('container')
+        !normalized['spec'].containsKey('conda')
+    }
+
+    def 'should compare two identical normalized trees as equal'() {
+        given:
+        def tree1 = [
+            workflowRun: [kind: 'WorkflowRun', spec: [workflow: [name: 'test']]],
+            outputs: [
+                'file.bam': [kind: 'FileOutput', spec: [checksum: [value: 'abc']]]
+            ]
+        ]
+        def tree2 = [
+            workflowRun: [kind: 'WorkflowRun', spec: [workflow: [name: 'test']]],
+            outputs: [
+                'file.bam': [kind: 'FileOutput', spec: [checksum: [value: 'abc']]]
+            ]
+        ]
+
+        when:
+        def diff = LinNormalizer.compare(tree1, tree2)
+
+        then:
+        diff.isEmpty()
+    }
+
+    def 'should detect differences in normalized trees'() {
+        given:
+        def tree1 = [
+            workflowRun: [kind: 'WorkflowRun', spec: [workflow: [name: 'test']]],
+            outputs: [
+                'file.bam': [kind: 'FileOutput', spec: [checksum: [value: 'abc']]]
+            ]
+        ]
+        def tree2 = [
+            workflowRun: [kind: 'WorkflowRun', spec: [workflow: [name: 'test']]],
+            outputs: [
+                'file.bam': [kind: 'FileOutput', spec: [checksum: [value: 'xyz']]]
+            ]
+        ]
+
+        when:
+        def diff = LinNormalizer.compare(tree1, tree2)
+
+        then:
+        !diff.isEmpty()
+        diff['outputs.file.bam.spec.checksum.value']['expected'] == 'abc'
+        diff['outputs.file.bam.spec.checksum.value']['actual'] == 'xyz'
+    }
+
+    def 'should detect missing keys'() {
+        given:
+        def tree1 = [outputs: ['a.txt': [checksum: 'abc'], 'b.txt': [checksum: 'def']]]
+        def tree2 = [outputs: ['a.txt': [checksum: 'abc']]]
+
+        when:
+        def diff = LinNormalizer.compare(tree1, tree2)
+
+        then:
+        !diff.isEmpty()
+        diff.containsKey('outputs.b.txt')
+    }
+
+    def 'should normalize workflow tree from store'() {
+        given:
+        def store = Mock(LinStore)
+        def normalizer = new LinNormalizer()
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "commit123")
+        def run = new WorkflowRun(wf, "session-1", "run_name", [])
+        def output = new FileOutput("/results/out.txt", new Checksum("hash", "nf", "std"),
+            "lid://wf1/out.txt", "lid://wf1", null, 100, null, null, null)
+
+        store.load("wf1") >> run
+        store.getSubKeys("wf1") >> ["wf1/out.txt"].stream()
+        store.load("wf1/out.txt") >> output
+
+        when:
+        def tree = normalizer.normalizeWorkflowTree(store, "lid://wf1")
+
+        then:
+        tree['workflowRun'] != null
+        tree['workflowRun']['kind'] == 'WorkflowRun'
+        tree['outputs'] != null
+        tree['outputs']['out.txt'] != null
+        tree['outputs']['out.txt']['kind'] == 'FileOutput'
+    }
+
+    def 'should throw when workflow not found'() {
+        given:
+        def store = Mock(LinStore)
+        def normalizer = new LinNormalizer()
+        store.load("nonexistent") >> null
+
+        when:
+        normalizer.normalizeWorkflowTree(store, "lid://nonexistent")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinNormalizerTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinNormalizerTest.groovy
@@ -56,6 +56,7 @@ fields normalize to the same shape. It is the shared kernel under both the CLI
 @Subject(LinNormalizer)
 class LinNormalizerTest extends Specification {
 
+    // TODO: tmpDir is unused — drop @TempDir + field
     @TempDir
     Path tmpDir
 

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinNormalizerTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinNormalizerTest.groovy
@@ -30,19 +30,36 @@ import nextflow.lineage.model.v1beta1.TaskRun
 import nextflow.lineage.model.v1beta1.Workflow
 import nextflow.lineage.model.v1beta1.WorkflowOutput
 import nextflow.lineage.model.v1beta1.WorkflowRun
+import spock.lang.Narrative
+import spock.lang.See
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.TempDir
+import spock.lang.Title
 
 /**
  * Tests for LinNormalizer
  *
  * @author Edmund Miller <edmund.a.miller@gmail.com>
  */
+@Title("Normalize lineage records for semantic comparison")
+@Narrative('''
+LinNormalizer strips ephemeral fields (session IDs, timestamps, absolute paths, LID
+back-references) from a lineage record so that two runs that differ only in these
+fields normalize to the same shape. It is the shared kernel under both the CLI
+`nextflow lineage validate` command and the Spock `LineageSnapshotter` integration.
+''')
+@See([
+    "https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md",
+    "https://spockframework.org/spock/docs/2.4/all_in_one.html#_specifications_as_documentation"
+])
+@Subject(LinNormalizer)
 class LinNormalizerTest extends Specification {
 
     @TempDir
     Path tmpDir
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d8--ignore-mechanism-flag--config-jsonpath-style")
     def 'should strip ephemeral fields from WorkflowRun'() {
         given:
         def normalizer = new LinNormalizer()
@@ -64,6 +81,7 @@ class LinNormalizerTest extends Specification {
         normalized['spec']['params'] != null
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d3--file-equivalence-checksum-only")
     def 'should strip timestamps from FileOutput'() {
         given:
         def normalizer = new LinNormalizer()
@@ -94,6 +112,7 @@ class LinNormalizerTest extends Specification {
         normalized['spec']['labels'] == ['experiment=test']
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d14--output-join-key-relative-path-under--outputdir")
     def 'should strip path field from FileOutput'() {
         given:
         def normalizer = new LinNormalizer()
@@ -171,6 +190,7 @@ class LinNormalizerTest extends Specification {
         normalized['spec']['codeChecksum']['value'] == 'hash123'
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d8--ignore-mechanism-flag--config-jsonpath-style")
     def 'should support additional ignore fields'() {
         given:
         def normalizer = new LinNormalizer()
@@ -197,6 +217,7 @@ class LinNormalizerTest extends Specification {
         !normalized['spec'].containsKey('conda')
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d2--equivalence-unit-outputs--key-inputs")
     def 'should compare two identical normalized trees as equal'() {
         given:
         def tree1 = [
@@ -219,6 +240,7 @@ class LinNormalizerTest extends Specification {
         diff.isEmpty()
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d6--failure-output-human-diff-default---json-for-ci")
     def 'should detect differences in normalized trees'() {
         given:
         def tree1 = [
@@ -256,6 +278,7 @@ class LinNormalizerTest extends Specification {
         diff.containsKey('outputs.b.txt')
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d5--subworkflow-handling-flatten-to-terminal-outputs")
     def 'should normalize workflow tree from store'() {
         given:
         def store = Mock(LinStore)

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinValidateIntegrationTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinValidateIntegrationTest.groovy
@@ -44,6 +44,8 @@ import spock.lang.Subject
 import spock.lang.Title
 import test.OutputCapture
 
+import static test.TestHelper.filterLogNoise
+
 /**
  * Integration tests for lineage validation functionality.
  * Tests end-to-end validation of workflow runs using the CLI command.
@@ -70,6 +72,9 @@ the shared `LineageValidator` core has drifted — both surfaces must stay in lo
 @Subject(LinCommandImpl)
 class LinValidateIntegrationTest extends Specification {
 
+    // FIXME: these are @Shared but reassigned per-test in setup() — drop @Shared
+    // or move init to setupSpec(); cleanup() deletes a dir later iterations may
+    // still need under parallel execution.
     @Shared
     Path tmpDir
 
@@ -79,6 +84,9 @@ class LinValidateIntegrationTest extends Specification {
     @Shared
     ConfigMap configMap
 
+    // TODO: extract a LineageFixtures helper — Workflow / WorkflowRun / FileOutput
+    // constructors and the createDirectories+encode+write triple repeat ~25 times
+    // across this spec and adjacent test files.
     LinEncoder encoder
 
     def reset() {
@@ -170,12 +178,7 @@ class LinValidateIntegrationTest extends Specification {
 
         when: 'Validate workflow runs'
         new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
-        def stdout = capture
-            .toString()
-            .readLines()
-            .findResults { line -> !line.contains('DEBUG') ? line : null }
-            .findResults { line -> !line.contains('INFO') ? line : null }
-            .findResults { line -> !line.contains('plugin') ? line : null }
+        def stdout = filterLogNoise(capture)
 
         then: 'Should pass - runs are semantically equivalent'
         noExceptionThrown()
@@ -327,12 +330,7 @@ class LinValidateIntegrationTest extends Specification {
 
         when: 'Validate workflow runs'
         new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
-        def stdout = capture
-            .toString()
-            .readLines()
-            .findResults { line -> !line.contains('DEBUG') ? line : null }
-            .findResults { line -> !line.contains('INFO') ? line : null }
-            .findResults { line -> !line.contains('plugin') ? line : null }
+        def stdout = filterLogNoise(capture)
 
         then: 'Should pass - all nested outputs match'
         noExceptionThrown()
@@ -358,12 +356,7 @@ class LinValidateIntegrationTest extends Specification {
         when: 'Validate with --ignore-fields commitId'
         new LinCommandImpl().validate(configMap, 
             ["lid://wf1", "--against", "lid://wf2", "--ignore-fields", "commitId"])
-        def stdout = capture
-            .toString()
-            .readLines()
-            .findResults { line -> !line.contains('DEBUG') ? line : null }
-            .findResults { line -> !line.contains('INFO') ? line : null }
-            .findResults { line -> !line.contains('plugin') ? line : null }
+        def stdout = filterLogNoise(capture)
 
         then: 'Should pass - commitId is ignored'
         noExceptionThrown()

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinValidateIntegrationTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinValidateIntegrationTest.groovy
@@ -36,8 +36,12 @@ import nextflow.lineage.serde.LinEncoder
 import nextflow.plugin.Plugins
 import nextflow.util.CacheHelper
 import org.junit.Rule
+import spock.lang.Narrative
+import spock.lang.See
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Title
 import test.OutputCapture
 
 /**
@@ -46,6 +50,24 @@ import test.OutputCapture
  *
  * @author Edmund Miller <edmund.a.miller@gmail.com>
  */
+@Title("nextflow lineage validate — end-to-end semantic equivalence check")
+@Narrative('''
+Drives `LinCommandImpl.validate` against a real on-disk lineage store populated
+with WorkflowRun + FileOutput records. These specs exercise the CI-led primary
+use case from the ADR: two runs that differ only in ephemeral fields (session,
+name, timestamps, absolute paths) must be reported as semantically equivalent;
+two runs whose published outputs, parameters, or workflow identity disagree
+must abort the command non-zero.
+
+Whenever a behaviour here disagrees with the Spock LineageSnapshotter integration
+the shared `LineageValidator` core has drifted — both surfaces must stay in lockstep.
+''')
+@See([
+    "https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md",
+    "https://github.com/nextflow-io/nextflow/pull/7167",
+    "https://github.com/nextflow-io/nextflow/pull/7168"
+])
+@Subject(LinCommandImpl)
 class LinValidateIntegrationTest extends Specification {
 
     @Shared
@@ -89,6 +111,10 @@ class LinValidateIntegrationTest extends Specification {
     @Rule
     OutputCapture capture = new OutputCapture()
 
+    @See([
+        "https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d2--equivalence-unit-outputs--key-inputs",
+        "https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d3--file-equivalence-checksum-only"
+    ])
     def 'should validate two equivalent workflow runs with outputs'() {
         given: 'Create two workflow runs with same structure'
         def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
@@ -156,6 +182,7 @@ class LinValidateIntegrationTest extends Specification {
         stdout.any { it.contains("semantically equivalent") }
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d13--difference-categories-outputs--params--workflow-identity--resources")
     def 'should detect different output checksums between runs'() {
         given: 'Create two workflow runs'
         def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
@@ -197,6 +224,7 @@ class LinValidateIntegrationTest extends Specification {
         error.message.contains("not equivalent")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d13--difference-categories-outputs--params--workflow-identity--resources")
     def 'should detect different parameters between runs'() {
         given: 'Create two workflow runs with different params'
         def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
@@ -221,6 +249,7 @@ class LinValidateIntegrationTest extends Specification {
         error.message.contains("not equivalent")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d5--subworkflow-handling-flatten-to-terminal-outputs")
     def 'should detect different number of outputs'() {
         given: 'Create two workflow runs'
         def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
@@ -262,6 +291,7 @@ class LinValidateIntegrationTest extends Specification {
         error.message.contains("not equivalent")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d14--output-join-key-relative-path-under--outputdir")
     def 'should validate runs with nested output directories'() {
         given: 'Create workflow runs'
         def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
@@ -309,6 +339,7 @@ class LinValidateIntegrationTest extends Specification {
         stdout.any { it.contains("semantically equivalent") }
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d8--ignore-mechanism-flag--config-jsonpath-style")
     def 'should ignore specified fields during validation'() {
         given: 'Create workflow runs with different commitIds'
         def wf1 = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "commit_v1")
@@ -339,6 +370,7 @@ class LinValidateIntegrationTest extends Specification {
         stdout.any { it.contains("semantically equivalent") }
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d6--failure-output-human-diff-default---json-for-ci")
     def 'should show diff when validation fails'() {
         given: 'Create workflow runs with different configs'
         def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinValidateIntegrationTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinValidateIntegrationTest.groovy
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.lineage
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+
+import nextflow.SysEnv
+import nextflow.config.ConfigMap
+import nextflow.exception.AbortOperationException
+import nextflow.file.FileHelper
+import nextflow.lineage.cli.LinCommandImpl
+import nextflow.lineage.fs.LinFileSystemProvider
+import nextflow.lineage.model.v1beta1.Checksum
+import nextflow.lineage.model.v1beta1.DataPath
+import nextflow.lineage.model.v1beta1.FileOutput
+import nextflow.lineage.model.v1beta1.Parameter
+import nextflow.lineage.model.v1beta1.Workflow
+import nextflow.lineage.model.v1beta1.WorkflowRun
+import nextflow.lineage.serde.LinEncoder
+import nextflow.plugin.Plugins
+import nextflow.util.CacheHelper
+import org.junit.Rule
+import spock.lang.Shared
+import spock.lang.Specification
+import test.OutputCapture
+
+/**
+ * Integration tests for lineage validation functionality.
+ * Tests end-to-end validation of workflow runs using the CLI command.
+ *
+ * @author Edmund Miller <edmund.a.miller@gmail.com>
+ */
+class LinValidateIntegrationTest extends Specification {
+
+    @Shared
+    Path tmpDir
+
+    @Shared
+    Path storeLocation
+
+    @Shared
+    ConfigMap configMap
+
+    LinEncoder encoder
+
+    def reset() {
+        def provider = FileHelper.getProviderFor('lid') as LinFileSystemProvider
+        provider?.reset()
+        LinStoreFactory.reset()
+    }
+
+    def setup() {
+        reset()
+        SysEnv.push([:])
+        tmpDir = Files.createTempDirectory('validate-test')
+        storeLocation = tmpDir.resolve("store")
+        Files.createDirectories(storeLocation)
+        configMap = new ConfigMap([lineage: [enabled: true, store: [location: storeLocation.toString(), logLocation: storeLocation.resolve(".log").toString()]]])
+        encoder = new LinEncoder()
+    }
+
+    def cleanup() {
+        Plugins.stop()
+        LinStoreFactory.reset()
+        SysEnv.pop()
+        tmpDir?.deleteDir()
+    }
+
+    def setupSpec() {
+        reset()
+    }
+
+    @Rule
+    OutputCapture capture = new OutputCapture()
+
+    def 'should validate two equivalent workflow runs with outputs'() {
+        given: 'Create two workflow runs with same structure'
+        def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
+        
+        // First workflow run
+        def run1 = new WorkflowRun(wf, "session-1", "eager_einstein",
+            [new Parameter("String", "input", "sample.fastq"),
+             new Parameter("Integer", "threads", 4)])
+        
+        // Second workflow run - different session/name but same params
+        def run2 = new WorkflowRun(wf, "session-2", "angry_turing",
+            [new Parameter("String", "input", "sample.fastq"),
+             new Parameter("Integer", "threads", 4)])
+
+        and: 'Create output files with same checksums'
+        def outputDir = tmpDir.resolve('outputs')
+        Files.createDirectories(outputDir)
+        
+        def outFile1 = outputDir.resolve('result.txt')
+        outFile1.text = 'identical output content'
+        def checksum = CacheHelper.hasher(outFile1).hash().toString()
+        def attrs = Files.readAttributes(outFile1, BasicFileAttributes)
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        and: 'Store outputs with same checksums but different timestamps/paths'
+        def output1 = new FileOutput(
+            outputDir.resolve('run1/result.txt').toString(),
+            new Checksum(checksum, "nextflow", "standard"),
+            "lid://wf1/result.txt", "lid://wf1", null,
+            attrs.size(), LinUtils.toDate(attrs.creationTime()), LinUtils.toDate(attrs.lastModifiedTime())
+        )
+        def output2 = new FileOutput(
+            outputDir.resolve('run2/result.txt').toString(),
+            new Checksum(checksum, "nextflow", "standard"),  // Same checksum!
+            "lid://wf2/result.txt", "lid://wf2", null,
+            attrs.size(), LinUtils.toDate(attrs.creationTime()).plusSeconds(100), // Different time
+            LinUtils.toDate(attrs.lastModifiedTime()).plusSeconds(100)
+        )
+        
+        def out1Path = storeLocation.resolve("wf1/result.txt/.data.json")
+        def out2Path = storeLocation.resolve("wf2/result.txt/.data.json")
+        Files.createDirectories(out1Path.parent)
+        Files.createDirectories(out2Path.parent)
+        out1Path.text = encoder.encode(output1)
+        out2Path.text = encoder.encode(output2)
+
+        when: 'Validate workflow runs'
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { line -> !line.contains('DEBUG') ? line : null }
+            .findResults { line -> !line.contains('INFO') ? line : null }
+            .findResults { line -> !line.contains('plugin') ? line : null }
+
+        then: 'Should pass - runs are semantically equivalent'
+        noExceptionThrown()
+        stdout.any { it.contains("semantically equivalent") }
+    }
+
+    def 'should detect different output checksums between runs'() {
+        given: 'Create two workflow runs'
+        def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf, "session-2", "run2", [])
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        and: 'Store outputs with DIFFERENT checksums'
+        def output1 = new FileOutput(
+            "/results/out.txt",
+            new Checksum("checksum_version_1", "nextflow", "standard"),
+            "lid://wf1/out.txt", "lid://wf1", null, 100, null, null
+        )
+        def output2 = new FileOutput(
+            "/results/out.txt",
+            new Checksum("checksum_version_2_DIFFERENT", "nextflow", "standard"),  // Different!
+            "lid://wf2/out.txt", "lid://wf2", null, 100, null, null
+        )
+        
+        def out1Path = storeLocation.resolve("wf1/out.txt/.data.json")
+        def out2Path = storeLocation.resolve("wf2/out.txt/.data.json")
+        Files.createDirectories(out1Path.parent)
+        Files.createDirectories(out2Path.parent)
+        out1Path.text = encoder.encode(output1)
+        out2Path.text = encoder.encode(output2)
+
+        when: 'Validate workflow runs'
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+
+        then: 'Should fail - checksums differ'
+        def error = thrown(AbortOperationException)
+        error.message.contains("not equivalent")
+    }
+
+    def 'should detect different parameters between runs'() {
+        given: 'Create two workflow runs with different params'
+        def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("String", "input", "sample_A.fastq")])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("String", "input", "sample_B.fastq")])  // Different input!
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        when: 'Validate workflow runs'
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+
+        then: 'Should fail - params differ'
+        def error = thrown(AbortOperationException)
+        error.message.contains("not equivalent")
+    }
+
+    def 'should detect different number of outputs'() {
+        given: 'Create two workflow runs'
+        def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf, "session-2", "run2", [])
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        and: 'First run has 2 outputs, second has 1'
+        def output1a = new FileOutput("/results/a.txt", new Checksum("hash_a", "nextflow", "standard"),
+            "lid://wf1/a.txt", "lid://wf1", null, 100, null, null)
+        def output1b = new FileOutput("/results/b.txt", new Checksum("hash_b", "nextflow", "standard"),
+            "lid://wf1/b.txt", "lid://wf1", null, 100, null, null)
+        def output2a = new FileOutput("/results/a.txt", new Checksum("hash_a", "nextflow", "standard"),
+            "lid://wf2/a.txt", "lid://wf2", null, 100, null, null)
+        // Note: wf2 is missing b.txt output
+        
+        def out1aPath = storeLocation.resolve("wf1/a.txt/.data.json")
+        def out1bPath = storeLocation.resolve("wf1/b.txt/.data.json")
+        def out2aPath = storeLocation.resolve("wf2/a.txt/.data.json")
+        Files.createDirectories(out1aPath.parent)
+        Files.createDirectories(out1bPath.parent)
+        Files.createDirectories(out2aPath.parent)
+        out1aPath.text = encoder.encode(output1a)
+        out1bPath.text = encoder.encode(output1b)
+        out2aPath.text = encoder.encode(output2a)
+
+        when: 'Validate workflow runs'
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+
+        then: 'Should fail - different number of outputs'
+        def error = thrown(AbortOperationException)
+        error.message.contains("not equivalent")
+    }
+
+    def 'should validate runs with nested output directories'() {
+        given: 'Create workflow runs'
+        def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf, "session-2", "run2", [])
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        and: 'Create nested outputs with same structure and checksums'
+        def paths = ['sample1/aligned.bam', 'sample1/aligned.bam.bai', 'sample2/aligned.bam', 'sample2/aligned.bam.bai']
+        paths.each { relativePath ->
+            def checksum = "hash_${relativePath.replace('/', '_')}"
+            def output1 = new FileOutput("/results/${relativePath}",
+                new Checksum(checksum, "nextflow", "standard"),
+                "lid://wf1/${relativePath}", "lid://wf1", null, 100, null, null)
+            def output2 = new FileOutput("/results/${relativePath}",
+                new Checksum(checksum, "nextflow", "standard"),
+                "lid://wf2/${relativePath}", "lid://wf2", null, 100, null, null)
+            
+            def out1Path = storeLocation.resolve("wf1/${relativePath}/.data.json")
+            def out2Path = storeLocation.resolve("wf2/${relativePath}/.data.json")
+            Files.createDirectories(out1Path.parent)
+            Files.createDirectories(out2Path.parent)
+            out1Path.text = encoder.encode(output1)
+            out2Path.text = encoder.encode(output2)
+        }
+
+        when: 'Validate workflow runs'
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { line -> !line.contains('DEBUG') ? line : null }
+            .findResults { line -> !line.contains('INFO') ? line : null }
+            .findResults { line -> !line.contains('plugin') ? line : null }
+
+        then: 'Should pass - all nested outputs match'
+        noExceptionThrown()
+        stdout.any { it.contains("semantically equivalent") }
+    }
+
+    def 'should ignore specified fields during validation'() {
+        given: 'Create workflow runs with different commitIds'
+        def wf1 = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "commit_v1")
+        def wf2 = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "commit_v2")
+        def run1 = new WorkflowRun(wf1, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf2, "session-2", "run2", [])
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        when: 'Validate with --ignore-fields commitId'
+        new LinCommandImpl().validate(configMap, 
+            ["lid://wf1", "--against", "lid://wf2", "--ignore-fields", "commitId"])
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { line -> !line.contains('DEBUG') ? line : null }
+            .findResults { line -> !line.contains('INFO') ? line : null }
+            .findResults { line -> !line.contains('plugin') ? line : null }
+
+        then: 'Should pass - commitId is ignored'
+        noExceptionThrown()
+        stdout.any { it.contains("semantically equivalent") }
+    }
+
+    def 'should show diff when validation fails'() {
+        given: 'Create workflow runs with different configs'
+        def wf = new Workflow([new DataPath("file:///path/to/main.nf")], "https://github.com/test/repo", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("Integer", "memory", 8)])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("Integer", "memory", 16)])  // Different memory!
+
+        and: 'Store workflow runs'
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        when: 'Validate workflow runs'
+        try {
+            new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+        } catch (AbortOperationException e) {
+            // Expected
+        }
+        def stdout = capture.toString()
+
+        then: 'Should show diff output'
+        stdout.contains("differ") || stdout.contains("---") || stdout.contains("+++")
+    }
+}

--- a/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
@@ -475,4 +475,187 @@ class LinCommandImplTest extends Specification{
         err.message == "Checksum of '${outputFile}' does not match with lineage metadata"
     }
 
+    def 'should validate equivalent workflow runs'() {
+        given:
+        def encoder = new LinEncoder()
+        // Create two workflow runs with same structure but different ephemeral fields
+        def wf1 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def wf2 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf1, "session-1", "crazy_einstein", 
+            [new Parameter("String", "input", "test.fastq")])
+        def run2 = new WorkflowRun(wf2, "session-2", "angry_turing",
+            [new Parameter("String", "input", "test.fastq")])
+        
+        // Store both runs
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        when:
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { line -> !line.contains('DEBUG') ? line : null }
+            .findResults { line -> !line.contains('INFO') ? line : null }
+            .findResults { line -> !line.contains('plugin') ? line : null }
+
+        then:
+        stdout.any { it.contains("semantically equivalent") }
+    }
+
+    def 'should detect differences between workflow runs'() {
+        given:
+        def encoder = new LinEncoder()
+        // Create two workflow runs with different params
+        def wf1 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def wf2 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf1, "session-1", "run1",
+            [new Parameter("String", "input", "test.fastq")])
+        def run2 = new WorkflowRun(wf2, "session-2", "run2",
+            [new Parameter("String", "input", "different.fastq")])  // Different param value
+        
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        when:
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+
+        then:
+        def err = thrown(AbortOperationException)
+        err.message.contains("not equivalent")
+    }
+
+    def 'should validate with outputs'() {
+        given:
+        def encoder = new LinEncoder()
+        def time = OffsetDateTime.ofInstant(Instant.ofEpochMilli(123456789), ZoneOffset.UTC)
+        def time2 = OffsetDateTime.ofInstant(Instant.ofEpochMilli(987654321), ZoneOffset.UTC)
+        
+        // Create workflow runs
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf, "session-2", "run2", [])
+        
+        // Create outputs with same checksums but different timestamps
+        def out1 = new FileOutput("/results/out.txt", new Checksum("hash123", "nextflow", "standard"),
+            "lid://wf1/out.txt", "lid://wf1", null, 1024, time, time, null)
+        def out2 = new FileOutput("/results/out.txt", new Checksum("hash123", "nextflow", "standard"),
+            "lid://wf2/out.txt", "lid://wf2", null, 1024, time2, time2, null)
+        
+        // Store runs and outputs
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid1out = storeLocation.resolve("wf1/out.txt/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        def lid2out = storeLocation.resolve("wf2/out.txt/.data.json")
+        Files.createDirectories(lid1out.parent)
+        Files.createDirectories(lid2out.parent)
+        lid1.text = encoder.encode(run1)
+        lid1out.text = encoder.encode(out1)
+        lid2.text = encoder.encode(run2)
+        lid2out.text = encoder.encode(out2)
+
+        when:
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { line -> !line.contains('DEBUG') ? line : null }
+            .findResults { line -> !line.contains('INFO') ? line : null }
+            .findResults { line -> !line.contains('plugin') ? line : null }
+
+        then:
+        // Should be equivalent because timestamps are ignored
+        stdout.any { it.contains("semantically equivalent") }
+    }
+
+    def 'should detect output checksum differences'() {
+        given:
+        def encoder = new LinEncoder()
+        def time = OffsetDateTime.ofInstant(Instant.ofEpochMilli(123456789), ZoneOffset.UTC)
+        
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf, "session-2", "run2", [])
+        
+        // Outputs with different checksums
+        def out1 = new FileOutput("/results/out.txt", new Checksum("hash123", "nextflow", "standard"),
+            "lid://wf1/out.txt", "lid://wf1", null, 1024, time, time, null)
+        def out2 = new FileOutput("/results/out.txt", new Checksum("different", "nextflow", "standard"),
+            "lid://wf2/out.txt", "lid://wf2", null, 1024, time, time, null)
+        
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid1out = storeLocation.resolve("wf1/out.txt/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        def lid2out = storeLocation.resolve("wf2/out.txt/.data.json")
+        Files.createDirectories(lid1out.parent)
+        Files.createDirectories(lid2out.parent)
+        lid1.text = encoder.encode(run1)
+        lid1out.text = encoder.encode(out1)
+        lid2.text = encoder.encode(run2)
+        lid2out.text = encoder.encode(out2)
+
+        when:
+        new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
+
+        then:
+        def err = thrown(AbortOperationException)
+        err.message.contains("not equivalent")
+    }
+
+    def 'should error if workflow not found'() {
+        when:
+        new LinCommandImpl().validate(configMap, ["lid://nonexistent", "--against", "lid://also-missing"])
+
+        then:
+        def err = thrown(AbortOperationException)
+        err.message.contains("not found")
+    }
+
+    def 'should error without --against argument'() {
+        when:
+        new LinCommandImpl().validate(configMap, ["lid://wf1"])
+
+        then:
+        def err = thrown(AbortOperationException)
+        err.message.contains("--against")
+    }
+
+    def 'should support --ignore-fields option'() {
+        given:
+        def encoder = new LinEncoder()
+        // Workflow runs with different scripts (normally would fail)
+        def wf1 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "commit1")
+        def wf2 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "commit2")  // Different commitId
+        def run1 = new WorkflowRun(wf1, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf2, "session-2", "run2", [])
+        
+        def lid1 = storeLocation.resolve("wf1/.data.json")
+        def lid2 = storeLocation.resolve("wf2/.data.json")
+        Files.createDirectories(lid1.parent)
+        Files.createDirectories(lid2.parent)
+        lid1.text = encoder.encode(run1)
+        lid2.text = encoder.encode(run2)
+
+        when:
+        new LinCommandImpl().validate(configMap, 
+            ["lid://wf1", "--against", "lid://wf2", "--ignore-fields", "commitId"])
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { line -> !line.contains('DEBUG') ? line : null }
+            .findResults { line -> !line.contains('INFO') ? line : null }
+            .findResults { line -> !line.contains('plugin') ? line : null }
+
+        then:
+        stdout.any { it.contains("semantically equivalent") }
+    }
+
 }

--- a/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
@@ -42,6 +42,7 @@ import nextflow.lineage.serde.LinEncoder
 import nextflow.plugin.Plugins
 import nextflow.util.CacheHelper
 import org.junit.Rule
+import spock.lang.See
 import spock.lang.Shared
 import spock.lang.Specification
 import test.OutputCapture
@@ -475,6 +476,7 @@ class LinCommandImplTest extends Specification{
         err.message == "Checksum of '${outputFile}' does not match with lineage metadata"
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d2--equivalence-unit-outputs--key-inputs")
     def 'should validate equivalent workflow runs'() {
         given:
         def encoder = new LinEncoder()
@@ -507,6 +509,7 @@ class LinCommandImplTest extends Specification{
         stdout.any { it.contains("semantically equivalent") }
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d13--difference-categories-outputs--params--workflow-identity--resources")
     def 'should detect differences between workflow runs'() {
         given:
         def encoder = new LinEncoder()
@@ -533,6 +536,7 @@ class LinCommandImplTest extends Specification{
         err.message.contains("not equivalent")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d3--file-equivalence-checksum-only")
     def 'should validate with outputs'() {
         given:
         def encoder = new LinEncoder()
@@ -576,6 +580,7 @@ class LinCommandImplTest extends Specification{
         stdout.any { it.contains("semantically equivalent") }
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d3--file-equivalence-checksum-only")
     def 'should detect output checksum differences'() {
         given:
         def encoder = new LinEncoder()
@@ -610,6 +615,7 @@ class LinCommandImplTest extends Specification{
         err.message.contains("not equivalent")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d6--failure-output-human-diff-default---json-for-ci")
     def 'should error if workflow not found'() {
         when:
         new LinCommandImpl().validate(configMap, ["lid://nonexistent", "--against", "lid://also-missing"])
@@ -619,6 +625,7 @@ class LinCommandImplTest extends Specification{
         err.message.contains("not found")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d4--baseline-model-peer-lid-and-snapshot-file-from-day-one")
     def 'should error without --against argument'() {
         when:
         new LinCommandImpl().validate(configMap, ["lid://wf1"])
@@ -628,6 +635,7 @@ class LinCommandImplTest extends Specification{
         err.message.contains("--against")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d8--ignore-mechanism-flag--config-jsonpath-style")
     def 'should support --ignore-fields option'() {
         given:
         def encoder = new LinEncoder()

--- a/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
@@ -498,12 +498,7 @@ class LinCommandImplTest extends Specification{
 
         when:
         new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
-        def stdout = capture
-            .toString()
-            .readLines()
-            .findResults { line -> !line.contains('DEBUG') ? line : null }
-            .findResults { line -> !line.contains('INFO') ? line : null }
-            .findResults { line -> !line.contains('plugin') ? line : null }
+        def stdout = filterLogNoise(capture)
 
         then:
         stdout.any { it.contains("semantically equivalent") }
@@ -568,12 +563,7 @@ class LinCommandImplTest extends Specification{
 
         when:
         new LinCommandImpl().validate(configMap, ["lid://wf1", "--against", "lid://wf2"])
-        def stdout = capture
-            .toString()
-            .readLines()
-            .findResults { line -> !line.contains('DEBUG') ? line : null }
-            .findResults { line -> !line.contains('INFO') ? line : null }
-            .findResults { line -> !line.contains('plugin') ? line : null }
+        def stdout = filterLogNoise(capture)
 
         then:
         // Should be equivalent because timestamps are ignored
@@ -655,12 +645,7 @@ class LinCommandImplTest extends Specification{
         when:
         new LinCommandImpl().validate(configMap, 
             ["lid://wf1", "--against", "lid://wf2", "--ignore-fields", "commitId"])
-        def stdout = capture
-            .toString()
-            .readLines()
-            .findResults { line -> !line.contains('DEBUG') ? line : null }
-            .findResults { line -> !line.contains('INFO') ? line : null }
-            .findResults { line -> !line.contains('plugin') ? line : null }
+        def stdout = filterLogNoise(capture)
 
         then:
         stdout.any { it.contains("semantically equivalent") }

--- a/modules/nf-lineage/src/test/nextflow/lineage/test/LineageSnapshotterTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/test/LineageSnapshotterTest.groovy
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.lineage.test
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+import nextflow.lineage.LinStore
+import nextflow.lineage.model.v1beta1.Checksum
+import nextflow.lineage.model.v1beta1.DataPath
+import nextflow.lineage.model.v1beta1.FileOutput
+import nextflow.lineage.model.v1beta1.Parameter
+import nextflow.lineage.model.v1beta1.Workflow
+import nextflow.lineage.model.v1beta1.WorkflowRun
+import nextflow.lineage.serde.LinSerializable
+import spock.lang.Specification
+import spock.lang.TempDir
+
+/**
+ * Tests for LineageSnapshotter
+ *
+ * @author Edmund Miller <edmund.a.miller@gmail.com>
+ */
+class LineageSnapshotterTest extends Specification {
+
+    @TempDir
+    Path tmpDir
+
+    Path snapshotDir
+    LinStore mockStore
+
+    def setup() {
+        snapshotDir = tmpDir.resolve('snapshots')
+        Files.createDirectories(snapshotDir)
+        mockStore = Mock(LinStore)
+    }
+
+    def 'should create snapshot on first run'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run = new WorkflowRun(wf, "session-1", "run1", 
+            [new Parameter("String", "input", "test.fastq")])
+        
+        mockStore.load("wf1") >> run
+        mockStore.getSubKeys("wf1") >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+
+        then:
+        noExceptionThrown()
+        Files.exists(snapshotDir.resolve("test-baseline.json"))
+    }
+
+    def 'should pass when snapshot matches'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1", 
+            [new Parameter("String", "input", "test.fastq")])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("String", "input", "test.fastq")])
+        
+        // First call returns run1 (for creating snapshot)
+        // Second call returns run2 (for comparing)
+        mockStore.load("wf1") >>> [run1, run2]
+        mockStore.getSubKeys("wf1") >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        // First run - creates snapshot
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+        // Second run - compares against snapshot
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should fail when snapshot differs'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("String", "input", "test.fastq")])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("String", "input", "different.fastq")])  // Different param
+        
+        mockStore.load("wf1") >>> [run1, run2]
+        mockStore.getSubKeys("wf1") >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        // First run - creates snapshot
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+        // Second run - should fail
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+
+        then:
+        def error = thrown(AssertionError)
+        error.message.contains("does not match snapshot")
+        error.message.contains("test-baseline")
+        // Should create .actual.json for debugging
+        Files.exists(snapshotDir.resolve("test-baseline.actual.json"))
+    }
+
+    def 'should update snapshot when updateSnapshots is true'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("String", "input", "old.fastq")])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("String", "input", "new.fastq")])
+        
+        mockStore.load("wf1") >>> [run1, run2]
+        mockStore.getSubKeys("wf1") >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        // First run - creates snapshot
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+        
+        // Enable update mode
+        snapshotter.withUpdateSnapshots(true)
+        
+        // Second run - updates snapshot instead of failing
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+
+        then:
+        noExceptionThrown()
+        // Snapshot should contain new value
+        snapshotDir.resolve("test-baseline.json").text.contains("new.fastq")
+    }
+
+    def 'should compare two runs directly with assertEquivalent'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("String", "input", "test.fastq")])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("String", "input", "test.fastq")])
+        
+        mockStore.load("wf1") >> run1
+        mockStore.load("wf2") >> run2
+        mockStore.getSubKeys(_) >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        snapshotter.assertEquivalent("lid://wf1", "lid://wf2")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should fail assertEquivalent when runs differ'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run1 = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("String", "input", "test.fastq")])
+        def run2 = new WorkflowRun(wf, "session-2", "run2",
+            [new Parameter("String", "input", "different.fastq")])
+        
+        mockStore.load("wf1") >> run1
+        mockStore.load("wf2") >> run2
+        mockStore.getSubKeys(_) >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        snapshotter.assertEquivalent("lid://wf1", "lid://wf2")
+
+        then:
+        def error = thrown(AssertionError)
+        error.message.contains("not semantically equivalent")
+    }
+
+    def 'should throw if snapshotDir not configured'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run = new WorkflowRun(wf, "session-1", "run1", [])
+        
+        mockStore.load("wf1") >> run
+        mockStore.getSubKeys("wf1") >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+        // Not calling withSnapshotDir()
+
+        when:
+        snapshotter.assertMatchesSnapshot("lid://wf1", "test-baseline")
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def 'should include outputs in snapshot comparison'() {
+        given:
+        def time = OffsetDateTime.ofInstant(Instant.ofEpochMilli(123456789), ZoneOffset.UTC)
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run = new WorkflowRun(wf, "session-1", "run1", [])
+        def output = new FileOutput("/results/out.txt", 
+            new Checksum("hash123", "nextflow", "standard"),
+            "lid://wf1/out.txt", "lid://wf1", null, 1024, time, time, null)
+        
+        mockStore.load("wf1") >> run
+        mockStore.load("wf1/out.txt") >> output
+        mockStore.getSubKeys("wf1") >> ["wf1/out.txt"].stream()
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        snapshotter.assertMatchesSnapshot("lid://wf1", "with-outputs")
+
+        then:
+        noExceptionThrown()
+        def snapshotContent = snapshotDir.resolve("with-outputs.json").text
+        snapshotContent.contains("hash123")
+        snapshotContent.contains("out.txt")
+    }
+
+    def 'should return normalized JSON for debugging'() {
+        given:
+        def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
+        def run = new WorkflowRun(wf, "session-1", "run1",
+            [new Parameter("String", "input", "test.fastq")])
+        
+        mockStore.load("wf1") >> run
+        mockStore.getSubKeys("wf1") >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+
+        when:
+        def json = snapshotter.getNormalizedJson("lid://wf1")
+
+        then:
+        json.contains("WorkflowRun")
+        json.contains("test.fastq")
+        !json.contains("session-1")  // sessionId should be stripped
+    }
+
+    def 'should support custom ignore fields'() {
+        given:
+        def wf1 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "commit1")
+        def wf2 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "commit2")
+        def run1 = new WorkflowRun(wf1, "session-1", "run1", [])
+        def run2 = new WorkflowRun(wf2, "session-2", "run2", [])
+        
+        mockStore.load("wf1") >> run1
+        mockStore.load("wf2") >> run2
+        mockStore.getSubKeys(_) >> { [].stream() }
+        
+        def snapshotter = new LineageSnapshotter(mockStore)
+            .withSnapshotDir(snapshotDir)
+            .withIgnoreFields(['commitId'])
+
+        when:
+        snapshotter.assertEquivalent("lid://wf1", "lid://wf2")
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/modules/nf-lineage/src/test/nextflow/lineage/test/LineageSnapshotterTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/test/LineageSnapshotterTest.groovy
@@ -30,14 +30,38 @@ import nextflow.lineage.model.v1beta1.Parameter
 import nextflow.lineage.model.v1beta1.Workflow
 import nextflow.lineage.model.v1beta1.WorkflowRun
 import nextflow.lineage.serde.LinSerializable
+import spock.lang.Narrative
+import spock.lang.See
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.TempDir
+import spock.lang.Title
 
 /**
  * Tests for LineageSnapshotter
  *
  * @author Edmund Miller <edmund.a.miller@gmail.com>
  */
+@Title("Spock snapshot integration for lineage validation")
+@Narrative('''
+LineageSnapshotter is the Spock-facing wrapper around the same validator core
+the CLI uses. It supports two flavours of assertion:
+
+ * `assertMatchesSnapshot(lid, id)` — compare a workflow run against a baseline
+   snapshot file on disk. The file is created on first run; subsequent runs
+   compare against it. `UPDATE_SNAPSHOTS=true` refreshes the baseline.
+ * `assertEquivalent(lidA, lidB)` — compare two runs directly, no file.
+
+Snapshot file format and ignore semantics must stay aligned with the CLI: if a
+test passes locally but `nextflow lineage validate` fails in CI (or vice versa)
+the abstraction has leaked.
+''')
+@See([
+    "https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d4--baseline-model-peer-lid-and-snapshot-file-from-day-one",
+    "https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d11--cli-vs-lineagesnapshotter-extract-shared-lineagevalidator",
+    "https://spockframework.org/spock/docs/2.4/all_in_one.html#_specifications_as_documentation"
+])
+@Subject(LineageSnapshotter)
 class LineageSnapshotterTest extends Specification {
 
     @TempDir
@@ -52,6 +76,7 @@ class LineageSnapshotterTest extends Specification {
         mockStore = Mock(LinStore)
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d4--baseline-model-peer-lid-and-snapshot-file-from-day-one")
     def 'should create snapshot on first run'() {
         given:
         def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
@@ -72,6 +97,7 @@ class LineageSnapshotterTest extends Specification {
         Files.exists(snapshotDir.resolve("test-baseline.json"))
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d2--equivalence-unit-outputs--key-inputs")
     def 'should pass when snapshot matches'() {
         given:
         def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
@@ -98,6 +124,7 @@ class LineageSnapshotterTest extends Specification {
         noExceptionThrown()
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d6--failure-output-human-diff-default---json-for-ci")
     def 'should fail when snapshot differs'() {
         given:
         def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
@@ -126,6 +153,7 @@ class LineageSnapshotterTest extends Specification {
         Files.exists(snapshotDir.resolve("test-baseline.actual.json"))
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d4--baseline-model-peer-lid-and-snapshot-file-from-day-one")
     def 'should update snapshot when updateSnapshots is true'() {
         given:
         def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
@@ -156,6 +184,7 @@ class LineageSnapshotterTest extends Specification {
         snapshotDir.resolve("test-baseline.json").text.contains("new.fastq")
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d11--cli-vs-lineagesnapshotter-extract-shared-lineagevalidator")
     def 'should compare two runs directly with assertEquivalent'() {
         given:
         def wf = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "abc123")
@@ -266,6 +295,7 @@ class LineageSnapshotterTest extends Specification {
         !json.contains("session-1")  // sessionId should be stripped
     }
 
+    @See("https://github.com/nextflow-io/nextflow/blob/master/adr/20260521-lineage-validate.md#d8--ignore-mechanism-flag--config-jsonpath-style")
     def 'should support custom ignore fields'() {
         given:
         def wf1 = new Workflow([new DataPath("/path/to/main.nf")], "test-wf", "commit1")

--- a/tests/checks/lineage-validate-basic.nf/.checks
+++ b/tests/checks/lineage-validate-basic.nf/.checks
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Test: Basic lineage validation
+# Verifies that two identical runs produce semantically equivalent lineage
+#
+
+set -e
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+PROJECT_ROOT="$(dirname "$TESTS_DIR")"
+
+# Use project launcher if NXF_CMD not set
+: "${NXF_CMD:=$PROJECT_ROOT/launch.sh}"
+: "${NXF_RUN:=$NXF_CMD run $TESTS_DIR/lineage-validate-basic.nf}"
+
+# Create temporary working directory
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+cd "$WORK_DIR"
+
+# Skip if lineage is not available
+if ! "$NXF_CMD" lineage --help &>/dev/null; then
+    echo "SKIP: lineage command not available"
+    exit 0
+fi
+
+# Create temporary lineage store
+LINEAGE_STORE="$WORK_DIR/lineage-store"
+mkdir -p "$LINEAGE_STORE"
+
+LINEAGE_CONFIG="lineage { enabled = true; store { location = '$LINEAGE_STORE' } }"
+
+#
+# First run
+#
+echo "=== First run ==="
+$NXF_RUN -c <(echo "$LINEAGE_CONFIG") --greeting Hello --name World 2>&1 | tee run1.out
+
+# Extract workflow run LID from first run
+RUN1_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 1 LID: $RUN1_LID"
+
+# Verify lineage was created
+[[ -n "$RUN1_LID" ]] || { echo "ERROR: No LID found for run 1"; exit 1; }
+
+# Clean work directory but keep lineage store
+rm -rf work .nextflow.log
+
+#
+# Second run with identical parameters
+#
+echo ""
+echo "=== Second run (identical params) ==="
+$NXF_RUN -c <(echo "$LINEAGE_CONFIG") --greeting Hello --name World 2>&1 | tee run2.out
+
+# Extract workflow run LID from second run
+RUN2_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 2 LID: $RUN2_LID"
+
+[[ -n "$RUN2_LID" ]] || { echo "ERROR: No LID found for run 2"; exit 1; }
+[[ "$RUN1_LID" != "$RUN2_LID" ]] || { echo "ERROR: LIDs should be different"; exit 1; }
+
+#
+# Validate: runs should be equivalent
+#
+echo ""
+echo "=== Validating lineage ==="
+"$NXF_CMD" lineage validate "$RUN2_LID" --against "$RUN1_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate.out
+
+# Check validation passed
+grep -q "semantically equivalent" validate.out || { echo "ERROR: Validation should pass"; exit 1; }
+
+echo ""
+echo "=== Test passed: Basic lineage validation ==="

--- a/tests/checks/lineage-validate-changes.nf/.checks
+++ b/tests/checks/lineage-validate-changes.nf/.checks
@@ -1,0 +1,135 @@
+#!/bin/bash
+#
+# Test: Lineage validation change detection
+# Verifies that validation detects parameter and output differences
+#
+
+set -e
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+PROJECT_ROOT="$(dirname "$TESTS_DIR")"
+
+# Use project launcher if NXF_CMD not set
+: "${NXF_CMD:=$PROJECT_ROOT/launch.sh}"
+: "${NXF_RUN:=$NXF_CMD run $TESTS_DIR/lineage-validate-changes.nf}"
+
+# Create temporary working directory
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+cd "$WORK_DIR"
+
+# Skip if lineage is not available
+if ! "$NXF_CMD" lineage --help &>/dev/null; then
+    echo "SKIP: lineage command not available"
+    exit 0
+fi
+
+# Create temporary lineage store
+LINEAGE_STORE="$WORK_DIR/lineage-store"
+mkdir -p "$LINEAGE_STORE"
+
+LINEAGE_CONFIG="lineage { enabled = true; store { location = '$LINEAGE_STORE' } }"
+
+#
+# Test 1: Different parameters should fail validation
+#
+echo "=== Test 1: Parameter change detection ==="
+
+# Run 1 with text A
+echo "--- Run 1: input_text=alpha ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_text alpha --multiplier 1 2>&1 | tee run1.out
+RUN1_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 1 LID: $RUN1_LID"
+rm -rf work .nextflow.log
+
+# Run 2 with text B (different!)
+echo ""
+echo "--- Run 2: input_text=beta ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_text beta --multiplier 1 2>&1 | tee run2.out
+RUN2_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 2 LID: $RUN2_LID"
+rm -rf work .nextflow.log
+
+# Validation should FAIL (different params = different outputs)
+echo ""
+echo "--- Validating (should fail) ---"
+if "$NXF_CMD" lineage validate "$RUN2_LID" --against "$RUN1_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate1.out; then
+    echo "ERROR: Validation should have failed (params differ)"
+    exit 1
+fi
+
+# Verify diff output was shown
+grep -q "differ" validate1.out || grep -q "not equivalent" validate1.out || \
+    { echo "ERROR: Should show difference message"; exit 1; }
+
+echo "Test 1 passed: Parameter change detected"
+
+
+#
+# Test 2: Same parameters but different multiplier (different output content)
+#
+echo ""
+echo "=== Test 2: Output content change detection ==="
+
+# Run 3 with multiplier 1
+echo "--- Run 3: multiplier=1 ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_text same --multiplier 1 2>&1 | tee run3.out
+RUN3_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 3 LID: $RUN3_LID"
+rm -rf work .nextflow.log
+
+# Run 4 with multiplier 3 (different content = different checksum)
+echo ""
+echo "--- Run 4: multiplier=3 ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_text same --multiplier 3 2>&1 | tee run4.out
+RUN4_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 4 LID: $RUN4_LID"
+rm -rf work .nextflow.log
+
+# Validation should FAIL (different output checksums)
+echo ""
+echo "--- Validating (should fail) ---"
+if "$NXF_CMD" lineage validate "$RUN4_LID" --against "$RUN3_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate2.out; then
+    echo "ERROR: Validation should have failed (output checksums differ)"
+    exit 1
+fi
+
+echo "Test 2 passed: Output change detected"
+
+
+#
+# Test 3: --ignore-fields should allow ignoring specific differences
+#
+echo ""
+echo "=== Test 3: --ignore-fields option ==="
+
+# Run 5 and 6 with same content but we'll test ignore functionality
+echo "--- Run 5 ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_text final --multiplier 2 2>&1 | tee run5.out
+RUN5_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 5 LID: $RUN5_LID"
+rm -rf work .nextflow.log
+
+echo ""
+echo "--- Run 6 (identical) ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_text final --multiplier 2 2>&1 | tee run6.out
+RUN6_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 6 LID: $RUN6_LID"
+rm -rf work .nextflow.log
+
+# Validation should PASS (identical runs)
+echo ""
+echo "--- Validating identical runs ---"
+"$NXF_CMD" lineage validate "$RUN6_LID" --against "$RUN5_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate3.out
+
+grep -q "semantically equivalent" validate3.out || { echo "ERROR: Identical runs should pass"; exit 1; }
+
+echo "Test 3 passed: Identical runs validated"
+
+echo ""
+echo "=== All tests passed: Change detection working ==="

--- a/tests/checks/lineage-validate-multi.nf/.checks
+++ b/tests/checks/lineage-validate-multi.nf/.checks
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# Test: Multi-process lineage validation
+# Verifies validation works with complex pipelines having multiple outputs
+#
+
+set -e
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+PROJECT_ROOT="$(dirname "$TESTS_DIR")"
+
+# Use project launcher if NXF_CMD not set
+: "${NXF_CMD:=$PROJECT_ROOT/launch.sh}"
+: "${NXF_RUN:=$NXF_CMD run $TESTS_DIR/lineage-validate-multi.nf}"
+
+# Create temporary working directory
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+cd "$WORK_DIR"
+
+# Skip if lineage is not available
+if ! "$NXF_CMD" lineage --help &>/dev/null; then
+    echo "SKIP: lineage command not available"
+    exit 0
+fi
+
+# Create temporary lineage store
+LINEAGE_STORE="$WORK_DIR/lineage-store"
+mkdir -p "$LINEAGE_STORE"
+
+LINEAGE_CONFIG="lineage { enabled = true; store { location = '$LINEAGE_STORE' } }"
+
+#
+# Test 1: Multi-sample pipeline produces consistent outputs
+#
+echo "=== Test 1: Multi-sample consistency ==="
+
+# Run 1
+echo "--- Run 1 ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --samples 'A,B,C' 2>&1 | tee run1.out
+RUN1_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 1 LID: $RUN1_LID"
+
+# Verify all processes ran
+[[ $(grep -c 'Submitted process > GENERATE' .nextflow.log) == 3 ]] || \
+    { echo "ERROR: Expected 3 GENERATE processes"; exit 1; }
+[[ $(grep -c 'Submitted process > ANALYZE' .nextflow.log) == 3 ]] || \
+    { echo "ERROR: Expected 3 ANALYZE processes"; exit 1; }
+[[ $(grep -c 'Submitted process > SUMMARIZE' .nextflow.log) == 1 ]] || \
+    { echo "ERROR: Expected 1 SUMMARIZE process"; exit 1; }
+
+rm -rf work .nextflow.log
+
+# Run 2 with same samples
+echo ""
+echo "--- Run 2 (identical) ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --samples 'A,B,C' 2>&1 | tee run2.out
+RUN2_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 2 LID: $RUN2_LID"
+rm -rf work .nextflow.log
+
+# Validate
+echo ""
+echo "--- Validating ---"
+"$NXF_CMD" lineage validate "$RUN2_LID" --against "$RUN1_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate1.out
+
+grep -q "semantically equivalent" validate1.out || \
+    { echo "ERROR: Multi-sample runs should be equivalent"; exit 1; }
+
+echo "Test 1 passed: Multi-sample pipeline validated"
+
+
+#
+# Test 2: Different sample sets should fail
+#
+echo ""
+echo "=== Test 2: Different samples detection ==="
+
+# Run 3 with different samples
+echo "--- Run 3: samples=X,Y ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --samples 'X,Y' 2>&1 | tee run3.out
+RUN3_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 3 LID: $RUN3_LID"
+rm -rf work .nextflow.log
+
+# Validate against first run (should fail - different samples)
+echo ""
+echo "--- Validating different samples (should fail) ---"
+if "$NXF_CMD" lineage validate "$RUN3_LID" --against "$RUN1_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate2.out; then
+    echo "ERROR: Validation should fail (different samples)"
+    exit 1
+fi
+
+echo "Test 2 passed: Different samples detected"
+
+
+#
+# Test 3: Same samples in different order should still match (outputs are same)
+#
+echo ""
+echo "=== Test 3: Sample order independence ==="
+
+# Run 4 with same samples, different order
+echo "--- Run 4: samples=C,A,B (reordered) ---"
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --samples 'C,A,B' 2>&1 | tee run4.out
+RUN4_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 4 LID: $RUN4_LID"
+rm -rf work .nextflow.log
+
+# Validate - should pass because params are normalized/compared properly
+echo ""
+echo "--- Validating reordered samples ---"
+# Note: This test may pass or fail depending on how params are compared
+# If it fails, that's also valid behavior (params differ)
+if "$NXF_CMD" lineage validate "$RUN4_LID" --against "$RUN1_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate3.out; then
+    echo "Test 3: Reordered samples validated as equivalent"
+else
+    echo "Test 3: Reordered samples detected as different (also valid)"
+fi
+
+echo ""
+echo "=== All multi-process tests passed ==="

--- a/tests/checks/lineage-validate-resume.nf/.checks
+++ b/tests/checks/lineage-validate-resume.nf/.checks
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Test: Lineage validation with resume mode
+# Verifies that resumed runs produce equivalent lineage to fresh runs
+#
+
+set -e
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+PROJECT_ROOT="$(dirname "$TESTS_DIR")"
+
+# Use project launcher if NXF_CMD not set
+: "${NXF_CMD:=$PROJECT_ROOT/launch.sh}"
+: "${NXF_RUN:=$NXF_CMD run $TESTS_DIR/lineage-validate-resume.nf}"
+
+# Create temporary working directory
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+cd "$WORK_DIR"
+
+# Skip if lineage is not available
+if ! "$NXF_CMD" lineage --help &>/dev/null; then
+    echo "SKIP: lineage command not available"
+    exit 0
+fi
+
+# Create temporary lineage store
+LINEAGE_STORE="$WORK_DIR/lineage-store"
+mkdir -p "$LINEAGE_STORE"
+
+LINEAGE_CONFIG="lineage { enabled = true; store { location = '$LINEAGE_STORE' } }"
+
+#
+# Test 1: Fresh run vs resumed run should be equivalent
+#
+echo "=== Test 1: Fresh run ==="
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_value hello 2>&1 | tee run1.out
+RUN1_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Fresh run LID: $RUN1_LID"
+
+# Verify all steps completed
+[[ $(grep -c 'Submitted process' .nextflow.log) == 3 ]] || \
+    { echo "ERROR: Expected 3 processes submitted"; exit 1; }
+
+# Keep work directory for resume
+mv .nextflow.log run1.nextflow.log
+
+
+#
+# Test 2: Resume same run (all cached)
+#
+echo ""
+echo "=== Test 2: Resume run (all cached) ==="
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_value hello -resume 2>&1 | tee run2.out
+RUN2_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Resume run LID: $RUN2_LID"
+
+# Verify all steps were cached
+[[ $(grep -c 'Cached process' .nextflow.log) == 3 ]] || \
+    { echo "ERROR: Expected 3 cached processes"; exit 1; }
+
+mv .nextflow.log run2.nextflow.log
+
+# Validate fresh vs resumed
+echo ""
+echo "--- Validating fresh vs resumed ---"
+"$NXF_CMD" lineage validate "$RUN2_LID" --against "$RUN1_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate1.out
+
+grep -q "semantically equivalent" validate1.out || \
+    { echo "ERROR: Fresh and resumed runs should be equivalent"; exit 1; }
+
+echo "Test 1-2 passed: Fresh and resumed runs are equivalent"
+
+
+#
+# Test 3: Partial resume (simulate failure and resume)
+#
+echo ""
+echo "=== Test 3: Fresh run for partial resume test ==="
+rm -rf work
+
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_value partial 2>&1 | tee run3.out
+RUN3_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 3 LID: $RUN3_LID"
+mv .nextflow.log run3.nextflow.log
+
+echo ""
+echo "=== Test 4: Another fresh run (should match) ==="
+rm -rf work
+
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_value partial 2>&1 | tee run4.out
+RUN4_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 4 LID: $RUN4_LID"
+mv .nextflow.log run4.nextflow.log
+
+# Validate two fresh runs
+echo ""
+echo "--- Validating two fresh runs ---"
+"$NXF_CMD" lineage validate "$RUN4_LID" --against "$RUN3_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate2.out
+
+grep -q "semantically equivalent" validate2.out || \
+    { echo "ERROR: Two fresh runs should be equivalent"; exit 1; }
+
+echo "Test 3-4 passed: Multiple fresh runs are equivalent"
+
+
+#
+# Test 5: Different input should fail validation even with resume
+#
+echo ""
+echo "=== Test 5: Different input detection ==="
+
+"$NXF_RUN" -c <(echo "$LINEAGE_CONFIG") --input_value different 2>&1 | tee run5.out
+RUN5_LID=$(grep -oE 'lid://[a-f0-9-]+' .nextflow.log | head -1)
+echo "Run 5 LID: $RUN5_LID"
+
+echo ""
+echo "--- Validating different input (should fail) ---"
+if "$NXF_CMD" lineage validate "$RUN5_LID" --against "$RUN3_LID" \
+    -c <(echo "$LINEAGE_CONFIG") 2>&1 | tee validate3.out; then
+    echo "ERROR: Different input should fail validation"
+    exit 1
+fi
+
+echo "Test 5 passed: Different input detected"
+
+echo ""
+echo "=== All resume tests passed ==="

--- a/tests/lineage-validate-basic.nf
+++ b/tests/lineage-validate-basic.nf
@@ -1,0 +1,54 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Basic lineage validation test
+ * Verifies that two identical runs produce semantically equivalent lineage
+ */
+
+params.greeting = 'Hello'
+params.name = 'World'
+
+process GREET {
+    input:
+    val greeting
+    val name
+
+    output:
+    path 'greeting.txt'
+
+    """
+    echo "${greeting}, ${name}!" > greeting.txt
+    """
+}
+
+process UPPERCASE {
+    input:
+    path input_file
+
+    output:
+    path 'result.txt'
+
+    """
+    cat ${input_file} | tr '[:lower:]' '[:upper:]' > result.txt
+    """
+}
+
+workflow {
+    GREET(params.greeting, params.name)
+    UPPERCASE(GREET.out)
+}

--- a/tests/lineage-validate-changes.nf
+++ b/tests/lineage-validate-changes.nf
@@ -1,0 +1,57 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Lineage validation test for detecting changes
+ * Verifies that validation detects parameter and output differences
+ */
+
+params.input_text = 'default text'
+params.multiplier = 1
+
+process TRANSFORM {
+    input:
+    val text
+    val multiplier
+
+    output:
+    path 'output.txt'
+
+    """
+    # Repeat text based on multiplier
+    for i in \$(seq 1 ${multiplier}); do
+        echo "${text}"
+    done > output.txt
+    """
+}
+
+process CHECKSUM {
+    input:
+    path input_file
+
+    output:
+    path 'checksum.txt'
+
+    """
+    md5sum ${input_file} | cut -d' ' -f1 > checksum.txt
+    """
+}
+
+workflow {
+    TRANSFORM(params.input_text, params.multiplier)
+    CHECKSUM(TRANSFORM.out)
+}

--- a/tests/lineage-validate-multi.nf
+++ b/tests/lineage-validate-multi.nf
@@ -1,0 +1,74 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Lineage validation test for multi-process workflows
+ * Verifies validation works with complex pipelines having multiple outputs
+ */
+
+params.samples = 'sample1,sample2,sample3'
+
+process GENERATE {
+    tag "${sample}"
+    
+    input:
+    val sample
+
+    output:
+    tuple val(sample), path("${sample}.txt")
+
+    """
+    echo "Data for ${sample}" > ${sample}.txt
+    echo "Line 2" >> ${sample}.txt
+    echo "Line 3" >> ${sample}.txt
+    """
+}
+
+process ANALYZE {
+    tag "${sample}"
+    
+    input:
+    tuple val(sample), path(input_file)
+
+    output:
+    tuple val(sample), path("${sample}.analysis.txt")
+
+    """
+    wc -l ${input_file} > ${sample}.analysis.txt
+    wc -c ${input_file} >> ${sample}.analysis.txt
+    """
+}
+
+process SUMMARIZE {
+    input:
+    path analysis_files
+
+    output:
+    path 'summary.txt'
+
+    """
+    cat ${analysis_files} | sort > summary.txt
+    """
+}
+
+workflow {
+    samples_ch = Channel.of(params.samples.split(','))
+    
+    GENERATE(samples_ch)
+    ANALYZE(GENERATE.out)
+    SUMMARIZE(ANALYZE.out.map { it[1] }.collect())
+}

--- a/tests/lineage-validate-resume.nf
+++ b/tests/lineage-validate-resume.nf
@@ -1,0 +1,69 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Lineage validation test for resume mode
+ * Verifies that resumed runs produce equivalent lineage to fresh runs
+ */
+
+params.input_value = 'test'
+
+process STEP1 {
+    input:
+    val x
+
+    output:
+    path 'step1.txt'
+
+    """
+    echo "Step 1: ${x}" > step1.txt
+    sleep 1
+    """
+}
+
+process STEP2 {
+    input:
+    path input_file
+
+    output:
+    path 'step2.txt'
+
+    """
+    cat ${input_file} > step2.txt
+    echo "Step 2 complete" >> step2.txt
+    sleep 1
+    """
+}
+
+process STEP3 {
+    input:
+    path input_file
+
+    output:
+    path 'final.txt'
+
+    """
+    cat ${input_file} > final.txt
+    echo "Step 3 final" >> final.txt
+    """
+}
+
+workflow {
+    STEP1(params.input_value)
+    STEP2(STEP1.out)
+    STEP3(STEP2.out)
+}


### PR DESCRIPTION
## Summary

First-pass implementation of `nextflow lineage validate` per the design in #7167 (stacked on that PR). Ships the v1 surface so we can use it in practice and feed back into the design.

What's in:

- **`LinNormalizer`** — encodes lineage records, strips ephemeral fields, supports `--output-base` relativization and `--ignore-fields`; provides recursive structural compare with diff paths
- **`nextflow lineage validate <lid> --against <lid>`** — CLI command with `-against`, `-ignore-fields`, `-output-base` options; emits JGit-style unified diff and exits non-zero on divergence
- **`LineageSnapshotter`** — Spock helper for pipeline tests; supports save-or-compare with `UPDATE_SNAPSHOTS` env var, plus direct `assertEquivalent(lidA, lidB)`
- **Integration tests** — seven scenarios covering equivalent runs, output checksum drift, parameter drift, output count mismatch, nested directories, `--ignore-fields`, and diff rendering
- **Regression test for JCommander wiring** — catches the option-parsing bug fixed in the last commit

Known gaps vs the ADR (deferred to follow-ups):

- No shared `LineageValidator` core yet; CLI and `LineageSnapshotter` still have parallel logic
- No snapshot-file baseline (`--against <file.json>`) or `--save-snapshot`
- No `--json` / `--summary` / CI auto-detection
- No diff categorisation, runtime-fingerprint handling, or one-hop causality enrichment
- No `LineageResolver` SPI; only `lid://` works today

Treat this as a working spike to validate the design against real lineage data — feedback expected to inform the v1.1 refactor.

## Test plan

- [ ] Run `./gradlew :nf-lineage:test --tests LinValidateIntegrationTest`
- [ ] Run `./gradlew :nextflow:test --tests LauncherTest` (regression for JCommander wiring)
- [ ] Manual: launch two pipeline runs against the local lineage store, `nextflow lineage validate lid://<runA> -against lid://<runB>`, confirm divergence on params/outputs and equivalence on identical runs
- [ ] Try `-ignore-fields commitId` to verify field exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #7167
2. **#7168** 👈 current
<!-- stack:links:end -->