### PR TITLE
Fix bucket cleanup in S3 test

### DIFF
--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
@@ -448,6 +448,8 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         then:
         thrown(UnsupportedOperationException)
 
+        cleanup:
+        deleteBucket(bucketName)
     }
 
     @Ignore // FIXME

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
@@ -441,7 +441,7 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
 
     def 'should throw unsupported when trying delete a bucket' () {
         given:
-        final bucketName = createBucket()
+        def bucketName = createBucket()
 
         when:
         Files.delete(s3path("s3://$bucketName"))


### PR DESCRIPTION
Fixes an S3 unit test that creates a bucket without deleting it on cleanup