### PR TITLE
Improve message error when enabling types with syntax parser v1

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
@@ -63,10 +63,9 @@ class NextflowMeta {
         boolean strict
         boolean moduleBinaries
 
-        //Adding this method to provide a meaningful error when trying to use static types wit syntax parser v1.
-        void setTypes(boolean types){
-            if (types)
-                throw new AbortOperationException("Static types only available in syntax parser v2. Set NXF_SYNTAX_PARSER=v2 to enable static types.")
+        void setTypes(boolean types) {
+            if( types )
+                throw new AbortOperationException("Static typing requires the strict parser -- set NXF_SYNTAX_PARSER=v2 in your environment to enable the strict parser")
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/NextflowMeta.groovy
@@ -62,6 +62,12 @@ class NextflowMeta {
         volatile float dsl
         boolean strict
         boolean moduleBinaries
+
+        //Adding this method to provide a meaningful error when trying to use static types wit syntax parser v1.
+        void setTypes(boolean types){
+            if (types)
+                throw new AbortOperationException("Static types only available in syntax parser v2. Set NXF_SYNTAX_PARSER=v2 to enable static types.")
+        }
     }
 
     final VersionNumber version


### PR DESCRIPTION
This pull request introduces a new error handling mechanism to improve developer feedback when using static types with an unsupported syntax parser version in Nextflow.

In current implementation when executing a pipeline enabling types in syntax parser v1. The user get this error

`ERROR ~ No such variable: types`

In `nextflow.log`, the user can see this stack trace, that do not provide a useful guide to know the cause of the error.

```
groovy.lang.MissingPropertyException: No such property: types for class: nextflow.NextflowMeta$Features
        at nextflow.NextflowMeta$Features.propertyMissing(NextflowMeta.groovy)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
        at groovy.lang.MetaClassImpl.invokeMissingProperty(MetaClassImpl.java:856)
       ...
```

This pull request introduces a new error handling mechanism to improve developer feedback when using static types with an unsupported syntax parser version in Nextflow.

Error Handling Enhancement:

* Added a `setTypes` method to the `NextflowMeta` class that throws an `AbortOperationException` with a clear error message if static types are enabled while using syntax parser v1, guiding users to set `NXF_SYNTAX_PARSER=v2` for static types support.

With this PR the user will get a message sucha as the following:

`Static types only available in syntax parser v2. Set NXF_SYNTAX_PARSER=v2 to enable static types. -- Check script 'module.nf' at line: 1 or see '.nextflow.log' file for more details`
