### PR TITLE
Fix docs CI on Python 3.14 by upgrading Sphinx

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, reopened, synchronize]
     paths:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-myst-parser==0.18.1
-sphinx==5.3.0
-sphinx-rtd-theme==1.1.1
-sphinxcontrib-mermaid==0.9.2
-sphinxext-rediraffe==0.2.7
-sphinx-tabs==3.4.5
+myst-parser==4.0.1
+sphinx==8.2.3
+sphinx-rtd-theme==3.1.0
+sphinxcontrib-mermaid==1.2.3
+sphinxext-rediraffe==0.3.0
+sphinx-tabs==3.5.0
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
## Summary
- Sphinx 5.x imports the stdlib `imghdr` module, removed in Python 3.13 (PEP 594). After CI bumped to Python 3.14.5 the docs build fails on `import sphinx.builders.epub3` → `ModuleNotFoundError: No module named 'imghdr'`.
- Bump Sphinx (5.3.0 → 8.2.3) and the companion packages that depend on it to versions that no longer rely on `imghdr`: `myst-parser`, `sphinx-rtd-theme`, `sphinxcontrib-mermaid`, `sphinxext-rediraffe`, `sphinx-tabs`.
- Also trigger the Docs CI workflow when the workflow file itself (`.github/workflows/docs.yml`) is edited — `docs/**` already covers `docs/requirements.txt`.

## Test plan
- [x] Reproduced the `imghdr` failure locally in a fresh Python 3.14 venv with the previous pins.
- [x] Replicated the exact CI flow (`pip install -r requirements.txt` + `make clean html`) in a fresh Python 3.14 venv with the new pins — build succeeds.
- [x] Confirm Docs CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)