### PR TITLE
Make plugin metadata prefetch resilient to registry rate limiting [#7176]

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     api ('org.jsoup:jsoup:1.15.4')
     api 'jline:jline:2.9'
     api 'org.pf4j:pf4j:3.14.1'
-    api 'dev.failsafe:failsafe:3.1.0'
+    api 'dev.failsafe:failsafe:3.3.2'
     api 'io.seqera:lib-trace:0.1.0'
     api 'com.fasterxml.woodstox:woodstox-core:7.1.1'
     api 'org.apache.commons:commons-compress:1.27.1'  // For tar.gz extraction

--- a/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/GridTaskHandler.groovy
@@ -21,13 +21,13 @@ import static nextflow.processor.TaskStatus.*
 import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
 import java.time.temporal.ChronoUnit
-import java.util.function.Predicate
 import java.util.regex.Pattern
 
 import dev.failsafe.Failsafe
 import dev.failsafe.RetryPolicy
 import dev.failsafe.event.EventListener
 import dev.failsafe.event.ExecutionAttemptedEvent
+import dev.failsafe.function.CheckedPredicate
 import dev.failsafe.function.CheckedSupplier
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
@@ -125,9 +125,9 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     @Memoized
-    protected Predicate<? extends Throwable> retryCondition(String reasonPattern) {
+    protected CheckedPredicate<? extends Throwable> retryCondition(String reasonPattern) {
         final pattern = Pattern.compile(reasonPattern)
-        return new Predicate<Throwable>() {
+        return new CheckedPredicate<Throwable>() {
             @Override
             boolean test(Throwable failure) {
                 if( failure instanceof ProcessNonZeroExitStatusException ) {
@@ -145,7 +145,7 @@ class GridTaskHandler extends TaskHandler implements FusionAwareTask {
         final listener = new EventListener<ExecutionAttemptedEvent>() {
             @Override
             void accept(ExecutionAttemptedEvent event) throws Throwable {
-                final failure = event.getLastFailure()
+                final failure = event.getLastException()
                 if( failure instanceof ProcessNonZeroExitStatusException ) {
                     final failure0 = (ProcessNonZeroExitStatusException)failure
                     final msg = """\

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -394,7 +394,7 @@ class PublishDir {
         final listener = new EventListener<ExecutionAttemptedEvent>() {
             @Override
             void accept(ExecutionAttemptedEvent event) throws Throwable {
-                log.debug "Failed to publish file: ${source.toUriString()}; to: ${target.toUriString()} [${mode.toString().toLowerCase()}] -- attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}"
+                log.debug "Failed to publish file: ${source.toUriString()}; to: ${target.toUriString()} [${mode.toString().toLowerCase()}] -- attempt: ${event.attemptCount}; reason: ${event.lastException.message}"
             }
         }
         final retryPolicy = RetryPolicy.builder()

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -33,9 +33,9 @@ dependencies {
     api 'com.google.guava:guava:33.0.0-jre'
     api 'org.pf4j:pf4j:3.14.1'
     api 'org.pf4j:pf4j-update:2.3.0'
-    api 'dev.failsafe:failsafe:3.1.0'
-    api 'io.seqera:lib-httpx:2.1.0'
-    api 'io.seqera:lib-retry:2.0.0'
+    api 'dev.failsafe:failsafe:3.3.2'
+    api 'io.seqera:lib-httpx:2.3.0'
+    api 'io.seqera:lib-retry:2.1.0'
     // patch gson dependency required by pf4j
     api 'com.google.code.gson:gson:2.13.1'
     api 'io.seqera:npr-api:0.22.0'

--- a/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
@@ -52,7 +52,9 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
     private final URI url
     private final HxClient httpClient
 
-    private Map<String, PluginInfo> plugins
+    // Initialised eagerly so that getPlugin()/refresh() are safe to call even when prefetch()
+    // was skipped (e.g. PluginUpdater skip-if-installed) or failed (non-fatal degradation).
+    private Map<String, PluginInfo> plugins = new HashMap<>()
 
     HttpPluginRepository(String id, URI url) {
         this.id = id
@@ -83,7 +85,16 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
     @Override
     void prefetch(List<PluginRef> plugins) {
         if (plugins && !plugins.isEmpty()) {
-            this.plugins = fetchMetadata(plugins)
+            try {
+                this.plugins = fetchMetadata(plugins)
+            }
+            catch (PluginRuntimeException e) {
+                // Don't abort Nextflow startup if the registry is unreachable or rate-limited:
+                // downstream code will either resolve the plugins from the local store or fail
+                // with a more specific error when the metadata is actually needed.
+                log.warn "Failed to prefetch plugin metadata from ${url} - cause: ${e.message}"
+                this.plugins = new HashMap<>()
+            }
         }
     }
 
@@ -99,10 +110,6 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
 
     @Override
     Map<String, PluginInfo> getPlugins() {
-        if (plugins==null) {
-            log.warn "getPlugins() called before prefetch() - plugins map will be empty"
-            return Map.of()
-        }
         return Collections.unmodifiableMap(plugins)
     }
 

--- a/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/HttpPluginRepository.groovy
@@ -84,17 +84,17 @@ class HttpPluginRepository implements PrefetchUpdateRepository {
     // like any other implementation of UpdateRepository.
     @Override
     void prefetch(List<PluginRef> plugins) {
-        if (plugins && !plugins.isEmpty()) {
-            try {
-                this.plugins = fetchMetadata(plugins)
-            }
-            catch (PluginRuntimeException e) {
-                // Don't abort Nextflow startup if the registry is unreachable or rate-limited:
-                // downstream code will either resolve the plugins from the local store or fail
-                // with a more specific error when the metadata is actually needed.
-                log.warn "Failed to prefetch plugin metadata from ${url} - cause: ${e.message}"
-                this.plugins = new HashMap<>()
-            }
+        if (!plugins)
+            return
+        try {
+            this.plugins = fetchMetadata(plugins)
+        }
+        catch (PluginRuntimeException e) {
+            // Don't abort Nextflow startup if the registry is unreachable or rate-limited:
+            // downstream code will either resolve the plugins from the local store or fail
+            // with a more specific error when the metadata is actually needed.
+            log.warn "Failed to prefetch plugin metadata from ${url} - cause: ${e.message}"
+            this.plugins = new HashMap<>()
         }
     }
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -166,13 +166,18 @@ class PluginUpdater extends UpdateManager {
         }
     }
 
-    private boolean isAlreadyInstalled(PluginRef ref) {
+    protected boolean isAlreadyInstalled(PluginRef ref) {
         // Only skip when the user has pinned a version: an unpinned spec needs remote metadata
         // to resolve the latest release.
         if( !ref.version )
             return false
-        final current = pluginManager.getPlugin(ref.id)
-        return current != null && current.descriptor.version == ref.version
+        // Check the on-disk plugin store rather than the runtime PluginManager: at prefetch
+        // time the local plugins have not been loaded into the manager yet (its per-run root
+        // is still empty), so pluginManager.getPlugin() would always return null. installPlugin()
+        // reuses the cached copy whenever the store directory exists (it only downloads when
+        // missing), so its presence is the authoritative signal that no remote metadata is
+        // required to start the plugin.
+        return pluginsStore != null && FilesEx.exists(pluginsStore.resolve("${ref.id}-${ref.version}"))
     }
 
     /**

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -20,13 +20,13 @@ import static java.nio.file.StandardCopyOption.*
 
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.function.Predicate
 import java.util.regex.Pattern
 
 import com.github.zafarkhaja.semver.Version
 import dev.failsafe.Failsafe
 import dev.failsafe.RetryPolicy
 import dev.failsafe.event.ExecutionAttemptedEvent
+import dev.failsafe.function.CheckedPredicate
 import dev.failsafe.function.CheckedSupplier
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -148,14 +148,31 @@ class PluginUpdater extends UpdateManager {
      * repository types to perform some data-loading optimisations.
      */
     void prefetchMetadata(List<PluginRef> plugins) {
+        // Skip plugins that are already installed at the requested pinned version: no remote
+        // metadata is needed to start them. This eliminates the registry round-trip on every
+        // Nextflow invocation in the common CI case (pinned versions, plugins already cached).
+        final needed = plugins.findAll { ref -> !isAlreadyInstalled(ref) }
+        if( !needed ) {
+            log.trace "All requested plugins are already installed - skipping registry metadata prefetch"
+            return
+        }
         // use direct field access to avoid the refresh() call in getRepositories()
         // which could fail anything which hasn't had a chance to prefetch yet
         for( def repo : this.@repositories ) {
             if( repo instanceof PrefetchUpdateRepository ) {
-                log.trace "Prefetching plugin metadata from repository: ${repo.getClass().getSimpleName()} [${repo.id}]; plugins=${plugins}"
-                repo.prefetch(plugins)
+                log.trace "Prefetching plugin metadata from repository: ${repo.getClass().getSimpleName()} [${repo.id}]; plugins=${needed}"
+                repo.prefetch(needed)
             }
         }
+    }
+
+    private boolean isAlreadyInstalled(PluginRef ref) {
+        // Only skip when the user has pinned a version: an unpinned spec needs remote metadata
+        // to resolve the latest release.
+        if( !ref.version )
+            return false
+        final current = pluginManager.getPlugin(ref.id)
+        return current != null && current.descriptor.version == ref.version
     }
 
     /**
@@ -268,11 +285,11 @@ class PluginUpdater extends UpdateManager {
         final listener = new dev.failsafe.event.EventListener<ExecutionAttemptedEvent<T>>() {
             @Override
             void accept(ExecutionAttemptedEvent<T> event) throws Throwable {
-                log.debug("Failed to download plugin: $id; version: $version - attempt: ${event.attemptCount}", event.lastFailure)
+                log.debug("Failed to download plugin: $id; version: $version - attempt: ${event.attemptCount}", event.lastException)
             }
         }
 
-        final condition = new Predicate<Throwable>() {
+        final condition = new CheckedPredicate<Throwable>() {
             @Override
             boolean test(Throwable error) {
                 return error?.cause instanceof ConnectException

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -411,8 +411,10 @@ class PluginsFacade implements PluginStateListener {
             final skippedIds = skippable.collect{ plugin -> plugin.id }
             log.debug "Plugin 'start' is not required in embedded mode -- ignoring for plugins: $skippedIds"
         }
-        // prefetch the plugins meta
-        updater.prefetchMetadata(startable)
+        // prefetch the plugins meta - skipped in offline mode to make the no-network guarantee
+        // explicit (in offline mode no remote repo is wired in, so this is also a no-op transitively)
+        if( !offline )
+            updater.prefetchMetadata(startable)
         // finally start the plugins
         for( PluginRef plugin : startable ) {
             updater.prepareAndStart(plugin.id, plugin.version)

--- a/modules/nf-commons/src/test/nextflow/plugin/HttpPluginRepositoryTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/HttpPluginRepositoryTest.groovy
@@ -23,7 +23,6 @@ import java.time.ZonedDateTime
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import nextflow.BuildInfo
 import org.junit.Rule
-import org.pf4j.PluginRuntimeException
 import spock.lang.Specification
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*
@@ -114,17 +113,18 @@ class HttpPluginRepositoryTest extends Specification {
         unit.prefetch([new PluginRef("nf-fake")])
 
         then:
-        def err = thrown PluginRuntimeException
-        err.message.startsWith("Unable to connect to http://localhost")
+        // Prefetch is an optimization, not a hard requirement: a connection failure must not
+        // abort Nextflow startup. Downstream code falls back to per-plugin lookups.
+        noExceptionThrown()
+        unit.getPlugins() == [:]
     }
 
     // ------------------------------------------------------------------------
 
     def 'handle prefetch error with percent chars in error message'() {
         given:
-        // Test that URLs containing '%' characters (like URL-encoded values) are handled
-        // correctly when an exception occurs. The '%' must be escaped to '%%' to avoid
-        // String.format interpretation in PluginRuntimeException.
+        // Test that URLs containing '%' characters (like URL-encoded values) don't trip
+        // String.format inside PluginRuntimeException when the underlying call fails.
         def repoWithEncodedUrl = new HttpPluginRepository("test-repo", new URI("http://localhost:${wiremock.port()}/path%20with%20spaces/"))
         wiremock.stop()
 
@@ -132,10 +132,9 @@ class HttpPluginRepositoryTest extends Specification {
         repoWithEncodedUrl.prefetch([new PluginRef("nf-fake")])
 
         then:
-        def err = thrown PluginRuntimeException
-        // Verify the error message is properly formatted and contains the URL with encoded spaces
-        err.message.contains("Unable to connect to")
-        err.message.contains("path%20with%20spaces")
+        // Should not throw - in particular, no IllegalFormatException from the '%' chars
+        noExceptionThrown()
+        repoWithEncodedUrl.getPlugins() == [:]
     }
 
     // ------------------------------------------------------------------------
@@ -151,11 +150,8 @@ class HttpPluginRepositoryTest extends Specification {
         unit.prefetch([new PluginRef("nf-fake")])
 
         then:
-        def err = thrown PluginRuntimeException
-        err.message == """\
-            Invalid response while fetching plugin metadata from: http://localhost:${wiremock.port()}/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}
-            - http status: 500
-            - response   : Server error!""".stripIndent()
+        noExceptionThrown()
+        unit.getPlugins() == [:]
     }
 
     // ------------------------------------------------------------------------
@@ -191,8 +187,27 @@ class HttpPluginRepositoryTest extends Specification {
         unit.prefetch([new PluginRef("nf-fake")])
 
         then:
-        def err = thrown PluginRuntimeException
-        err.message.startsWith("Invalid response while fetching plugin metadata from: http://localhost")
+        noExceptionThrown()
+        unit.getPlugins() == [:]
+    }
+
+    // ------------------------------------------------------------------------
+
+    def 'prefetch degrades gracefully when the registry keeps returning 429'() {
+        given:
+        wiremock.stubFor(get(urlEqualTo("/v1/plugins/dependencies?plugins=nf-fake&nextflowVersion=${BuildInfo.version}"))
+            .willReturn(aResponse()
+                .withStatus(429)
+                .withHeader("Retry-After", "1")
+                .withBody('Too Many Requests')))
+
+        when:
+        unit.prefetch([new PluginRef("nf-fake")])
+
+        then:
+        noExceptionThrown()
+        // The map is initialised to empty so getPlugin() doesn't NPE downstream
+        unit.getPlugins() == [:]
     }
 
     // ------------------------------------------------------------------------

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginUpdaterTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginUpdaterTest.groovy
@@ -88,6 +88,33 @@ class PluginUpdaterTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should detect already-installed pinned plugin from the on-disk store' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        and:
+        def remote = remoteRepository(folder.resolve('repo'), ['1.0.0'])
+        and:
+        def local = localCache(folder.resolve('plugins'), ['1.0.0'])
+        def manager = new LocalPluginManager(local)
+        def updater = new PluginUpdater(manager, local, remote, false)
+
+        expect:
+        // at prefetch time the local plugins have NOT been loaded into the manager yet
+        manager.getPlugin(PLUGIN_ID) == null
+        and:
+        // pinned + present in the store -> already installed, no remote metadata needed
+        updater.isAlreadyInstalled(PluginRef.parse('my-plugin@1.0.0'))
+        and:
+        // pinned but a different version is not installed
+        !updater.isAlreadyInstalled(PluginRef.parse('my-plugin@9.9.9'))
+        and:
+        // unpinned spec always needs remote metadata to resolve the latest release
+        !updater.isAlreadyInstalled(PluginRef.parse('my-plugin'))
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'should update a plugin' () {
         given:
         def folder = Files.createTempDirectory('test')

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -24,7 +24,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeoutException
-import java.util.function.Predicate
+import dev.failsafe.function.CheckedPredicate
 
 import com.azure.compute.batch.BatchClient
 import com.azure.compute.batch.BatchClientBuilder
@@ -460,7 +460,7 @@ class AzBatchService implements Closeable {
         final retryDelay = config.batch().jobQuotaRetryDelay
 
         // define retry condition for job quota errors
-        final cond = new Predicate<? extends Throwable>() {
+        final cond = new CheckedPredicate<? extends Throwable>() {
             @Override
             boolean test(Throwable t) {
                 return t instanceof HttpResponseException && isJobQuotaError((HttpResponseException) t)
@@ -1111,12 +1111,12 @@ class AzBatchService implements Closeable {
      * @param cond A predicate that determines when a retry should be triggered
      * @return The {@link RetryPolicy} instance
      */
-    protected <T> RetryPolicy<T> retryPolicy(Predicate<? extends Throwable> cond) {
+    protected <T> RetryPolicy<T> retryPolicy(CheckedPredicate<? extends Throwable> cond) {
         final cfg = config.retryConfig()
         final listener = new EventListener<ExecutionAttemptedEvent<T>>() {
             @Override
             void accept(ExecutionAttemptedEvent<T> event) throws Throwable {
-                log.debug("Azure TooManyRequests response error - attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}")
+                log.debug("Azure TooManyRequests response error - attempt: ${event.attemptCount}; reason: ${event.lastException.message}")
             }
         }
         return RetryPolicy.<T>builder()
@@ -1139,7 +1139,7 @@ class AzBatchService implements Closeable {
      */
     protected <T> T apply(CheckedSupplier<T> action) {
         // define the retry condition
-        final cond = new Predicate<? extends Throwable>() {
+        final cond = new CheckedPredicate<? extends Throwable>() {
             @Override
             boolean test(Throwable t) {
                 if( t instanceof HttpResponseException && t.response.statusCode in RETRY_CODES )

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzFileSystem.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzFileSystem.groovy
@@ -29,7 +29,7 @@ import java.nio.file.attribute.UserPrincipalLookupService
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeoutException
-import java.util.function.Predicate
+import dev.failsafe.function.CheckedPredicate
 
 import com.azure.core.util.polling.SyncPoller
 import com.azure.storage.blob.BlobServiceClient
@@ -527,7 +527,7 @@ class AzFileSystem extends FileSystem {
      * @param cond A predicate that determines when a retry should be triggered
      * @return The {@link dev.failsafe.RetryPolicy} instance
      */
-    protected <T> RetryPolicy<T> retryPolicy(Predicate<? extends Throwable> cond) {
+    protected <T> RetryPolicy<T> retryPolicy(CheckedPredicate<? extends Throwable> cond) {
         // this is needed because apparently bytebuddy used by testing framework is not able
         // to handle properly this method signature using both generics and `@Memoized` annotation.
         // therefore the `@Memoized` has been moved to the inner method invocation
@@ -535,12 +535,12 @@ class AzFileSystem extends FileSystem {
     }
 
     @Memoized
-    protected RetryPolicy retryPolicy0(Predicate<? extends Throwable> cond) {
+    protected RetryPolicy retryPolicy0(CheckedPredicate<? extends Throwable> cond) {
         final cfg = AzConfig.getConfig().retryConfig()
         final listener = new EventListener<ExecutionAttemptedEvent>() {
             @Override
             void accept(ExecutionAttemptedEvent event) throws Throwable {
-                log.debug("Azure I/O exception - attempt: ${event.attemptCount}; cause: ${event.lastFailure?.message}")
+                log.debug("Azure I/O exception - attempt: ${event.attemptCount}; cause: ${event.lastException?.message}")
             }
         }
         return RetryPolicy.builder()

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.util.function.Predicate
+import dev.failsafe.function.CheckedPredicate
 
 import com.azure.compute.batch.models.BatchPool
 import com.azure.compute.batch.models.BatchJobCreateContent
@@ -643,7 +643,7 @@ class AzBatchServiceTest extends Specification {
         AzBatchService svc = Spy(new AzBatchService(exec))
 
         when:
-        final policy = svc.retryPolicy(Mock(Predicate))
+        final policy = svc.retryPolicy(Mock(CheckedPredicate))
         then:
         policy.config.delay.toMillis() == 100
         policy.config.maxDelay.toMillis() == 200

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -59,6 +59,10 @@ dependencies {
     api 'com.google.cloud:google-cloud-nio:0.128.5'
     api 'com.google.cloud:google-cloud-storage:2.58.0'
     api 'io.seqera:lib-cloudinfo:1.0.0'
+    // Override the old lib-httpx pulled transitively by lib-cloudinfo, otherwise the plugin
+    // bundles failsafe-3.1.0 which clashes with the failsafe-3.3.2 the plugin is compiled
+    // against (java.lang.NoSuchMethodError on handleIf(CheckedPredicate) at runtime).
+    api 'io.seqera:lib-httpx:2.3.0'
     // Force patched version to address CVE-2025-55163 (MadeYouReset HTTP/2 DDoS vulnerability)
     runtimeOnly 'io.grpc:grpc-netty-shaded:1.75.0'
     // Force patched version to address GHSA-72hv-8253-57qq (jackson-core Number Length Constraint Bypass DoS)

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -19,7 +19,7 @@ package nextflow.cloud.google.batch.client
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeoutException
-import java.util.function.Predicate
+import dev.failsafe.function.CheckedPredicate
 
 import com.google.api.gax.core.CredentialsProvider
 import com.google.api.gax.rpc.DeadlineExceededException
@@ -156,12 +156,12 @@ class BatchClient {
      * @param cond A predicate that determines when a retry should be triggered
      * @return The {@link dev.failsafe.RetryPolicy} instance
      */
-    protected <T> RetryPolicy<T> retryPolicy(Predicate<? extends Throwable> cond) {
+    protected <T> RetryPolicy<T> retryPolicy(CheckedPredicate<? extends Throwable> cond) {
         final cfg = config.batch.getRetryConfig()
         final listener = new EventListener<ExecutionAttemptedEvent<T>>() {
             @Override
             void accept(ExecutionAttemptedEvent<T> event) throws Throwable {
-                log.debug("[GOOGLE BATCH] response error - attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}")
+                log.debug("[GOOGLE BATCH] response error - attempt: ${event.attemptCount}; reason: ${event.lastException.message}")
             }
         }
         return RetryPolicy.<T>builder()
@@ -184,7 +184,7 @@ class BatchClient {
      */
     protected <T> T apply(CheckedSupplier<T> action) {
         // define the retry condition
-        final cond = new Predicate<? extends Throwable>() {
+        final cond = new CheckedPredicate<? extends Throwable>() {
             @Override
             boolean test(Throwable t) {
                 if( t instanceof UnavailableException )

--- a/plugins/nf-k8s/src/main/nextflow/k8s/client/K8sClient.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/client/K8sClient.groovy
@@ -47,7 +47,7 @@ import org.yaml.snakeyaml.Yaml
 
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeoutException
-import java.util.function.Predicate
+import dev.failsafe.function.CheckedPredicate
 
 /**
  * Kubernetes API client
@@ -735,13 +735,13 @@ class K8sClient {
      * @param cond A predicate that determines when a retry should be triggered
      * @return The {@link dev.failsafe.RetryPolicy} instance
      */
-    protected <T> RetryPolicy<T> retryPolicy(Predicate<? extends Throwable> cond) {
+    protected <T> RetryPolicy<T> retryPolicy(CheckedPredicate<? extends Throwable> cond) {
         final cfg = config.retryConfig
         final listener = new EventListener<ExecutionAttemptedEvent<T>>() {
             @Override
             void accept(ExecutionAttemptedEvent<T> event) throws Throwable {
-                log.debug("K8s response error - attempt: ${event.attemptCount}; reason: ${event.lastFailure.message}")
-                final t = event.lastFailure
+                log.debug("K8s response error - attempt: ${event.attemptCount}; reason: ${event.lastException.message}")
+                final t = event.lastException
                 if( t instanceof K8sResponseException && t.response.code == 401 )
                     refreshToken()
             }
@@ -784,7 +784,7 @@ class K8sClient {
      */
     protected <T> T apply(CheckedSupplier<T> action) {
         // define the retry condition
-        final cond = new Predicate<? extends Throwable>() {
+        final cond = new CheckedPredicate<? extends Throwable>() {
             @Override
             boolean test(Throwable t) {
                 if ( t instanceof K8sResponseException && t.response.code in RETRY_CODES )

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -52,6 +52,10 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.14.1'
     api 'io.seqera:sched-client:0.59.0'
+    // Override the old lib-httpx pulled transitively by sched-client, otherwise the plugin
+    // bundles failsafe-3.1.0 which clashes with the failsafe-3.3.2 the plugin is compiled
+    // against (java.lang.NoSuchMethodError on handleIf(CheckedPredicate) at runtime).
+    api 'io.seqera:lib-httpx:2.3.0'
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.apache.groovy:groovy:4.0.31"

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.14.1'
-    compileOnly 'io.seqera:lib-httpx:2.1.0'
+    compileOnly 'io.seqera:lib-httpx:2.3.0'
     api 'io.seqera:lib-platform-oidc:0.1.0'
 
     api('io.seqera:tower-api:1.121.0') {

--- a/plugins/nf-wave/build.gradle
+++ b/plugins/nf-wave/build.gradle
@@ -53,11 +53,11 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.14.1'
     compileOnly 'io.seqera:lib-trace:0.1.0'
-    compileOnly 'io.seqera:lib-httpx:2.1.0'
+    compileOnly 'io.seqera:lib-httpx:2.3.0'
     compileOnly 'org.apache.commons:commons-lang3:3.18.0'
 
     // Force lib-httpx version to avoid conflicts with older versions from nf-commons
-    testImplementation 'io.seqera:lib-httpx:2.1.0'
+    testImplementation 'io.seqera:lib-httpx:2.3.0'
 
     api 'org.apache.commons:commons-compress:1.26.1'
     api 'com.google.code.gson:gson:2.13.1'


### PR DESCRIPTION
## Summary

Fixes [#7176](https://github.com/nextflow-io/nextflow/issues/7176) — under burst CI load the plugin registry returns HTTP 429 with `Retry-After`, but the HTTP client ignored the hint and every attempt landed inside the same rate-limit window, aborting Nextflow startup.

Four layered changes:

1. **Skip registry round-trip when plugins are already cached** — `PluginUpdater.prefetchMetadata` filters out plugins that are pinned to a specific version and already installed locally. When every requested plugin matches, the registry call is skipped entirely. Unpinned specs still go through so latest-release resolution keeps working.

2. **Non-fatal prefetch** — `HttpPluginRepository.prefetch` catches `PluginRuntimeException`, logs a `warn`, and leaves an empty plugins map. Prefetch is an optimization, not a hard requirement; a sustained rate-limit window or true outage must not abort startup. The lazy `getPlugin(id)` path still surfaces per-plugin errors when an actually-missing plugin is needed downstream. The `plugins` field is initialised eagerly so `getPlugin` and `refresh` are safe to call when prefetch was skipped or failed.

3. **Honor `Retry-After` in the HTTP layer** — picks up `lib-httpx@2.3.0` + `lib-retry@2.1.0` ([libseqera#72](https://github.com/seqeralabs/libseqera/pull/72)) so `HxClient` retries on 429/503 honor the server-supplied delay as a lower bound, capped by the configured `maxDelay`.

4. **Explicit `NXF_OFFLINE` guard** — `PluginsFacade.start()` skips `prefetchMetadata` entirely when `NXF_OFFLINE=true`. Currently handled transitively (no `PrefetchUpdateRepository` is wired in offline mode, so the iteration is a no-op), but an explicit `if (!offline)` at the call site makes the no-network guarantee unmissable in the code and protects against regressions if a remote `PrefetchUpdateRepository` is later added to the offline-mode repo list by mistake.

### Why the Failsafe bump

`lib-retry@2.1.0` targets Failsafe ≥3.2.1 because `RetryPolicyBuilder.handleIf` now requires `CheckedPredicate` and `ExecutionAttemptedEvent` renamed `getLastFailure` → `getLastException`. Bumping Nextflow's direct Failsafe dependency from `3.1.0` → `3.3.2` aligns with the lib and surfaces some pre-existing API drift that is migrated mechanically (no behavior change):

- `event.lastFailure` → `event.lastException`
- `Predicate<? extends Throwable>` → `CheckedPredicate<? extends Throwable>` on `RetryPolicyBuilder.handleIf`

Sites touched: `PluginUpdater`, `PublishDir`, `GridTaskHandler`, `K8sClient`, `BatchClient` (nf-google), `AzBatchService`, `AzFileSystem` (nf-azure), and the matching `AzBatchServiceTest` `Mock` declaration.

### End-to-end behavior

- **CI common case** (pinned + already cached): zero registry calls.
- **CI cold case** (first install of a pinned plugin): registry returns 429 → `HxClient` waits `min(maxDelay=90s, max(backoff, Retry-After))` → retries up to 5x → usually succeeds.
- **Sustained outage / hard rate-limit**: retries exhaust → `prefetch()` degrades non-fatally → startup continues; downstream operations that genuinely need the metadata fail with a specific error.

## Test plan

- [x] `:nf-commons:test --tests HttpPluginRepositoryTest --tests PluginUpdaterTest` — green
- [x] `:plugins:nf-k8s:test`, `:plugins:nf-google:test`, `:plugins:nf-azure:test --tests AzBatchServiceTest --tests AzFileSystemTest` — green
- [x] All affected plugins compile cleanly under Failsafe 3.3.2 (`./gradlew compileGroovy` on each)
- [x] New WireMock test `'prefetch degrades gracefully when the registry keeps returning 429'` in `HttpPluginRepositoryTest`
- [ ] CI to verify end-to-end on a real Nextflow invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)