### PR TITLE
Fix world-readable seqera-auth.config credential file

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/auth/AuthCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/auth/AuthCommandImpl.groovy
@@ -1081,8 +1081,13 @@ class AuthCommandImpl extends BaseCommandImpl implements CmdAuth.AuthCommand {
         }
         authConfigText.append("}\n")
 
-        // Write the seqera-auth.config file
-        Files.writeString(authFile, authConfigText.toString(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+        // Write the seqera-auth.config file with owner-only permissions.
+        // Tighten the permissions *before* writing the bearer tokens so the
+        // file is never world-readable while it holds credential data.
+        Files.deleteIfExists(authFile)
+        Files.createFile(authFile)
+        authFile.setPermissions('rw-------')
+        Files.writeString(authFile, authConfigText.toString(), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
 
         // Add includeConfig line to main config file if it doesn't exist
         addIncludeConfigToMainFile(configFile)

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/auth/AuthCommandImplTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/auth/AuthCommandImplTest.groovy
@@ -27,6 +27,8 @@ import test.OutputCapture
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
 
 /**
  * Test CmdAuth functionality
@@ -215,6 +217,49 @@ param2 = 'value2'"""
         authContent.contains('accessToken = \'test-token-123\'')
         authContent.contains('endpoint = \'https://api.cloud.seqera.io\'')
         authContent.contains('enabled = true')
+    }
+
+    def 'should write seqera-auth.config with owner-only permissions'() {
+        given:
+        def cmd = Spy(AuthCommandImpl)
+        def authFile = tempDir.resolve('seqera-auth.config')
+        def configFile = tempDir.resolve('config')
+
+        cmd.getAuthFile() >> authFile
+        cmd.getConfigFile() >> configFile
+
+        def config = ['tower.accessToken': 'test-token']
+
+        when:
+        cmd.writeConfig(config, null)
+
+        then:
+        Files.exists(authFile)
+        Files.getPosixFilePermissions(authFile) == EnumSet.of(
+            PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+    }
+
+    def 'should re-harden permissions when overwriting an existing world-readable file'() {
+        given:
+        def cmd = Spy(AuthCommandImpl)
+        def authFile = tempDir.resolve('seqera-auth.config')
+        def configFile = tempDir.resolve('config')
+
+        Files.writeString(authFile, 'tower { accessToken = "stale" }')
+        Files.setPosixFilePermissions(authFile, PosixFilePermissions.fromString('rw-r--r--'))
+
+        cmd.getAuthFile() >> authFile
+        cmd.getConfigFile() >> configFile
+
+        def config = ['tower.accessToken': 'test-token']
+
+        when:
+        cmd.writeConfig(config, null)
+
+        then:
+        Files.getPosixFilePermissions(authFile) == EnumSet.of(
+            PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+        Files.readString(authFile).contains('test-token')
     }
 
     def 'should write config with workspace metadata'() {


### PR DESCRIPTION
Write the Seqera Platform token file with owner-only (0600) permissions.

Fixes GHSA-92qf-fcph-v5wr