### PR TITLE
Fix cast and instanceof with record types

### DIFF
--- a/adr/20260501-type-system.md
+++ b/adr/20260501-type-system.md
@@ -243,9 +243,40 @@ channel.of('a', 'b', 'c')   // Channel<String>
 
 ### Static typing and the runtime
 
-The type system exists as a separate layer from the runtime. That is, the type system defines the standard namespaces and types as interfaces, and the runtime types need only be compatible with those interfaces. Nextflow-specific types (e.g. `Duration`, `MemoryUnit`) can implement the corresponding type interface directly. Types inherited from Java (e.g. `Integer`, `String`, `List`) are modeled in the type system using "shim" interfaces, which are used during type checking and discarded prior at runtime.
+The type system exists as a separate layer from the runtime. That is, the type system defines the standard namespaces and types as interfaces, and the runtime types need only be compatible with those interfaces. Nextflow-specific types (e.g. `Duration`, `MemoryUnit`) can implement the corresponding type interface directly. Types inherited from Java (e.g. `Integer`, `String`, `List`) are modeled in the type system using "shim" interfaces, which are used during type checking and discarded at runtime.
 
 This approach allows us to introduce type checking without modifying runtime behavior. Nextflow still generates dynamically-typed Groovy code, but this code is validated by the type checker, so it is effectively statically-typed. This approach is similar to [TypeScript](https://www.typescriptlang.org/), where TypeScript code is type-checked at compile-time and converted to JavaScript at runtime by discarding type annotations. Static compilation (e.g. `@CompileStatic`) may be explored in the future, but it is not clear whether the performance improvement of statically-compiled code is worth the extra compilation time and additional constraints on the generated Groovy code.
+
+### Type conversions
+
+There are a few cases where type checking can only be performed at runtime. Pipeline inputs are validated and converted to the appropriate type based on the `params` block (e.g. `--max_cpus 16` is converted to the number `16` based on the declaration `max_cpus: Integer`). However, complex inputs such as samplesheets must be loaded and explicitly converted using a type cast (`as`).
+
+For example, a CSV samplesheet needs to be loaded as a channel of records:
+
+```groovy
+params {
+    input: Path
+}
+
+workflow {
+    csv = params.input
+    samples = csv.splitCsv(header: true) as List<Sample>
+    channel.fromList(samples).view()
+}
+
+record Sample {
+    id: String
+    fastq_1: Path
+    fastq_2: Path?
+}
+```
+
+Nextflow extends Groovy's `as` operator to support parameterized types and record types. In the above example:
+
+1. the `splitCsv` function returns a list of maps,
+2. the type cast converts each map to a record, verifying that it satisfies the requirements of `Sample`.
+
+This way, the `as` operator provides a guarantee to the type checker and enforces that guarantee at runtime.
 
 ### Migration plan
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -28,6 +28,7 @@ import nextflow.exception.AbortOperationException
 import nextflow.script.dsl.ProcessDslV1
 import nextflow.script.dsl.ProcessDslV2
 import nextflow.secret.SecretsLoader
+import nextflow.util.TypeHelper
 
 /**
  * Any user defined script will extends this class, it provides the base execution context
@@ -217,6 +218,16 @@ abstract class BaseScript extends Script implements ExecutionContext {
      */
     protected void declareType(Class type) {
         meta.addDefinition(new TypeDef(type))
+    }
+
+    /**
+     * Runtime check replacing {@code instanceof} for record types.
+     *
+     * @param value
+     * @param type
+     */
+    protected boolean _instanceof_record_type(Object value, Class type) {
+        return TypeHelper.instanceofRecordType(value, type)
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -221,6 +221,21 @@ abstract class BaseScript extends Script implements ExecutionContext {
     }
 
     /**
+     * Runtime type cast that supports parameterized types and record types.
+     *
+     * @param value
+     * @param type
+     */
+    protected Object _as_type(Object value, Class type) {
+        return TypeHelper.asType(value, type)
+    }
+
+    protected Object _as_type(Object value, Class clazz, String field) {
+        final type = clazz.getField(field).getGenericType()
+        return TypeHelper.asType(value, type)
+    }
+
+    /**
      * Runtime check replacing {@code instanceof} for record types.
      *
      * @param value

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
@@ -79,7 +79,7 @@ class ScriptTypesTest extends Dsl2Spec {
         result == 'Sample(id: 1, fastq: 1.fastq)'
     }
 
-    def 'should strip record type casts' () {
+    def 'should cast value to record type' () {
 
         when:
         def result = runScript(
@@ -95,7 +95,41 @@ class ScriptTypesTest extends Dsl2Spec {
             '''
         )
         then:
-        result == new RecordMap(id: '1', fastq: '1.fastq')
+        result instanceof RecordMap
+        result.id == '1'
+        result.fastq == '1.fastq'
+    }
+
+    def 'should cast value to parameterized type'() {
+        when:
+        def samples = runScript(
+            '''\
+            workflow {
+                [
+                  [id: '1', fastq: '1.fastq'],
+                  [id: '2', fastq: '2.fastq'],
+                  [id: '3', fastq: '3.fastq']
+                ] as List<Sample>
+            }
+
+            record Sample {
+                id: String
+                fastq: String
+            }
+            '''
+        )
+        then:
+        samples instanceof List
+        samples.size() == 3
+        samples[0] instanceof RecordMap
+        samples[0].id == '1'
+        samples[0].fastq == '1.fastq'
+        samples[1] instanceof RecordMap
+        samples[1].id == '2'
+        samples[1].fastq == '2.fastq'
+        samples[2] instanceof RecordMap
+        samples[2].id == '3'
+        samples[2].fastq == '3.fastq'
     }
 
     def 'should replace instanceof on record type with runtime check' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
@@ -21,6 +21,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import nextflow.exception.ScriptCompilationException
+import nextflow.util.RecordMap
 import test.Dsl2Spec
 
 import static test.ScriptHelper.*
@@ -76,6 +77,25 @@ class ScriptTypesTest extends Dsl2Spec {
         )
         then:
         result == 'Sample(id: 1, fastq: 1.fastq)'
+    }
+
+    def 'should strip record type casts' () {
+
+        when:
+        def result = runScript(
+            '''\
+            workflow {
+                record(id: '1', fastq: '1.fastq') as Sample
+            }
+
+            record Sample {
+                id: String
+                fastq: String
+            }
+            '''
+        )
+        then:
+        result == new RecordMap(id: '1', fastq: '1.fastq')
     }
 
     def 'should report error for invalid record call' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
@@ -132,6 +132,23 @@ class ScriptTypesTest extends Dsl2Spec {
         samples[2].fastq == '3.fastq'
     }
 
+    def 'should strip unsupported type annotations' () {
+
+        when:
+        runScript(
+            '''\
+            // strip Tuple type from cast expression
+            ['1', '1.fastq', '2.fastq'] as Tuple<String,String,String>
+
+            // strip type annotation in variable declaration
+            def ch: Channel = channel.empty()
+            '''
+        )
+
+        then:
+        noExceptionThrown()
+    }
+
     def 'should replace instanceof on record type with runtime check' () {
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptTypesTest.groovy
@@ -98,6 +98,33 @@ class ScriptTypesTest extends Dsl2Spec {
         result == new RecordMap(id: '1', fastq: '1.fastq')
     }
 
+    def 'should replace instanceof on record type with runtime check' () {
+
+        when:
+        def result = runScript(
+            '''\
+            workflow {
+                [
+                    test1: record(id: '1', fastq: file('1.fastq')) instanceof Sample,
+                    test2: record(id: '2') instanceof Sample,
+                    test3: 42 instanceof Integer,
+                    test4: '42' instanceof Integer
+                ]
+            }
+
+            record Sample {
+               	id: String
+               	fastq: Path
+            }
+            '''
+        )
+        then:
+        result.test1 == true
+        result.test2 == false
+        result.test3 == true
+        result.test4 == false
+    }
+
     def 'should report error for invalid record call' () {
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
@@ -280,28 +280,6 @@ class ScriptLoaderV2Test extends Dsl2Spec {
         noExceptionThrown()
     }
 
-    def 'should strip unsupported type annotations' () {
-
-        given:
-        def session = new Session()
-        def parser = new ScriptLoaderV2(session)
-
-        def TEXT = '''
-            // strip cast type
-            ['1', '1.fastq', '2.fastq'] as Tuple<String,String,String>
-
-            // strip type annotation in variable declaration
-            def ch: Channel = channel.empty()
-            '''
-
-        when:
-        parser.parse(TEXT)
-        parser.runScript()
-
-        then:
-        noExceptionThrown()
-    }
-
     def 'should register outputs and topic emissions' () {
 
         given:

--- a/modules/nf-commons/src/main/nextflow/util/TypeHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/TypeHelper.groovy
@@ -192,4 +192,26 @@ class TypeHelper {
         return result
     }
 
+    /**
+     * Returns {@code true} if {@code value} is a {@link RecordMap} that
+     * contains every non-nullable field declared by {@code type}.
+     *
+     * @param value the value to test
+     * @param type  the record type class
+     */
+    static boolean instanceofRecordType(Object value, Class type) {
+        if( value !instanceof RecordMap )
+            return false
+        final record = (RecordMap) value
+        for( final field : type.getDeclaredFields() ) {
+            if( field.isSynthetic() )
+                continue
+            if( field.isAnnotationPresent(Nullable.class) )
+                continue
+            if( record.get(field.getName()) == null )
+                return false
+        }
+        return true
+    }
+
 }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -48,7 +48,6 @@ import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.VariableScope;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
-import org.codehaus.groovy.ast.expr.DeclarationExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;

--- a/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
@@ -70,7 +70,7 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
         // Erase record type parameters so that records (with type Record)
         // can be dispatched to these methods at runtime
         for( var param : node.getParameters() ) {
-            if( param.getType().redirect() instanceof RecordNode )
+            if( isNamedRecordType(param.getType()) )
                 param.setType(ClassHelper.dynamicType());
         }
         super.visitMethod(node);
@@ -95,17 +95,25 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
     }
 
     private Expression stripTypeAnnotation(CastExpression node) {
-        return STRIP_TYPES.contains(node.getType())
+        return shouldStripType(node.getType())
             ? node.getExpression()
             : node;
     }
 
     private Expression stripTypeAnnotation(DeclarationExpression node) {
         if( node.getLeftExpression() instanceof VariableExpression ve ) {
-            if( STRIP_TYPES.contains(ve.getType()) )
+            if( shouldStripType(ve.getType()) )
                 node.setLeftExpression(new VariableExpression(ve.getName()));
         }
         return node;
+    }
+
+    private boolean shouldStripType(ClassNode type) {
+        return STRIP_TYPES.contains(type) || isNamedRecordType(type);
+    }
+
+    private boolean isNamedRecordType(ClassNode type) {
+        return type.redirect() instanceof RecordNode;
     }
 
 }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
@@ -113,13 +113,17 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
 
     private Expression transformCast(CastExpression node) {
         var type = node.getType();
+        if( STRIP_TYPES.contains(node.getType()) ) {
+            return node.getExpression();
+        }
         if( type.getGenericsTypes() != null ) {
             var fn = parameterizedType(type);
             return callThisX("_as_type", args(transform(node.getExpression()), classX(fn.getDeclaringClass()), constX(fn.getName())));
         }
-        else {
+        if( isNamedRecordType(type) ) {
             return callThisX("_as_type", args(transform(node.getExpression()), classX(type)));
         }
+        return node;
     }
 
     // Parameterized types in type casts are preserved from

--- a/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
@@ -16,6 +16,7 @@
 
 package nextflow.script.control;
 
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 import nextflow.script.ast.RecordNode;
@@ -26,6 +27,7 @@ import nextflow.script.types.Value;
 import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.CastExpression;
@@ -95,7 +97,7 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
         }
 
         if( node instanceof CastExpression ce ) {
-            return stripTypeAnnotation(ce);
+            return transformCast(ce);
         }
 
         if( node instanceof ClosureExpression ce ) {
@@ -110,10 +112,37 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
         return super.transform(node);
     }
 
-    private Expression stripTypeAnnotation(CastExpression node) {
-        return shouldStripType(node.getType())
-            ? node.getExpression()
-            : node;
+    private Expression transformCast(CastExpression node) {
+        var type = node.getType();
+        if( type.getGenericsTypes() != null ) {
+            var fn = parameterizedType(type);
+            return callThisX("_as_type", args(transform(node.getExpression()), classX(fn.getDeclaringClass()), constX(fn.getName())));
+        }
+        else {
+            return callThisX("_as_type", args(transform(node.getExpression()), classX(type)));
+        }
+    }
+
+    private ClassNode hiddenClassNode;
+
+    private FieldNode parameterizedType(ClassNode type) {
+        if( hiddenClassNode == null ) {
+            var moduleNode = sourceUnit.getAST();
+            var scriptClass = moduleNode.getClasses().get(0);
+            var packageName = scriptClass.getNameWithoutPackage();
+            this.hiddenClassNode = new RecordNode(packageName + "." + "__ParameterizedTypes");
+            moduleNode.addClass(hiddenClassNode);
+        }
+        var name = "_" + hiddenClassNode.getFields().size();
+        var fn = new FieldNode(
+            name,
+            Modifier.PUBLIC,
+            type,
+            hiddenClassNode,
+            null
+        );
+        hiddenClassNode.addField(fn);
+        return fn;
     }
 
     private Expression stripTypeAnnotation(DeclarationExpression node) {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
@@ -51,10 +51,9 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
  * - The Tuple type can be specified with variable type arguments,
  *   but this is not supported by the JVM.
  *
- * - User-defined record types are only used to validate records with
- *   type RecordMap. Record types must be stripped from type annotations
- *   and type casts, and instanceof expressions on a record type must be
- *   replaced with a runtime check.
+ * - User-defined record types are only used to validate records
+ *   with type RecordMap. Casts and instanceof expressions must
+ *   be replaced with runtime checks.
  *
  * @author Ben Sherman <bentshermman@gmail.com>
  */
@@ -123,6 +122,24 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
         }
     }
 
+    // Parameterized types in type casts are preserved from
+    // type erasure by storing the parameterized type in a
+    // field of a hidden class.
+    //
+    // For example:
+    // ```
+    // samples as List<Sample>
+    // ```
+    //
+    // Becomes:
+    // ```
+    // class __ParameterizedTypes {
+    //   List<Sample> _1
+    // }
+    //
+    // _as_type(samples, __ParameterizedTypes, '_1')
+    // ```
+    //
     private ClassNode hiddenClassNode;
 
     private FieldNode parameterizedType(ClassNode type) {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/StripTypesVisitor.java
@@ -27,20 +27,32 @@ import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.CastExpression;
+import org.codehaus.groovy.ast.expr.ClassExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.DeclarationExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Types;
+
+import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
 
 /**
  * Strip type annotations that are used by the Nextflow type checker
- * but not supported by the Groovy runtime.
+ * but not supported by the Groovy runtime:
  *
- * For example, Nextflow allows the Tuple type to be specified
- * with variable type arguments, which is not supported by the JVM,
- * so these type annotations must be removed.
+ * - The dataflow types (Channel and Value) are not compatible with
+ *   the runtime types used when static typing is disabled.
+ *
+ * - The Tuple type can be specified with variable type arguments,
+ *   but this is not supported by the JVM.
+ *
+ * - User-defined record types are only used to validate records with
+ *   type RecordMap. Record types must be stripped from type annotations
+ *   and type casts, and instanceof expressions on a record type must be
+ *   replaced with a runtime check.
  *
  * @author Ben Sherman <bentshermman@gmail.com>
  */
@@ -78,6 +90,10 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
 
     @Override
     public Expression transform(Expression node) {
+        if( node instanceof BinaryExpression be && be.getOperation().getType() == Types.KEYWORD_INSTANCEOF ) {
+            return transformInstanceof(be);
+        }
+
         if( node instanceof CastExpression ce ) {
             return stripTypeAnnotation(ce);
         }
@@ -106,6 +122,13 @@ public class StripTypesVisitor extends ClassCodeExpressionTransformer {
                 node.setLeftExpression(new VariableExpression(ve.getName()));
         }
         return node;
+    }
+
+    private Expression transformInstanceof(BinaryExpression node) {
+        var right = node.getRightExpression();
+        if( right instanceof ClassExpression ce && isNamedRecordType(ce.getType()) )
+            return callThisX("_instanceof_record_type", args(transform(node.getLeftExpression()), right));
+        return super.transform(node);
     }
 
     private boolean shouldStripType(ClassNode type) {

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/Types.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/Types.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import nextflow.script.ast.ASTNodeMarker;
-import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GenericsType;
@@ -122,14 +121,6 @@ public class Types {
         return spec.get(new GenericsType.GenericsTypeName(name)).getType();
     }
 
-    private static String tupleName(ClassNode type) {
-        var sb = new StringBuilder();
-        sb.append('(');
-        genericsTypeNames(type.getGenericsTypes(), sb);
-        sb.append(')');
-        return sb.toString();
-    }
-
     private static String typeName(ClassNode type) {
         var sb = new StringBuilder();
 
@@ -170,7 +161,7 @@ public class Types {
             getName(type.getTypeName());
     }
 
-    private static String getName(Class type) {
+    private static String getName(Class<?> type) {
         return getName(type.getSimpleName());
     }
 


### PR DESCRIPTION
This PR fixes the use of casting records to a named record type, for example:

```groovy
workflow {
    record(id: '1', fastq: file('1.fastq')) as Sample
}

record Sample {
    id: String
    fastq: Path
}
```

Casting a record to a named record type should be a no-op at runtime. It is only used by the type checker to validate that the record satisfies the requirements of the record type.

If the cast is is not removed at runtime, the record would be cast to an instance of `Sample`, since record types are compiled to actual classes at runtime with an implicit constructor. This would break the runtime's assumption that all records are `RecordMap`s.