### PR TITLE
Fix issue with workflow completion handler being called twice

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -759,7 +759,7 @@ class Session implements ISession {
     }
 
     final protected void shutdown0() {
-        log.trace "Shutdown: $shutdownCallbacks"
+        log.trace "Invoking ${shutdownCallbacks.size()} shutdown callbacks"
         shutdownInitiated = true
         while( shutdownCallbacks.size() ) {
             final hook = shutdownCallbacks.poll()
@@ -767,7 +767,7 @@ class Session implements ISession {
                 hook.run()
             }
             catch( Exception e ) {
-                log.debug "Failed to execute shutdown hook: $hook", e
+                log.debug "Failed to execute shutdown hook: ${hook.class.name}", e
             }
         }
 

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -37,6 +37,8 @@ import nextflow.util.VersionNumber
 import spock.lang.Specification
 import spock.lang.Unroll
 import test.TestHelper
+
+import static test.ScriptHelper.*
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -347,12 +349,6 @@ class SessionTest extends Specification {
         'foo|bar'   | ['baz']       | "There's no process matching config selector: foo|bar"
     }
 
-
-    static Map cfg(String config) {
-        new ConfigSlurper().parse(config).toMap()
-    }
-
-
     def 'should fetch containers definition' () {
 
         String text
@@ -362,7 +358,7 @@ class SessionTest extends Specification {
                 process.container = 'beta'
                 '''
         then:
-        new Session(cfg(text)).fetchContainers() == 'beta'
+        new Session(loadConfig(text)).fetchContainers() == 'beta'
 
 
         when:
@@ -373,7 +369,7 @@ class SessionTest extends Specification {
                 }
                 '''
         then:
-        new Session(cfg(text)).fetchContainers() == ['proc1': 'alpha', 'proc2': 'beta']
+        new Session(loadConfig(text)).fetchContainers() == ['proc1': 'alpha', 'proc2': 'beta']
 
 
         when:
@@ -386,7 +382,7 @@ class SessionTest extends Specification {
                 process.container = 'gamma'
                 '''
         then:
-        new Session(cfg(text)).fetchContainers() == ['proc1': 'alpha', 'proc2': 'beta', 'default': 'gamma']
+        new Session(loadConfig(text)).fetchContainers() == ['proc1': 'alpha', 'proc2': 'beta', 'default': 'gamma']
 
 
         when:
@@ -395,7 +391,7 @@ class SessionTest extends Specification {
                 '''
 
         def meta = Mock(WorkflowMetadata); meta.getRevision() >> '1.2'
-        def session = new Session(cfg(text))
+        def session = new Session(loadConfig(text))
         session.binding.setVariable('workflow',meta)
         then:
         session.fetchContainers() == 'ngi/rnaseq:1.2'

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Paths
 import java.time.OffsetDateTime
 
 import nextflow.Session
+import nextflow.SysEnv
 import nextflow.BuildInfo
 import nextflow.exception.AbortRunException
 import nextflow.exception.WorkflowScriptErrorException
@@ -28,13 +29,20 @@ import nextflow.trace.WorkflowStats
 import nextflow.trace.WorkflowStatsObserver
 import nextflow.util.Duration
 import nextflow.util.VersionNumber
+import org.junit.Rule
 import spock.lang.Specification
+import test.OutputCapture
 import test.TestHelper
+
+import static test.ScriptHelper.*
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class WorkflowMetadataTest extends Specification {
+
+    @Rule
+    OutputCapture capture = new OutputCapture()
 
     def 'should capture the abort cause in errorReport and errorMessage' () {
         given:
@@ -302,6 +310,32 @@ class WorkflowMetadataTest extends Specification {
         println metadata.executor
         then:
         thrown(MissingPropertyException)
+    }
+
+    def 'should invoke shutdown callbacks once'() {
+        given:
+        SysEnv.push(NXF_TRACE: 'nextflow')
+
+        when:
+        runScript(
+            '''\
+            workflow {
+                main:
+                println 'entry workflow > main'
+
+                onComplete:
+                println 'entry workflow > onComplete'
+            }
+            '''
+        )
+        then:
+        TestHelper.filterLogNoise(capture) == [
+            'entry workflow > main',
+            'entry workflow > onComplete'
+        ]
+
+        cleanup:
+        SysEnv.pop()
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
@@ -329,7 +329,7 @@ class WorkflowMetadataTest extends Specification {
             '''
         )
         then:
-        TestHelper.filterLogNoise(capture) == [
+        TestHelper.filterLogNoise(capture, true) == [
             'entry workflow > main',
             'entry workflow > onComplete'
         ]

--- a/modules/nextflow/src/testFixtures/groovy/test/TestHelper.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/TestHelper.groovy
@@ -132,7 +132,7 @@ class TestHelper {
         output.readLines().findAll { line ->
             !line.contains('DEBUG') &&
             !line.contains('INFO') &&
-            (includeWarn || !line.contains('WARN')) &&
+            (!includeWarn || !line.contains('WARN')) &&
             !line.contains('plugin') &&
             !line.contains('-> [')  // pf4j dependency graph lines
         }

--- a/modules/nextflow/src/testFixtures/groovy/test/TestHelper.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/TestHelper.groovy
@@ -132,7 +132,7 @@ class TestHelper {
         output.readLines().findAll { line ->
             !line.contains('DEBUG') &&
             !line.contains('INFO') &&
-            (!includeWarn || !line.contains('WARN')) &&
+            (includeWarn || !line.contains('WARN')) &&
             !line.contains('plugin') &&
             !line.contains('-> [')  // pf4j dependency graph lines
         }


### PR DESCRIPTION
This PR fixes an issue (reported internally) where the `onComplete` handler is called twice when trace logging is enabled

When a closure is rendered in a GString, it is actually invoked:

```groovy
hook = { -> println 'hello!' }
println "$hook"
```

```
$ groovy test.groovy
hello!
null
```

As a result, we need to be careful about printing closures directly. This PR fixes the log messages in `Session::shutdown0()` and adds a test to confirm it