### PR TITLE
Add successful-hash index to the default cache

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1044,7 +1044,7 @@ class Session implements ISession {
         // -- update the successful-hash index so a later resume resolves this
         //    task in a single lookup, even if it succeeded after retries
         if( trace?.isCompleted() && handler.task.contentHash && handler.task.hash )
-            cache.putHashIndexAsync(handler.task.contentHash, handler.task.hash)
+            cache.putSuccessfulHashAsync(handler.task.contentHash, handler.task.hash)
 
         // set the pipeline to return non-exit code if specified
         if( handler.task.errorAction == ErrorStrategy.IGNORE && failOnIgnore() ) {
@@ -1065,7 +1065,7 @@ class Session implements ISession {
             // -- refresh the successful-hash index (self-heals a stale pointer
             //    and upgrades a scan-path resume to a fast-path resume)
             if( handler.task.contentHash && handler.task.hash )
-                cache.putHashIndexAsync(handler.task.contentHash, handler.task.hash)
+                cache.putSuccessfulHashAsync(handler.task.contentHash, handler.task.hash)
         }
 
         notifyEvent(observersV1, ob -> ob.onProcessCached(handler, trace))

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1041,6 +1041,11 @@ class Session implements ISession {
         final trace = handler.safeTraceRecord()
         cache.putTaskAsync(handler, trace)
 
+        // -- update the successful-hash index so a later resume resolves this
+        //    task in a single lookup, even if it succeeded after retries
+        if( trace?.isCompleted() && handler.task.contentHash && handler.task.hash )
+            cache.putHashIndexAsync(handler.task.contentHash, handler.task.hash)
+
         // set the pipeline to return non-exit code if specified
         if( handler.task.errorAction == ErrorStrategy.IGNORE && failOnIgnore() ) {
             log.debug "Setting fail-on-ignore flag due to ignored task '${handler.task.lazyName()}'"
@@ -1057,6 +1062,10 @@ class Session implements ISession {
         // otherwise it means that the event is trigger by a `stored dir` driven task
         if( trace ) {
             cache.cacheTaskAsync(handler)
+            // -- refresh the successful-hash index (self-heals a stale pointer
+            //    and upgrades a scan-path resume to a fast-path resume)
+            if( handler.task.contentHash && handler.task.hash )
+                cache.putHashIndexAsync(handler.task.contentHash, handler.task.hash)
         }
 
         notifyEvent(observersV1, ob -> ob.onProcessCached(handler, trace))

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1063,8 +1063,10 @@ class Session implements ISession {
         if( trace ) {
             cache.cacheTaskAsync(handler)
             // -- refresh the successful-hash index (self-heals a stale pointer
-            //    and upgrades a scan-path resume to a fast-path resume)
-            if( handler.task.contentHash && handler.task.hash )
+            //    and upgrades a scan-path resume to a fast-path resume); skip it
+            //    when the resume already came from the index, where the pointer
+            //    is known to be correct and the rewrite would be redundant
+            if( !handler.task.resumedFromIndex && handler.task.contentHash && handler.task.hash )
                 cache.putSuccessfulHashAsync(handler.task.contentHash, handler.task.hash)
         }
 

--- a/modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy
@@ -95,8 +95,8 @@ class CacheDB implements Closeable {
      * @param contentHash The content-based task hash (before try-mixing)
      * @return The {@link HashCode} of a successful execution, or {@code null} if absent
      */
-    HashCode getHashIndex(HashCode contentHash) {
-        return store.getHashIndex(contentHash)
+    HashCode getSuccessfulHash(HashCode contentHash) {
+        return store.getSuccessfulHash(contentHash)
     }
 
     /**
@@ -104,8 +104,8 @@ class CacheDB implements Closeable {
      * same writer agent as {@link #putTaskAsync}, so it is serialized AFTER the
      * corresponding entry write (commit-marker discipline).
      */
-    void putHashIndexAsync(HashCode contentHash, HashCode finalHash) {
-        writer.send { store.putHashIndex(contentHash, finalHash) }
+    void putSuccessfulHashAsync(HashCode contentHash, HashCode finalHash) {
+        writer.send { store.putSuccessfulHash(contentHash, finalHash) }
     }
 
     void incTaskEntry( HashCode hash ) {
@@ -140,6 +140,12 @@ class CacheDB implements Closeable {
         }
         else {
             store.deleteEntry(hash)
+            // -- remove the successful-hash index pointer, but only when it
+            //    targets this very entry (a failed attempt shares the same
+            //    content hash, yet the pointer aims at the successful one)
+            final contentHash = record.size()>3 && record[3]!=null ? HashCode.fromBytes((byte[])record[3]) : null
+            if( contentHash != null && store.getSuccessfulHash(contentHash) == hash )
+                store.deleteSuccessfulHash(contentHash)
             return true
         }
     }
@@ -161,10 +167,13 @@ class CacheDB implements Closeable {
         // only the 'cache' is active and
         TaskContext ctx = proc.isCacheable() && task.hasCacheableValues() ? task.context : null
 
-        def record = new ArrayList(3)
+        def record = new ArrayList(4)
         record[0] = trace.serialize()
         record[1] = ctx != null ? ctx.serialize() : null
         record[2] = 1
+        // fourth slot keeps the task content hash so the successful-hash index
+        // pointer can be located and removed when this entry is deleted
+        record[3] = task.contentHash?.asBytes()
 
         // -- save in the db
         store.putEntry( key, KryoHelper.serialize(record) )

--- a/modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy
@@ -142,10 +142,17 @@ class CacheDB implements Closeable {
             store.deleteEntry(hash)
             // -- remove the successful-hash index pointer, but only when it
             //    targets this very entry (a failed attempt shares the same
-            //    content hash, yet the pointer aims at the successful one)
-            final contentHash = record.size()>3 && record[3]!=null ? HashCode.fromBytes((byte[])record[3]) : null
-            if( contentHash != null && store.getSuccessfulHash(contentHash) == hash )
-                store.deleteSuccessfulHash(contentHash)
+            //    content hash, yet the pointer aims at the successful one).
+            //    Best-effort: a bad/unreadable pointer must never derail entry
+            //    removal -- it self-heals on the next resume.
+            try {
+                final contentHash = record.size()>3 && record[3]!=null ? HashCode.fromBytes((byte[])record[3]) : null
+                if( contentHash != null && store.getSuccessfulHash(contentHash) == hash )
+                    store.deleteSuccessfulHash(contentHash)
+            }
+            catch( Exception e ) {
+                log.debug "Unable to clean successful-hash index pointer for entry $hash -- ${e.message}"
+            }
             return true
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy
@@ -89,6 +89,25 @@ class CacheDB implements Closeable {
         return new TaskEntry(trace,ctx)
     }
 
+    /**
+     * Retrieve the final hash of a successful execution for the given content hash.
+     *
+     * @param contentHash The content-based task hash (before try-mixing)
+     * @return The {@link HashCode} of a successful execution, or {@code null} if absent
+     */
+    HashCode getHashIndex(HashCode contentHash) {
+        return store.getHashIndex(contentHash)
+    }
+
+    /**
+     * Asynchronously write the successful-hash index pointer. Enqueued on the
+     * same writer agent as {@link #putTaskAsync}, so it is serialized AFTER the
+     * corresponding entry write (commit-marker discipline).
+     */
+    void putHashIndexAsync(HashCode contentHash, HashCode finalHash) {
+        writer.send { store.putHashIndex(contentHash, finalHash) }
+    }
+
     void incTaskEntry( HashCode hash ) {
         final payload = store.getEntry(hash)
         if( !payload ) {

--- a/modules/nextflow/src/main/groovy/nextflow/cache/CacheStore.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/CacheStore.groovy
@@ -45,12 +45,17 @@ interface CacheStore {
      * Retrieve the final hash of a successful execution for the given content hash,
      * or {@code null} if no successful-hash index entry exists.
      */
-    HashCode getHashIndex(HashCode contentHash)
+    HashCode getSuccessfulHash(HashCode contentHash)
 
     /**
      * Map a task content hash to the final hash of a successful execution.
      */
-    void putHashIndex(HashCode contentHash, HashCode finalHash)
+    void putSuccessfulHash(HashCode contentHash, HashCode finalHash)
+
+    /**
+     * Remove the successful-hash index entry for the given content hash.
+     */
+    void deleteSuccessfulHash(HashCode contentHash)
 
     void writeIndex(HashCode key, boolean cached)
     Iterator<Index> iterateIndex()

--- a/modules/nextflow/src/main/groovy/nextflow/cache/CacheStore.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/CacheStore.groovy
@@ -41,6 +41,17 @@ interface CacheStore {
     void putEntry(HashCode key, byte[] value)
     void deleteEntry(HashCode key)
 
+    /**
+     * Retrieve the final hash of a successful execution for the given content hash,
+     * or {@code null} if no successful-hash index entry exists.
+     */
+    HashCode getHashIndex(HashCode contentHash)
+
+    /**
+     * Map a task content hash to the final hash of a successful execution.
+     */
+    void putHashIndex(HashCode contentHash, HashCode finalHash)
+
     void writeIndex(HashCode key, boolean cached)
     Iterator<Index> iterateIndex()
     void deleteIndex()

--- a/modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheStore.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheStore.groovy
@@ -185,4 +185,27 @@ class DefaultCacheStore implements CacheStore {
     void deleteEntry(HashCode key) {
         db.delete(key.asBytes())
     }
+
+    /** Key-space prefix that isolates hash-index keys from entry keys
+     *  (entry keys are exactly KEY_SIZE bytes with no prefix). */
+    private static final byte HASH_INDEX_PREFIX = 0x01
+
+    private byte[] indexKey(HashCode contentHash) {
+        final h = contentHash.asBytes()
+        final k = new byte[h.length + 1]
+        k[0] = HASH_INDEX_PREFIX
+        System.arraycopy(h, 0, k, 1, h.length)
+        return k
+    }
+
+    @Override
+    HashCode getHashIndex(HashCode contentHash) {
+        final value = db.get(indexKey(contentHash))
+        return value != null ? HashCode.fromBytes(value) : null
+    }
+
+    @Override
+    void putHashIndex(HashCode contentHash, HashCode finalHash) {
+        db.put(indexKey(contentHash), finalHash.asBytes())
+    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheStore.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheStore.groovy
@@ -28,12 +28,33 @@ import org.iq80.leveldb.Options
 import org.iq80.leveldb.impl.Iq80DBFactory
 /**
  * Implement the default nextflow cache store that save the cache data
- * into the local directory using an embedded LevelDVB instance
+ * into the local directory using an embedded LevelDVB instance *
+ *
+ * KEY-SPACE CONTRACT
+ * ------------------
+ * This single LevelDB instance holds two disjoint key namespaces:
+ *
+ *   - task entries:        key = <hash>            (exactly KEY_SIZE bytes)
+ *   - successful-hash idx:  key = 0x01 + <hash>     (KEY_SIZE + 1 bytes)
+ *
+ * The {@link #SUCCESSFUL_HASH_INDEX_PREFIX} byte makes index keys one byte longer than
+ * entry keys, so the two namespaces can never collide (LevelDB compares the
+ * full byte sequence). All key construction goes through {@link #successfulIndexKey}
+ * for index keys and {@code key.asBytes()} for entry keys -- do not build raw
+ * keys elsewhere.
+ *
+ * NOTE: the store is never iterated by LevelDB key (record enumeration uses
+ * the separate flat index file via {@link #iterateIndex}). If a key scan is
+ * ever added, it MUST filter by this contract (length / prefix) so it does
+ * not treat index pointers as task-entry records.
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @CompileStatic
 class DefaultCacheStore implements CacheStore {
+
+    /** Prefix byte for successful-hash index keys -- see KEY-SPACE CONTRACT above. */
+    private static final byte SUCCESSFUL_HASH_INDEX_PREFIX = 0x01
 
     /** The underlying Level DB instance */
     private DB db
@@ -186,26 +207,27 @@ class DefaultCacheStore implements CacheStore {
         db.delete(key.asBytes())
     }
 
-    /** Key-space prefix that isolates hash-index keys from entry keys
-     *  (entry keys are exactly KEY_SIZE bytes with no prefix). */
-    private static final byte HASH_INDEX_PREFIX = 0x01
-
-    private byte[] indexKey(HashCode contentHash) {
+    private byte[] successfulIndexKey(HashCode contentHash) {
         final h = contentHash.asBytes()
         final k = new byte[h.length + 1]
-        k[0] = HASH_INDEX_PREFIX
+        k[0] = SUCCESSFUL_HASH_INDEX_PREFIX
         System.arraycopy(h, 0, k, 1, h.length)
         return k
     }
 
     @Override
-    HashCode getHashIndex(HashCode contentHash) {
-        final value = db.get(indexKey(contentHash))
+    HashCode getSuccessfulHash(HashCode contentHash) {
+        final value = db.get(successfulIndexKey(contentHash))
         return value != null ? HashCode.fromBytes(value) : null
     }
 
     @Override
-    void putHashIndex(HashCode contentHash, HashCode finalHash) {
-        db.put(indexKey(contentHash), finalHash.asBytes())
+    void putSuccessfulHash(HashCode contentHash, HashCode finalHash) {
+        db.put(successfulIndexKey(contentHash), finalHash.asBytes())
+    }
+
+    @Override
+    void deleteSuccessfulHash(HashCode contentHash) {
+        db.delete(successfulIndexKey(contentHash))
     }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -883,8 +883,12 @@ class TaskProcessor {
                 return false
             final entry = session.cache.getTaskEntry(indexed, this)
             final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
+            // mark the clone so notifyTaskCached skips rewriting an already-correct
+            // index pointer (the scan path leaves the flag unset to self-heal)
+            final taskCopy = task.clone()
+            taskCopy.resumedFromIndex = true
             return entry && entry.trace.isCompleted() && resumeDir?.exists() \
-                    && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
+                    && checkCachedOutput(taskCopy, resumeDir, indexed, entry)
         }
         catch( Throwable t ) {
             log.trace "[${safeTaskName(task)}] Successful-hash index lookup failed -- falling back to scan -- ${t.message}"

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -801,6 +801,35 @@ class TaskProcessor {
     @CompileStatic
     final protected void checkCachedOrLaunchTask( TaskRun task, HashCode hash, boolean shouldTryCache ) {
 
+        // Capture the content hash ONLY on the first attempt. Retries re-enter
+        // via resumeOrDie -> checkCachedOrLaunchTask(taskCopy, taskCopy.hash, false),
+        // where `hash` is the previous (chained) final hash, not the content hash.
+        // makeCopy()/clone() carry contentHash forward, so the null guard keeps
+        // the index key consistent across the whole retry chain.
+        if( task.contentHash == null )
+            task.contentHash = hash
+
+        // Fast resume path: resolve a previously successful execution via the
+        // successful-hash index in a single lookup, skipping the attempt scan.
+        if( shouldTryCache ) {
+            try {
+                final indexed = session.cache.getHashIndex(task.contentHash)
+                if( indexed ) {
+                    final entry = session.cache.getTaskEntry(indexed, this)
+                    final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
+                    final ok = entry && entry.trace.isCompleted() && resumeDir?.exists() \
+                            && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
+                    if( ok )
+                        return
+                    // stale/invalid pointer -> fall through; a successful resume
+                    // or execution rewrites the pointer (self-heal)
+                }
+            }
+            catch( Throwable t ) {
+                log.trace "[${safeTaskName(task)}] Successful-hash index lookup failed -- falling back to scan -- ${t.message}"
+            }
+        }
+
         int tries = task.failCount +1
         while( true ) {
             hash = HashBuilder.defaultHasher().putBytes(hash.asBytes()).putInt(tries).hash()

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -809,26 +809,10 @@ class TaskProcessor {
         if( task.contentHash == null )
             task.contentHash = hash
 
-        // Fast resume path: resolve a previously successful execution via the
-        // successful-hash index in a single lookup, skipping the attempt scan.
-        if( shouldTryCache ) {
-            try {
-                final indexed = session.cache.getHashIndex(task.contentHash)
-                if( indexed ) {
-                    final entry = session.cache.getTaskEntry(indexed, this)
-                    final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
-                    final ok = entry && entry.trace.isCompleted() && resumeDir?.exists() \
-                            && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
-                    if( ok )
-                        return
-                    // stale/invalid pointer -> fall through; a successful resume
-                    // or execution rewrites the pointer (self-heal)
-                }
-            }
-            catch( Throwable t ) {
-                log.trace "[${safeTaskName(task)}] Successful-hash index lookup failed -- falling back to scan -- ${t.message}"
-            }
-        }
+        // fast resume path: try to resolve a previously successful execution via
+        // the successful-hash index, otherwise fall back to the scan below
+        if( shouldTryCache && resumeFromSuccessfulHashIndex(task) )
+            return
 
         int tries = task.failCount +1
         while( true ) {
@@ -877,6 +861,35 @@ class TaskProcessor {
             break
         }
 
+    }
+
+    /**
+     * Fast resume path for {@link #checkCachedOrLaunchTask}: resolve a previously
+     * successful execution via the successful-hash index in a single lookup,
+     * skipping the iterate-and-bump scan. The index maps the task content hash
+     * (see {@link TaskRun#contentHash}) to the final hash of the successful attempt.
+     *
+     * @param task The task being resolved; its {@code contentHash} must be set
+     * @return {@code true} if the task was resumed from the indexed entry;
+     *      {@code false} to fall back to the scan (index miss, stale/invalid
+     *      pointer, or lookup error). A stale pointer self-heals on the next
+     *      successful resume or execution.
+     */
+    @CompileStatic
+    private boolean resumeFromSuccessfulHashIndex(TaskRun task ) {
+        try {
+            final indexed = session.cache.getSuccessfulHash(task.contentHash)
+            if( !indexed )
+                return false
+            final entry = session.cache.getTaskEntry(indexed, this)
+            final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
+            return entry && entry.trace.isCompleted() && resumeDir?.exists() \
+                    && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
+        }
+        catch( Throwable t ) {
+            log.trace "[${safeTaskName(task)}] Successful-hash index lookup failed -- falling back to scan -- ${t.message}"
+            return false
+        }
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -83,6 +83,14 @@ class TaskRun implements Cloneable {
      */
     HashCode hash
 
+    /**
+     * The content-based hash of the task, captured on the first attempt
+     * (before per-attempt try-mixing). Used as the key of the successful-hash
+     * index that maps this content hash to the {@link #hash} of a successful
+     * execution. Preserved across retries by {@code clone()} / {@code makeCopy()}.
+     */
+    volatile HashCode contentHash
+
     /*
      * The processor that creates this 'task'
      */

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -91,6 +91,15 @@ class TaskRun implements Cloneable {
      */
     volatile HashCode contentHash
 
+    /**
+     * Marks a (cloned) task that was resumed via the successful-hash index
+     * fast-path. When set, the index pointer is already known to be correct, so
+     * the redundant rewrite in {@code Session.notifyTaskCached} is skipped. Set
+     * only on the short-lived clone used to validate the cached output; never
+     * carried by the original task or its retry copies.
+     */
+    transient boolean resumedFromIndex
+
     /*
      * The processor that creates this 'task'
      */

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -83,6 +83,45 @@ class SessionTest extends Specification {
         0 * cache.putSuccessfulHashAsync(_, _)
     }
 
+    def 'should refresh the hash index on a scan-path resume'() {
+        given:
+        def session = new Session()
+        def cache = Mock(CacheDB)
+        session.@cache = cache
+        and:
+        def content = HashCode.fromInt(1)
+        def finalHash = HashCode.fromInt(2)
+        // resumedFromIndex defaults to false -> scan-path resume
+        def task = new TaskRun(hash: finalHash, contentHash: content)
+        def trace = new TraceRecord([status: 'COMPLETED'])
+        def handler = Mock(TaskHandler) { getTask() >> task; getTraceRecord() >> trace }
+
+        when:
+        session.notifyTaskCached(handler)
+        then: 'the pointer is (re)written to self-heal / upgrade to the fast-path'
+        1 * cache.cacheTaskAsync(handler)
+        1 * cache.putSuccessfulHashAsync(content, finalHash)
+    }
+
+    def 'should not refresh the hash index when resumed from the index fast-path'() {
+        given:
+        def session = new Session()
+        def cache = Mock(CacheDB)
+        session.@cache = cache
+        and:
+        def content = HashCode.fromInt(1)
+        def finalHash = HashCode.fromInt(2)
+        def task = new TaskRun(hash: finalHash, contentHash: content, resumedFromIndex: true)
+        def trace = new TraceRecord([status: 'COMPLETED'])
+        def handler = Mock(TaskHandler) { getTask() >> task; getTraceRecord() >> trace }
+
+        when:
+        session.notifyTaskCached(handler)
+        then: 'the pointer is already correct, so the redundant rewrite is skipped'
+        1 * cache.cacheTaskAsync(handler)
+        0 * cache.putSuccessfulHashAsync(_, _)
+    }
+
     def 'test baseDir and binDir'() {
 
         setup:

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -22,12 +22,10 @@ import java.nio.file.attribute.PosixFilePermission
 
 import com.google.common.hash.HashCode
 import nextflow.cache.CacheDB
-import nextflow.config.Manifest
 import nextflow.container.ContainerConfig
 import nextflow.container.DockerConfig
 import nextflow.container.PodmanConfig
 import nextflow.container.SarusConfig
-import nextflow.exception.AbortOperationException
 import nextflow.file.FileHelper
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskRun
@@ -37,8 +35,6 @@ import nextflow.trace.TraceFileObserver
 import nextflow.trace.TraceHelper
 import nextflow.trace.TraceRecord
 import nextflow.trace.WorkflowStatsObserver
-import nextflow.util.Duration
-import nextflow.util.VersionNumber
 import spock.lang.Specification
 import spock.lang.Unroll
 import test.TestHelper
@@ -67,7 +63,7 @@ class SessionTest extends Specification {
         session.notifyTaskComplete(handler)
         then:
         1 * cache.putTaskAsync(handler, trace)
-        1 * cache.putHashIndexAsync(content, finalHash)
+        1 * cache.putSuccessfulHashAsync(content, finalHash)
     }
 
     def 'should not write hash index when the task is not completed'() {
@@ -84,7 +80,7 @@ class SessionTest extends Specification {
         session.notifyTaskComplete(handler)
         then:
         1 * cache.putTaskAsync(handler, trace)
-        0 * cache.putHashIndexAsync(_, _)
+        0 * cache.putSuccessfulHashAsync(_, _)
     }
 
     def 'test baseDir and binDir'() {

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -20,6 +20,8 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermission
 
+import com.google.common.hash.HashCode
+import nextflow.cache.CacheDB
 import nextflow.config.Manifest
 import nextflow.container.ContainerConfig
 import nextflow.container.DockerConfig
@@ -27,10 +29,13 @@ import nextflow.container.PodmanConfig
 import nextflow.container.SarusConfig
 import nextflow.exception.AbortOperationException
 import nextflow.file.FileHelper
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskRun
 import nextflow.script.ScriptFile
 import nextflow.script.WorkflowMetadata
 import nextflow.trace.TraceFileObserver
 import nextflow.trace.TraceHelper
+import nextflow.trace.TraceRecord
 import nextflow.trace.WorkflowStatsObserver
 import nextflow.util.Duration
 import nextflow.util.VersionNumber
@@ -45,6 +50,42 @@ import static test.ScriptHelper.*
  */
 class SessionTest extends Specification {
 
+
+    def 'should write hash index when a completed task is notified'() {
+        given:
+        def session = new Session()
+        def cache = Mock(CacheDB)
+        session.@cache = cache
+        and:
+        def content = HashCode.fromInt(1)
+        def finalHash = HashCode.fromInt(2)
+        def task = new TaskRun(hash: finalHash, contentHash: content)
+        def trace = new TraceRecord([status: 'COMPLETED'])
+        def handler = Mock(TaskHandler) { getTask() >> task; safeTraceRecord() >> trace }
+
+        when:
+        session.notifyTaskComplete(handler)
+        then:
+        1 * cache.putTaskAsync(handler, trace)
+        1 * cache.putHashIndexAsync(content, finalHash)
+    }
+
+    def 'should not write hash index when the task is not completed'() {
+        given:
+        def session = new Session()
+        def cache = Mock(CacheDB)
+        session.@cache = cache
+        and:
+        def task = new TaskRun(hash: HashCode.fromInt(2), contentHash: HashCode.fromInt(1))
+        def trace = new TraceRecord([status: 'FAILED'])
+        def handler = Mock(TaskHandler) { getTask() >> task; safeTraceRecord() >> trace }
+
+        when:
+        session.notifyTaskComplete(handler)
+        then:
+        1 * cache.putTaskAsync(handler, trace)
+        0 * cache.putHashIndexAsync(_, _)
+    }
 
     def 'test baseDir and binDir'() {
 

--- a/modules/nextflow/src/test/groovy/nextflow/cache/CacheDBTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cache/CacheDBTest.groovy
@@ -121,6 +121,27 @@ class CacheDBTest extends Specification {
 
     }
 
+    def 'should delegate hash index read and write' () {
+        given:
+        def store = Mock(CacheStore)
+        def cache = new CacheDB(store)
+        and:
+        def content = HashCode.fromInt(1)
+        def finalHash = HashCode.fromInt(2)
+
+        when:
+        def result = cache.getHashIndex(content)
+        then:
+        1 * store.getHashIndex(content) >> finalHash
+        result == finalHash
+
+        when:
+        cache.putHashIndexAsync(content, finalHash)
+        cache.close()
+        then:
+        1 * store.putHashIndex(content, finalHash)
+    }
+
     def 'should write some tasks and iterate over them' () {
 
         setup:

--- a/modules/nextflow/src/test/groovy/nextflow/cache/CacheDBTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cache/CacheDBTest.groovy
@@ -29,6 +29,7 @@ import nextflow.script.BodyDef
 import nextflow.script.ProcessConfig
 import nextflow.trace.TraceRecord
 import nextflow.util.CacheHelper
+import nextflow.util.KryoHelper
 import spock.lang.Specification
 /**
  *
@@ -181,6 +182,27 @@ class CacheDBTest extends Specification {
         cleanup:
         cache?.close()
         folder?.deleteDir()
+    }
+
+    def 'should not fail entry removal when the index cleanup throws' () {
+        given:
+        def store = Mock(CacheStore)
+        def cache = new CacheDB(store)
+        and:
+        def hash = CacheHelper.hasher('SUCCESS').hash()
+        def content = CacheHelper.hasher('CONTENT').hash()
+        and: 'a ref-count-1 entry carrying its content hash in the fourth slot'
+        def payload = KryoHelper.serialize([null, null, 1, content.asBytes()])
+
+        when:
+        def removed = cache.removeTaskEntry(hash)
+
+        then: 'a throwing index lookup is swallowed; the entry is still removed'
+        1 * store.getEntry(hash) >> payload
+        1 * store.deleteEntry(hash)
+        1 * store.getSuccessfulHash(content) >> { throw new RuntimeException('boom') }
+        0 * store.deleteSuccessfulHash(_)
+        removed
     }
 
     def 'should write some tasks and iterate over them' () {

--- a/modules/nextflow/src/test/groovy/nextflow/cache/CacheDBTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cache/CacheDBTest.groovy
@@ -19,8 +19,6 @@ package nextflow.cache
 import java.nio.file.Files
 
 import com.google.common.hash.HashCode
-import nextflow.cache.CacheDB
-import nextflow.cache.DefaultCacheStore
 import nextflow.executor.CachedTaskHandler
 import nextflow.processor.TaskContext
 import nextflow.processor.TaskEntry
@@ -130,16 +128,59 @@ class CacheDBTest extends Specification {
         def finalHash = HashCode.fromInt(2)
 
         when:
-        def result = cache.getHashIndex(content)
+        def result = cache.getSuccessfulHash(content)
         then:
-        1 * store.getHashIndex(content) >> finalHash
+        1 * store.getSuccessfulHash(content) >> finalHash
         result == finalHash
 
         when:
-        cache.putHashIndexAsync(content, finalHash)
+        cache.putSuccessfulHashAsync(content, finalHash)
         cache.close()
         then:
-        1 * store.putHashIndex(content, finalHash)
+        1 * store.putSuccessfulHash(content, finalHash)
+    }
+
+    private makeHandler(HashCode hash, HashCode contentHash) {
+        def proc = Mock(TaskProcessor)
+        proc.getTaskBody() >> new BodyDef(null,'source')
+        proc.getConfig() >> new ProcessConfig([:])
+        def task = Mock(TaskRun)
+        task.getProcessor() >> proc
+        task.getHash() >> hash
+        task.getContentHash() >> contentHash
+        return new CachedTaskHandler(task, new TraceRecord())
+    }
+
+    def 'should remove the hash index pointer when its target entry is deleted' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def store = new DefaultCacheStore(UUID.randomUUID(), 'test_1', folder)
+        def cache = new CacheDB(store).open()
+        and:
+        def content = CacheHelper.hasher('CONTENT').hash()
+        def successHash = CacheHelper.hasher('SUCCESS').hash()
+        def failHash = CacheHelper.hasher('FAIL').hash()
+        and: 'a successful entry carrying its content hash, indexed'
+        cache.writeTaskEntry0(makeHandler(successHash, content), new TraceRecord([task_id:1, exit:0]))
+        store.putSuccessfulHash(content, successHash)
+        and: 'a failed-attempt entry for the SAME content hash (not the index target)'
+        cache.writeTaskEntry0(makeHandler(failHash, content), new TraceRecord([task_id:1, exit:1]))
+
+        when: 'the failed-attempt entry is removed'
+        def removedFail = cache.removeTaskEntry(failHash)
+        then: 'the entry is gone but the pointer to the successful entry survives'
+        removedFail
+        store.getSuccessfulHash(content) == successHash
+
+        when: 'the successful entry (the index target) is removed'
+        def removedSuccess = cache.removeTaskEntry(successHash)
+        then: 'its index pointer is removed too'
+        removedSuccess
+        store.getSuccessfulHash(content) == null
+
+        cleanup:
+        cache?.close()
+        folder?.deleteDir()
     }
 
     def 'should write some tasks and iterate over them' () {

--- a/modules/nextflow/src/test/groovy/nextflow/cache/DefaultCacheStoreTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cache/DefaultCacheStoreTest.groovy
@@ -56,4 +56,40 @@ class DefaultCacheStoreTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should get and put hash index entries' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def uuid = UUID.randomUUID()
+        def store = new DefaultCacheStore(uuid, 'test_1', folder); store.open()
+        and:
+        def content = CacheHelper.hasher('CONTENT').hash()
+        def finalHash = CacheHelper.hasher('FINAL').hash()
+
+        expect: 'absent key returns null'
+        store.getHashIndex(content) == null
+
+        when:
+        store.putHashIndex(content, finalHash)
+        then: 'round-trips'
+        store.getHashIndex(content) == finalHash
+
+        and: 'index key does not collide with an entry key of the same hash'
+        store.getEntry(content) == null
+        store.putEntry(content, 'ENTRY'.bytes)
+        new String(store.getEntry(content)) == 'ENTRY'
+        store.getHashIndex(content) == finalHash
+
+        when: 'the cache is dropped'
+        store.close()
+        store.drop()
+        and: 'reopened on the same session location'
+        store = new DefaultCacheStore(uuid, 'test_1', folder); store.open()
+        then: 'the index entry is gone'
+        store.getHashIndex(content) == null
+
+        cleanup:
+        store?.close()
+        folder?.deleteDir()
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/cache/DefaultCacheStoreTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cache/DefaultCacheStoreTest.groovy
@@ -66,26 +66,32 @@ class DefaultCacheStoreTest extends Specification {
         def finalHash = CacheHelper.hasher('FINAL').hash()
 
         expect: 'absent key returns null'
-        store.getHashIndex(content) == null
+        store.getSuccessfulHash(content) == null
 
         when:
-        store.putHashIndex(content, finalHash)
+        store.putSuccessfulHash(content, finalHash)
         then: 'round-trips'
-        store.getHashIndex(content) == finalHash
+        store.getSuccessfulHash(content) == finalHash
 
         and: 'index key does not collide with an entry key of the same hash'
         store.getEntry(content) == null
         store.putEntry(content, 'ENTRY'.bytes)
         new String(store.getEntry(content)) == 'ENTRY'
-        store.getHashIndex(content) == finalHash
+        store.getSuccessfulHash(content) == finalHash
+
+        when: 'the index entry is deleted'
+        store.deleteSuccessfulHash(content)
+        then:
+        store.getSuccessfulHash(content) == null
 
         when: 'the cache is dropped'
+        store.putSuccessfulHash(content, finalHash)
         store.close()
         store.drop()
         and: 'reopened on the same session location'
         store = new DefaultCacheStore(uuid, 'test_1', folder); store.open()
         then: 'the index entry is gone'
-        store.getHashIndex(content) == null
+        store.getSuccessfulHash(content) == null
 
         cleanup:
         store?.close()

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService
 import com.google.common.hash.HashCode
 import groovyx.gpars.agent.Agent
 import nextflow.Session
+import nextflow.cache.CacheDB
 import nextflow.exception.IllegalArityException
 import nextflow.exception.ProcessException
 import nextflow.exception.ProcessUnrecoverableException
@@ -634,6 +635,66 @@ class TaskProcessorTest extends Specification {
         task.getConfig() >> new TaskConfig()
         and:
         1 * exec.submit(task)
+    }
+
+    def 'should consult the hash index on resume and fall through to scan when stale' () {
+        given:
+        def cache = Mock(CacheDB)
+        def session = Mock(Session) { getCache() >> cache }
+        def exec = Mock(Executor)
+        def processor = Spy(new TaskProcessor(session: session, executor: exec))
+        and:
+        def content = HashCode.fromInt(100)
+        def staleHash = HashCode.fromInt(200)
+        def workDir = Files.createTempDirectory('wd').resolve('x')  // does not exist yet
+        def task = Mock(TaskRun) {
+            getConfig() >> new TaskConfig()
+            getName() >> 'foo'
+            getFailCount() >> 0
+            getContentHash() >> content
+            getWorkDirFor(_) >> workDir
+        }
+
+        when:
+        processor.checkCachedOrLaunchTask(task, content, true)
+
+        then: 'the index is consulted; a stale pointer falls through to the scan, which submits'
+        1 * cache.getHashIndex(content) >> staleHash
+        1 * cache.getTaskEntry(staleHash, processor) >> null
+        (1.._) * cache.getTaskEntry(_, processor) >> null
+        1 * exec.submit(task)
+
+        cleanup:
+        workDir?.parent?.deleteDir()
+    }
+
+    def 'should not consult the hash index when shouldTryCache is false' () {
+        given:
+        def cache = Mock(CacheDB)
+        def session = Mock(Session) { getCache() >> cache }
+        def exec = Mock(Executor)
+        def processor = Spy(new TaskProcessor(session: session, executor: exec))
+        and:
+        def content = HashCode.fromInt(100)
+        def workDir = Files.createTempDirectory('wd').resolve('x')
+        def task = Mock(TaskRun) {
+            getConfig() >> new TaskConfig()
+            getName() >> 'foo'
+            getFailCount() >> 0
+            getContentHash() >> content
+            getWorkDirFor(_) >> workDir
+        }
+
+        when:
+        processor.checkCachedOrLaunchTask(task, content, false)
+
+        then: 'no index lookup; the task is submitted via the scan path'
+        0 * cache.getHashIndex(_)
+        (1.._) * cache.getTaskEntry(_, processor) >> null
+        1 * exec.submit(task)
+
+        cleanup:
+        workDir?.parent?.deleteDir()
     }
 
     def 'should collect a task' () {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -659,7 +659,7 @@ class TaskProcessorTest extends Specification {
         processor.checkCachedOrLaunchTask(task, content, true)
 
         then: 'the index is consulted; a stale pointer falls through to the scan, which submits'
-        1 * cache.getHashIndex(content) >> staleHash
+        1 * cache.getSuccessfulHash(content) >> staleHash
         1 * cache.getTaskEntry(staleHash, processor) >> null
         (1.._) * cache.getTaskEntry(_, processor) >> null
         1 * exec.submit(task)
@@ -689,7 +689,7 @@ class TaskProcessorTest extends Specification {
         processor.checkCachedOrLaunchTask(task, content, false)
 
         then: 'no index lookup; the task is submitted via the scan path'
-        0 * cache.getHashIndex(_)
+        0 * cache.getSuccessfulHash(_)
         (1.._) * cache.getTaskEntry(_, processor) >> null
         1 * exec.submit(task)
 

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import ch.artecat.grengine.Grengine
+import com.google.common.hash.HashCode
 import nextflow.Session
 import nextflow.ast.TaskCmdXform
 import nextflow.container.DockerConfig
@@ -42,6 +43,7 @@ import nextflow.script.params.StdOutParam
 import nextflow.script.params.ValueInParam
 import nextflow.script.params.ValueOutParam
 import nextflow.util.BlankSeparatedList
+import nextflow.util.CacheHelper
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
 import spock.lang.Specification
@@ -56,6 +58,18 @@ class TaskRunTest extends Specification {
 
     def setupSpec() {
         new Session()
+    }
+
+    def 'should carry contentHash across clone'() {
+        given:
+        def task = new TaskRun(config: new TaskConfig([:]), context: new TaskContext(holder: [:]))
+        task.contentHash = CacheHelper.hasher('abc').hash()
+
+        when:
+        def copy = task.clone()
+
+        then:
+        copy.contentHash == task.contentHash
     }
 
     def testGetOutputsByType() {

--- a/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy
+++ b/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy
@@ -159,7 +159,7 @@ class CloudCacheStore implements CacheStore {
     }
 
     @Override
-    HashCode getHashIndex(HashCode contentHash) {
+    HashCode getSuccessfulHash(HashCode contentHash) {
         try {
             return HashCode.fromString(new String(getIndexPath(contentHash).bytes))
         }
@@ -169,10 +169,15 @@ class CloudCacheStore implements CacheStore {
     }
 
     @Override
-    void putHashIndex(HashCode contentHash, HashCode finalHash) {
+    void putSuccessfulHash(HashCode contentHash, HashCode finalHash) {
         final p = getIndexPath(contentHash)
         Files.createDirectories(p.parent)
         p.bytes = finalHash.toString().bytes
+    }
+
+    @Override
+    void deleteSuccessfulHash(HashCode contentHash) {
+        getIndexPath(contentHash).delete()
     }
 
     private Path getIndexPath(HashCode contentHash) {

--- a/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy
+++ b/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy
@@ -157,4 +157,27 @@ class CloudCacheStore implements CacheStore {
     private Path getCachePath(HashCode key) {
         dataPath.resolve(key.toString())
     }
+
+    @Override
+    HashCode getHashIndex(HashCode contentHash) {
+        try {
+            return HashCode.fromString(new String(getIndexPath(contentHash).bytes))
+        }
+        catch( NoSuchFileException e ) {
+            return null
+        }
+    }
+
+    @Override
+    void putHashIndex(HashCode contentHash, HashCode finalHash) {
+        final p = getIndexPath(contentHash)
+        Files.createDirectories(p.parent)
+        p.bytes = finalHash.toString().bytes
+    }
+
+    private Path getIndexPath(HashCode contentHash) {
+        // per-session: dataPath == basePath/<uniqueId>, so the index is NOT
+        // shared across sessions (cross-session indexing is a separate feature)
+        dataPath.resolve('index').resolve(contentHash.toString())
+    }
 }

--- a/plugins/nf-cloudcache/src/test/nextflow/cache/CloudCacheStoreTest.groovy
+++ b/plugins/nf-cloudcache/src/test/nextflow/cache/CloudCacheStoreTest.groovy
@@ -34,12 +34,17 @@ class CloudCacheStoreTest extends Specification {
         def finalHash = CacheHelper.hasher('FINAL').hash()
 
         expect:
-        store.getHashIndex(content) == null
+        store.getSuccessfulHash(content) == null
 
         when:
-        store.putHashIndex(content, finalHash)
+        store.putSuccessfulHash(content, finalHash)
         then:
-        store.getHashIndex(content) == finalHash
+        store.getSuccessfulHash(content) == finalHash
+
+        when:
+        store.deleteSuccessfulHash(content)
+        then:
+        store.getSuccessfulHash(content) == null
 
         cleanup:
         store?.close()
@@ -53,12 +58,12 @@ class CloudCacheStoreTest extends Specification {
         def finalHash = CacheHelper.hasher('FINAL').hash()
         and: 'session A writes a pointer'
         def storeA = new CloudCacheStore(UUID.randomUUID(), 'run_A', base)
-        storeA.putHashIndex(content, finalHash)
+        storeA.putSuccessfulHash(content, finalHash)
         and: 'a different session B over the same base'
         def storeB = new CloudCacheStore(UUID.randomUUID(), 'run_B', base)
 
         expect: 'session B does not see session A pointer'
-        storeB.getHashIndex(content) == null
+        storeB.getSuccessfulHash(content) == null
 
         cleanup:
         storeA?.close(); storeB?.close()

--- a/plugins/nf-cloudcache/src/test/nextflow/cache/CloudCacheStoreTest.groovy
+++ b/plugins/nf-cloudcache/src/test/nextflow/cache/CloudCacheStoreTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cache
+
+import java.nio.file.Files
+
+import nextflow.util.CacheHelper
+import spock.lang.Specification
+
+class CloudCacheStoreTest extends Specification {
+
+    def 'should get and put hash index entries' () {
+        given:
+        def base = Files.createTempDirectory('cloudcache')
+        // note: open() is not needed - the hash-index methods are independent of
+        // the run-index writer and create their own parent directory on write
+        def store = new CloudCacheStore(UUID.randomUUID(), 'run_1', base)
+        and:
+        def content = CacheHelper.hasher('CONTENT').hash()
+        def finalHash = CacheHelper.hasher('FINAL').hash()
+
+        expect:
+        store.getHashIndex(content) == null
+
+        when:
+        store.putHashIndex(content, finalHash)
+        then:
+        store.getHashIndex(content) == finalHash
+
+        cleanup:
+        store?.close()
+        base?.deleteDir()
+    }
+
+    def 'hash index is scoped per session (uniqueId)' () {
+        given:
+        def base = Files.createTempDirectory('cloudcache')
+        def content = CacheHelper.hasher('CONTENT').hash()
+        def finalHash = CacheHelper.hasher('FINAL').hash()
+        and: 'session A writes a pointer'
+        def storeA = new CloudCacheStore(UUID.randomUUID(), 'run_A', base)
+        storeA.putHashIndex(content, finalHash)
+        and: 'a different session B over the same base'
+        def storeB = new CloudCacheStore(UUID.randomUUID(), 'run_B', base)
+
+        expect: 'session B does not see session A pointer'
+        storeB.getHashIndex(content) == null
+
+        cleanup:
+        storeA?.close(); storeB?.close()
+        base?.deleteDir()
+    }
+}

--- a/specs/260601-successful-hash-index/spec.md
+++ b/specs/260601-successful-hash-index/spec.md
@@ -109,8 +109,13 @@ loop continues to serve two roles: write-side collision avoidance for retries
 within a run, and the fallback read path for caches that predate the index. On
 any successful resume or execution, the index pointer is written (or rewritten).
 
-The alternative — splitting the method into `tryResumeFromIndex()` and
-`launchTask()` — was rejected for this change as a larger blast radius on a
+To keep `checkCachedOrLaunchTask` readable, the fast-path's lookup/validation
+logic is **extracted into a private `resumeFromSuccessfulHashIndex(task)` helper** rather
+than inlined; the method itself only gains the content-hash capture and a
+single `if( shouldTryCache && resumeFromSuccessfulHashIndex(task) ) return`. The original
+loop body is **not** refactored — it stays byte-for-byte as before. This is a
+narrower change than splitting the whole method into `tryResumeFromIndex()` +
+`launchTask()`, which was rejected as a larger blast radius on a
 concurrency-sensitive method with no behavioural benefit.
 
 ### Component changes
@@ -119,25 +124,52 @@ concurrency-sensitive method with no behavioural benefit.
 implementations.
 
 ```java
-HashCode getHashIndex(HashCode contentHash)            // null if absent
-void     putHashIndex(HashCode contentHash, HashCode finalHash)
+HashCode getSuccessfulHash(HashCode contentHash)            // null if absent
+void     putSuccessfulHash(HashCode contentHash, HashCode finalHash)
+void     deleteSuccessfulHash(HashCode contentHash)
 ```
 
-The index is **forward only** (`contentHash → finalHash`) and there is no
-reverse link: `finalHash = H(contentHash + tries)` is one-way, and cache
-entries / the run-index are keyed by finalHash. `nextflow clean` and
-`removeTaskEntry` only ever hold a finalHash, so they cannot locate the
-corresponding index key — which is why there is no `deleteHashIndex` and no
-per-entry index cleanup (see *Edge cases* and *Backward compatibility*). The
-index is wiped wholesale by a full cache `drop()`.
+The index is **forward only** (`contentHash → finalHash`): `finalHash =
+H(contentHash + tries)` is one-way, and cache entries / the run-index are keyed
+by finalHash, so `removeTaskEntry(finalHash)` cannot derive the index key from
+the hash alone. To make per-entry cleanup possible, the **content hash is
+stored in the cache entry record itself** (a fourth slot — see *CacheDB*
+below). When an entry is deleted, `removeTaskEntry` recovers the content hash
+from the record and **conditionally** removes the index pointer — only when the
+pointer actually targets the entry being deleted (a failed attempt shares the
+same content hash, but the pointer aims at the *successful* finalHash, so it
+must be preserved). A full cache `drop()` still wipes the index wholesale.
 
 - `DefaultCacheStore` (LevelDB): store the pointer under a **namespaced key** —
-  a 1-byte prefix (e.g. `0x01`) prepended to `contentHash.asBytes()`. Task-entry
-  keys are exactly `KEY_SIZE` bytes with no prefix, so a prefixed key can never
-  collide with an entry key. Value = `finalHash.asBytes()`.
+  a 1-byte prefix (`0x01`) prepended to `contentHash.asBytes()`, value =
+  `finalHash.asBytes()`.
+
+  **Key-space contract.** The single LevelDB instance hosts two disjoint key
+  namespaces — task entries at `key = <hash>` (exactly `KEY_SIZE` bytes) and
+  index pointers at `key = 0x01 + <hash>` (`KEY_SIZE + 1` bytes). The extra byte
+  makes the two lengths different, so an index key can never byte-collide with an
+  entry key (LevelDB compares the full byte sequence). This is the idiomatic
+  embedded-KV pattern (one ordered store, prefixed keys for multiple logical
+  record types — as used by, e.g., Bitcoin Core / go-ethereum, and the role
+  RocksDB column families fill); it is preferred over a second LevelDB instance
+  here because the index shares the entries' lifecycle (created, cleaned, and
+  `drop()`-ed together), access pattern (point lookups), and durability, so none
+  of the triggers that justify a separate store apply — and a shared store keeps
+  one lifecycle and preserves the option of atomic batched writes.
+
+  *Invariant to preserve:* all key construction goes through a single
+  `successfulIndexKey()` builder; the store is **never** iterated by LevelDB key (record
+  enumeration uses the separate flat index file), so this heterogeneous keyspace
+  is invisible today. Should a LevelDB key scan ever be added, it MUST filter by
+  this contract (length / prefix) so it does not treat index pointers as
+  task-entry records. The contract is documented at the top of the entry/index
+  accessors in `DefaultCacheStore`.
 - `CloudCacheStore` (`nf-cloudcache`): implement the same seam as a small object
-  whose payload is the finalHash. This keeps the interface fully implemented
-  across stores; no cloud coordination logic is added here.
+  whose payload is the finalHash. Here separation is by **path** (a per-session
+  `index/` subdir, see below), the natural namespacing for an object store —
+  i.e. each backend uses the idiom native to its medium. This keeps the
+  interface fully implemented across stores; no cloud coordination logic is
+  added here.
 
 **Session scoping (default / non-global cache).** This index is intentionally
 **per-session**, preserving today's resume semantics — it is *not* a
@@ -160,12 +192,22 @@ explicit and matches how task entries are already partitioned.)
 **2. `CacheDB`** (`nextflow.cache.CacheDB`) — thin delegators mirroring the
 existing `getTaskEntry` / `putTaskAsync` pattern.
 
-- `HashCode getHashIndex(HashCode contentHash)` → `store.getHashIndex(...)`.
-- `void putHashIndexAsync(HashCode contentHash, HashCode finalHash)` — enqueued
+- `HashCode getSuccessfulHash(HashCode contentHash)` → `store.getSuccessfulHash(...)`.
+- `void putSuccessfulHashAsync(HashCode contentHash, HashCode finalHash)` — enqueued
   on the **same `writer` Agent** used by `putTaskAsync`, so the index write is
   serialized *after* the corresponding entry write. This enforces the
   commit-marker discipline: a reader following the index never lands on an entry
   that is not yet durable.
+- `writeTaskEntry0` writes a **fourth record slot** holding
+  `task.contentHash?.asBytes()`, alongside the existing `[trace, ctx,
+  refCount]`. This is a backward-compatible record extension: code that reads
+  the record ignores extra slots, and entries written before this change simply
+  lack slot 3.
+- `removeTaskEntry(finalHash)`, when the ref-count reaches zero and the entry is
+  deleted, recovers the content hash from slot 3 and removes the index pointer
+  **iff** `getSuccessfulHash(contentHash) == finalHash` (the pointer targets the
+  deleted entry). Old 3-slot entries → no content hash → the pointer is left to
+  self-heal on the next resume.
 
 **3. `TaskRun`** (`nextflow.processor.TaskRun`).
 
@@ -177,8 +219,10 @@ existing `getTaskEntry` / `putTaskAsync` pattern.
 
 ### Read path (resume)
 
-A fast-path block added at the top of `checkCachedOrLaunchTask`, before the
-existing loop:
+A minimal fast-path is added at the top of `checkCachedOrLaunchTask`, before the
+existing loop — the content-hash capture plus a single delegation to a
+`resumeFromSuccessfulHashIndex` helper. The loop body is left **byte-for-byte unchanged**;
+all new lookup logic lives in the helper, keeping the method's complexity flat:
 
 ```
 // Capture the content hash ONLY on the first attempt. Retries re-enter this
@@ -189,25 +233,31 @@ existing loop:
 if( task.contentHash == null )
     task.contentHash = hash
 
-if( shouldTryCache ) {
+// fast resume path; otherwise fall back to the scan below
+if( shouldTryCache && resumeFromSuccessfulHashIndex(task) )
+    return
+
+// existing iterate-and-bump loop, unchanged
+```
+
+with the helper:
+
+```
+private boolean resumeFromSuccessfulHashIndex( TaskRun task ) {
     try {
-        final indexed = session.cache.getHashIndex(task.contentHash)
-        if( indexed ) {
-            final entry = session.cache.getTaskEntry(indexed, this)
-            final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
-            final cached = entry && entry.trace.isCompleted()
-                    && resumeDir?.exists()
-                    && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
-            if( cached )
-                return                          // resumed via index, no walk
-            // stale/invalid pointer -> fall through; rewrite on success
-        }
+        final indexed = session.cache.getSuccessfulHash(task.contentHash)
+        if( !indexed )
+            return false
+        final entry = session.cache.getTaskEntry(indexed, this)
+        final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
+        return entry && entry.trace.isCompleted() && resumeDir?.exists()
+                && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
     }
     catch( Throwable t ) {
         log.trace("Hash-index lookup failed -- falling back to scan", t)
+        return false   // stale/invalid pointer or error -> scan; self-heals on success
     }
 }
-// existing iterate-and-bump loop, unchanged
 ```
 
 **Why the hash sequence chains.** On the first call, `hash` is the content
@@ -226,12 +276,12 @@ writes, so it covers every success path without touching the
 - **`notifyTaskComplete`** (a task finished executing): after
   `cache.putTaskAsync(handler, trace)`, if `trace?.isCompleted()` and
   `handler.task.contentHash` is set, enqueue
-  `cache.putHashIndexAsync(handler.task.contentHash, handler.task.hash)`.
+  `cache.putSuccessfulHashAsync(handler.task.contentHash, handler.task.hash)`.
 - **`notifyTaskCached`** (a task resumed from cache — fired by
   `checkCachedOutput` for both the fast-path and the scan-path): after the
   existing `cache.cacheTaskAsync(handler)`, if `trace` is present and
   `handler.task.contentHash` is set, enqueue the same
-  `putHashIndexAsync(...)`. This rewrites the pointer on every resume, which
+  `putSuccessfulHashAsync(...)`. This rewrites the pointer on every resume, which
   both self-heals a stale pointer and upgrades a scan-path resume to a
   fast-path resume next time.
 
@@ -248,28 +298,34 @@ contentHash are content-equivalent, so the write is idempotent.
 | Pointer targets an incomplete entry | Cannot occur under commit-marker discipline; defensive `isCompleted()` check treats it as stale regardless. |
 | Two tasks, same contentHash, within one run | `tries++` + `lockManager` allocate distinct workdirs as today; index write is idempotent. No new race. |
 | Retry within the same run | Index is written only on success; a failed attempt writes nothing. The relaunch succeeds at a fresh `tries` and writes the pointer. No `previousTryCount` needed. |
-| `getHashIndex` throws / corrupt pointer | Caught; logged at trace; fall through to loop. The index is strictly an optimization, never fatal. |
-| `nextflow clean <runName>` / `removeTaskEntry` deletes an entry | The index is **not** touched — clean only holds the finalHash and cannot recover the contentHash key. The forward pointer is left orphaned and self-heals on the next resume (target entry missing → fall through → rewrite). Orphaned pointers are tiny (~a few dozen bytes) and harmless. |
+| `getSuccessfulHash` throws / corrupt pointer | Caught; logged at trace; fall through to loop. The index is strictly an optimization, never fatal. |
+| `removeTaskEntry` deletes the **successful** entry (ref-count → 0) | The content hash is recovered from record slot 3; since `getSuccessfulHash(contentHash) == finalHash`, the pointer is removed too. |
+| `removeTaskEntry` deletes a **failed-attempt** entry sharing the same content hash | `getSuccessfulHash(contentHash)` points at the *successful* finalHash (≠ the deleted hash), so the pointer is **preserved**. |
+| `removeTaskEntry` deletes an old 3-slot entry (no content hash) | No content hash to recover → pointer untouched; self-heals on next resume. |
+| `nextflow clean <runName>` of a single-run session | Every entry is removed and then `drop()` wipes the whole per-session DB, index included. |
 
 ### Backward compatibility
 
-- Old caches have no index keys → `getHashIndex` returns `null` → the existing
+- Old caches have no index keys → `getSuccessfulHash` returns `null` → the existing
   loop runs exactly as today. Such caches retain the original #6884 limitation
   until a fresh run repopulates the index, after which resume is correct.
-- No on-disk format version bump: new namespaced keys are simply absent in old
-  LevelDB databases.
+- No on-disk format version bump: new namespaced index keys are simply absent in
+  old LevelDB databases, and the new fourth record slot is a backward-compatible
+  extension (readers ignore extra slots; old 3-slot entries lack it).
 - Nothing to migrate from #6903, since it is not merged.
-- Orphaned index pointers (from partial `nextflow clean`) accumulate but are
-  negligible in size and self-heal on resume; a full cache `drop()` removes
-  them. No per-entry index cleanup is performed.
+- An entry written before this change carries no content hash, so deleting it
+  cannot clean its index pointer; the orphaned pointer self-heals on the next
+  resume. A full cache `drop()` removes any remaining pointers.
 
 ## Testing
 
-- **`DefaultCacheStoreTest`** — round-trip `putHashIndex` / `getHashIndex`;
-  absent key returns `null`; prefixed index keys never collide with entry keys;
-  `drop()` removes index keys.
+- **`DefaultCacheStoreTest`** — round-trip `putSuccessfulHash` / `getSuccessfulHash` /
+  `deleteSuccessfulHash`; absent key returns `null`; prefixed index keys never
+  collide with entry keys; `drop()` removes index keys.
 - **`CacheDBTest`** — delegators; async ordering (entry committed before its
-  index pointer).
+  index pointer); `removeTaskEntry` removes the pointer for the successful
+  entry it targets, **preserves** the pointer when a failed-attempt entry
+  sharing the same content hash is removed.
 - **`TaskProcessorTest`** (primary behavioural coverage):
   - success after N failed attempts resolves on resume in a single index
     lookup, with no scan;

--- a/specs/260601-successful-hash-index/spec.md
+++ b/specs/260601-successful-hash-index/spec.md
@@ -1,0 +1,293 @@
+# Successful-Hash Index for the Default Cache
+
+- Author: Jorge Ejarque
+- Date: 2026-06-01
+- Status: draft
+
+## Summary
+
+Add a small index to Nextflow's default task cache that maps a task's
+**content hash** to the **final hash** of its first successful execution. On
+resume, the cache resolves a completed task in a single index lookup instead of
+walking the sequence of per-attempt hashes. This is an alternative to the
+`previousTryCount` approach proposed in PR #6903 for the same underlying
+problem (issue #6884): a task that succeeds only after one or more failed or
+aborted attempts must be re-discoverable on resume without re-executing.
+
+## Problem
+
+### How the default cache resolves a task today
+
+When a process invocation is evaluated, Nextflow computes a content-based hash
+of the task (`new TaskHasher(task).compute()` in
+`TaskProcessor.checkCachedOrLaunchTask`). It then enters an *iterate-and-bump*
+loop:
+
+```
+int tries = task.failCount + 1
+while( true ) {
+    hash = H(contentHash + tries)              // per-attempt "final hash"
+    entry = session.cache.getTaskEntry(hash)
+    resumeDir = entry?.trace?.workDir
+    exists = resumeDir?.exists()
+    if( shouldTryCache && exists && entry.trace.isCompleted()
+            && checkCachedOutput(...) )
+        break                                  // cache hit -> resume
+    if( exists ) { tries++; continue }         // attempt slot taken -> bump
+    // else: allocate workdir for `hash` and launch
+}
+```
+
+The `tries` counter mixed into the hash gives every retry attempt a distinct
+hash and workdir. A first-attempt success lives at `H(contentHash + 1)`; a
+success after two failures lives at `H(contentHash + 3)`.
+
+### The failure mode (issue #6884)
+
+A task that fails on attempt 1 and succeeds on attempt 2 has cache entries at
+`H(contentHash + 1)` (failed/aborted) and `H(contentHash + 2)` (completed). On
+resume, the loop must walk past the failed attempt to find the success. That
+walk is only correct as long as every intermediate attempt's workdir and cache
+entry still exist on disk and carry the expected status. When that coupling
+breaks — a failed-attempt workdir was cleaned, an entry was written without the
+expected status, the run was killed mid-retry — the walk can stop early and
+**re-execute a task that had already completed successfully**. The reported
+reproduction:
+
+1. Configure a task to fail on attempt 1, succeed on attempt 2.
+2. Run until that task completes; kill the pipeline.
+3. Resume; let it complete; kill again.
+4. Resume once more — the already-completed task re-executes instead of
+   resuming.
+
+PR #6903 addresses this by recording the count of prior unsuccessful attempts
+(`previousTryCount`) on `TaskRun` and folding failed/aborted history into the
+starting `tries`, so the walk lands on the right slot. That keeps the fragile
+walk but makes its starting point recoverable.
+
+### This proposal
+
+Record the answer directly. When a task succeeds, store
+`contentHash -> finalHash` in an index. On resume, one lookup returns the hash
+of the successful execution, and the cache validates and resumes that entry
+without walking the attempt sequence at all. The walk reverts to its original,
+narrow role: allocating a fresh hash slot when launching or retrying.
+
+## Goals
+
+- Resolve a completed task on resume in a single index lookup, regardless of
+  how many failed/aborted attempts preceded it.
+- Fully replace the `previousTryCount` mechanism for the default cache — one
+  mechanism, not two.
+- Always on, no configuration flag. A strict improvement with graceful
+  fallback to today's behaviour.
+- Keep the change small and reviewable, and keep the proven launch/collision
+  loop untouched.
+
+## Non-goals
+
+- Cross-pipeline / cross-machine cache sharing, content-based input hashing,
+  atomic-create coordination, or ref-counting redesign. Out of scope.
+- Migrating existing caches. Old caches simply lack the index and fall back to
+  current behaviour; a subsequent run repopulates the index.
+
+## Terminology
+
+- **contentHash** — `new TaskHasher(task).compute()`; the task's
+  content-based identity *before* per-attempt try-mixing. The index **key**.
+- **finalHash** — `H(contentHash + tries)`; the value assigned to `task.hash`
+  and used as the cache-entry key. The index **value**.
+
+## Design
+
+### Approach
+
+A surgical fast-path at the top of `checkCachedOrLaunchTask`. When the index
+returns a pointer and the target entry validates, resume directly and return.
+Otherwise fall through to the existing iterate-and-bump loop unchanged. The
+loop continues to serve two roles: write-side collision avoidance for retries
+within a run, and the fallback read path for caches that predate the index. On
+any successful resume or execution, the index pointer is written (or rewritten).
+
+The alternative — splitting the method into `tryResumeFromIndex()` and
+`launchTask()` — was rejected for this change as a larger blast radius on a
+concurrency-sensitive method with no behavioural benefit.
+
+### Component changes
+
+**1. `CacheStore` interface** (`nextflow.cache.CacheStore`) and both
+implementations.
+
+```java
+HashCode getHashIndex(HashCode contentHash)            // null if absent
+void     putHashIndex(HashCode contentHash, HashCode finalHash)
+```
+
+The index is **forward only** (`contentHash → finalHash`) and there is no
+reverse link: `finalHash = H(contentHash + tries)` is one-way, and cache
+entries / the run-index are keyed by finalHash. `nextflow clean` and
+`removeTaskEntry` only ever hold a finalHash, so they cannot locate the
+corresponding index key — which is why there is no `deleteHashIndex` and no
+per-entry index cleanup (see *Edge cases* and *Backward compatibility*). The
+index is wiped wholesale by a full cache `drop()`.
+
+- `DefaultCacheStore` (LevelDB): store the pointer under a **namespaced key** —
+  a 1-byte prefix (e.g. `0x01`) prepended to `contentHash.asBytes()`. Task-entry
+  keys are exactly `KEY_SIZE` bytes with no prefix, so a prefixed key can never
+  collide with an entry key. Value = `finalHash.asBytes()`.
+- `CloudCacheStore` (`nf-cloudcache`): implement the same seam as a small object
+  whose payload is the finalHash. This keeps the interface fully implemented
+  across stores; no cloud coordination logic is added here.
+
+**Session scoping (default / non-global cache).** This index is intentionally
+**per-session**, preserving today's resume semantics — it is *not* a
+cross-session/global index (that is the separate `nf-cloudcache-global`
+feature, out of scope here). Scoping is enforced by *storage location*, not by
+the key:
+
+- `DefaultCacheStore` already isolates per session: its LevelDB lives at
+  `<baseDir>/cache/<uniqueId>/db`, and `-resume` reuses the same `uniqueId`, so
+  a prefixed key written there is inherently session-scoped.
+- `CloudCacheStore` must place the index object under its per-session
+  `dataPath` (`<basePath>/<uniqueId>`), i.e. at
+  `<basePath>/<uniqueId>/index/<contentHash>` — **not** under a shared
+  `<basePath>/index/...` prefix, which would leak pointers across sessions.
+
+(The content hash already incorporates the session id via `TaskHasher`, so the
+key is session-specific too; storage-location scoping makes the guarantee
+explicit and matches how task entries are already partitioned.)
+
+**2. `CacheDB`** (`nextflow.cache.CacheDB`) — thin delegators mirroring the
+existing `getTaskEntry` / `putTaskAsync` pattern.
+
+- `HashCode getHashIndex(HashCode contentHash)` → `store.getHashIndex(...)`.
+- `void putHashIndexAsync(HashCode contentHash, HashCode finalHash)` — enqueued
+  on the **same `writer` Agent** used by `putTaskAsync`, so the index write is
+  serialized *after* the corresponding entry write. This enforces the
+  commit-marker discipline: a reader following the index never lands on an entry
+  that is not yet durable.
+
+**3. `TaskRun`** (`nextflow.processor.TaskRun`).
+
+- New field `HashCode contentHash`, set from the `hash` argument inside
+  `checkCachedOrLaunchTask`. Required because `task.hash` only ever holds the
+  finalHash, and the index write at task-completion time needs the key.
+- This field **replaces** PR #6903's `previousTryCount`; that field and its
+  associated increment logic are not introduced.
+
+### Read path (resume)
+
+A fast-path block added at the top of `checkCachedOrLaunchTask`, before the
+existing loop:
+
+```
+// Capture the content hash ONLY on the first attempt. Retries re-enter this
+// method via resumeOrDie -> checkCachedOrLaunchTask(taskCopy, taskCopy.hash,
+// false), where the `hash` argument is the previous attempt's (chained) final
+// hash, not the content hash. makeCopy()/clone() carry contentHash forward, so
+// the null guard preserves the original key across the whole retry chain.
+if( task.contentHash == null )
+    task.contentHash = hash
+
+if( shouldTryCache ) {
+    try {
+        final indexed = session.cache.getHashIndex(task.contentHash)
+        if( indexed ) {
+            final entry = session.cache.getTaskEntry(indexed, this)
+            final resumeDir = entry ? FileHelper.asPath(entry.trace.getWorkDir()) : null
+            final cached = entry && entry.trace.isCompleted()
+                    && resumeDir?.exists()
+                    && checkCachedOutput(task.clone(), resumeDir, indexed, entry)
+            if( cached )
+                return                          // resumed via index, no walk
+            // stale/invalid pointer -> fall through; rewrite on success
+        }
+    }
+    catch( Throwable t ) {
+        log.trace("Hash-index lookup failed -- falling back to scan", t)
+    }
+}
+// existing iterate-and-bump loop, unchanged
+```
+
+**Why the hash sequence chains.** On the first call, `hash` is the content
+hash and the loop computes `H(hash + tries)`, reassigning `hash` in place each
+iteration — so attempt 2 is `H(H(contentHash + 1) + 2)`, etc. The resume walk
+reproduces the same chain because it reassigns `hash` identically. The index
+therefore stores `contentHash → <final chained hash of the successful
+attempt>`, and the fast-path jumps straight to it without replaying the chain.
+
+### Write path
+
+The index write is centralized in `Session`, alongside the existing entry
+writes, so it covers every success path without touching the
+`checkCachedOrLaunchTask` loop body:
+
+- **`notifyTaskComplete`** (a task finished executing): after
+  `cache.putTaskAsync(handler, trace)`, if `trace?.isCompleted()` and
+  `handler.task.contentHash` is set, enqueue
+  `cache.putHashIndexAsync(handler.task.contentHash, handler.task.hash)`.
+- **`notifyTaskCached`** (a task resumed from cache — fired by
+  `checkCachedOutput` for both the fast-path and the scan-path): after the
+  existing `cache.cacheTaskAsync(handler)`, if `trace` is present and
+  `handler.task.contentHash` is set, enqueue the same
+  `putHashIndexAsync(...)`. This rewrites the pointer on every resume, which
+  both self-heals a stale pointer and upgrades a scan-path resume to a
+  fast-path resume next time.
+
+Because both writes go through the `writer` Agent *after* the corresponding
+entry write, the commit-marker discipline holds. Writes are last-writer-wins:
+the process is single-writer, and all successful executions for a given
+contentHash are content-equivalent, so the write is idempotent.
+
+### Edge cases
+
+| Case | Behaviour |
+|------|-----------|
+| Stale pointer (entry GC'd, workdir gone, output check fails) | Fast-path validation fails → fall through to loop → success rewrites the pointer. Self-heals in one lookup. |
+| Pointer targets an incomplete entry | Cannot occur under commit-marker discipline; defensive `isCompleted()` check treats it as stale regardless. |
+| Two tasks, same contentHash, within one run | `tries++` + `lockManager` allocate distinct workdirs as today; index write is idempotent. No new race. |
+| Retry within the same run | Index is written only on success; a failed attempt writes nothing. The relaunch succeeds at a fresh `tries` and writes the pointer. No `previousTryCount` needed. |
+| `getHashIndex` throws / corrupt pointer | Caught; logged at trace; fall through to loop. The index is strictly an optimization, never fatal. |
+| `nextflow clean <runName>` / `removeTaskEntry` deletes an entry | The index is **not** touched — clean only holds the finalHash and cannot recover the contentHash key. The forward pointer is left orphaned and self-heals on the next resume (target entry missing → fall through → rewrite). Orphaned pointers are tiny (~a few dozen bytes) and harmless. |
+
+### Backward compatibility
+
+- Old caches have no index keys → `getHashIndex` returns `null` → the existing
+  loop runs exactly as today. Such caches retain the original #6884 limitation
+  until a fresh run repopulates the index, after which resume is correct.
+- No on-disk format version bump: new namespaced keys are simply absent in old
+  LevelDB databases.
+- Nothing to migrate from #6903, since it is not merged.
+- Orphaned index pointers (from partial `nextflow clean`) accumulate but are
+  negligible in size and self-heal on resume; a full cache `drop()` removes
+  them. No per-entry index cleanup is performed.
+
+## Testing
+
+- **`DefaultCacheStoreTest`** — round-trip `putHashIndex` / `getHashIndex`;
+  absent key returns `null`; prefixed index keys never collide with entry keys;
+  `drop()` removes index keys.
+- **`CacheDBTest`** — delegators; async ordering (entry committed before its
+  index pointer).
+- **`TaskProcessorTest`** (primary behavioural coverage):
+  - success after N failed attempts resolves on resume in a single index
+    lookup, with no scan;
+  - the exact #6884 reproduction (fail → retry → succeed, kill, resume, kill,
+    resume) resumes the completed task instead of re-executing it;
+  - stale pointer (target workdir removed) falls back, re-resumes or
+    re-executes, and rewrites the pointer;
+  - index miss on a legacy entry falls through to the loop unchanged.
+- **`CloudCacheStoreTest`** — `index/<hash>` object round-trip against a mocked
+  store.
+- **Integration** — a `tests/` case reproducing #6884 end-to-end.
+
+## Files affected
+
+- `modules/nextflow/src/main/groovy/nextflow/cache/CacheStore.groovy`
+- `modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheStore.groovy`
+- `modules/nextflow/src/main/groovy/nextflow/cache/CacheDB.groovy`
+- `modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy`
+- `modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy`
+- `plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheStore.groovy`
+- Tests as listed above.

--- a/tests/checks/resume-retried-with-abort.nf/.checks
+++ b/tests/checks/resume-retried-with-abort.nf/.checks
@@ -1,0 +1,35 @@
+set -e
+
+#
+# run with abort
+#
+echo ''
+timeout --signal=INT 6 $NXF_RUN | tee stdout || true
+
+[[ `< .nextflow.log grep -c 'Submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
+
+#
+# RESUME mode with fail and abort
+#
+echo ''
+timeout --signal=INT 12 $NXF_RUN -resume | tee stdout || true
+
+[[ `< .nextflow.log grep -c 'Submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
+[[ `< .nextflow.log grep -c 'Re-submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
+
+#
+# RESUME mode with completed and abort
+#
+echo ''
+timeout --signal=INT 20 $NXF_RUN -resume | tee stdout || true
+
+[[ `< .nextflow.log grep -c 'Submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
+[[ `< .nextflow.log grep -c 'Re-submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
+
+#
+# RESUME mode with cached and finish
+#
+echo ''
+$NXF_RUN -resume | tee stdout
+
+[[ `< .nextflow.log grep -c 'Cached process > SMALL_SLEEP_RETRY'` == 1 ]] || false

--- a/tests/checks/resume-retried-with-abort.nf/.checks
+++ b/tests/checks/resume-retried-with-abort.nf/.checks
@@ -1,24 +1,25 @@
 set -e
 
 #
-# run with abort
+# run with abort -- abort while the retried attempt is still sleeping (window ~5-15s)
 #
 echo ''
-timeout --signal=INT 6 $NXF_RUN | tee stdout || true
+timeout --signal=INT 8 $NXF_RUN | tee stdout || true
 
 [[ `< .nextflow.log grep -c 'Submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
 
 #
-# RESUME mode with fail and abort
+# RESUME mode with fail and abort -- abort again mid retried attempt (window ~5-15s)
 #
 echo ''
-timeout --signal=INT 12 $NXF_RUN -resume | tee stdout || true
+timeout --signal=INT 8 $NXF_RUN -resume | tee stdout || true
 
 [[ `< .nextflow.log grep -c 'Submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
 [[ `< .nextflow.log grep -c 'Re-submitted process > SMALL_SLEEP_RETRY'` == 1 ]] || false
 
 #
-# RESUME mode with completed and abort
+# RESUME mode with completed and abort -- let the retried attempt complete (~15s)
+# then abort while LONG_SLEEP is still running (window ~15-30s)
 #
 echo ''
 timeout --signal=INT 20 $NXF_RUN -resume | tee stdout || true

--- a/tests/resume-retried-with-abort.nf
+++ b/tests/resume-retried-with-abort.nf
@@ -41,13 +41,17 @@ process SMALL_SLEEP_RETRY {
     script:
     """
     echo "SMALL_SLEEP_RETRY attempt: ${task.attempt}"
-    sleep 7
 
     if [[ ${task.attempt} -eq 1 ]]; then
+      # first attempt fails fast so the retry is reached early in each resume
+      sleep 3
       echo "Failing first attempt on purpose"
       exit 1
     fi
 
+    # the second (successful) attempt runs long, giving the abort a wide,
+    # timing-insensitive window to land in while it is still in flight
+    sleep 10
     echo "Second attempt succeeded"
     """
 }

--- a/tests/resume-retried-with-abort.nf
+++ b/tests/resume-retried-with-abort.nf
@@ -1,0 +1,58 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+process LONG_SLEEP {
+    tag "long-sleep"
+
+    output:
+    stdout
+
+    script:
+    '''
+    echo "LONG_SLEEP start"
+    sleep 30
+    echo "LONG_SLEEP done"
+    '''
+}
+
+process SMALL_SLEEP_RETRY {
+    tag "small-sleep-retry"
+
+    errorStrategy 'retry'
+    maxRetries 1
+
+    output:
+    stdout
+
+    script:
+    """
+    echo "SMALL_SLEEP_RETRY attempt: ${task.attempt}"
+    sleep 7
+
+    if [[ ${task.attempt} -eq 1 ]]; then
+      echo "Failing first attempt on purpose"
+      exit 1
+    fi
+
+    echo "Second attempt succeeded"
+    """
+}
+
+workflow {
+    LONG_SLEEP()
+    SMALL_SLEEP_RETRY()
+}


### PR DESCRIPTION
## Summary

Adds a **per-session forward index** to Nextflow's default task cache that maps a task's *content hash* → the *final (per-attempt) hash* of its first successful execution. On resume, the cache resolves a completed task in a **single index lookup** instead of walking the iterate-and-bump per-attempt hash sequence — so a task that succeeded only after one or more failed/aborted attempts is recovered without re-executing.

This is an **alternative to #6903** for the same underlying problem (#6884). Instead of recovering the starting point of the fragile per-attempt scan (`previousTryCount`), the successful hash is recorded directly and looked up on resume. The existing iterate-and-bump loop is left untouched as the fallback.

Apart from the #6884 fix, this PR also enables safely removing the previously failed, aborted executions without affecting the successful task cache resume process. 

## Design

- **`CacheStore` SPI** — `getSuccessfulHash` / `putSuccessfulHash` / `deleteSuccessfulHash`, implemented by:
  - `DefaultCacheStore` (LevelDB) — namespaced key (1-byte prefix, no collision with entry keys); inherently per-session (DB lives under `cache/<uniqueId>`). The two key namespaces (entry keys vs prefixed index keys) are documented as a key-space contract on the store.
  - `CloudCacheStore` (`nf-cloudcache`) — object under the **per-session** `dataPath` (`basePath/<uniqueId>/index/<hash>`), not a shared prefix. Cross-session/global indexing is intentionally out of scope.
- **`CacheDB`** — `getSuccessfulHash` + `putSuccessfulHashAsync`, enqueued on the same writer `Agent` **after** the entry write (commit-marker discipline: a reader never follows the index to a not-yet-durable entry). `writeTaskEntry0` stores the task content hash in a fourth record slot so `removeTaskEntry` can clean the index pointer when an entry is deleted.
- **`TaskRun`** — `contentHash`, captured once on the first attempt (null-guarded) and preserved across retries via `clone()`/`makeCopy()`. Replaces #6903's `previousTryCount`.
- **`Session`** — writes the pointer on successful execution (`notifyTaskComplete`, gated on `isCompleted()`) and on resume (`notifyTaskCached`, self-heals a stale pointer and upgrades a scan-path resume to a fast-path one).
- **`TaskProcessor.checkCachedOrLaunchTask`** — content-hash capture plus a one-line delegation to a private `resumeFromSuccessfulHashIndex(task)` helper; falls through to the unchanged iterate-and-bump loop on miss/stale/error.

**Index cleanup.** On entry removal (`removeTaskEntry`, ref-count → 0) the content hash is recovered from the record and the index pointer is **conditionally** deleted — only when it targets the deleted entry, so removing a *failed* attempt that shares the same content hash never clobbers the pointer to the *successful* one. Old 3-slot entries carry no content hash, so their pointer self-heals on the next resume; a full cache `drop()` wipes the index wholesale.

Always on, graceful fallback. The fourth record slot is a **backward-compatible** extension — older versions deserialize the record, use slots 0–2, and ignore the extra slot. **Cross-version cache compatibility validated:** a run on this branch resumes correctly (tasks **cached**) on released 26.04.x and 25.10.x, and vice-versa.

## Testing

- Unit: `DefaultCacheStoreTest` (round-trip + `deleteSuccessfulHash` + key non-collision + `drop()`), `CloudCacheStoreTest` (incl. per-session isolation + delete), `CacheDBTest` (delegation + conditional index cleanup: successful-entry pointer removed, failed-entry pointer preserved), `SessionTest`, `TaskProcessorTest`, `TaskRunTest`.
- Integration: `tests/resume-retried-with-abort.nf` — reproduces #6884 across abort/retry/resume cycles and asserts the retried→succeeded task resumes **cached** (verified locally: final resume reports `cached=1`).

Closes #6884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
