### PR TITLE
Mirror test containers to public.cr.seqera.io to harden CI against quay.io outages

### DIFF
--- a/tests-v1/nextflow.config
+++ b/tests-v1/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 } 
 
 process {
-  container = 'quay.io/nextflow/tests'
+  container = 'public.cr.seqera.io/mirror/tests'
 }
 
 

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 } 
 
 process {
-  container = 'quay.io/nextflow/tests'
+  container = 'public.cr.seqera.io/mirror/tests'
 }
 
 

--- a/validation/awsbatch-unstage-fail.config
+++ b/validation/awsbatch-unstage-fail.config
@@ -6,7 +6,7 @@
 workDir = 's3://nextflow-ci/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-ci'
-process.container = 'quay.io/nextflow/test-aws-unstage-fail:1.0'
+process.container = 'public.cr.seqera.io/mirror/test-aws-unstage-fail:1.0'
 aws.region = 'eu-west-1'
 aws.batch.maxTransferAttempts = 3 
 aws.batch.delayBetweenAttempts = '5 sec'

--- a/validation/awsbatch.config
+++ b/validation/awsbatch.config
@@ -6,7 +6,7 @@
 workDir = 's3://nextflow-ci/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-ci'
-process.container = 'quay.io/nextflow/rnaseq-nf:latest'
+process.container = 'public.cr.seqera.io/mirror/rnaseq-nf:latest'
 aws.region = 'eu-west-1'
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
 aws.batch.maxTransferAttempts = 3 

--- a/validation/awsfargate.config
+++ b/validation/awsfargate.config
@@ -6,7 +6,7 @@
 workDir = 's3://nextflow-ci/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-fg'
-process.container = 'quay.io/nextflow/rnaseq-nf:latest'
+process.container = 'public.cr.seqera.io/mirror/rnaseq-nf:latest'
 aws.region = 'eu-west-1'
 aws.batch.platformType = 'fargate'
 aws.batch.jobRole = 'arn:aws:iam::195996028523:role/nf-batchjobrole'

--- a/validation/azure.config
+++ b/validation/azure.config
@@ -5,7 +5,7 @@
 
 process {
   executor = 'azurebatch'
-  container = 'quay.io/nextflow/rnaseq-nf:v1.1'
+  container = 'public.cr.seqera.io/mirror/rnaseq-nf:v1.1'
   queue = 'nextflow-ci'
 }
 

--- a/validation/google.config
+++ b/validation/google.config
@@ -7,6 +7,6 @@ params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
 params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
 params.multiqc = 'gs://rnaseq-nf/multiqc'
 process.executor = 'google-batch'
-process.container = 'quay.io/nextflow/rnaseq-nf:latest'
+process.container = 'public.cr.seqera.io/mirror/rnaseq-nf:latest'
 process.machineType = "n1-standard-1"
 workDir = 'gs://rnaseq-nf/scratch'

--- a/validation/test-overwrite.nf
+++ b/validation/test-overwrite.nf
@@ -3,7 +3,7 @@ workflow {
 }
 
 process foo {
-  container 'quay.io/nextflow/bash'
+  container 'public.cr.seqera.io/mirror/bash'
   publishDir "gs://rnaseq-nf/scratch/tests", overwrite: true
   output:
   path 'hello.txt'


### PR DESCRIPTION
## Rationale

The integration and validation test suites pull a handful of container images from **`quay.io/nextflow/*`**. When quay.io is degraded, those pulls fail and the failures are unrelated to the code under test:

- local Docker integration tests (`tests/checks/*.nf`) fail with **exit 125** (container failed to start) — they pull `quay.io/nextflow/tests`;
- cloud validation tests fail mid-pipeline (e.g. the `MULTIQC` step) — they pull `quay.io/nextflow/rnaseq-nf`.

These exact symptoms were observed on recent CI runs (including on `master`), caused by a quay.io outage rather than any regression.

## Change

Point the test configs at the same images, mirrored to the Seqera public registry:

```
quay.io/nextflow/<name>[:tag]  ->  public.cr.seqera.io/mirror/<name>[:tag]
```

The mirror images are **byte-for-byte copies** (identical digests, multi-arch preserved), so behaviour is unchanged — only the source registry differs.

### Updated references
| File | Image |
|------|-------|
| `tests/nextflow.config`, `tests-v1/nextflow.config` | `tests` |
| `validation/awsbatch.config`, `awsfargate.config`, `google.config` | `rnaseq-nf:latest` |
| `validation/azure.config` | `rnaseq-nf:v1.1` |
| `validation/awsbatch-unstage-fail.config` | `test-aws-unstage-fail:1.0` |
| `validation/test-overwrite.nf` | `bash` |

All five images have been mirrored and verified to resolve at `public.cr.seqera.io/mirror/` with digests matching the quay.io sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
