### PR TITLE
Add `-help-json` flag for machine-readable CLI help

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -524,6 +524,29 @@ Use this to learn about command-specific options, refresh your memory about synt
 $ nextflow help run
 ```
 
+(cli-machine-readable-help)=
+
+### Machine-readable help
+
+:::{versionadded} 26.06.0-edge
+:::
+
+The `-help-json` option prints the help and options for a command as JSON instead of the human-formatted help text. This provides a stable, structured description of the CLI for tools and AI agents to consume, without scraping the rendered `-help` output.
+
+The option is contextual, so you can discover the CLI one command at a time. At the top level, it lists the global options and an index of every available command:
+
+```console
+$ nextflow -help-json
+```
+
+Add it to any command to get that command's full options and arguments:
+
+```console
+$ nextflow run -help-json
+```
+
+The output describes each option with its name, flags, type, help text, and default value (where applicable). The schema is derived directly from the CLI definitions, so it stays in sync with the available commands and options.
+
 ### Version information
 
 The `-v` and `-version` options print Nextflow version information.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -533,7 +533,7 @@ $ nextflow help run
 
 The `-help-json` option prints the help and options for a command as JSON instead of the human-formatted help text. This provides a stable, structured description of the CLI for tools and AI agents to consume, without scraping the rendered `-help` output.
 
-The option is contextual, so you can discover the CLI one command at a time. At the top level, it lists the global options and an index of every available command:
+The option is contextual. You can discover the CLI one command at a time. At the top level, it lists the global options and an index of every available command:
 
 ```console
 $ nextflow -help-json
@@ -545,7 +545,7 @@ Add it to any command to get that command's full options and arguments:
 $ nextflow run -help-json
 ```
 
-The output describes each option with its name, flags, type, help text, and default value (where applicable). The schema is derived directly from the CLI definitions, so it stays in sync with the available commands and options.
+The output describes each option with its name, flags, type, help text, and default value (where applicable). The schema is derived directly from the CLI definitions. It stays in sync with the available commands and options.
 
 ### Version information
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -533,25 +533,20 @@ $ nextflow help run
 
 The `-help-json` option prints the help and options for a command as JSON instead of the human-formatted help text. This provides a stable, structured description of the CLI for tools and AI agents to consume, without scraping the rendered `-help` output.
 
-The option is contextual. You can discover the CLI one command at a time. At the top level, it lists the global options and an index of every available command under a `subcommands` key:
+The option is contextual, following a progressive-disclosure model. At the top level, it returns the global options plus a recursive index of the whole command tree under a `subcommands` key — every command and its nested sub-commands (for example `module` → `create`, `install`, ...) by name and description. This is the map of the CLI, without per-command detail:
 
 ```console
 $ nextflow -help-json
 ```
 
-Add it to any command to get that command's full options and arguments:
+Add it to any command to get that command's full options and arguments. Commands that group sub-commands (such as `fs`, `secrets`, and `module`) nest those sub-commands under the same `subcommands` key, recursively, so a single call covers the whole command tree:
 
 ```console
 $ nextflow run -help-json
-```
-
-Commands that group sub-commands (such as `fs`, `secrets`, and `module`) nest them under the same `subcommands` key, recursively, so a single call covers the whole command tree:
-
-```console
 $ nextflow module -help-json
 ```
 
-The output describes each option with its name, flags, type, help text, and default value (where applicable). The schema is derived directly from the CLI definitions. It stays in sync with the available commands and options.
+The output describes each option with its name, flags, type, help text, and default value (where applicable). Hidden options are included but flagged with `"hidden": true`, so tools can choose to surface or skip them. The schema is derived directly from the CLI definitions, so it stays in sync with the available commands and options.
 
 ### Version information
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -533,7 +533,7 @@ $ nextflow help run
 
 The `-help-json` option prints the help and options for a command as JSON instead of the human-formatted help text. This provides a stable, structured description of the CLI for tools and AI agents to consume, without scraping the rendered `-help` output.
 
-The option is contextual. You can discover the CLI one command at a time. At the top level, it lists the global options and an index of every available command:
+The option is contextual. You can discover the CLI one command at a time. At the top level, it lists the global options and an index of every available command under a `subcommands` key:
 
 ```console
 $ nextflow -help-json
@@ -543,6 +543,12 @@ Add it to any command to get that command's full options and arguments:
 
 ```console
 $ nextflow run -help-json
+```
+
+Commands that group sub-commands (such as `fs`, `secrets`, and `module`) nest them under the same `subcommands` key, recursively, so a single call covers the whole command tree:
+
+```console
+$ nextflow module -help-json
 ```
 
 The output describes each option with its name, flags, type, help text, and default value (where applicable). The schema is derived directly from the CLI definitions. It stays in sync with the available commands and options.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -539,7 +539,7 @@ The option is contextual, following a progressive-disclosure model. At the top l
 $ nextflow -help-json
 ```
 
-Add it to any command to get that command's full options and arguments. Commands that group sub-commands (such as `fs`, `secrets`, and `module`) nest those sub-commands under the same `subcommands` key, recursively, so a single call covers the whole command tree:
+Add it to any command to get that command's full options and arguments. Commands that group sub-commands (such as `fs`, `secrets`, `plugin`, and `module`) nest those sub-commands under the same `subcommands` key, recursively, so a single call covers the whole command tree:
 
 ```console
 $ nextflow run -help-json

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,6 +33,12 @@ Available options:
 `-h`
 : Print available commands and options.
 
+`-help-json`
+: :::{versionadded} 26.06.0-edge
+  :::
+: Print the help and options as JSON, for consumption by tools and LLMs (see {ref}`cli-machine-readable-help`).
+: Works as a top-level option (`nextflow -help-json`) and on any command (e.g. `nextflow run -help-json`).
+
 `-log`
 : Set Nextflow log file path (default: `.nextflow.log`). Must be a local path.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,7 +37,7 @@ Available options:
 : :::{versionadded} 26.06.0-edge
   :::
 : Print the help and options as JSON, for consumption by tools and LLMs (see {ref}`cli-machine-readable-help`).
-: Works as a top-level option (`nextflow -help-json`) and on any command (e.g. `nextflow run -help-json`).
+: Works as a top-level option (`nextflow -help-json`) and on any command. For example, `nextflow run -help-json`.
 
 `-log`
 : Set Nextflow log file path (default: `.nextflow.log`). Must be a local path.

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
@@ -75,6 +75,9 @@ class CliOptions {
     @Parameter(names = ['-h'], description = 'Print this help', help = true)
     boolean help
 
+    @Parameter(names = ['-help-json'], description = 'Print the command help and options as JSON (for tools and LLMs)', help = true)
+    boolean helpJson
+
     @Parameter(names = ['-q','-quiet'], description = 'Do not print information messages' )
     boolean quiet
 

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cli
+
+import java.lang.reflect.Field
+
+import com.beust.jcommander.DynamicParameter
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.Parameters
+import groovy.json.JsonOutput
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+
+/**
+ * Build a machine-readable (JSON) description of the Nextflow command line
+ * interface by introspecting the JCommander {@link Parameter} / {@link Parameters}
+ * annotations.
+ *
+ * This powers the global {@code -help-json} flag, which lets tools and LLMs
+ * discover the CLI one command at a time without scraping the rendered
+ * {@code -help} text:
+ *
+ * <pre>
+ *   nextflow -help-json            # global options + index of all commands
+ *   nextflow run -help-json        # full option/argument detail for `run`
+ * </pre>
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+@CompileStatic
+class CliSchema {
+
+    /**
+     * Build the schema for the top-level program: the global options plus a
+     * name + description index of every available command.
+     */
+    static String root(CliOptions options, List<CmdBase> commands) {
+        final schema = [
+            name        : 'nextflow',
+            path        : 'nextflow',
+            usage       : 'nextflow [options] COMMAND [arg...]',
+            params      : paramsOf(CliOptions),
+            subcommands : commandIndex(commands),
+        ]
+        return render(schema)
+    }
+
+    /**
+     * Build the schema for a single command: its usage, options and positional
+     * arguments.
+     */
+    static String command(CmdBase cmd) {
+        final clazz = cmd.getClass()
+        final params = paramsOf(clazz)
+        final schema = [
+            name   : cmd.name,
+            path   : "nextflow ${cmd.name}".toString(),
+            usage  : usageOf(cmd, params),
+            params : params,
+        ] as Map<String,Object>
+
+        final description = descriptionOf(clazz)
+        if( description )
+            schema.help = description
+        final aliases = aliasesOf(clazz)
+        if( aliases )
+            schema.aliases = aliases
+
+        return render(schema)
+    }
+
+    /**
+     * Map each command name to its description and aliases. Nextflow commands
+     * are flat (no nested groups), so a single index lists them all; drill into
+     * any one with {@code nextflow <command> -help-json}.
+     */
+    @CompileDynamic
+    private static Map<String,Object> commandIndex(List<CmdBase> commands) {
+        final index = new TreeMap<String,Object>()
+        for( CmdBase cmd : commands ) {
+            final clazz = cmd.getClass()
+            final description = descriptionOf(clazz)
+            // only advertise commands that opt in with a description, matching `-help`
+            if( !description )
+                continue
+            final entry = [help: description] as Map<String,Object>
+            final aliases = aliasesOf(clazz)
+            if( aliases )
+                entry.aliases = aliases
+            index[cmd.name] = entry
+        }
+        return index
+    }
+
+    /**
+     * Introspect the {@link Parameter} / {@link DynamicParameter} annotations of
+     * a command (or options) class into a list of JSON-friendly maps. Inherited
+     * fields are included; hidden and meta options ({@code -h}, {@code -help},
+     * {@code -help-json}) are skipped.
+     */
+    @CompileDynamic
+    private static List<Map<String,Object>> paramsOf(Class clazz) {
+        final instance = newInstance(clazz)
+        final result = []
+        for( Field field : declaredFields(clazz) ) {
+            final p = field.getAnnotation(Parameter)
+            final dp = field.getAnnotation(DynamicParameter)
+            if( p )
+                addParam(result, field, p.names() as List<String>, p.description(), p.hidden(), p.required(), p.arity(), instance)
+            else if( dp )
+                addParam(result, field, dp.names() as List<String>, dp.description(), dp.hidden(), false, -1, instance)
+        }
+        // sort for a stable, deterministic ordering: reflection field order is not
+        // guaranteed by the JVM, but this is a machine-readable contract
+        result.sort { it.opts ? it.opts[0] : it.name }
+        return result
+    }
+
+    @CompileDynamic
+    private static void addParam(List result, Field field, List<String> names, String description, boolean hidden, boolean required, int arity, Object instance) {
+        if( hidden )
+            return
+        if( names.any { it in META_OPTIONS } )
+            return
+
+        final isArgument = !names
+        final isFlag = field.getType() == boolean || field.getType() == Boolean || arity == 0
+        final entry = [
+            name : field.getName(),
+            kind : isArgument ? 'argument' : 'option',
+            type : typeName(field),
+        ] as Map<String,Object>
+        if( names )
+            entry.opts = names
+        if( description )
+            entry.help = description
+        if( required )
+            entry.required = true
+        if( isFlag )
+            entry.is_flag = true
+
+        final defValue = defaultOf(field, instance)
+        if( defValue != null && !isFlag )
+            entry.default = defValue
+
+        result << entry
+    }
+
+    /** Build a usage string, e.g. {@code nextflow run [options] <args>}. */
+    private static String usageOf(CmdBase cmd, List<Map<String,Object>> params) {
+        final pieces = ["nextflow ${cmd.name}".toString()]
+        if( params.any { it.kind == 'option' } )
+            pieces << '[options]'
+        if( params.any { it.kind == 'argument' } )
+            pieces << '[args...]'
+        return pieces.join(' ')
+    }
+
+    @CompileDynamic
+    private static String descriptionOf(Class clazz) {
+        return clazz.getAnnotation(Parameters)?.commandDescription() ?: null
+    }
+
+    @CompileDynamic
+    private static List<String> aliasesOf(Class clazz) {
+        final names = clazz.getAnnotation(Parameters)?.commandNames()
+        return names ? (names as List<String>) : null
+    }
+
+    private static String typeName(Field field) {
+        return field.getType().getSimpleName()
+    }
+
+    /** Read a field's default value from a fresh instance, ignoring empty values. */
+    @CompileDynamic
+    private static Object defaultOf(Field field, Object instance) {
+        if( instance == null )
+            return null
+        try {
+            field.setAccessible(true)
+            final value = field.get(instance)
+            if( value == null || value == false )
+                return null
+            if( value instanceof Collection && value.isEmpty() )
+                return null
+            if( value instanceof Map && value.isEmpty() )
+                return null
+            return value instanceof CharSequence || value instanceof Number || value instanceof Boolean
+                ? value
+                : value.toString()
+        }
+        catch( Exception e ) {
+            return null
+        }
+    }
+
+    private static Object newInstance(Class clazz) {
+        try {
+            return clazz.getDeclaredConstructor().newInstance()
+        }
+        catch( Exception e ) {
+            return null
+        }
+    }
+
+    /** Collect declared fields from the class and its superclasses. */
+    private static List<Field> declaredFields(Class clazz) {
+        final fields = new ArrayList<Field>()
+        Class current = clazz
+        while( current != null && current != Object ) {
+            fields.addAll(current.getDeclaredFields())
+            current = current.getSuperclass()
+        }
+        return fields
+    }
+
+    private static String render(Map schema) {
+        return JsonOutput.prettyPrint(JsonOutput.toJson(schema))
+    }
+
+    private static final List<String> META_OPTIONS = ['-h', '-help', '-help-json']
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
@@ -109,8 +109,9 @@ class CliSchema {
     /**
      * Introspect the {@link Parameter} / {@link DynamicParameter} annotations of
      * a command (or options) class into a list of JSON-friendly maps. Inherited
-     * fields are included; hidden and meta options ({@code -h}, {@code -help},
-     * {@code -help-json}) are skipped.
+     * fields are included; the meta options ({@code -h}, {@code -help},
+     * {@code -help-json}) are skipped, and hidden options are kept but flagged
+     * with {@code hidden: true}.
      */
     @CompileDynamic
     private static List<Map<String,Object>> paramsOf(Class clazz) {
@@ -132,8 +133,6 @@ class CliSchema {
 
     @CompileDynamic
     private static void addParam(List result, Field field, List<String> names, String description, boolean hidden, boolean required, int arity, Object instance) {
-        if( hidden )
-            return
         if( names.any { it in META_OPTIONS } )
             return
 
@@ -152,6 +151,9 @@ class CliSchema {
             entry.required = true
         if( isFlag )
             entry.is_flag = true
+        // hidden params are kept (parity with rich-click) but flagged so consumers can skip them
+        if( hidden )
+            entry.hidden = true
 
         final defValue = defaultOf(field, instance)
         if( defValue != null && !isFlag )

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
@@ -61,15 +61,26 @@ class CliSchema {
 
     /**
      * Build the schema for a single command: its usage, options and positional
-     * arguments.
+     * arguments. Commands that dispatch to nested sub-commands (those
+     * implementing {@link SubcommandAware}) describe them recursively under a
+     * {@code subcommands} key.
      */
     static String command(CmdBase cmd) {
+        return render(commandSchema(cmd.name, "nextflow ${cmd.name}".toString(), cmd))
+    }
+
+    /**
+     * Build the schema map for a command at the given {@code path} (e.g.
+     * {@code nextflow module create}). Recurses into nested sub-commands.
+     */
+    @CompileStatic
+    private static Map<String,Object> commandSchema(String name, String path, CmdBase cmd) {
         final clazz = cmd.getClass()
         final params = paramsOf(clazz)
         final schema = [
-            name   : cmd.name,
-            path   : "nextflow ${cmd.name}".toString(),
-            usage  : usageOf(cmd, params),
+            name   : name,
+            path   : path,
+            usage  : usageOf(path, params),
             params : params,
         ] as Map<String,Object>
 
@@ -79,8 +90,42 @@ class CliSchema {
         final aliases = aliasesOf(clazz)
         if( aliases )
             schema.aliases = aliases
+        if( cmd instanceof SubcommandAware ) {
+            final subcommands = subcommandIndex(path, (cmd as SubcommandAware).getSubcommands())
+            if( subcommands )
+                schema.subcommands = subcommands
+        }
 
-        return render(schema)
+        return schema
+    }
+
+    /**
+     * Build the nested {@code subcommands} index for a {@link SubcommandAware}
+     * command. Sub-commands backed by a full {@link CmdBase} are introspected
+     * recursively for complete option/argument detail; those whose arguments
+     * are parsed manually surface a lightweight name + description entry,
+     * matching the top-level command index.
+     */
+    @CompileStatic
+    private static Map<String,Object> subcommandIndex(String parentPath, List<SubcommandAware.Subcommand> subcommands) {
+        final index = new TreeMap<String,Object>()
+        for( SubcommandAware.Subcommand sub : subcommands ) {
+            index[sub.name] = sub.command != null
+                ? commandSchema(sub.name, "${parentPath} ${sub.name}".toString(), sub.command)
+                : leafEntry(sub.help, sub.aliases)
+        }
+        return index
+    }
+
+    /** A lightweight index entry carrying only help text and aliases, when present. */
+    @CompileDynamic
+    private static Map<String,Object> leafEntry(String help, List<String> aliases) {
+        final entry = [:] as Map<String,Object>
+        if( help )
+            entry.help = help
+        if( aliases )
+            entry.aliases = aliases
+        return entry
     }
 
     /**
@@ -97,11 +142,7 @@ class CliSchema {
             // only advertise commands that opt in with a description, matching `-help`
             if( !description )
                 continue
-            final entry = [help: description] as Map<String,Object>
-            final aliases = aliasesOf(clazz)
-            if( aliases )
-                entry.aliases = aliases
-            index[cmd.name] = entry
+            index[cmd.name] = leafEntry(description, aliasesOf(clazz))
         }
         return index
     }
@@ -162,9 +203,9 @@ class CliSchema {
         result << entry
     }
 
-    /** Build a usage string, e.g. {@code nextflow run [options] <args>}. */
-    private static String usageOf(CmdBase cmd, List<Map<String,Object>> params) {
-        final pieces = ["nextflow ${cmd.name}".toString()]
+    /** Build a usage string, e.g. {@code nextflow run [options] [args...]}. */
+    private static String usageOf(String path, List<Map<String,Object>> params) {
+        final pieces = [path]
         if( params.any { it.kind == 'option' } )
             pieces << '[options]'
         if( params.any { it.kind == 'argument' } )

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
@@ -303,7 +303,7 @@ class CliSchema {
     }
 
     /** Soft line-length budget for the compact renderer. */
-    private static final int MAX_WIDTH = 100
+    private static final int MAX_WIDTH = 160
     private static final int INDENT = 2
 
     private static String render(Map schema) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliSchema.groovy
@@ -35,7 +35,7 @@ import groovy.transform.CompileStatic
  * {@code -help} text:
  *
  * <pre>
- *   nextflow -help-json            # global options + index of all commands
+ *   nextflow -help-json            # global options + the full command tree
  *   nextflow run -help-json        # full option/argument detail for `run`
  * </pre>
  *
@@ -46,7 +46,10 @@ class CliSchema {
 
     /**
      * Build the schema for the top-level program: the global options plus a
-     * name + description index of every available command.
+     * recursive index of the whole command tree by name + description (e.g.
+     * {@code module} → {@code create}, {@code install}, ...). This is the
+     * progressive-disclosure entry point — full option/argument detail is
+     * revealed by drilling into a command with {@code nextflow <cmd> -help-json}.
      */
     static String root(CliOptions options, List<CmdBase> commands) {
         final schema = [
@@ -129,22 +132,50 @@ class CliSchema {
     }
 
     /**
-     * Map each command name to its description and aliases. Nextflow commands
-     * are flat (no nested groups), so a single index lists them all; drill into
-     * any one with {@code nextflow <command> -help-json}.
+     * Lightweight, recursive index of the command tree: each command mapped to
+     * its description plus — for commands that dispatch sub-commands — a nested
+     * index of the same shape, all the way down. Deliberately carries only names
+     * and help text (no params, aliases or paths): it's the map of the CLI, and
+     * full detail is disclosed by drilling into a command.
      */
     @CompileDynamic
     private static Map<String,Object> commandIndex(List<CmdBase> commands) {
         final index = new TreeMap<String,Object>()
         for( CmdBase cmd : commands ) {
-            final clazz = cmd.getClass()
-            final description = descriptionOf(clazz)
+            final description = descriptionOf(cmd.getClass())
             // only advertise commands that opt in with a description, matching `-help`
             if( !description )
                 continue
-            index[cmd.name] = leafEntry(description, aliasesOf(clazz))
+            index[cmd.name] = indexEntry(description, cmd)
         }
         return index
+    }
+
+    /** One node of the lightweight index: help text, plus a nested index when the command dispatches sub-commands. */
+    @CompileDynamic
+    private static Map<String,Object> indexEntry(String help, CmdBase cmd) {
+        final entry = [:] as Map<String,Object>
+        if( help )
+            entry.help = help
+        if( cmd instanceof SubcommandAware ) {
+            final nested = new TreeMap<String,Object>()
+            for( SubcommandAware.Subcommand sub : (cmd as SubcommandAware).getSubcommands() ) {
+                final subHelp = sub.command != null ? descriptionOf(sub.command.getClass()) : sub.help
+                nested[sub.name] = sub.command != null ? indexEntry(subHelp, sub.command) : leafHelp(subHelp)
+            }
+            if( nested )
+                entry.subcommands = nested
+        }
+        return entry
+    }
+
+    /** A leaf index node carrying only help text (for manually-parsed sub-commands). */
+    @CompileDynamic
+    private static Map<String,Object> leafHelp(String help) {
+        final entry = [:] as Map<String,Object>
+        if( help )
+            entry.help = help
+        return entry
     }
 
     /**
@@ -271,8 +302,56 @@ class CliSchema {
         return fields
     }
 
+    /** Soft line-length budget for the compact renderer. */
+    private static final int MAX_WIDTH = 100
+    private static final int INDENT = 2
+
     private static String render(Map schema) {
-        return JsonOutput.prettyPrint(JsonOutput.toJson(schema))
+        return format(schema, 0, 0)
+    }
+
+    /**
+     * Render JSON that stays human-readable but is condensed: any object or
+     * array that fits within {@link #MAX_WIDTH} columns is kept on a single
+     * line, and only the containers that overflow are expanded — so leaf maps
+     * like a single parameter print as one tidy line instead of a dozen.
+     *
+     * @param value the value to render
+     * @param indent leading-whitespace width of the line this value starts on
+     * @param col    column at which this value's first character is placed
+     *               (accounts for any {@code "key": } prefix already emitted)
+     */
+    @CompileDynamic
+    private static String format(Object value, int indent, int col) {
+        final oneLine = inline(value)
+        if( col + oneLine.length() <= MAX_WIDTH )
+            return oneLine
+
+        final childIndent = indent + INDENT
+        final pad = ' ' * childIndent
+        if( value instanceof Map && !value.isEmpty() ) {
+            final parts = value.collect { k, v ->
+                final key = JsonOutput.toJson(k.toString()) + ': '
+                pad + key + format(v, childIndent, childIndent + key.length())
+            }
+            return '{\n' + parts.join(',\n') + '\n' + (' ' * indent) + '}'
+        }
+        if( value instanceof List && !value.isEmpty() ) {
+            final parts = value.collect { v -> pad + format(v, childIndent, childIndent) }
+            return '[\n' + parts.join(',\n') + '\n' + (' ' * indent) + ']'
+        }
+        // scalar (or empty container) that can't be broken — emit as-is
+        return oneLine
+    }
+
+    /** Single-line JSON for a value, with {@code ": "} / {@code ", "} spacing for readability (unlike minified output). */
+    @CompileDynamic
+    private static String inline(Object value) {
+        if( value instanceof Map )
+            return value.isEmpty() ? '{}' : '{' + value.collect { k, v -> JsonOutput.toJson(k.toString()) + ': ' + inline(v) }.join(', ') + '}'
+        if( value instanceof List )
+            return value.isEmpty() ? '[]' : '[' + value.collect { inline(it) }.join(', ') + ']'
+        return JsonOutput.toJson(value)
     }
 
     private static final List<String> META_OPTIONS = ['-h', '-help', '-help-json']

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdAuth.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdAuth.groovy
@@ -74,7 +74,7 @@ import org.pf4j.ExtensionPoint
 @Slf4j
 @CompileStatic
 @Parameters(commandDescription = "Manage Seqera Platform authentication")
-class CmdAuth extends CmdBase implements UsageAware {
+class CmdAuth extends CmdBase implements UsageAware, SubcommandAware {
 
     /**
      * Interface for auth sub-commands that defines the contract for command execution and help text.
@@ -91,6 +91,11 @@ class CmdAuth extends CmdBase implements UsageAware {
          * @return the name of this sub-command (e.g., "login", "logout")
          */
         String getName()
+
+        /**
+         * @return a one-line description of this sub-command
+         */
+        String getDescription()
 
         /**
          * Executes the sub-command with the provided arguments.
@@ -182,10 +187,8 @@ class CmdAuth extends CmdBase implements UsageAware {
             result << 'Usage: nextflow auth <sub-command> [options]'
             result << ''
             result << 'Commands:'
-            result << '  login    Authenticate with Seqera Platform'
-            result << '  logout   Remove authentication and revoke access token'
-            result << '  status   Show current authentication status and configuration'
-            result << '  config   Configure Seqera Platform settings'
+            final len = commands.collect { it.name.size() }.max()
+            commands.each { result << "  ${it.name.padRight(len)}   ${it.description}".toString() }
             result << ''
         } else {
             def sub = commands.find { it.name == args[0] }
@@ -234,6 +237,11 @@ class CmdAuth extends CmdBase implements UsageAware {
         throw new AbortOperationException(msg)
     }
 
+    @Override
+    List<SubcommandAware.Subcommand> getSubcommands() {
+        commands.collect { new SubcommandAware.Subcommand(name: it.name, help: it.description) }
+    }
+
     /**
      * Implements the {@code nextflow auth login} sub-command for authenticating with Seqera Platform.
      *
@@ -271,6 +279,9 @@ class CmdAuth extends CmdBase implements UsageAware {
 
         @Override
         String getName() { 'login' }
+
+        @Override
+        String getDescription() { 'Authenticate with Seqera Platform' }
 
         @Override
         void apply(List<String> args) {
@@ -336,6 +347,9 @@ class CmdAuth extends CmdBase implements UsageAware {
         String getName() { 'logout' }
 
         @Override
+        String getDescription() { 'Remove authentication and revoke access token' }
+
+        @Override
         void apply(List<String> args) {
             if (args.size() > 0) {
                 throw new AbortOperationException("Too many arguments for ${name} command")
@@ -394,6 +408,9 @@ class CmdAuth extends CmdBase implements UsageAware {
 
         @Override
         String getName() { 'config' }
+
+        @Override
+        String getDescription() { 'Configure Seqera Platform settings' }
 
         @Override
         void apply(List<String> args) {
@@ -472,6 +489,9 @@ class CmdAuth extends CmdBase implements UsageAware {
 
         @Override
         String getName() { 'status' }
+
+        @Override
+        String getDescription() { 'Show current authentication status and configuration' }
 
         @Override
         void apply(List<String> args) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdAuth.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdAuth.groovy
@@ -190,6 +190,7 @@ class CmdAuth extends CmdBase implements UsageAware, SubcommandAware {
             final len = commands.collect { it.name.size() }.max()
             commands.each { result << "  ${it.name.padRight(len)}   ${it.description}".toString() }
             result << ''
+            result << Launcher.HELP_JSON_TIP
         } else {
             def sub = commands.find { it.name == args[0] }
             if (sub)

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdBase.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdBase.groovy
@@ -42,4 +42,7 @@ abstract class CmdBase implements Runnable {
 
     @Parameter(names=['-h','-help'], description = 'Print the command usage', arity = 0, help = true)
     boolean help
+
+    @Parameter(names=['-help-json'], description = 'Print the command help and options as JSON (for tools and LLMs)', arity = 0, help = true)
+    boolean helpJson
 }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFs.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFs.groovy
@@ -44,7 +44,7 @@ import nextflow.plugin.Plugins
 @CompileStatic
 @Slf4j
 @Parameters(commandDescription = "Perform filesystem operations")
-class CmdFs extends CmdBase implements UsageAware {
+class CmdFs extends CmdBase implements UsageAware, SubcommandAware {
 
     static final public NAME = 'fs'
 
@@ -259,6 +259,11 @@ class CmdFs extends CmdBase implements UsageAware {
 
     private SubCmd findCmd( String name ) {
         commands.find { it.name == name }
+    }
+
+    @Override
+    List<SubcommandAware.Subcommand> getSubcommands() {
+        commands.collect { new SubcommandAware.Subcommand(name: it.name, help: it.description) }
     }
 
     private void traverse( String source, Closure op ) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFs.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFs.groovy
@@ -313,6 +313,7 @@ class CmdFs extends CmdBase implements UsageAware, SubcommandAware {
             result << "  ${it.name}\t${it.description}"
             }
             result << ''
+            result << Launcher.HELP_JSON_TIP
             println result.join('\n').toString()
         }
         else {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLaunch.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLaunch.groovy
@@ -168,6 +168,7 @@ class CmdLaunch extends CmdBase implements UsageAware {
         result << '  -workspace-secret <name>  Workspace secret name to use in the pipeline (can be specified multiple times)'
         result << '  --<param>=<value>         Set a parameter used by the pipeline'
         result << ''
+        result << Launcher.HELP_JSON_TIP
         println result.join('\n').toString()
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -34,7 +34,7 @@ import org.pf4j.ExtensionPoint
  */
 @CompileStatic
 @Parameters(commandDescription = "Explore workflows lineage metadata", commandNames = ['li'])
-class CmdLineage extends CmdBase implements UsageAware {
+class CmdLineage extends CmdBase implements UsageAware, SubcommandAware {
 
     private static final String NAME = 'lineage'
 
@@ -147,6 +147,11 @@ class CmdLineage extends CmdBase implements UsageAware {
         if( matches )
             msg += " -- Did you mean one of these?\n" + matches.collect { "  $it"}.join('\n')
         throw new AbortOperationException(msg)
+    }
+
+    @Override
+    List<SubcommandAware.Subcommand> getSubcommands() {
+        commands.collect { new SubcommandAware.Subcommand(name: it.name, help: it.description) }
     }
 
     class CmdList implements SubCmd {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -123,6 +123,7 @@ class CmdLineage extends CmdBase implements UsageAware, SubcommandAware {
             commands.forEach {len = it.name.size() > len ? it.name.size() : len }
             commands.sort(){it.name}.each { result << "  ${it.name.padRight(len)}\t${it.description}".toString()  }
             result << ''
+            result << Launcher.HELP_JSON_TIP
             println result.join('\n').toString()
         }
         else {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdModule.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdModule.groovy
@@ -150,6 +150,7 @@ class CmdModule extends CmdBase implements UsageAware, SubcommandAware {
                 result << "  ${it.name.padRight(12)}${description}"
             }
             result << ''
+            result << Launcher.HELP_JSON_TIP
             println result.join('\n').toString()
         } else {
             final sub = findCmd(args[0])

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdModule.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdModule.groovy
@@ -42,7 +42,7 @@ import nextflow.exception.AbortOperationException
 @CompileStatic
 @Slf4j
 @Parameters(commandDescription = "Manage Nextflow modules")
-class CmdModule extends CmdBase implements UsageAware {
+class CmdModule extends CmdBase implements UsageAware, SubcommandAware {
 
     static final public String NAME = 'module'
 
@@ -118,6 +118,11 @@ class CmdModule extends CmdBase implements UsageAware {
 
     private CmdBase findCmd(String name) {
         commands.find { it.name == name || name in it.aliases }
+    }
+
+    @Override
+    List<SubcommandAware.Subcommand> getSubcommands() {
+        commands.collect { new SubcommandAware.Subcommand(name: it.name, command: it) }
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
@@ -35,11 +35,24 @@ import org.eclipse.jgit.api.Git
  */
 @CompileStatic
 @Parameters(commandDescription = "Execute plugin-specific commands")
-class CmdPlugin extends CmdBase implements UsageAware {
+class CmdPlugin extends CmdBase implements UsageAware, SubcommandAware {
 
     @Override
     String getName() {
         return 'plugin'
+    }
+
+    /**
+     * The statically-known sub-commands, surfaced in {@code -help-json}. The
+     * dynamic {@code <plugin-name>:<command>} form is resolved at runtime and so
+     * can't be introspected here.
+     */
+    @Override
+    List<SubcommandAware.Subcommand> getSubcommands() {
+        return [
+            new SubcommandAware.Subcommand(name: 'install', help: 'Install a plugin'),
+            new SubcommandAware.Subcommand(name: 'create', help: 'Create a new plugin project from the template'),
+        ]
     }
 
     @DynamicParameter(names = "--", description = "Custom plugin parameters go here", hidden = true)
@@ -114,6 +127,7 @@ class CmdPlugin extends CmdBase implements UsageAware {
         result << ''
         result << 'See the documentation of an individual plugin for its plugin-specific commands.'
         result << ''
+        result << Launcher.HELP_JSON_TIP
     }
 
     @Override

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdSecret.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdSecret.groovy
@@ -83,6 +83,7 @@ class CmdSecret extends CmdBase implements UsageAware, SubcommandAware {
             result << 'Commands:'
             commands.collect{ it.name }.sort().each { result << "  $it".toString()  }
             result << ''
+            result << Launcher.HELP_JSON_TIP
         }
         else {
             def sub = commands.find { it.name == args[0] }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdSecret.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdSecret.groovy
@@ -32,10 +32,11 @@ import nextflow.secret.SecretsProvider
 @Slf4j
 @CompileStatic
 @Parameters(commandDescription = "Manage pipeline secrets")
-class CmdSecret extends CmdBase implements UsageAware {
+class CmdSecret extends CmdBase implements UsageAware, SubcommandAware {
 
     interface SubCmd {
         String getName()
+        String getDescription()
         void apply(List<String> result)
         void usage(List<String> result)
     }
@@ -133,6 +134,11 @@ class CmdSecret extends CmdBase implements UsageAware {
         throw new AbortOperationException(msg)
     }
 
+    @Override
+    List<SubcommandAware.Subcommand> getSubcommands() {
+        commands.collect { new SubcommandAware.Subcommand(name: it.name, help: it.description) }
+    }
+
     private void addOption(String fieldName, List<String> result) {
         def annot = this.class.getDeclaredField(fieldName)?.getAnnotation(Parameter)
         if( annot ) {
@@ -148,6 +154,9 @@ class CmdSecret extends CmdBase implements UsageAware {
 
         @Override
         String getName() { 'set' }
+
+        @Override
+        String getDescription() { 'Set a key-pair in the secrets store' }
 
         @Override
         void apply(List<String> result) {
@@ -176,6 +185,9 @@ class CmdSecret extends CmdBase implements UsageAware {
         String getName() { 'get' }
 
         @Override
+        String getDescription() { 'Get a secret value with the name' }
+
+        @Override
         void apply(List<String> result) {
             if( result.size() != 1 )
                 throw new AbortOperationException("Wrong number of arguments")
@@ -200,6 +212,9 @@ class CmdSecret extends CmdBase implements UsageAware {
     class ListCmd implements SubCmd {
         @Override
         String getName() { 'list' }
+
+        @Override
+        String getDescription() { 'List all names in the secrets store' }
 
         @Override
         void apply(List<String> result) {
@@ -231,6 +246,9 @@ class CmdSecret extends CmdBase implements UsageAware {
     class DeleteCmd implements SubCmd {
         @Override
         String getName() { 'delete' }
+
+        @Override
+        String getDescription() { 'Delete an entry from the secrets store' }
 
         @Override
         void apply(List<String> result) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -56,6 +56,13 @@ import static nextflow.util.SysHelper.dumpThreads
 class Launcher {
 
     /**
+     * One-line hint, appended to usage help, pointing users at the
+     * machine-readable {@code -help-json} flag. Shared across the top-level
+     * and all sub-command help screens for consistency.
+     */
+    static final String HELP_JSON_TIP = 'Tip: add -help-json to any command for machine-readable help.'
+
+    /**
      * Create the application command line parser
      *
      * @return An instance of {@code CliBuilder}
@@ -398,13 +405,14 @@ class Launcher {
             }
 
             jcommander.usage(command)
+            println "\n$HELP_JSON_TIP\n"
             return
         }
 
         println "Usage: nextflow [options] COMMAND [arg...]\n"
         printOptions(CliOptions)
         printCommands(allCommands)
-        println "Tip: add -help-json to any command for machine-readable help as JSON.\n"
+        println "$HELP_JSON_TIP\n"
     }
 
     @CompileDynamic

--- a/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -404,6 +404,7 @@ class Launcher {
         println "Usage: nextflow [options] COMMAND [arg...]\n"
         printOptions(CliOptions)
         printCommands(allCommands)
+        println "Tip: add -help-json to any command for machine-readable help as JSON.\n"
     }
 
     @CompileDynamic
@@ -478,6 +479,10 @@ class Launcher {
         return this
     }
 
+    private boolean isHelpJson() {
+        options.helpJson || command?.helpJson
+    }
+
     protected void checkForHelp() {
         if( options.help || !command || command.help ) {
             if( command instanceof UsageAware ) {
@@ -516,6 +521,13 @@ class Launcher {
             // -- print out the version number, then exit
             if ( options.version ) {
                 println getVersion(fullVersion)
+                return 0
+            }
+
+            // -- print out the machine-readable JSON help, then exit
+            if( isHelpJson() ) {
+                final json = command ? CliSchema.command(command) : CliSchema.root(options, allCommands)
+                println json
                 return 0
             }
 
@@ -705,9 +717,6 @@ class Launcher {
 
     }
 
-    /*
-     * The application 'logo'
-     */
     /*
      * The application 'logo'
      */

--- a/modules/nextflow/src/main/groovy/nextflow/cli/SubcommandAware.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/SubcommandAware.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cli
+
+import groovy.transform.CompileStatic
+
+/**
+ * Implemented by commands that dispatch to nested sub-commands (e.g. {@code fs},
+ * {@code secrets}, {@code module}). This lets {@link CliSchema} describe those
+ * sub-commands recursively under {@code -help-json}, since the global flag is
+ * resolved against the top-level command and can't drill into a sub-command on
+ * its own.
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+@CompileStatic
+interface SubcommandAware {
+
+    /**
+     * @return the nested sub-commands of this command, in a normalised form
+     *         that {@link CliSchema} can render.
+     */
+    List<Subcommand> getSubcommands()
+
+    /**
+     * A normalised description of a single nested sub-command.
+     *
+     * <p>When {@link #command} is set, the sub-command is a full
+     * {@link CmdBase} and {@link CliSchema} introspects it for complete
+     * option/argument detail (recursing further if it too is
+     * {@code SubcommandAware}). Otherwise only {@link #name}, {@link #help}
+     * and {@link #aliases} are surfaced — the right granularity for
+     * sub-commands whose arguments are parsed manually rather than via
+     * JCommander annotations.
+     */
+    static class Subcommand {
+        String name
+        String help
+        List<String> aliases
+        CmdBase command
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cli
+
+import groovy.json.JsonSlurper
+import spock.lang.Specification
+
+/**
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+class CliSchemaTest extends Specification {
+
+    private static Map parse(String json) {
+        return new JsonSlurper().parseText(json) as Map
+    }
+
+    def 'should build the root schema with global options and a command index' () {
+        given:
+        def commands = [ new CmdInfo(), new CmdRun(), new CmdLineage() ] as List<CmdBase>
+
+        when:
+        def schema = parse(CliSchema.root(new CliOptions(), commands))
+
+        then:
+        schema.name == 'nextflow'
+        schema.path == 'nextflow'
+        schema.usage.startsWith('nextflow')
+
+        and: 'global options are reported, but meta options are hidden'
+        def opts = schema.params.collectMany { it.opts ?: [] }
+        '-config' in opts
+        !('-h' in opts)
+        !('-help-json' in opts)
+
+        and: 'commands are indexed by name with their description'
+        schema.subcommands.size() == 3
+        schema.subcommands.containsKey('run')
+        schema.subcommands.containsKey('info')
+        schema.subcommands.run.help
+
+        and: 'aliases are surfaced when present'
+        schema.subcommands.lineage.aliases == ['li']
+    }
+
+    def 'should build a command schema with options and arguments' () {
+        when:
+        def schema = parse(CliSchema.command(new CmdRun()))
+
+        then:
+        schema.name == 'run'
+        schema.path == 'nextflow run'
+        schema.help
+        schema.usage.startsWith('nextflow run')
+
+        and: 'a known option is reported with its metadata'
+        def resume = schema.params.find { it.name == 'resume' }
+        resume.kind == 'option'
+        '-resume' in resume.opts
+
+        and: 'a boolean option is flagged'
+        def cache = schema.params.find { it.opts == ['-cache'] }
+        cache.is_flag == true
+
+        and: 'positional arguments are reported as arguments'
+        schema.params.any { it.kind == 'argument' }
+
+        and: 'meta options are excluded'
+        !schema.params.collectMany { it.opts ?: [] }.contains('-help-json')
+    }
+
+    def 'should expose command aliases' () {
+        when:
+        def schema = parse(CliSchema.command(new CmdLineage()))
+
+        then:
+        schema.name == 'lineage'
+        schema.aliases == ['li']
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
@@ -55,6 +55,10 @@ class CliSchemaTest extends Specification {
 
         and: 'aliases are surfaced when present'
         schema.subcommands.lineage.aliases == ['li']
+
+        and: 'hidden options are reported but flagged'
+        def debug = schema.params.find { '-debug' in (it.opts ?: []) }
+        debug.hidden == true
     }
 
     def 'should build a command schema with options and arguments' () {

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
@@ -96,4 +96,31 @@ class CliSchemaTest extends Specification {
         schema.aliases == ['li']
     }
 
+    def 'should recurse into manually-parsed sub-commands as an index' () {
+        when:
+        def schema = parse(CliSchema.command(new CmdSecret()))
+
+        then: 'each sub-command is indexed by name with its description'
+        schema.subcommands.size() == 4
+        schema.subcommands.containsKey('get')
+        schema.subcommands.containsKey('set')
+        schema.subcommands.get.help == 'Get a secret value with the name'
+
+        and: 'manually-parsed sub-commands have no introspected params'
+        !schema.subcommands.get.containsKey('params')
+    }
+
+    def 'should recurse into JCommander-backed sub-commands with full detail' () {
+        when:
+        def schema = parse(CliSchema.command(new CmdModule()))
+
+        then: 'sub-commands carry their own path, usage and params'
+        def create = schema.subcommands.create
+        create.name == 'create'
+        create.path == 'nextflow module create'
+        create.usage.startsWith('nextflow module create')
+        create.help == 'Create a new module skeleton'
+        create.params instanceof List
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CliSchemaTest.groovy
@@ -53,8 +53,14 @@ class CliSchemaTest extends Specification {
         schema.subcommands.containsKey('info')
         schema.subcommands.run.help
 
-        and: 'aliases are surfaced when present'
-        schema.subcommands.lineage.aliases == ['li']
+        and: 'the index is lightweight - help only, no params or aliases'
+        !schema.subcommands.run.containsKey('params')
+        !schema.subcommands.lineage.containsKey('aliases')
+
+        and: 'the index recurses into nested sub-commands by name + help'
+        schema.subcommands.lineage.subcommands.containsKey('view')
+        schema.subcommands.lineage.subcommands.view.help
+        !schema.subcommands.lineage.subcommands.view.containsKey('params')
 
         and: 'hidden options are reported but flagged'
         def debug = schema.params.find { '-debug' in (it.opts ?: []) }


### PR DESCRIPTION
## Why

Coding agents and tooling increasingly drive the Nextflow CLI, but the only machine interface to it today is the rendered `-help` text. Scraping that output is brittle: it's formatted for humans, wraps to the terminal width, and changes layout without notice. An LLM (or any tool) wanting to know "what flags does `nextflow run` take, and what type is each one?" has to parse prose.

This adds a structured, stable contract for that question. It's a direct port of the idea in [nf-core/tools#4310](https://github.com/nf-core/tools/pull/4310), which added `--help-json` to the nf-core CLI for the same reason — so agents can discover the CLI reliably one command at a time, rather than pulling the whole tree into context or guessing from help text.

The design follows the same principles as the nf-core PR:

- **Progressive disclosure.** `nextflow -help-json` returns the global options plus a recursive index of the whole command tree by name + description (including nested sub-commands like `module create`) — the map of the CLI, without the detail. Drilling into a command (`nextflow run -help-json`) returns that command's full option/argument detail. Agents see the whole shape up front, then load detail only where they need it.
- **Introspection, not parsing.** A small `CliSchema` class reads the JCommander `@Parameter` / `@Parameters` annotations directly — the same source of truth that drives `-help` — so the JSON can't drift from the real CLI.
- **Discoverable.** A one-line tip on every `-help` screen (top-level and each sub-command) points tools and agents at the flag.

The flag is marked as a `help`-style option, so it works even when required arguments are missing (just like `-help`).

## What it looks like

`nextflow -help-json` — global options + a recursive name/description index of the whole tree (no per-command detail; just the map):

<details>
<summary>Full <code>nextflow -help-json</code> output</summary>

```json
{
  "name": "nextflow",
  "path": "nextflow",
  "usage": "nextflow [options] COMMAND [arg...]",
  "params": [
    {"name": "config", "kind": "option", "type": "List", "opts": ["-C"], "help": "Use the specified configuration file(s) overriding any defaults"},
    {"name": "jvmOpts", "kind": "option", "type": "Map", "opts": ["-D"], "help": "Set JVM properties"},
    {"name": "background", "kind": "option", "type": "boolean", "opts": ["-bg"], "help": "Execute nextflow in background", "is_flag": true},
    {"name": "userConfig", "kind": "option", "type": "List", "opts": ["-c", "-config"], "help": "Add the specified file to configuration set"},
    {
      "name": "ignoreConfigIncludes",
      "kind": "option",
      "type": "boolean",
      "opts": ["-config-ignore-includes"],
      "help": "Disable the parsing of config includes",
      "is_flag": true
    },
    {"name": "debug", "kind": "option", "type": "List", "opts": ["-debug"], "hidden": true},
    {"name": "logFile", "kind": "option", "type": "String", "opts": ["-log"], "help": "Set nextflow log file path"},
    {"name": "quiet", "kind": "option", "type": "boolean", "opts": ["-q", "-quiet"], "help": "Do not print information messages", "is_flag": true},
    {
      "name": "remoteDebug",
      "kind": "option",
      "type": "boolean",
      "opts": ["-remote-debug"],
      "help": "Enable JVM interactive remote debugging (experimental)",
      "is_flag": true
    },
    {
      "name": "selfUpdate",
      "kind": "option",
      "type": "boolean",
      "opts": ["-self-update"],
      "help": "Update nextflow to the latest version",
      "is_flag": true,
      "hidden": true
    },
    {"name": "syslog", "kind": "option", "type": "String", "opts": ["-syslog"], "help": "Send logs to syslog server (eg. localhost:514)"},
    {
      "name": "trace",
      "kind": "option",
      "type": "List",
      "opts": ["-trace"],
      "help": "Enable trace level logging for the specified package name - multiple packages can be provided separating them with a comma e.g. '-trace nextflow,io.seqera'"
    },
    {"name": "version", "kind": "option", "type": "boolean", "opts": ["-v", "-version"], "help": "Print the program version", "is_flag": true}
  ],
  "subcommands": {
    "auth": {
      "help": "Manage Seqera Platform authentication",
      "subcommands": {
        "config": {"help": "Configure Seqera Platform settings"},
        "login": {"help": "Authenticate with Seqera Platform"},
        "logout": {"help": "Remove authentication and revoke access token"},
        "status": {"help": "Show current authentication status and configuration"}
      }
    },
    "clean": {"help": "Clean up project cache and work directories"},
    "clone": {"help": "Clone a project into a folder"},
    "config": {"help": "Print a project configuration"},
    "console": {"help": "Launch Nextflow interactive console"},
    "drop": {"help": "Delete the local copy of a project"},
    "fs": {
      "help": "Perform filesystem operations",
      "subcommands": {
        "cat": {"help": "Print a file to the stdout"},
        "cp": {"help": "Copy a file"},
        "ls": {"help": "List the content of a folder"},
        "mv": {"help": "Move a file"},
        "rm": {"help": "Remove a file"},
        "stat": {"help": "Print file to meta info"}
      }
    },
    "help": {"help": "Print the usage help for a command"},
    "info": {"help": "Print project and system runtime information"},
    "inspect": {"help": "Inspect process settings in a pipeline project"},
    "kuberun": {"help": "Execute a workflow in a Kubernetes cluster (experimental)"},
    "launch": {"help": "Launch a workflow in Seqera Platform"},
    "lineage": {
      "help": "Explore workflows lineage metadata",
      "subcommands": {
        "check": {"help": "Checks the integrity of an lineage file path"},
        "diff": {"help": "Show differences between two lineage descriptions"},
        "find": {"help": "Find lineage metadata descriptions matching with a query"},
        "list": {"help": "List the executions with lineage enabled"},
        "render": {"help": "Render the lineage graph for a workflow output"},
        "view": {"help": "Print the description of a Lineage ID (lid)"}
      }
    },
    "lint": {"help": "Lint Nextflow scripts and config files"},
    "list": {"help": "List all downloaded projects"},
    "log": {"help": "Print executions log and runtime info"},
    "logfile": {"help": "Print the contents of a Nextflow log file"},
    "module": {
      "help": "Manage Nextflow modules",
      "subcommands": {
        "create": {"help": "Create a new module skeleton"},
        "install": {"help": "Install a module from the registry"},
        "list": {"help": "List all installed modules"},
        "publish": {"help": "Publish a module to the registry"},
        "remove": {"help": "Remove an installed module"},
        "run": {"help": "Run a module directly from the registry"},
        "search": {"help": "Search for modules in the registry"},
        "spec": {"help": "Generate a meta.yml spec for a local module"},
        "validate": {"help": "Validate a module structure and metadata"},
        "view": {"help": "Show module information and usage template"}
      }
    },
    "plugin": {
      "help": "Execute plugin-specific commands",
      "subcommands": {"create": {"help": "Create a new plugin project from the template"}, "install": {"help": "Install a plugin"}}
    },
    "pull": {"help": "Download or update a project"},
    "run": {"help": "Execute a pipeline project"},
    "secrets": {
      "help": "Manage pipeline secrets",
      "subcommands": {
        "delete": {"help": "Delete an entry from the secrets store"},
        "get": {"help": "Get a secret value with the name"},
        "list": {"help": "List all names in the secrets store"},
        "set": {"help": "Set a key-pair in the secrets store"}
      }
    },
    "self-update": {"help": "Update nextflow runtime to the latest available version"},
    "view": {"help": "View project script file(s)"}
  }
}
```

</details>

`nextflow info -help-json` — a single command's full detail (options first, arguments last; the hidden `-dd` is surfaced with a flag rather than dropped). Output is condensed: entries that fit within ~160 columns stay on one line (see `args`), and only longer ones expand:

```json
{
  "name": "info",
  "path": "nextflow info",
  "usage": "nextflow info [options] [args...]",
  "params": [
    {"name": "detailed", "kind": "option", "type": "boolean", "opts": ["-d"], "help": "Show detailed information", "is_flag": true},
    {"name": "moreDetailed", "kind": "option", "type": "boolean", "opts": ["-dd"], "is_flag": true, "hidden": true},
    {"name": "format", "kind": "option", "type": "String", "opts": ["-o"], "help": "Output format, either: text (default), json, yaml"},
    {"name": "checkForUpdates", "kind": "option", "type": "boolean", "opts": ["-u", "-check-updates"], "help": "Check for remote updates", "is_flag": true},
    {"name": "args", "kind": "argument", "type": "List", "help": "project name"}
  ],
  "help": "Print project and system runtime information"
}
```

The flag is discoverable from the normal human-readable help. A one-line tip is appended to every `-help` screen — the top-level usage and each sub-command:

```console
$ nextflow -help
Usage: nextflow [options] COMMAND [arg...]

Options:
  ...
Commands:
  ...
  view          View project script file(s)

Tip: add -help-json to any command for machine-readable help.
```

```console
$ nextflow module -help
Usage: nextflow module <command> [options]

Commands:
  ...
  validate    Validate a module structure and metadata

Tip: add -help-json to any command for machine-readable help.
```

## Notes

- The universal meta flags (`-h`, `-help`, `-help-json`) are excluded from the reported parameters. Hidden options are *included* but flagged with `"hidden": true` (e.g. `info`'s `-dd`), so tools can choose to surface or ignore them.
- The root index recurses through the entire command tree (including nested sub-commands like `module create`, `lineage view`) but carries only names + help text — no params, aliases or paths. Full option/argument detail is disclosed by drilling into a command, e.g. `nextflow module -help-json`, which reports `module`'s own options plus the full detail of each nested sub-command. `plugin` lists its statically-known sub-commands (`install`, `create`); its dynamic `<plugin-name>:<command>` calls are resolved at runtime and can't be introspected.
- Output is rendered by a small width-aware formatter: it stays valid, human-readable JSON but condenses any object or array that fits within ~160 columns onto a single line, so a leaf node prints as `{"help": "..."}` rather than spread across several lines.
- New unit tests in `CliSchemaTest` cover the root schema, a command schema, and alias surfacing. Existing `LauncherTest` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



