### PR TITLE
Surface allocated resources to self-sizing task commands (nf-seqera)

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -311,6 +311,15 @@ class TaskRun implements Cloneable {
     def script
 
     /**
+     * The live command {@link GString} produced by the script block, retained before it
+     * is flattened to a string. Lets an executor inspect which command values were
+     * interpolated (e.g. from {@code task.memory}/{@code task.cpus}) together with the
+     * AST {@link #body} metadata. Null when the script is not a GString (no interpolation),
+     * a template file, or a shell block.
+     */
+    GString scriptGString
+
+    /**
      * The process source as entered by the user in the process definition
      */
     String source
@@ -862,6 +871,11 @@ class TaskRun implements Cloneable {
             }
             else {
                 script = result.toString()
+                // retain the live GString (before flattening) only on the plain scriptlet path,
+                // where `script` IS this GString's toString — so an executor can inspect which
+                // command values were interpolated from task.memory/task.cpus. Not for shell
+                // (!{...}) or template scripts, where `script` is rendered differently.
+                this.scriptGString = result instanceof GString ? (GString) result : null
             }
         }
         catch( ProcessException e ) {

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.14.1'
-    api 'io.seqera:sched-client:0.59.0'
+    api 'io.seqera:sched-client:0.60.0-SNAPSHOT'
     // Override the old lib-httpx pulled transitively by sched-client, otherwise the plugin
     // bundles failsafe-3.1.0 which clashes with the failsafe-3.3.2 the plugin is compiled
     // against (java.lang.NoSuchMethodError on handleIf(CheckedPredicate) at runtime).

--- a/plugins/nf-seqera/src/main/io/seqera/executor/ResourceInterpolator.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/ResourceInterpolator.groovy
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.executor
+
+import java.util.regex.Pattern
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.util.MemoryUnit
+
+/**
+ * Rewrites a task command so that values derived from {@code task.memory} and
+ * {@code task.cpus} become shell-variable placeholders, letting the scheduler fill
+ * in the <em>actually allocated</em> value at launch time.
+ *
+ * <p>The problem (see sched#492): when resource optimization reduces a task's
+ * allocation below its request, any value the command computed from the request
+ * (e.g. a tool's {@code --max-mem} self-sizing flag) is now wrong and the task can
+ * OOM. The command is rendered before the scheduler decides the allocation, so it
+ * cannot be patched afterwards.
+ *
+ * <p>This works at materialization time, with no re-execution of the user script,
+ * using three signals:
+ * <ul>
+ *   <li>the live command {@link GString} (already evaluated) — exact <em>location</em>
+ *       of every interpolated value, recursing into nested GStrings;</li>
+ *   <li>the raw script {@code source} — the interpolation <em>expressions</em>, aligned
+ *       to the GString values by order;</li>
+ *   <li>the AST variable references ({@code task} referenced at all) — a cheap gate.</li>
+ * </ul>
+ * A value is memory/cpus-derived when its source expression references
+ * {@code task.memory}/{@code task.cpus} (directly, or through a local variable whose
+ * definition does). Such numeric values are replaced with {@code ${SEQERA_TASK_MEM_n}} /
+ * {@code ${SEQERA_TASK_CPUS_n}} and recorded as {@link Binding}s.
+ *
+ * <p>Safety: the parsed command template is validated against the live GString (the
+ * literal text between interpolations must match, ignoring whitespace/escaping) before
+ * any attribution, so a mis-identified template cannot produce wrong bindings. A
+ * placeholder that would land inside shell single-quotes (where it would not expand) or
+ * any parse/validation failure causes the original command to be returned unchanged —
+ * never producing a worse command than today.
+ *
+ * @author Paolo Di Tommaso
+ */
+@Slf4j
+@CompileStatic
+class ResourceInterpolator {
+
+    static enum Resource { MEMORY, CPUS }
+
+    /** A placeholder to be resolved by the scheduler at launch time. */
+    @Canonical
+    static class Binding {
+        String name
+        Resource resource
+        BigDecimal value
+    }
+
+    @Canonical
+    static class Result {
+        String script
+        List<Binding> bindings
+        boolean changed() { bindings != null && !bindings.isEmpty() }
+    }
+
+    private static class Template {
+        List<String> exprs
+        String literals
+    }
+
+    private static final String MEM_VAR = 'SEQERA_TASK_MEM_'
+    private static final String CPUS_VAR = 'SEQERA_TASK_CPUS_'
+    private static final Pattern PLACEHOLDER = Pattern.compile('\\$\\{SEQERA_TASK_')
+    // anchored so task.memoryUsage / task.cpusPerNode / mytask.memory are NOT matched
+    private static final Pattern MEM_REF = Pattern.compile(/(?<![A-Za-z0-9_.])task\s*\.\s*memory(?![A-Za-z0-9_])/)
+    private static final Pattern CPUS_REF = Pattern.compile(/(?<![A-Za-z0-9_.])task\s*\.\s*cpus(?![A-Za-z0-9_])/)
+
+    /**
+     * @param command   the live command GString (retained by TaskRun before flattening)
+     * @param source    the raw script-block source (TaskRun body source)
+     * @param refNames  the AST-referenced variable names (TaskRun body valRefs)
+     * @param reqCpus   the requested cpus the command was rendered with
+     * @param reqMem    the requested memory the command was rendered with
+     */
+    static Result interpolate(GString command, String source, Set<String> refNames, int reqCpus, MemoryUnit reqMem) {
+        final base = command != null ? command.toString() : null
+        // -- gates: need a command GString, a source, a positive request, and a `task` reference
+        if( command == null || !source || reqMem == null || reqCpus <= 0 )
+            return new Result(base, [])
+        if( refNames != null && !refNames.contains('task') )
+            return new Result(base, [])
+
+        try {
+            // -- the command template = the last interpolating string literal in the source
+            final templateText = lastStringLiteral(source)
+            if( templateText == null )
+                return new Result(base, [])
+            final template = parseTemplate(templateText)
+            // -- validate the parsed template actually corresponds to this command, so a
+            //    mis-identified literal cannot produce wrong attributions
+            if( !matches(template, command) )
+                return new Result(base, [])
+
+            final ctx = new Ctx(defs: parseGStringDefs(source))
+            final placeholdered = render(command, template.exprs, ctx)
+
+            // -- a placeholder that lands inside shell single-quotes would not expand: bail
+            if( placeholderInSingleQuotes(placeholdered) ) {
+                log.debug "[SEQERA] Resource interpolation skipped: placeholder inside single-quotes"
+                return new Result(base, [])
+            }
+            return new Result(placeholdered, ctx.bindings)
+        }
+        catch( Exception e ) {
+            log.debug "[SEQERA] Resource interpolation skipped: ${e.message}"
+            return new Result(base, [])
+        }
+    }
+
+    // ---- recursive render ---------------------------------------------------
+
+    private static class Ctx {
+        Map<String,String> defs
+        List<Binding> bindings = []
+        int memCount = 0
+        int cpusCount = 0
+    }
+
+    /**
+     * Walk a GString together with the ordered source expressions for its slots,
+     * emitting resource-derived numeric values as shell-variable placeholders.
+     */
+    private static String render(GString g, List<String> exprs, Ctx ctx) {
+        final strings = g.strings
+        final values = g.values
+        if( exprs == null || exprs.size() != values.length )
+            throw new IllegalStateException("interpolation count mismatch")
+
+        final sb = new StringBuilder()
+        for( int i = 0; i < strings.length; i++ ) {
+            sb.append(strings[i])
+            if( i < values.length ) {
+                final v = values[i]
+                final e = exprs[i]?.trim()
+                final kind = classify(e, ctx.defs)
+                if( kind == Resource.MEMORY || kind == Resource.CPUS ) {
+                    final num = asNumber(v)
+                    if( num == null ) {
+                        sb.append(str(v))
+                    }
+                    else {
+                        final name = kind == Resource.MEMORY ? MEM_VAR + (ctx.memCount++) : CPUS_VAR + (ctx.cpusCount++)
+                        ctx.bindings << new Binding(name, kind, num)
+                        sb.append('${').append(name).append('}')
+                    }
+                }
+                else if( kind == null && v instanceof GString && isLocalGString(e, ctx.defs) ) {
+                    // one level of indirection: recurse into the local var's nested GString,
+                    // but only if its definition template validates against the nested value
+                    final nested = (GString) v
+                    final defTpl = parseTemplate(ctx.defs[e])
+                    if( matches(defTpl, nested) )
+                        sb.append(render(nested, defTpl.exprs, ctx))
+                    else
+                        sb.append(str(v))
+                }
+                else {
+                    sb.append(str(v))   // constant or joint expression -> unchanged
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    /**
+     * @return MEMORY/CPUS when the expression references exactly one resource directly;
+     *         null otherwise (constant, joint memory+cpus, or a local variable).
+     */
+    private static Resource classify(String expr, Map<String,String> defs) {
+        if( !expr )
+            return null
+        final mem = MEM_REF.matcher(expr).find()
+        final cpus = CPUS_REF.matcher(expr).find()
+        if( mem && cpus )
+            return null          // joint -> cannot scale by one resource (safe)
+        if( mem )
+            return Resource.MEMORY
+        if( cpus )
+            return Resource.CPUS
+        return null
+    }
+
+    private static boolean isLocalGString(String expr, Map<String,String> defs) {
+        if( !isLocalVar(expr) )
+            return false
+        final body = defs[expr]
+        if( body == null )
+            return false
+        final mem = MEM_REF.matcher(body).find()
+        final cpus = CPUS_REF.matcher(body).find()
+        // recurse only for a single-resource local; joint locals are left untouched
+        return mem ^ cpus
+    }
+
+    private static boolean isLocalVar(String expr) {
+        expr != null && expr.matches(/[A-Za-z_][A-Za-z0-9_]*/)
+    }
+
+    // ---- template parsing & validation -------------------------------------
+
+    /**
+     * The parsed template literals must reproduce the live GString's literal segments,
+     * and the interpolation count must match. Comparison ignores whitespace and
+     * backslashes so source escaping / line-continuations do not cause false negatives
+     * (which would only forgo the optimization, never mis-attribute).
+     */
+    private static boolean matches(Template t, GString g) {
+        if( t == null || t.exprs.size() != g.values.length )
+            return false
+        return normalize(t.literals) == normalize(String.join('', g.strings))
+    }
+
+    private static String normalize(String s) {
+        s == null ? '' : s.replaceAll(/[\s\\]/, '')
+    }
+
+    /**
+     * Parse a GString template into its ordered interpolation expressions and the
+     * concatenation of the literal text around them. Handles {@code ${ ... }} (balanced
+     * braces) and {@code $dotted.path}; an escaped {@code \$} is treated as a literal.
+     */
+    static Template parseTemplate(String template) {
+        final exprs = new ArrayList<String>()
+        final lit = new StringBuilder()
+        if( template != null ) {
+            final n = template.length()
+            int i = 0
+            while( i < n ) {
+                final c = template.charAt(i)
+                if( c == ('\\' as char) && i + 1 < n ) {
+                    lit.append(c).append(template.charAt(i + 1)); i += 2; continue
+                }
+                if( c == ('$' as char) && i + 1 < n ) {
+                    final next = template.charAt(i + 1)
+                    if( next == ('{' as char) ) {
+                        int depth = 1, j = i + 2
+                        while( j < n && depth > 0 ) {
+                            final cj = template.charAt(j)
+                            if( cj == ('{' as char) ) depth++
+                            else if( cj == ('}' as char) ) { depth--; if( depth == 0 ) break }
+                            j++
+                        }
+                        exprs << template.substring(i + 2, j)
+                        i = j + 1
+                        continue
+                    }
+                    else if( Character.isJavaIdentifierStart(next) ) {
+                        int j = i + 1
+                        while( j < n && (Character.isJavaIdentifierPart(template.charAt(j)) || template.charAt(j) == ('.' as char)) ) {
+                            if( template.charAt(j) == ('.' as char) && (j + 1 >= n || !Character.isJavaIdentifierPart(template.charAt(j + 1))) )
+                                break
+                            j++
+                        }
+                        exprs << template.substring(i + 1, j)
+                        i = j
+                        continue
+                    }
+                }
+                lit.append(c); i++
+            }
+        }
+        final t = new Template()
+        t.exprs = exprs
+        t.literals = lit.toString()
+        return t
+    }
+
+    /** @deprecated kept for tests; use {@link #parseTemplate}. */
+    static List<String> parseInterpolations(String template) {
+        parseTemplate(template).exprs
+    }
+
+    /**
+     * Extract the inner text of the interpolating string literal that closes last in the
+     * source — for a process script block this is the command template (the closure's
+     * return value). Supports triple-double-quoted (""") and dollar-slashy ($/.../$);
+     * other forms return null and are left unchanged (safe).
+     */
+    static String lastStringLiteral(String source) {
+        String best = null
+        int bestEnd = -1
+        // triple-double-quoted
+        final tdClose = source.lastIndexOf('"""')
+        if( tdClose >= 0 ) {
+            final open = source.lastIndexOf('"""', tdClose - 1)
+            if( open >= 0 && open + 3 <= tdClose && tdClose + 3 > bestEnd ) {
+                best = source.substring(open + 3, tdClose); bestEnd = tdClose + 3
+            }
+        }
+        // dollar-slashy  $/ ... /$
+        final dsClose = source.lastIndexOf('/$')
+        if( dsClose >= 0 ) {
+            final open = source.lastIndexOf('$/', dsClose - 1)
+            if( open >= 0 && open + 2 <= dsClose && dsClose + 2 > bestEnd ) {
+                best = source.substring(open + 2, dsClose); bestEnd = dsClose + 2
+            }
+        }
+        return best
+    }
+
+    /**
+     * Find {@code def NAME = <string literal>} definitions whose literal references a
+     * resource, returning NAME -> the literal's inner template text. Used to follow one
+     * level of local-variable indirection. The literal may sit inside a larger expression
+     * (e.g. a ternary): the first resource-referencing literal is used.
+     */
+    static Map<String,String> parseGStringDefs(String source) {
+        final defs = new LinkedHashMap<String,String>()
+        final m = source =~ /(?m)\bdef\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/
+        while( m.find() ) {
+            final name = m.group(1) as String
+            final rhs = m.group(2) as String
+            final lit = firstResourceLiteral(rhs)
+            if( lit != null )
+                defs[name] = lit
+        }
+        return defs
+    }
+
+    private static String firstResourceLiteral(String rhs) {
+        for( String q : ['"""', "'''", '"', "'"] ) {
+            int from = 0
+            while( true ) {
+                final open = rhs.indexOf(q, from)
+                if( open < 0 ) break
+                final close = rhs.indexOf(q, open + q.length())
+                if( close < 0 ) break
+                final inner = rhs.substring(open + q.length(), close)
+                if( MEM_REF.matcher(inner).find() || CPUS_REF.matcher(inner).find() )
+                    return inner
+                from = close + q.length()
+            }
+        }
+        return null
+    }
+
+    // ---- shell safety -------------------------------------------------------
+
+    /**
+     * @return true if any {@code ${SEQERA_TASK_*}} placeholder falls inside a shell
+     *         single-quoted region, where it would not be expanded at runtime.
+     */
+    static boolean placeholderInSingleQuotes(String s) {
+        boolean inSingle = false, inDouble = false
+        final n = s.length()
+        for( int i = 0; i < n; i++ ) {
+            final c = s.charAt(i)
+            if( c == ('\\' as char) && !inSingle ) { i++; continue }   // backslash escape (not inside '...')
+            if( c == ('\'' as char) && !inDouble ) { inSingle = !inSingle; continue }
+            if( c == ('"' as char) && !inSingle ) { inDouble = !inDouble; continue }
+            if( inSingle && s.startsWith('${SEQERA_TASK_', i) )
+                return true
+        }
+        return false
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    private static String str(Object v) { v == null ? '' : v.toString() }
+
+    private static BigDecimal asNumber(Object v) {
+        if( v == null )
+            return null
+        try {
+            return new BigDecimal(v.toString().trim())
+        }
+        catch( NumberFormatException e ) {
+            return null
+        }
+    }
+}

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -25,6 +25,8 @@ import io.seqera.executor.Labels
 import io.seqera.sched.api.schema.v1a1.AcceleratorType
 import io.seqera.sched.api.schema.v1a1.GetTaskLogsResponse
 import io.seqera.sched.api.schema.v1a1.NextflowTask
+import io.seqera.sched.api.schema.v1a1.ResourceBinding
+import io.seqera.sched.api.schema.v1a1.ResourceBindingType
 import io.seqera.sched.api.schema.v1a1.ResourceLimit
 import io.seqera.sched.api.schema.v1a1.ResourceRequirement
 import io.seqera.sched.api.schema.v1a1.Task
@@ -42,6 +44,7 @@ import nextflow.fusion.FusionAwareTask
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskRun
 import nextflow.processor.TaskStatus
+import nextflow.script.TokenValRef
 import nextflow.trace.TraceRecord
 /**
  * Task handler for the Seqera scheduler executor.
@@ -78,6 +81,21 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
      */
     private volatile CloudMachineInfo machineInfo
 
+    /**
+     * Resource-derived placeholder bindings captured from the command at launcher
+     * preparation; shipped with the task so the scheduler can fill them with the
+     * allocated value. Null/empty when the command has no self-sizing values.
+     */
+    private List<ResourceBinding> resourceBindings
+
+    /**
+     * Default values for the placeholder env vars: the value as rendered from the
+     * *request*. Injected into the task environment so that backends which do not resolve
+     * bindings (or before the scheduler overrides them) still produce a valid command
+     * identical to today's behavior.
+     */
+    private Map<String,String> resourceBindingDefaults
+
     SeqeraTaskHandler(TaskRun task, SeqeraExecutor executor) {
         super(task)
         this.client = executor.getClient()
@@ -91,8 +109,51 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
     @Override
     void prepareLauncher() {
         assert fusionEnabled()
+        // rewrite self-sizing command values into placeholders BEFORE the wrapper is built,
+        // so .command.sh carries ${SEQERA_TASK_*} that the scheduler fills at launch
+        interpolateResources()
         final launcher = fusionLauncher()
         launcher.build()
+    }
+
+    /**
+     * Replace command values derived from {@code task.memory}/{@code task.cpus} with shell
+     * placeholders so the scheduler can substitute the <em>allocated</em> value at launch
+     * (see {@link ResourceInterpolator}). Safe no-op on anything it cannot confidently rewrite.
+     */
+    protected void interpolateResources() {
+        try {
+            final body = task.getBody()
+            final Set<String> refNames = new HashSet<>()
+            if( body?.valRefs ) {
+                for( TokenValRef r : body.valRefs )
+                    refNames.add(r.name)
+            }
+            final res = ResourceInterpolator.interpolate(
+                    task.getScriptGString(),
+                    body?.source,
+                    refNames,
+                    task.config.getCpus(),
+                    task.config.getMemory() )
+            if( res?.changed() ) {
+                task.script = res.script
+                final bindings = new ArrayList<ResourceBinding>()
+                final defaults = new LinkedHashMap<String,String>()
+                for( ResourceInterpolator.Binding b : res.bindings ) {
+                    bindings << new ResourceBinding()
+                            .name(b.name)
+                            .resource(b.resource == ResourceInterpolator.Resource.MEMORY ? ResourceBindingType.MEMORY : ResourceBindingType.CPUS)
+                            .value(b.value.doubleValue())
+                    defaults.put(b.name, b.value.toPlainString())
+                }
+                this.resourceBindings = bindings
+                this.resourceBindingDefaults = defaults
+                log.debug "[SEQERA] Resource interpolation applied: ${bindings.size()} binding(s) for task `${task.lazyName()}`"
+            }
+        }
+        catch( Exception e ) {
+            log.debug "[SEQERA] Resource interpolation skipped for task `${task.lazyName()}`: ${e.message}"
+        }
     }
 
     @Override
@@ -150,6 +211,9 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
         final delta = Labels.delta(taskLabels, executor.runResourceLabels)
         if( delta )
             schedTask.labels(delta)
+        // attach resource-derived placeholder bindings captured at launcher preparation
+        if( resourceBindings )
+            schedTask.resourceBindings(resourceBindings)
         log.debug "[SEQERA] Enqueueing task for batch submission: ${schedTask}"
         // Enqueue for batch submission - status will be set by setBatchTaskId callback
         executor.getBatchSubmitter().submit(this, schedTask)
@@ -162,10 +226,17 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
     protected Map<String, String> getTaskEnvironment() {
         final configEnv = executor.getSeqeraConfig()?.taskEnvironment
         final fusionEnv = fusionLauncher().fusionEnv()
-        if( !configEnv )
-            return fusionEnv
-        final result = new LinkedHashMap<String, String>(configEnv)
+        final result = new LinkedHashMap<String, String>()
+        if( configEnv )
+            result.putAll(configEnv)
         result.putAll(fusionEnv)
+        // seed placeholder defaults with the as-requested value. The scheduler overrides
+        // these with the allocated value at launch (ECS); backends that don't resolve
+        // bindings keep the default, so the command stays valid and identical to today.
+        if( resourceBindingDefaults ) {
+            for( Map.Entry<String,String> e : resourceBindingDefaults.entrySet() )
+                result.putIfAbsent(e.key, e.value)
+        }
         return result
     }
 

--- a/plugins/nf-seqera/src/test/io/seqera/executor/ResourceInterpolatorTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/ResourceInterpolatorTest.groovy
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.executor
+
+import nextflow.util.MemoryUnit
+import spock.lang.Specification
+
+/**
+ * Validates capture of resource-derived command values from the live command GString
+ * plus the raw script source, with no re-execution of the user script.
+ *
+ * <p>Each test builds a real {@code command} GString (what {@code TaskRun.scriptGString}
+ * would hold, with the requested values already interpolated) and the matching raw
+ * {@code source} (a non-interpolating triple-single-quoted string, so {@code ${task.x}}
+ * stays verbatim) — exactly the two artifacts Nextflow presents at materialization.
+ *
+ * @author Paolo Di Tommaso
+ */
+class ResourceInterpolatorTest extends Specification {
+
+    private static final Set<String> TASK_REF = ['task'] as Set
+    private static final ResourceInterpolator.Resource MEM = ResourceInterpolator.Resource.MEMORY
+    private static final ResourceInterpolator.Resource CPU = ResourceInterpolator.Resource.CPUS
+
+    /** Substitute each binding's original value back into the placeholdered script. */
+    private static String restore(ResourceInterpolator.Result res) {
+        String s = res.script
+        for( ResourceInterpolator.Binding b : res.bindings )
+            s = s.replace('${' + b.name + '}', b.value.toPlainString())
+        return s
+    }
+
+    // ---- direct self-sizing values -----------------------------------------
+
+    def 'placeholders a direct self-sizing memory expression (the sched#492 bcftools case)'() {
+        given:
+        def reqMem = MemoryUnit.of('36864 MB')
+        GString command = "bcftools sort --max-mem ${(reqMem.toMega() * 0.9) as int}M out.vcf"
+        def source = '''"""bcftools sort --max-mem ${(task.memory.toMega()*0.9) as int}M out.vcf"""'''
+
+        expect: 'the request is baked into the rendered command'
+        command.toString() == 'bcftools sort --max-mem 33177M out.vcf'
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 6, reqMem)
+
+        then:
+        res.changed()
+        res.script == 'bcftools sort --max-mem ${SEQERA_TASK_MEM_0}M out.vcf'
+        res.bindings.size() == 1
+        res.bindings[0].resource == MEM
+        res.bindings[0].value == 33177.0
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders a realistic multi-line command (continuations + surrounding interpolations)'() {
+        given:
+        def reqMem = MemoryUnit.of('36864 MB')
+        def prefix = 'SAMPLE_21'
+        def vcf = 'SAMPLE_21.vcf'
+        GString command = """\
+            bcftools sort \\
+                --output ${prefix}.vcf.gz \\
+                --max-mem ${(reqMem.toMega() * 0.9) as int}M \\
+                --temp-dir . \\
+                ${vcf}
+            """
+        def source = '''\
+            """
+            bcftools sort \\
+                --output ${prefix}.vcf.gz \\
+                --max-mem ${(task.memory.toMega() * 0.9) as int}M \\
+                --temp-dir . \\
+                ${vcf}
+            """
+            '''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 6, reqMem)
+
+        then: 'only the memory value is placeholdered; prefix/vcf are left untouched'
+        res.changed()
+        res.bindings.size() == 1
+        res.bindings[0].resource == MEM
+        res.bindings[0].value == 33177.0
+        res.script.contains('--max-mem ${SEQERA_TASK_MEM_0}M')
+        res.script.contains('--output SAMPLE_21.vcf.gz')
+        !res.script.contains('33177')
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders a JVM -Xmx flag sized from giga (unit-agnostic)'() {
+        given:
+        def reqMem = MemoryUnit.of('32 GB')
+        GString command = "java -Xmx${reqMem.toGiga()}g -jar picard.jar"
+        def source = '''"""java -Xmx${task.memory.toGiga()}g -jar picard.jar"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 4, reqMem)
+
+        then:
+        res.changed()
+        res.script == 'java -Xmx${SEQERA_TASK_MEM_0}g -jar picard.jar'
+        res.bindings[0].resource == MEM
+        res.bindings[0].value == 32.0
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders a memory value rendered in bytes (large number)'() {
+        given:
+        def reqMem = MemoryUnit.of('32 GB')
+        GString command = "STAR --limitBAMsortRAM ${reqMem.toBytes()}"
+        def source = '''"""STAR --limitBAMsortRAM ${task.memory.toBytes()}"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 4, reqMem)
+
+        then:
+        res.changed()
+        res.script == 'STAR --limitBAMsortRAM ${SEQERA_TASK_MEM_0}'
+        res.bindings[0].value == new BigDecimal(reqMem.toBytes())
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders a cpus value with arithmetic'() {
+        given:
+        def reqCpus = 4
+        GString command = "bwa mem -t ${reqCpus * 2} ref.fa reads.fq"
+        def source = '''"""bwa mem -t ${task.cpus * 2} ref.fa reads.fq"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, reqCpus, MemoryUnit.of('8 GB'))
+
+        then: 'the rendered value (8) is captured; the launch-time ratio preserves the x2'
+        res.changed()
+        res.script == 'bwa mem -t ${SEQERA_TASK_CPUS_0} ref.fa reads.fq'
+        res.bindings[0].resource == CPU
+        res.bindings[0].value == 8.0
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders both cpus and memory in a multi-line command'() {
+        given:
+        def reqMem = MemoryUnit.of('16 GB')
+        def reqCpus = 8
+        GString command = """\
+            mytool \\
+                --threads ${reqCpus} \\
+                --memory ${reqMem.toMega()}
+            """
+        def source = '''\
+            """
+            mytool \\
+                --threads ${task.cpus} \\
+                --memory ${task.memory.toMega()}
+            """
+            '''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, reqCpus, reqMem)
+
+        then:
+        res.changed()
+        res.bindings.size() == 2
+        res.bindings.find { it.resource == CPU }.value == 8.0
+        res.bindings.find { it.resource == MEM }.value == 16384.0
+        res.script.contains('--threads ${SEQERA_TASK_CPUS_0}')
+        res.script.contains('--memory ${SEQERA_TASK_MEM_0}')
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders two distinct memory references in one command'() {
+        given:
+        def reqMem = MemoryUnit.of('8 GB')
+        GString command = "tool --heap ${reqMem.toMega()} --buffer ${reqMem.toMega()}"
+        def source = '''"""tool --heap ${task.memory.toMega()} --buffer ${task.memory.toMega()}"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 4, reqMem)
+
+        then: 'each reference gets its own placeholder'
+        res.changed()
+        res.script == 'tool --heap ${SEQERA_TASK_MEM_0} --buffer ${SEQERA_TASK_MEM_1}'
+        res.bindings.size() == 2
+        res.bindings.every { it.resource == MEM && it.value == 8192.0 }
+        restore(res) == command.toString()
+    }
+
+    def 'placeholders a value inside double-quotes (which still expands in bash)'() {
+        given:
+        def reqMem = MemoryUnit.of('4 GB')
+        GString command = "sh -c \"java -Xmx${reqMem.toGiga()}g\" && echo done"
+        def source = '''"""sh -c "java -Xmx${task.memory.toGiga()}g" && echo done"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 2, reqMem)
+
+        then: 'inside double-quotes ${VAR} still expands, so the rewrite is applied'
+        res.changed()
+        res.script == 'sh -c "java -Xmx${SEQERA_TASK_MEM_0}g" && echo done'
+        restore(res) == command.toString()
+    }
+
+    // ---- indirection through local variables --------------------------------
+
+    def 'follows one level of local-variable indirection (skesa: ternary + nested GString)'() {
+        given:
+        def reqMem = MemoryUnit.of('200 MB')
+        def reqCpus = 8
+        def memory = reqMem ? "--memory ${reqMem.toMega()} MB" : ''
+        GString command = "skesa --cores ${reqCpus} ${memory}"
+        def source = '''\
+            def memory = task.memory ? "--memory ${task.memory.toMega()} MB" : ''
+            """skesa --cores ${task.cpus} ${memory}"""
+            '''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, reqCpus, reqMem)
+
+        then: 'both the direct cpus value and the indirected memory value are placeholdered'
+        res.changed()
+        res.script == 'skesa --cores ${SEQERA_TASK_CPUS_0} --memory ${SEQERA_TASK_MEM_0} MB'
+        res.bindings.find { it.resource == CPU }.value == 8.0
+        res.bindings.find { it.resource == MEM }.value == 200.0
+        restore(res) == command.toString()
+    }
+
+    def 'limitation: a scalar (non-GString) local derived from a resource is left unchanged (safe)'() {
+        given: 'def avail = task.memory.toMega() is a number, not a nested GString'
+        def reqMem = MemoryUnit.of('36864 MB')
+        def avail = (reqMem.toMega() * 0.9) as int
+        GString command = "bcftools sort --max-mem ${avail}M out.vcf"
+        def source = '''\
+            def avail = (task.memory.toMega() * 0.9) as int
+            """bcftools sort --max-mem ${avail}M out.vcf"""
+            '''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 6, reqMem)
+
+        then: 'not optimized, but never corrupted — identical to today'
+        !res.changed()
+        res.script == command.toString()
+    }
+
+    // ---- joint expressions & no-ops -----------------------------------------
+
+    def 'leaves a joint memory+cpus expression untouched, placeholders the pure cpus value'() {
+        given:
+        def reqMem = MemoryUnit.of('16 GB')
+        def reqCpus = 4
+        GString command = """\
+            samtools sort \\
+                -@ ${reqCpus} \\
+                -m ${(reqMem.toMega() / reqCpus) as int}M \\
+                -o out.bam in.bam
+            """
+        def source = '''\
+            """
+            samtools sort \\
+                -@ ${task.cpus} \\
+                -m ${(task.memory.toMega() / task.cpus) as int}M \\
+                -o out.bam in.bam
+            """
+            '''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, reqCpus, reqMem)
+
+        then: 'per-thread memory depends on both resources -> left literal; only -@ is placeholdered'
+        res.changed()
+        res.bindings.size() == 1
+        res.bindings[0].resource == CPU
+        res.script.contains('-@ ${SEQERA_TASK_CPUS_0}')
+        res.script.contains('-m 4096M')
+        restore(res) == command.toString()
+    }
+
+    def 'no-op when no command value derives from resources'() {
+        given:
+        GString command = "echo ${'hello'} attempt=${1}"
+        def source = '''"""echo ${greeting} attempt=${task.attempt}"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 4, MemoryUnit.of('4 GB'))
+
+        then:
+        !res.changed()
+        res.script == 'echo hello attempt=1'
+    }
+
+    def 'gate: skips when the script does not reference task'() {
+        given:
+        def reqMem = MemoryUnit.of('1 GB')
+        GString command = "do --mem ${reqMem.toMega()}"
+        def source = '''"""do --mem ${someVar}"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, ['someVar'] as Set, 1, reqMem)
+
+        then:
+        !res.changed()
+        res.script == command.toString()
+    }
+
+    def 'does not match longer property names like task.memoryUsage'() {
+        given:
+        GString command = "echo ${999}"
+        def source = '''"""echo ${task.memoryUsage}"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 2, MemoryUnit.of('1 GB'))
+
+        then:
+        !res.changed()
+        res.script == 'echo 999'
+    }
+
+    // ---- safety fallbacks ---------------------------------------------------
+
+    def 'falls back when the placeholder would land inside shell single-quotes (would not expand)'() {
+        given:
+        def reqMem = MemoryUnit.of('512 MB')
+        GString command = "tool --opt 'mem=${reqMem.toMega()}'"
+        def source = '''"""tool --opt 'mem=${task.memory.toMega()}'"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 2, reqMem)
+
+        then: 'a ${VAR} inside single-quotes is inert in bash -> leave unchanged'
+        !res.changed()
+        res.script == "tool --opt 'mem=512'"
+    }
+
+    def 'consistency guard: falls back when the source template does not match the command'() {
+        given: 'the source template parses to fewer interpolations than the command has'
+        def reqMem = MemoryUnit.of('1 GB')
+        GString command = "x ${reqMem.toMega()} y ${reqMem.toMega()}"
+        def source = '''"""x ${task.memory.toMega()} y"""'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 1, reqMem)
+
+        then:
+        !res.changed()
+        res.script == command.toString()
+    }
+
+    def 'falls back for unrecognized (single double-quoted) command forms'() {
+        given: 'lastStringLiteral only handles """ and $/.../$'
+        def reqMem = MemoryUnit.of('1 GB')
+        GString command = "do --mem ${reqMem.toMega()}"
+        def source = '''"do --mem ${task.memory.toMega()}"'''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 1, reqMem)
+
+        then:
+        !res.changed()
+    }
+
+    def 'no-op when there is no command GString'() {
+        expect:
+        !ResourceInterpolator.interpolate(null, 'whatever', TASK_REF, 4, MemoryUnit.of('4 GB')).changed()
+    }
+
+    // ---- alternate command forms --------------------------------------------
+
+    def 'supports dollar-slashy command templates'() {
+        given:
+        def reqMem = MemoryUnit.of('512 MB')
+        GString command = "tool --mem ${reqMem.toMega()}"
+        def source = '''\
+            def x = 1
+            $/tool --mem ${task.memory.toMega()}/$
+            '''
+
+        when:
+        def res = ResourceInterpolator.interpolate(command, source, TASK_REF, 2, reqMem)
+
+        then:
+        res.changed()
+        res.script == 'tool --mem ${SEQERA_TASK_MEM_0}'
+        restore(res) == command.toString()
+    }
+
+    // ---- low-level helpers --------------------------------------------------
+
+    def 'parses interpolation expressions in order'() {
+        expect:
+        ResourceInterpolator.parseInterpolations('a ${task.cpus} b $task.memory c') == ['task.cpus', 'task.memory']
+        ResourceInterpolator.parseInterpolations('--max-mem ${(task.memory.toMega()*0.9) as int}M') == ['(task.memory.toMega()*0.9) as int']
+        ResourceInterpolator.parseInterpolations('no interpolation here') == []
+    }
+
+    def 'placeholderInSingleQuotes detects only single-quoted placeholders'() {
+        expect:
+        // single-quoted Groovy literals keep ${...} verbatim (no GString interpolation)
+        ResourceInterpolator.placeholderInSingleQuotes('a \'${SEQERA_TASK_MEM_0}\' b')
+        !ResourceInterpolator.placeholderInSingleQuotes('a "X${SEQERA_TASK_MEM_0}" b')
+        !ResourceInterpolator.placeholderInSingleQuotes('a ${SEQERA_TASK_MEM_0} b')
+    }
+}

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -30,10 +30,13 @@ import io.seqera.sched.api.schema.v1a1.ResourceRequirement
 import io.seqera.sched.api.schema.v1a1.Task
 import io.seqera.sched.api.schema.v1a1.TaskAttempt
 import io.seqera.sched.api.schema.v1a1.TaskState as SchedTaskState
+import io.seqera.sched.api.schema.v1a1.ResourceBindingType
 import io.seqera.sched.api.schema.v1a1.TaskStatus as SchedTaskStatus
 import io.seqera.sched.client.SchedClient
 import nextflow.cloud.types.CloudMachineInfo
 import nextflow.cloud.types.PriceModel
+import nextflow.script.BodyDef
+import nextflow.script.TokenValRef
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
 import nextflow.exception.ProcessException
@@ -1045,5 +1048,61 @@ class SeqeraTaskHandlerTest extends Specification {
             containerMeta() >> null
         }
         return new SeqeraTaskHandler(taskRun, executor)
+    }
+
+    def 'interpolateResources rewrites the command and captures resource bindings'() {
+        given:
+        def reqMem = MemoryUnit.of('36864 MB')
+        GString command = "bcftools sort --max-mem ${(reqMem.toMega() * 0.9) as int}M out.vcf"
+        def source = '"""bcftools sort --max-mem ${(task.memory.toMega()*0.9) as int}M out.vcf"""'
+        def body = new BodyDef({ -> command }, source, 'script', [new TokenValRef('task', 1, 1)])
+        def taskConfig = Mock(TaskConfig) {
+            getCpus() >> 6
+            getMemory() >> reqMem
+        }
+        def taskRun = Mock(TaskRun) {
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getScriptGString() >> command
+            getBody() >> body
+            getConfig() >> taskConfig
+            lazyName() >> 'BCFTOOLS_SORT'
+        }
+        def executor = Mock(SeqeraExecutor) { getClient() >> Mock(SchedClient) }
+        def handler = new SeqeraTaskHandler(taskRun, executor)
+
+        when:
+        handler.interpolateResources()
+
+        then: 'the self-sizing value is replaced by a shell placeholder'
+        1 * taskRun.setScript('bcftools sort --max-mem ${SEQERA_TASK_MEM_0}M out.vcf')
+
+        and: 'the binding is captured for shipping to the scheduler'
+        def bindings = handler.@resourceBindings
+        bindings.size() == 1
+        bindings[0].getName() == 'SEQERA_TASK_MEM_0'
+        bindings[0].getResource() == ResourceBindingType.MEMORY
+        bindings[0].getValue() == 33177d
+    }
+
+    def 'interpolateResources is a no-op when the command has no resource-derived values'() {
+        given:
+        GString command = "echo ${'hello'}"
+        def body = new BodyDef({ -> command }, '"""echo ${greeting}"""', 'script', [new TokenValRef('greeting', 1, 1)])
+        def taskRun = Mock(TaskRun) {
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getScriptGString() >> command
+            getBody() >> body
+            getConfig() >> Mock(TaskConfig) { getCpus() >> 1; getMemory() >> MemoryUnit.of('1 GB') }
+            lazyName() >> 'FOO'
+        }
+        def executor = Mock(SeqeraExecutor) { getClient() >> Mock(SchedClient) }
+        def handler = new SeqeraTaskHandler(taskRun, executor)
+
+        when:
+        handler.interpolateResources()
+
+        then:
+        0 * taskRun.setScript(_)
+        handler.@resourceBindings == null
     }
 }


### PR DESCRIPTION
## What & why

**Companion client change to seqeralabs/sched#493** — together they fix the `qr/v2` request-vs-allocation OOM (seqeralabs/sched#492).

When the Seqera scheduler's optimizer reduces a task's **memory allocation** below its **request**, tools that self-size from the *requested* memory over-commit and get OOM-killed. The motivating case: nf-core `BCFTOOLS_SORT` renders `--max-mem 33177.6M` (= `task.memory × 0.90`) from a 36,864 MiB request, but the container cgroup enforced only 8,704 MiB — bcftools tried to reserve ~29.8 GB in ~8.5 GB and died with `exit 255`. Affects any self-sizing tool (`bcftools`/`samtools --max-mem`, JVM `-Xmx`, STAR `--limitBAMsortRAM`, `skesa --memory`, …).

The command is rendered **before** the scheduler decides the allocation, so it can't be patched afterward. This change captures the resource-derived command values and turns them into shell placeholders; the scheduler (sched#493) fills them with the **allocated** value at launch — keeping the memory cost savings while eliminating the OOM.

## How it works (Seqera executor only; no re-execution of the user script)

At task materialization:

1. **`TaskRun`** retains the live command `GString` (before it's flattened to a string), on the plain scriptlet path only — a minimal hook so the executor can inspect which command values were interpolated.
2. **`ResourceInterpolator`** (new) locates resource-derived values from three signals — the live command `GString` (exact positions, recursing into nested GStrings), the raw `body.source` (the interpolation *expressions*), and the AST `valRefs` (a `task`-referenced gate). A value is memory/cpus-derived when its expression references `task.memory`/`task.cpus` directly or through one level of local-variable indirection. Each such numeric value is replaced with `${SEQERA_TASK_MEM_n}` / `${SEQERA_TASK_CPUS_n}`.
3. **`SeqeraTaskHandler`** rewrites `task.script` before the launcher builds `.command.sh`, ships the bindings on the task, and seeds each placeholder with its **as-requested value** as an environment default.

The placeholder is a plain shell variable expanded by bash at runtime — `.command.sh` is never rewritten by the scheduler.

## Safety (never worse than today)

The parsed command template is validated against the live `GString` (literal text must match, ignoring whitespace/escaping) before any attribution, so a mis-identified template cannot produce wrong bindings. The original command is returned unchanged on: a placeholder that would land inside shell single-quotes (where it wouldn't expand), a joint `memory`+`cpus` expression, a non-numeric value, or any parse/validation failure. And because the client seeds the placeholders with the request value, backends that don't resolve bindings (or an older scheduler) still produce a valid command identical to today's behavior.

## Dependency / merge order

- `nf-seqera` is bumped to `io.seqera:sched-client:0.60.0-SNAPSHOT`, which provides the `ResourceBinding` API added in seqeralabs/sched#493. **This PR builds once that artifact is published**, so it depends on sched#493 landing first. Draft until then.

## Tests

- `ResourceInterpolatorTest` — 21 cases: direct self-sizing (bcftools, `-Xmx` giga, STAR bytes), cpus arithmetic, multi-line commands with continuations, two memory refs, double-quote expansion, local-variable indirection (skesa ternary), joint mem+cpus left untouched, and the safety fallbacks (single-quote, template mismatch, unrecognized form, anchored `task.memoryUsage`).
- `SeqeraTaskHandlerTest` — `prepareLauncher` rewrites `task.script` and captures bindings; no-op when nothing is resource-derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
