### PR TITLE
Improve Azure Batch VM image diagnostics and fix stale 24.04 docs

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -569,7 +569,7 @@ When Nextflow creates a pool of compute nodes, it selects:
 
 These settings determine the operating system, version, and available features for each compute node in your pool.
 
-By default, Nextflow creates pool nodes suitable for most bioinformatics workloads based on Ubuntu 22.04. You can customize the OS in your pool configuration to meet specific requirements.
+By default, Nextflow creates pool nodes suitable for most bioinformatics workloads based on Ubuntu 24.04. You can customize the OS in your pool configuration to meet specific requirements.
 
 Below are example configurations for common operating systems used in scientific computing:
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -696,7 +696,9 @@ class AzBatchService implements Closeable {
     protected BatchSupportedImage getImage(AzPoolOpts opts) {
         PagedIterable<BatchSupportedImage> images = apply(() -> client.listSupportedImages())
 
+        final available = new ArrayList<String>()
         for (BatchSupportedImage it : images) {
+            available.add("${it.imageReference.publisher}:${it.imageReference.offer}:${it.nodeAgentSkuId}:${it.osType}:${it.verificationType}".toString())
             if( !it.nodeAgentSkuId.equalsIgnoreCase(opts.sku) )
                 continue
             if( it.osType != opts.osType )
@@ -709,6 +711,7 @@ class AzBatchService implements Closeable {
                 return it
         }
 
+        log.debug "[AZURE BATCH] No VM image matching sku=$opts.sku; publisher=$opts.publisher; offer=$opts.offer; OS type=$opts.osType; verification type=$opts.verification - supported images: $available"
         throw new IllegalStateException("Cannot find a matching VM image with publisher=$opts.publisher; offer=$opts.offer; OS type=$opts.osType; verification type=$opts.verification")
     }
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -120,7 +120,7 @@ class AzPoolOpts implements CacheFunnel, ConfigScope {
 
     @ConfigOption
     @Description("""
-        The ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.centos 8`).
+        The ID of the Compute Node agent SKU which the pool identified with `<name>` supports (default: `batch.node.ubuntu 24.04`).
     """)
     final String sku
 


### PR DESCRIPTION
## Summary

Backport of diagnostic and documentation improvements from the STABLE-25.10.x branch (cherry-picked from `114d0e4c`), with the parts already present on master excluded.

- Log the list of supported Azure Batch VM images when no matching image is found, to aid troubleshooting pool-creation failures.
- Fix a stale "Ubuntu 22.04" reference in `docs/azure.md` that was missed when the default image was updated to Ubuntu 24.04 (#6844).
- Fix the stale `batch.node.centos 8` default shown in the `sku` config `@Description` (now `batch.node.ubuntu 24.04`).

Note: the `DEFAULT_SKU` constant and the pool-id test hash are already correct on master via #6844, so they are intentionally not part of this change.

## Test plan

- Existing `AzBatchServiceTest` continues to pass (pool-id hash unchanged on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)