### PR TITLE
Add module directive to lineage TaskRun record

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdLineageTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdLineageTest.groovy
@@ -197,7 +197,7 @@ class CmdLineageTest extends Specification {
                 'this is a script',
                 [new Parameter( "val", "sample_id","ggal_gut"),
                 new Parameter("path","reads",["lid://45678/output.txt"])],
-                null, null, null, null, [:],[], null)
+                null, null, null, null, null, [:],[], null)
         lidFile3.text = encoder.encode(entry)
         entry  = new FileOutput("path/to/file",new Checksum("45372qe","nextflow","standard"),
                 "lid://45678", "lid://45678", null, 1234, time, time, null)
@@ -205,7 +205,7 @@ class CmdLineageTest extends Specification {
         entry = new TaskRun("u345-2346-1stw2", "bar",
                 new Checksum("abfs2556","nextflow","standard"),
                 'this is a script',
-                null,null, null, null, null, [:],[], null)
+                null,null, null, null, null, null, [:],[], null)
         lidFile5.text = encoder.encode(entry)
         final network = """\
             flowchart TB

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -265,6 +265,7 @@ class LinObserver implements TraceObserverV2 {
             normalizer.normalizePath(task.getCondaEnv()),
             normalizer.normalizePath(task.getSpackEnv()),
             task.config?.getArchitecture()?.toString(),
+            task.config?.getModule() ?: null,
             getTaskGlobalVars(task),
             getTaskBinEntries(task).collect { Path p -> new DataPath(
                 normalizer.normalizePath(p.normalize()),

--- a/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/TaskRun.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/TaskRun.groovy
@@ -65,6 +65,10 @@ class TaskRun implements LinSerializable {
      */
     String architecture
     /**
+     * Environment modules used for the task run
+     */
+    List<String> module
+    /**
      * Global variables defined in the task run
      */
     Map globalVars

--- a/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/TaskRun.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/TaskRun.groovy
@@ -67,7 +67,7 @@ class TaskRun implements LinSerializable {
     /**
      * Environment modules used for the task run
      */
-    List<String> module
+    List<String> envModule
     /**
      * Global variables defined in the task run
      */

--- a/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/LinObserverTest.groovy
@@ -682,7 +682,7 @@ class LinObserverTest extends Specification {
                 new Parameter("path", "file1", ['lid://78567890/file1.txt']),
                 new Parameter("path", "file2", [[path: normalizer.normalizePath(file), checksum: [value:fileHash, algorithm: "nextflow", mode:  "standard"]]]),
                 new Parameter("val", "id", "value")
-            ], null, null, null, null, [:], [], "lid://hash")
+            ], null, null, null, null, null, [:], [], "lid://hash")
         def dataOutput1 = new FileOutput(outFile1.toString(), new Checksum(fileHash1, "nextflow", "standard"),
             "lid://1234567890", "lid://hash", "lid://1234567890", attrs1.size(), LinUtils.toDate(attrs1.creationTime()), LinUtils.toDate(attrs1.lastModifiedTime()) )
         def dataOutput2 = new FileOutput(outFile2.toString(), new Checksum(fileHash2, "nextflow", "standard"),

--- a/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/cli/LinCommandImplTest.groovy
@@ -225,7 +225,7 @@ class LinCommandImplTest extends Specification{
              new Parameter("path","reads", ["lid://45678/output.txt"] ),
              new Parameter("path","input", [new DataPath("path/to/file",new Checksum("45372qe","nextflow","standard"))])
             ],
-            null, null, null, null, [:],[])
+            null, null, null, null, null, [:],[])
         lidFile3.text = encoder.encode(entry)
         entry  = new FileOutput("path/to/file",new Checksum("45372qe","nextflow","standard"),
             "lid://45678", "lid://45678", null, 1234, time, time, null)
@@ -233,7 +233,7 @@ class LinCommandImplTest extends Specification{
         entry = new TaskRun("u345-2346-1stw2", "bar",
             new Checksum("abfs2556","nextflow","standard"),
             'this is a script',
-            null,null, null, null, null, [:],[])
+            null,null, null, null, null, null, [:],[])
         lidFile5.text = encoder.encode(entry)
         final network = """\
             flowchart TB

--- a/modules/nf-lineage/src/test/nextflow/lineage/serde/LinEncoderTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/serde/LinEncoderTest.groovy
@@ -204,7 +204,7 @@ class LinEncoderTest extends Specification{
         def taskRun = new TaskRun(
             uniqueId.toString(),"name", new Checksum("78910", "nextflow", "standard"), 'this is a script',
             [new Parameter("String", "param1", "value1")], "container:version", "conda", "spack", "amd64",
-            [a: "A", b: "B"], [new DataPath("path/to/file", new Checksum("78910", "nextflow", "standard"))]
+            ["samtools/1.9"], [a: "A", b: "B"], [new DataPath("path/to/file", new Checksum("78910", "nextflow", "standard"))]
         )
         when:
         def encoded = encoder.encode(taskRun)
@@ -222,6 +222,7 @@ class LinEncoderTest extends Specification{
         result.conda == "conda"
         result.spack == "spack"
         result.architecture == "amd64"
+        result.module == ["samtools/1.9"]
         result.globalVars == [a: "A", b: "B"]
         result.binEntries.size() == 1
         result.binEntries.get(0).path == "path/to/file"

--- a/modules/nf-lineage/src/test/nextflow/lineage/serde/LinEncoderTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/serde/LinEncoderTest.groovy
@@ -222,7 +222,7 @@ class LinEncoderTest extends Specification{
         result.conda == "conda"
         result.spack == "spack"
         result.architecture == "amd64"
-        result.module == ["samtools/1.9"]
+        result.envModule == ["samtools/1.9"]
         result.globalVars == [a: "A", b: "B"]
         result.binEntries.size() == 1
         result.binEntries.get(0).path == "path/to/file"


### PR DESCRIPTION
Closes part of #7202.

The task cache hash keys on environment `module` directives (`TaskHasher` adds `task.config.getModule()` to the hash), but the lineage `TaskRun` record had no field for them. As a result, comparing two task runs with `nextflow lineage diff` could not surface a `module` change that invalidated the cache, even though the record already captures the other environment inputs (`conda`, `spack`, `container`, `architecture`).

This adds a `module` field to the `TaskRun` v1beta1 model and populates it in `LinObserver`, alongside the existing environment fields.

### Example

```nextflow
process GREET {
    module 'samtools/1.9'
    input:  val name
    output: path 'out.txt'
    script: """ echo "Hello ${name}" > out.txt """
}
workflow { GREET(Channel.of('world')) }
```

Changing `samtools/1.9` to `samtools/1.17` and re-running with `-resume` correctly re-runs the task. Before this change, `lineage diff` of the two task runs showed only the parent run id changing; now it shows the `module` field changing.

### Scope

This covers the `module` directive only. The `eval` output commands and the stub-run flag (the other cache-hash inputs missing from the record, per #7202) are left out: representing `eval` commands needs a design decision, and the stub flag is partially covered already via `codeChecksum` switching to the stub source. Those remain tracked in #7202.

This makes the record consistent with that cache-hash input; it does not make `lineage diff` a full substitute for `-dump-hashes`, since the record stores resolved values rather than the ordered hash-key list and `DataPath` checksums always use the default hash mode.

### Tests

- `LinEncoderTest` now round-trips a populated `module` field.
- `LinObserverTest`, `LinCommandImplTest` updated for the new field.
- `LinTypeAdapterFactoryTest` confirms records without a `module` field still decode (backward compatible).
