### PR TITLE
Remove deprecated `echo` process directive

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -212,9 +212,7 @@ class TaskConfig extends LazyMap implements Cloneable {
     }
 
     boolean getDebug() {
-        // check both `debug` and `echo` for backward
-        // compatibility until `echo` is not removed
-        def value = get('debug') || get('echo')
+        def value = get('debug')
         return toBool(value)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
@@ -19,7 +19,6 @@ package nextflow.script.dsl
 import java.util.regex.Pattern
 
 import groovy.transform.TypeChecked
-import groovy.util.logging.Slf4j
 import nextflow.exception.IllegalConfigException
 import nextflow.exception.IllegalDirectiveException
 import nextflow.exception.ScriptRuntimeException
@@ -38,7 +37,6 @@ import nextflow.script.ProcessDef
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
-@Slf4j
 @TypeChecked
 class ProcessBuilder {
 
@@ -200,18 +198,6 @@ class ProcessBuilder {
             config.put('disk', value)
         else
             config.put('disk', [request: value])
-    }
-
-    /**
-     * Implements the {@code echo} directive for backwards compatibility.
-     *
-     * note: without this method definition {@link BaseScript#echo} will be invoked
-     *
-     * @param value
-     */
-    void echo( value ) {
-        log.warn1('The `echo` directive has been deprecated - use `debug` instead')
-        config.put('debug', value)
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -191,6 +191,24 @@ class TaskConfigTest extends Specification {
         config.getErrorStrategy() == ErrorStrategy.RETRY
     }
 
+    def 'should get debug flag' () {
+        expect:
+        new TaskConfig(opts).getDebug() == expected
+
+        where:
+        opts            | expected
+        [:]             | false
+        [debug: false]  | false
+        [debug: true]   | true
+    }
+
+    def 'should ignore the removed echo directive' () {
+        // the deprecated `echo` directive has been removed and no longer
+        // enables the debug output
+        expect:
+        new TaskConfig([echo: true]).getDebug() == false
+    }
+
     def testMaxErrors() {
         when:
         def config = new TaskConfig()


### PR DESCRIPTION
## Summary

Removes the long-deprecated `echo` process directive, which has been superseded by `debug`.

- Deletes `ProcessBuilder.echo()` (the alias that warned and forwarded to `debug`), along with the now-unused `@Slf4j` annotation/import.
- Drops the `echo` backward-compat fallback in `TaskConfig.getDebug()`.

## Behavior change

Using `echo` inside a process now resolves to `BaseScript.echo()`, which already throws a `DeprecationException` with a clear message directing users to `debug` — so users get an explicit error rather than a silent no-op.

A `process.echo = true` setting in `nextflow.config` is now ignored (previously it silently mapped to `debug`).

## Tests

- `TaskConfigTest`: added `getDebug` coverage and a regression test asserting `echo` no longer enables debug output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)