### PR TITLE
Remove support for `when:` section in typed processes

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -752,7 +752,7 @@ Input repeaters do not support tuples. Use the {ref}`operator-combine` operator 
 A process can declare multiple inputs, which allows it to accept inputs from multiple dataflow sources.
 
 :::{warning}
-Do not supply more than one channel when calling a process with multiple inputs. Invoking a process with multiple channels can lead to {ref}`non-deterministic behavior <cache-nondeterministic-inputs>`. All additional inputs should be dataflow values. 
+Do not supply more than one channel when calling a process with multiple inputs. Invoking a process with multiple channels can lead to {ref}`non-deterministic behavior <cache-nondeterministic-inputs>`. All additional inputs should be dataflow values.
 :::
 
 When a process is defined with multiple inputs, it waits for a value from each input and launches a new task with the combined values. When one of the inputs is a channel, the process repeats until all values in the channel are consumed. If the channel is empty, the process will not launch any tasks.
@@ -1155,7 +1155,7 @@ See also: {ref}`process-multiple-inputs`.
 ## When
 
 :::{note}
-As a best practice, conditional logic should be implemented in the calling workflow (e.g. using an `if` statement or {ref}`operator-filter` operator) instead of the process definition.
+The `when:` section is not supported with {ref}`typed processes <process-typed-page>`. As a best practice, conditional logic should be implemented in the calling workflow (e.g. using an `if` statement or {ref}`operator-filter` operator) instead of the process definition.
 :::
 
 The `when` section allows you to define a condition that must be satisfied in order to execute the process. The condition can be any expression that returns a boolean value.
@@ -1345,7 +1345,7 @@ process hello {
 }
 ```
 
-In the above example, the {ref}`process-memory` is set according to previous trace record metrics. In the first attempt, when no trace metrics are available, it is set to 1 GB. In each subsequent attempt, the requested memory is doubled. 
+In the above example, the {ref}`process-memory` is set according to previous trace record metrics. In the first attempt, when no trace metrics are available, it is set to 1 GB. In each subsequent attempt, the requested memory is doubled.
 
 :::{note}
 Many fields from the previous task attempts are accessible. See {ref}`trace-report` for a list of available fields.

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ProcessNodeV2.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ProcessNodeV2.java
@@ -18,7 +18,6 @@ package nextflow.script.ast;
 import java.lang.reflect.Modifier;
 
 import nextflow.script.types.Record;
-import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.Parameter;
@@ -40,19 +39,17 @@ public class ProcessNodeV2 extends ProcessNode {
     public final Statement stagers;
     public final Statement outputs;
     public final Statement topics;
-    public final Expression when;
     public final String type;
     public final Statement exec;
     public final Statement stub;
 
-    public ProcessNodeV2(String name, Statement directives, Parameter[] inputs, Statement stagers, Statement outputs, Statement topics, Expression when, String type, Statement exec, Statement stub) {
+    public ProcessNodeV2(String name, Statement directives, Parameter[] inputs, Statement stagers, Statement outputs, Statement topics, String type, Statement exec, Statement stub) {
         super(name, inputs, dummyReturnType(outputs));
         this.directives = directives;
         this.inputs = inputs;
         this.stagers = stagers;
         this.outputs = outputs;
         this.topics = topics;
-        this.when = when;
         this.type = type;
         this.exec = exec;
         this.stub = stub;

--- a/modules/nf-lang/src/main/java/nextflow/script/ast/ScriptVisitorSupport.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/ast/ScriptVisitorSupport.java
@@ -99,7 +99,6 @@ public abstract class ScriptVisitorSupport extends ClassCodeVisitorSupport imple
         visit(node.stagers);
         visit(node.outputs);
         visit(node.topics);
-        visit(node.when);
         visit(node.exec);
         visit(node.stub);
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ProcessToGroovyVisitorV2.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ProcessToGroovyVisitorV2.java
@@ -57,13 +57,10 @@ public class ProcessToGroovyVisitorV2 {
 
     private SourceUnit sourceUnit;
 
-    private ScriptNode moduleNode;
-
     private ScriptToGroovyHelper sgh;
 
     public ProcessToGroovyVisitorV2(SourceUnit sourceUnit) {
         this.sourceUnit = sourceUnit;
-        this.moduleNode = (ScriptNode) sourceUnit.getAST();
         this.sgh = new ScriptToGroovyHelper(sourceUnit);
     }
 
@@ -90,7 +87,6 @@ public class ProcessToGroovyVisitorV2 {
             processInputs(node.inputs),
             processOutputs(node.outputs),
             processTopics(node.topics),
-            processWhen(node.when),
             processStub(node.stub),
             stmt(createX(
                 "nextflow.script.BodyDef",
@@ -316,18 +312,6 @@ public class ProcessToGroovyVisitorV2 {
             })
             .toList();
         return block(null, statements);
-    }
-
-    private Statement processWhen(Expression when) {
-        if( when instanceof EmptyExpression )
-            return EmptyStatement.INSTANCE;
-        return stmt(callThisX("when", createX(
-            "nextflow.script.TaskClosure",
-            args(
-                closureX(null, block(stmt(when))),
-                constX(sgh.getSourceText(when))
-            )
-        )));
     }
 
     private Statement processStub(Statement stub) {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptResolveVisitor.java
@@ -172,7 +172,6 @@ public class ScriptResolveVisitor extends ScriptVisitorSupport {
         resolveTypedOutputs(node.outputs);
         resolver.visit(node.outputs);
         resolver.visit(node.topics);
-        resolver.visit(node.when);
         resolver.visit(node.exec);
         resolver.visit(node.stub);
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -342,17 +342,13 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         for( var input : asFlatParams(node.inputs) ) {
             vsc.declare(input, input);
 
-            // suppress "unused variable" warnings since Path inputs are implicity staged
+            // suppress "unused variable" warnings since Path inputs are implicitly staged
             vsc.findVariableDeclaration(input.getName(), input);
         }
 
         vsc.pushScope(ProcessDsl.StageDsl.class);
         visitDirectives(node.stagers, "stage directive", false);
         vsc.popScope();
-
-        if( !(node.when instanceof EmptyExpression) )
-            vsc.addWarning("Process `when` section will not be supported in a future version", "", node.when);
-        visit(node.when);
 
         visit(node.exec);
         visit(node.stub);

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -465,13 +465,6 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 fmt.appendNewLine();
             }
         }
-        if( !(node.when instanceof EmptyExpression) ) {
-            fmt.appendIndent();
-            fmt.append("when:\n");
-            fmt.appendIndent();
-            fmt.visit(node.when);
-            fmt.append("\n\n");
-        }
         fmt.appendIndent();
         fmt.append(node.type);
         fmt.append(":\n");

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -492,13 +492,16 @@ public class ScriptAstBuilder {
         if( !typingEnabled && !topics.isEmpty() )
             collectSyntaxError(new SyntaxException("The `topic:` section is not supported in a legacy process", topics));
 
+        if( typingEnabled && !(when instanceof EmptyExpression) )
+            collectSyntaxError(new SyntaxException("The `when:` section is not supported in a typed process", when));
+
         if( ctx.body.blockStatements() != null ) {
             if( !directives.isEmpty() || ctx.body.processInputs() != null || !outputs.isEmpty() || !topics.isEmpty() )
                 collectSyntaxError(new SyntaxException("The `script:` or `exec:` label is required when other sections are present", exec));
         }
 
         var result = typingEnabled
-            ? new ProcessNodeV2(name, directives, inputsV2, stagers, outputs, topics, when, type, exec, stub)
+            ? new ProcessNodeV2(name, directives, inputsV2, stagers, outputs, topics, type, exec, stub)
             : new ProcessNodeV1(name, directives, inputsV1, outputs, when, type, exec, stub);
         ast(result, ctx);
         groovydocManager.handle(result, ctx);

--- a/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
@@ -395,6 +395,28 @@ class ScriptAstBuilderTest extends Specification {
         errors.size() == 0
     }
 
+    def 'should report error for invalid when section' () {
+        when:
+        def errors = check(
+            '''\
+            nextflow.enable.types = true
+
+            process hello {
+                when:
+                task.ext.when
+
+                exec:
+                println 'hello!'
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 4
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == "The `when:` section is not supported in a typed process"
+    }
+
     def 'should report an error for invalid process tuple input' () {
         when:
         def errors = check(


### PR DESCRIPTION
This PR removes support for `when:` in typed processes.

While it was preserved during the preview period to ease migration, the stable version of typed processes should not support it

Aside from being an anti-pattern, `when:` can actually break semantic guarantees of dataflow logic. If a process is called with a dataflow value and returns a dataflow value, and I use `when:` to disable that process via config, it will return an "empty" dataflow value which is invalid

Rather than deprecating it across the board, it will remain allowed in legacy processes and removed in typed processes. Migrating to static typing is the best point at which to also migrate away from `when:` because records and type checking makes it easier to do
