### PR TITLE
Preserve order of plugin declarations in config

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -327,7 +327,7 @@ class ConfigDsl extends Script {
 
         void id(String value) {
             final target = dsl.getTarget()
-            final plugins = (Set) target.computeIfAbsent('plugins', (k) -> new HashSet<>())
+            final plugins = (Set) target.computeIfAbsent('plugins', (k) -> new LinkedHashSet<>())
             plugins.add(value)
         }
     }


### PR DESCRIPTION
In nf-nomad team we are using 2 plugins, nf-nomad and nf-s5cmd.

nf-s5cmd declares a dependency against nf-nomad and in previous version of nextflow all works fine and plugins are resolved, doesnt matter the order you declare the plugins in the nextflow.config 

With last version of pf4j (from 3.12 to 3.14.1) it seems pf4j requires base plugin (nf-nomad) be loaded first 

If we specify the plugins via command line ( i.e. `-plugins nf-nomad@0.5.0-edge1,nf-nomad-s5cmd@99.99.99`) they are loaded in the right order ( as CmdRun parses this as `config.plugins = cmdRun.plugins.tokenize(',')` ) and pf4j works fine 

but if we use the `plugin` DSL in, `nextflow.config`  nextflow are using a `Hashset` and it can't guarantee the order so pipelines fail randomly

This PR uses `LinkedHashSet` to guarantee the order as declared in the closure