### PR TITLE
Add GPU metrics to workflow-level execution summary

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportSummary.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportSummary.groovy
@@ -63,8 +63,6 @@ class ReportSummary {
             return realtime / request * 100 as Double
         }
 
-        // GPU series read the Fusion trace `gpu` block carried as a transient
-        // field on TraceRecord (snake_case keys as emitted by Fusion trace.json)
         mappers.gpuUsage = { TraceRecord record -> record.getGpuMetrics()?.get('pct') as Double }
         mappers.gpuMemPeak = { TraceRecord record -> record.getGpuMetrics()?.get('peak_mem_used') as Double }
         mappers.gpuMemAvg = { TraceRecord record -> record.getGpuMetrics()?.get('avg_mem') as Double }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportSummary.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportSummary.groovy
@@ -62,6 +62,12 @@ class ReportSummary {
             if( !request ) return null
             return realtime / request * 100 as Double
         }
+
+        // GPU series read the Fusion trace `gpu` block carried as a transient
+        // field on TraceRecord (snake_case keys as emitted by Fusion trace.json)
+        mappers.gpuUsage = { TraceRecord record -> record.getGpuMetrics()?.get('pct') as Double }
+        mappers.gpuMemPeak = { TraceRecord record -> record.getGpuMetrics()?.get('peak_mem_used') as Double }
+        mappers.gpuMemAvg = { TraceRecord record -> record.getGpuMetrics()?.get('avg_mem') as Double }
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ReportSummaryTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ReportSummaryTest.groovy
@@ -173,6 +173,64 @@ class ReportSummaryTest extends Specification {
 
     }
 
+    def 'should get gpu summary stats' () {
+        given:
+        def GPU_PCT = [75, 90, 60, 85]
+        def GPU_MEM_PEAK = [11388, 12000, 9000, 11500]
+        def GPU_MEM_AVG = [6161, 7000, 5000, 6500]
+
+        def report = new ReportSummary()
+
+        4.times { int index ->
+            def t = new TraceRecord([process: 'gpu_proc', name: "gpu_proc-$index"])
+            t.gpuMetrics = [
+                name: 'Tesla T4',
+                pct: GPU_PCT[index],
+                peak_mem_used: GPU_MEM_PEAK[index],
+                avg_mem: GPU_MEM_AVG[index] ]
+            report.add(t)
+        }
+        // a cpu-only task contributes nothing to the gpu series
+        report.add(new TraceRecord([process: 'gpu_proc', name: 'cpu-only', '%cpu': 50]))
+
+        when:
+        def gpuUsage = report.compute('gpuUsage')
+        def gpuMemPeak = report.compute('gpuMemPeak')
+        def gpuMemAvg = report.compute('gpuMemAvg')
+        then:
+        gpuUsage.min == quantile(GPU_PCT, 0)
+        gpuUsage.q1 == quantile(GPU_PCT, 25)
+        gpuUsage.q2 == quantile(GPU_PCT, 50)
+        gpuUsage.q3 == quantile(GPU_PCT, 75)
+        gpuUsage.max == quantile(GPU_PCT, 100)
+        gpuUsage.mean == mean(GPU_PCT)
+        gpuUsage.minLabel == 'gpu_proc-2'
+        gpuUsage.maxLabel == 'gpu_proc-1'
+
+        gpuMemPeak.min == quantile(GPU_MEM_PEAK, 0)
+        gpuMemPeak.max == quantile(GPU_MEM_PEAK, 100)
+        gpuMemPeak.mean == mean(GPU_MEM_PEAK)
+
+        gpuMemAvg.min == quantile(GPU_MEM_AVG, 0)
+        gpuMemAvg.max == quantile(GPU_MEM_AVG, 100)
+        gpuMemAvg.mean == mean(GPU_MEM_AVG)
+    }
+
+    def 'should return null gpu summary when no task reports gpu metrics' () {
+        given:
+        def report = new ReportSummary()
+        10.times { int index ->
+            def t = new TraceRecord([process: 'foo', name: "foo-$index", '%cpu': 10 + index])
+            report.add(t)
+        }
+
+        expect:
+        report.compute('cpu') != null
+        report.compute('gpuUsage') == null
+        report.compute('gpuMemPeak') == null
+        report.compute('gpuMemAvg') == null
+    }
+
     def 'should set q1,q2,q3 labels' () {
         given:
         def records = []

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ReportSummaryTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ReportSummaryTest.groovy
@@ -208,10 +208,16 @@ class ReportSummaryTest extends Specification {
         gpuUsage.maxLabel == 'gpu_proc-1'
 
         gpuMemPeak.min == quantile(GPU_MEM_PEAK, 0)
+        gpuMemPeak.q1 == quantile(GPU_MEM_PEAK, 25)
+        gpuMemPeak.q2 == quantile(GPU_MEM_PEAK, 50)
+        gpuMemPeak.q3 == quantile(GPU_MEM_PEAK, 75)
         gpuMemPeak.max == quantile(GPU_MEM_PEAK, 100)
         gpuMemPeak.mean == mean(GPU_MEM_PEAK)
 
         gpuMemAvg.min == quantile(GPU_MEM_AVG, 0)
+        gpuMemAvg.q1 == quantile(GPU_MEM_AVG, 25)
+        gpuMemAvg.q2 == quantile(GPU_MEM_AVG, 50)
+        gpuMemAvg.q3 == quantile(GPU_MEM_AVG, 75)
         gpuMemAvg.max == quantile(GPU_MEM_AVG, 100)
         gpuMemAvg.mean == mean(GPU_MEM_AVG)
     }


### PR DESCRIPTION
## Problem

#7022 added Fusion GPU metrics collection: the `gpu` block from `.fusion/trace.json` is parsed on task completion, carried as a transient `gpuMetrics` field on `TraceRecord`, and included in the per-task payload sent to Seqera Platform. This works — per-task GPU metrics show correctly in the task details view.

However, the **workflow-level** metrics summary never includes GPU data. The per-process box-and-whisker stats sent at workflow completion are computed by `ResourcesAggregator` → `ReportSummary`, whose mapper table contains only nine series (`cpu`, `mem`, `vmem`, `time`, `reads`, `writes`, `cpuUsage`, `memUsage`, `timeUsage`). GPU was never added there.

The visible effect in Seqera Platform: a GPU run shows GPU metrics in *Task details → Metrics*, but the run-level *Metrics* tab shows only CPU/memory plots. The platform already has the schema, API, and frontend charts for the workflow-level GPU series (`gpuUsage`, `gpuMemPeak`, `gpuMemAvg`) — the data just never arrives.

## Change

Add three GPU series mappers to `ReportSummary`, reading the transient `gpuMetrics` map attached by #7022 (snake_case keys as emitted by Fusion):

| Series | Fusion trace key | Semantics |
|---|---|---|
| `gpuUsage` | `pct` | GPU compute utilisation (%) |
| `gpuMemPeak` | `peak_mem_used` | peak GPU memory used (MiB) |
| `gpuMemAvg` | `avg_mem` | average GPU memory used (MiB) |

The series names match the fields expected by Seqera Platform's `WorkflowMetrics` model, so no platform change is required — the new series flow automatically through `ResourcesAggregator.computeSummaryList()` into the workflow completion request.

## Behaviour notes

- Tasks without GPU data return `null` from the mappers and are skipped, same as the existing `memUsage`/`timeUsage` series when requests are missing.
- Runs with no GPU tasks produce no GPU series at all (`Summary.compute()` returns `null` on empty series), so existing behaviour is unchanged for non-GPU workloads.
- The HTML execution report is unaffected: `ReportTemplate.js` reads specific named keys from the summary JSON and ignores unknown ones.

## Tests

- `should get gpu summary stats` — quartiles/mean/labels computed across GPU tasks, with a CPU-only task correctly excluded from the GPU series.
- `should return null gpu summary when no task reports gpu metrics` — no GPU series for non-GPU runs.

Verified locally: `ReportSummaryTest`, `ResourcesAggregatorTest`, `ReportObserverTest`, and nf-tower `TowerObserverTest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)