### PR TITLE
Fix orphaned Tower heartbeat sender when abort races onFlowBegin

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerObserver.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerObserver.groovy
@@ -87,7 +87,29 @@ class TowerObserver implements TraceObserverV2 {
 
     private LinkedBlockingQueue<ProcessEvent> events = new LinkedBlockingQueue()
 
-    private Thread sender
+    private volatile Thread sender
+
+    /**
+     * Guards the start/stop lifecycle of the {@link #sender} thread. {@code onFlowBegin}
+     * (main thread) and {@code onFlowComplete} (invoked by {@code Session.abort()} from the
+     * signal handler or a task-monitor thread) must not race on {@link #sender}, otherwise
+     * a sender started after completion is never told to stop and heartbeats forever.
+     */
+    private final Object senderLock = new Object()
+
+    /**
+     * Set once the flow has completed/aborted. Prevents {@code onFlowBegin} from starting a
+     * sender thread when completion has already been processed (see workflow 3fCcx5lf7bgOtp).
+     */
+    private boolean terminated
+
+    /**
+     * Set when {@code onFlowBegin} has been invoked. Gates the completion trace: a workflow
+     * that failed before {@code onFlowBegin} must not send {@code /complete} (Platform returns
+     * 403, see #6816), whereas one that began - even if the sender thread was never started
+     * because completion raced begin - should still be closed with a {@code /complete}.
+     */
+    private volatile boolean beginInvoked
 
     private Duration requestInterval = REQUEST_INTERVAL
 
@@ -239,11 +261,18 @@ class TowerObserver implements TraceObserverV2 {
     @Override
     void onFlowBegin() {
         // configure error retry
-
+        this.beginInvoked = true
         final payload = client.traceBegin(makeBeginReq(session), workspaceId, workflowId)
         this.watchUrl ?= payload.watchUrl
         session.workflowMetadata.platform.workflowUrl ?= watchUrl
-        this.sender = Threads.start('Tower-thread', this.&sendTasks0)
+        synchronized (senderLock) {
+            // if the flow already completed/aborted while the begin request was in-flight,
+            // do not start the sender: it would never receive the `completed` event and
+            // would keep sending heartbeats forever (see workflow 3fCcx5lf7bgOtp)
+            if( terminated )
+                return
+            this.sender = Threads.start('Tower-thread', this.&sendTasks0)
+        }
         final msg = "Monitor the execution with Seqera Platform using this URL: ${watchUrl}"
         log.info(LoggerHelper.STICKY, msg)
     }
@@ -255,17 +284,23 @@ class TowerObserver implements TraceObserverV2 {
     void onFlowComplete() {
         // publish runtime reports
         reports.publishRuntimeReports()
-        // submit the completion record
-        if( sender ) {
-            events << new ProcessEvent(completed: true)
-            // wait the submission of pending events
-            sender.join()
+        // mark the flow as terminated and queue the stop event: a concurrent onFlowBegin
+        // either observes `terminated` and skips starting the thread, or has already
+        // started it and gets stopped here via the `completed` event
+        synchronized (senderLock) {
+            terminated = true
+            if( sender )
+                events << new ProcessEvent(completed: true)
         }
+        // wait the submission of pending events (outside the lock - join() blocks)
+        sender?.join()
         // wait and flush reports content
         reports.flowComplete()
         // notify the workflow completion
-        // note: only send complete if onFlowBegin was invoked (sender is set there)
-        if( workflowId && sender ) {
+        // note: send complete only if onFlowBegin was invoked - sending it for a workflow
+        // that never began yields a 403 from Platform (see #6816). It is NOT gated on the
+        // sender thread, so a completion that raced begin still closes the run.
+        if( workflowId && beginInvoked ) {
             client.traceComplete(makeCompleteReq(session), workspaceId, workflowId)
         }
     }

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerObserverTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerObserverTest.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Files
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneId
+import java.util.concurrent.atomic.AtomicInteger
 
 import nextflow.Session
 import nextflow.SysEnv
@@ -34,8 +35,10 @@ import nextflow.script.WorkflowMetadata
 import nextflow.trace.TraceRecord
 import nextflow.trace.WorkflowStats
 import nextflow.trace.WorkflowStatsObserver
+import nextflow.util.Duration
 import nextflow.util.ProcessHelper
 import spock.lang.Specification
+import spock.lang.Timeout
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -414,6 +417,29 @@ class TowerObserverTest extends Specification {
         0 * towerClient.traceComplete(_, _, _)
     }
 
+    def 'should send complete request when onFlowBegin was invoked even if the sender raced and was not started' () {
+        given:
+        def session = Mock(Session)
+        def towerClient = Mock(TowerClient)
+        def observer = Spy(new TowerObserver(session, towerClient, null, [:]))
+        def reports = Mock(TowerReports)
+        observer.@reports = reports
+        observer.@workflowId = 'xyz-123'
+        // begin was invoked (so the run is "running" on Platform) but the sender thread
+        // was never started because completion raced onFlowBegin
+        observer.@beginInvoked = true
+        observer.@sender = null
+        observer.makeCompleteReq(_) >> [:]
+
+        when:
+        observer.onFlowComplete()
+
+        then:
+        1 * reports.publishRuntimeReports()
+        1 * reports.flowComplete()
+        1 * towerClient.traceComplete(_, _, _)
+    }
+
     def 'should apply platform metadata from trace create response'() {
         given:
         def metadata = new WorkflowMetadata()
@@ -587,5 +613,46 @@ class TowerObserverTest extends Specification {
         thrown(AbortRunException)
     }
 
+    @Timeout(15)
+    def 'onFlowComplete before onFlowBegin must not leave an orphaned heartbeat sender'() {
+        given: 'onFlowComplete is driven by abort() from a different thread than onFlowBegin'
+        def session = Mock(Session)
+        def meta = Mock(WorkflowMetadata)
+        def platform = Mock(PlatformMetadata)
+        session.getWorkflowMetadata() >> meta
+        meta.getPlatform() >> platform
+
+        def heartbeats = new AtomicInteger()
+        def client = Mock(TowerClient)
+        client.traceBegin(_, _, _) >> [watchUrl: 'http://localhost/watch/1']
+        client.traceHeartbeat(_, _, _) >> { heartbeats.incrementAndGet() }
+
+        def observer = Spy(new TowerObserver(session, client, null, [:]))
+        observer.@reports = Mock(TowerReports)
+        observer.@workflowId = 'wf-123'
+        // short intervals so an orphan sender would heartbeat quickly
+        observer.setAliveInterval(Duration.of('50ms'))
+        observer.setRequestInterval(Duration.of('50ms'))
+        observer.makeBeginReq(_) >> [:]
+        observer.makeHeartbeatReq() >> [:]
+
+        when: 'an abort drives onFlowComplete BEFORE onFlowBegin started the sender ...'
+        observer.onFlowComplete()
+        and: '... and onFlowBegin runs afterwards (its traceBegin had been in-flight)'
+        observer.onFlowBegin()
+        and: 'a would-be orphan is given time to heartbeat'
+        sleep 300
+
+        then: 'no orphaned Tower-thread is started, so no heartbeat is ever sent'
+        observer.@sender == null
+        heartbeats.get() == 0
+
+        cleanup: 'stop the thread if the code orphaned one, so the JVM can exit'
+        final t = observer.@sender
+        if( t ) {
+            observer.@events << new TowerObserver.ProcessEvent(completed: true)
+            t.join(3000)
+        }
+    }
 
 }


### PR DESCRIPTION
## Problem

A Nextflow run can keep sending `trace/<id>/heartbeat` to Seqera Platform **indefinitely** after the run is already terminal — the heartbeats are rejected ("Unexpected execution status") but never stop. Observed for workflow `3fCcx5lf7bgOtp` on 25.10.3.

### Root cause

`onFlowBegin()` starts the telemetry `Tower-thread` and `onFlowComplete()` stops it (by queueing a `completed` event and `join()`-ing). But `onFlowComplete()` can be invoked by `Session.abort()` from a **different thread** (the signal handler, or a task-monitor via `fault()→abort()`) while `onFlowBegin()` is still running on the main thread. The start and stop race on the non-`volatile` `sender` field, and the start/stop/complete decisions were guarded by **inconsistent conditions**:

- if `onFlowComplete()` observes `sender == null` (begin not finished), it skips the stop logic;
- `onFlowBegin()` then starts the sender afterwards → an **orphaned thread** that never receives `completed` and heartbeats forever.

The Platform-side log for the affected run shows the tell-tale order: `begin` → `complete` → `progress` (rejected) → `heartbeat` every 60s thereafter.

## Fix

- Coordinate the sender lifecycle with a `senderLock` + a `terminated` flag: `onFlowBegin()` does not start the thread once completion has been processed, and `onFlowComplete()` reliably stops a thread that was already started. The orphan cannot occur in any interleaving. `sender` is now `volatile`; `join()` stays outside the lock.
- Gate the `/complete` trace on a new `beginInvoked` flag instead of on `sender`. A completion that raced begin still **closes the run** on Platform, while preserving #6816 (no `/complete` when `onFlowBegin` was never invoked — Platform returns 403).

## Tests

`TowerObserverTest`:
- new regression: `onFlowComplete` before `onFlowBegin` must not leave an orphaned heartbeat sender (fails on `master` without the fix);
- new: `/complete` **is** sent when begin was invoked even if the sender raced and was not started;
- existing #6816 test (`should not send complete request when onFlowBegin was not invoked`) still green.

Full `nf-tower` module suite: **407 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)