### PR TITLE
Bump default plugin create template to v0.4.0

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdPlugin.groovy
@@ -49,7 +49,7 @@ class CmdPlugin extends CmdBase implements UsageAware {
     List<String> args
 
     @Parameter(names = ['-template'], description = 'Plugin template version to use', hidden = true)
-    String templateVersion = 'v0.3.0'
+    String templateVersion = 'v0.4.0'
 
     /**
      * Print the command usage help

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdPluginCreateTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdPluginCreateTest.groovy
@@ -63,7 +63,7 @@ class CmdPluginCreateTest extends Specification {
         Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("'foo.plugin.HelloWorldExtension'")
         Path.of(folder.resolve('hello/build.gradle').toUri()).text.contains("'foo.plugin.HelloWorldFactory'")
         and:
-        Path.of(folder.resolve('hello/README.md').toUri()).text.contains("# hello-world-plugin plugin")
+        Path.of(folder.resolve('hello/README.md').toUri()).text.contains("# hello-world-plugin")
         Path.of(folder.resolve('hello/README.md').toUri()).text.contains("nextflow run hello -plugins hello-world-plugin@0.1.0")
         cleanup:
         folder?.deleteDir()


### PR DESCRIPTION
## Summary

Bumps the default `nextflow plugin create` template version from `v0.3.0` to `v0.4.0`.

The [`nf-plugin-template@v0.4.0`](https://github.com/nextflow-io/nf-plugin-template/releases/tag/v0.4.0) release:
- targets **Nextflow 25.10.0** (`nextflowVersion`)
- uses **nextflow-plugin-gradle 1.0.0-beta.15**
- ships a `README.md` restructured for the Nextflow Plugin Registry (required sections: **Summary / Get Started / Examples / License**, plus a removable *Plugin development* section)

## Changes

- `CmdPlugin.groovy` — default `templateVersion` `v0.3.0` → `v0.4.0`
- `CmdPluginCreateTest.groovy` — README-title assertion relaxed (`# hello-world-plugin plugin` → `# hello-world-plugin`) to match the new template title; the `nextflow run … -plugins …@0.1.0` assertion is unchanged

## Test

`CmdPluginCreateTest` clones the live template tag at runtime; it passes against `v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)