### PR TITLE
Add -help as alias for -h in top-level CLI options

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CliOptions.groovy
@@ -72,7 +72,7 @@ class CliOptions {
     /**
      * Print out the 'help' and exit
      */
-    @Parameter(names = ['-h'], description = 'Print this help', help = true)
+    @Parameter(names = ['-h','-help'], description = 'Print this help', help = true)
     boolean help
 
     @Parameter(names = ['-q','-quiet'], description = 'Do not print information messages' )


### PR DESCRIPTION
## Summary

Adds `-help` as an alias for `-h` in the top-level CLI options, so `nextflow -help` works just like `nextflow -h` and `nextflow help`.

Previously the top-level launcher (`CliOptions`) only accepted `-h`, while per-command options (`CmdBase`) already accepted both `-h` and `-help`. This brings the top-level options in line, so `-h` and `-help` are now accepted consistently across the launcher, every command, and their sub-commands.

## Changes

- `CliOptions.groovy`: `@Parameter(names = ['-h','-help'], ...)` for the `help` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)