### PR TITLE
Claude Code hooks (1/4): EditorConfig formatting

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,35 @@
+# Claude Code Hooks for Nextflow Development
+
+This directory contains [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks)
+configured to improve the Nextflow development experience. Each hook is a small,
+self-contained Bash script under `hooks/`, wired up in `settings.json`.
+
+Hooks are added incrementally — one per pull request — so each can be reviewed and
+understood on its own. This file documents the hooks that are currently wired up.
+
+## Requirements
+
+- [`jq`](https://jqlang.github.io/jq/) — hooks parse the Claude Code JSON payload with it.
+  If `jq` is not on `PATH`, the hooks no-op silently.
+
+## Hooks
+
+### 1. EditorConfig enforcement (PostToolUse, async)
+- **Script**: `hooks/format-editorconfig.sh`
+- **Trigger**: after every `Edit`/`Write`/`MultiEdit` on a source file
+  (`.groovy`, `.java`, `.gradle`, `.md`, `.txt`, `.yml`, `.yaml`, `.json`)
+- **Action**: applies `.editorconfig` rules with `eclint fix`
+- **Dependencies**: `eclint` (optional — install with `npm install -g eclint`; the hook
+  skips silently if it is not present)
+- **`async: true`**: runs in the background so formatting never blocks the conversation
+
+## Enabling / disabling
+
+Hooks are configured in `.claude/settings.json`. Disable one by removing its entry;
+adjust timeouts there as needed.
+
+## Troubleshooting
+
+1. Ensure scripts are executable: `chmod +x .claude/hooks/*.sh`
+2. Verify `jq` is installed
+3. Inspect hook execution with `claude --debug` or the transcript (Ctrl-R)

--- a/.claude/hooks/format-editorconfig.sh
+++ b/.claude/hooks/format-editorconfig.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# EditorConfig enforcement hook for Nextflow development.
+#
+# After an Edit/Write/MultiEdit, apply the project .editorconfig rules to the
+# edited source file with `eclint fix`. Non-blocking: warns on failure, never
+# stops Claude. Skips silently if eclint is not installed.
+#
+# Reads the Claude Code hook payload as JSON on stdin (requires `jq`).
+
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+tool_name=$(jq -r '.tool_name // ""' <<<"$input")
+file_path=$(jq -r '.tool_input.file_path // ""' <<<"$input")
+
+case "$tool_name" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+[[ -n "$file_path" && -f "$file_path" ]] || exit 0
+
+# Skip dot-directories (.git, .gradle, ...) and build outputs.
+case "$file_path" in
+  */build/*|*/.*/*) exit 0 ;;
+esac
+
+# Only format known source extensions.
+case "$file_path" in
+  *.groovy|*.java|*.gradle|*.md|*.txt|*.yml|*.yaml|*.json) ;;
+  *) exit 0 ;;
+esac
+
+# eclint is an optional dependency: skip quietly if it isn't installed.
+command -v eclint >/dev/null 2>&1 || exit 0
+
+if out=$(eclint fix "$file_path" 2>&1); then
+  jq -n --arg f "$(basename "$file_path")" \
+    '{suppressOutput: true, systemMessage: ("✓ EditorConfig formatting applied to " + $f)}'
+else
+  echo "Warning: eclint failed for $file_path: $out" >&2
+  exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-editorconfig.sh",
+            "timeout": 30,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First of a 5-PR stack that adds [Claude Code hooks](https://docs.claude.com/en/docs/claude-code/hooks)
for **developing the Nextflow engine** (not for authoring Nextflow scripts — that tooling
lives in `nextflow-io/agent-skills`). This was previously one large PR (#6429); it's split
into one hook per PR so each can be reviewed and understood on its own.

All hooks are small, self-contained **Bash** scripts under `.claude/hooks/`, wired up in
`.claude/settings.json`. They parse the Claude Code JSON payload with `jq` (the only added
dependency; hooks no-op silently if `jq` is absent).

## This PR — EditorConfig enforcement (PostToolUse, async)
- `hooks/format-editorconfig.sh`: after every `Edit`/`Write`/`MultiEdit` on a source file
  (`.groovy`/`.java`/`.gradle`/`.md`/`.txt`/`.yml`/`.yaml`/`.json`), apply the project
  `.editorconfig` rules via `eclint fix`.
- `eclint` is an **optional** dependency — the hook skips silently if it isn't installed
  (no global `npm install` side effect).
- Runs with **`async: true`** so formatting happens in the background and never blocks the
  conversation.
- Also adds the `.claude/settings.json` + `.claude/README.md` scaffolding the later PRs build on.

## The stack (review front-to-back)
1. **(this PR)** EditorConfig formatting (async)
2. Build check — `make compile` on Stop/SubagentStop — #7241
3. Test runner — run the edited file's gradle test class — #7242
4. IntelliJ IDEA formatter (async, optional) — #7243
5. Integration test runner — run the edited `tests/*.nf` case (`asyncRewake`) — #7244

Each later PR targets the previous branch, so `settings.json`/`README.md` grow cleanly with
no cross-PR conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)