### PR TITLE
Claude Code hooks (2/4): build check on Stop

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -23,6 +23,13 @@ understood on its own. This file documents the hooks that are currently wired up
   skips silently if it is not present)
 - **`async: true`**: runs in the background so formatting never blocks the conversation
 
+### 2. Build check (Stop + SubagentStop)
+- **Script**: `hooks/check-build.sh`
+- **Trigger**: when Claude (or a subagent) finishes responding
+- **Action**: runs `make compile` to catch syntax/compilation errors early
+- **Failure mode**: blocking — feeds a parsed error summary back to Claude so it
+  can fix the breakage before yielding
+
 ## Enabling / disabling
 
 Hooks are configured in `.claude/settings.json`. Disable one by removing its entry;

--- a/.claude/hooks/check-build.sh
+++ b/.claude/hooks/check-build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Build check hook for Nextflow development.
+#
+# On Stop / SubagentStop, run `make compile` to catch syntax and compilation
+# errors. On failure, block and feed a parsed error summary back to Claude.
+#
+# Reads the Claude Code hook payload as JSON on stdin (requires `jq`).
+
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+event=$(jq -r '.hook_event_name // ""' <<<"$input")
+
+case "$event" in
+  Stop|SubagentStop) ;;
+  *) exit 0 ;;
+esac
+
+start=$SECONDS
+if out=$(make compile 2>&1); then
+  jq -n --arg s "$(( SECONDS - start ))" \
+    '{suppressOutput: true, systemMessage: ("✓ Build check passed (" + $s + "s)")}'
+else
+  summary=$(printf '%s\n' "$out" | grep -iE 'error|failed|exception' | tail -n 10)
+  [[ -n "$summary" ]] || summary=$(printf '%s\n' "$out" | tail -n 20)
+  jq -n --arg r "Build check failed:
+$summary" \
+    '{decision: "block", reason: $r, stopReason: "Build compilation failed"}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,28 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-build.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-build.sh",
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Part 2 of the Claude Code engine-development hooks stack. **Targets `hooks-1-editorconfig`**
(PR #7240) — review/merge that one first.

## This PR — Build check (Stop + SubagentStop)
- `hooks/check-build.sh`: when Claude or a subagent finishes responding, run `make compile`
  to catch syntax/compilation errors early.
- On failure: blocks and feeds a parsed error summary back to Claude (falling back to the
  tail of the output when no error lines match) so it fixes the breakage before yielding.
- Bash; matches on `hook_event_name` `Stop`/`SubagentStop`; parses the payload with `jq`.

## Stack
1. EditorConfig formatting — #7240
2. **(this PR)** Build check
3. Test runner
4. IntelliJ IDEA formatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)