### PR TITLE
Claude Code hooks (4/4): IntelliJ IDEA formatter

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -43,6 +43,15 @@ understood on its own. This file documents the hooks that are currently wired up
   without gaps, so no declarative `if` is used here. Runs per edit, so the timeout is
   generous (300s); narrow the matcher if per-edit test runs are too heavy.
 
+### 4. IntelliJ IDEA formatter (PostToolUse, async)
+- **Script**: `hooks/format-idea.sh`
+- **Trigger**: after an `Edit`/`Write`/`MultiEdit` on a `.groovy` file
+- **Action**: runs IntelliJ IDEA's headless formatter to match project code style
+- **Dependencies**: IntelliJ IDEA (Community or Ultimate). Located via the `IDEA_SH`
+  environment variable or common macOS/Linux/JetBrains-Toolbox install paths
+- **`async: true`**: runs in the background; non-blocking — skips silently if IDEA is not
+  installed and only warns (never blocks) if the formatter errors
+
 ## Enabling / disabling
 
 Hooks are configured in `.claude/settings.json`. Disable one by removing its entry;

--- a/.claude/hooks/format-idea.sh
+++ b/.claude/hooks/format-idea.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# IntelliJ IDEA formatter hook for Nextflow development.
+#
+# After an Edit/Write/MultiEdit on a .groovy file, run IntelliJ IDEA's headless
+# formatter to match project code style. IDEA is located via the IDEA_SH
+# environment variable or common install paths.
+#
+# Non-blocking: skips silently if IDEA is not installed (optional), and only
+# warns (never blocks) if the formatter errors. Wired with `async: true`, so it
+# runs in the background and does not hold up the conversation.
+#
+# Reads the Claude Code hook payload as JSON on stdin (requires `jq`).
+
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+tool_name=$(jq -r '.tool_name // ""' <<<"$input")
+file_path=$(jq -r '.tool_input.file_path // ""' <<<"$input")
+
+case "$tool_name" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+case "$file_path" in *.groovy) ;; *) exit 0 ;; esac
+[[ -f "$file_path" ]] || exit 0
+case "$file_path" in */build/*|*/.*/*) exit 0 ;; esac
+
+find_idea() {
+  if [[ -n "${IDEA_SH:-}" && -x "$IDEA_SH" ]]; then
+    echo "$IDEA_SH"; return 0
+  fi
+  local candidates=(
+    "/Applications/IntelliJ IDEA.app/Contents/MacOS/idea"
+    "/Applications/IntelliJ IDEA CE.app/Contents/MacOS/idea"
+    "/Applications/IntelliJ IDEA Ultimate.app/Contents/MacOS/idea"
+    "/usr/local/bin/idea.sh"
+    "/opt/idea/bin/idea.sh"
+    "/snap/intellij-idea-community/current/bin/idea.sh"
+    "/snap/intellij-idea-ultimate/current/bin/idea.sh"
+    "$HOME/.local/share/JetBrains/Toolbox/apps/IDEA-U/bin/idea.sh"
+    "$HOME/.local/share/JetBrains/Toolbox/apps/IDEA-C/bin/idea.sh"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    [[ -x "$c" ]] && { echo "$c"; return 0; }
+  done
+  command -v idea 2>/dev/null && return 0
+  return 1
+}
+
+# IDEA is an optional dependency: skip quietly if it isn't installed.
+idea=$(find_idea) || exit 0
+
+# Prefer a sibling format.sh, else fall back to `idea format`.
+idea_dir=$(dirname "$idea")
+if [[ -x "$idea_dir/format.sh" ]]; then
+  fmt=("$idea_dir/format.sh" -allowDefaults "$file_path")
+else
+  fmt=("$idea" format -allowDefaults "$file_path")
+fi
+
+if ! out=$("${fmt[@]}" 2>&1); then
+  # Non-blocking: a formatting failure should never stop the workflow.
+  echo "Warning: IDEA formatter failed for $file_path: ${out:-(no output)}" >&2
+  exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,12 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-idea.sh",
+            "timeout": 60,
+            "async": true
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-tests.sh",
             "timeout": 300
           }


### PR DESCRIPTION
Part 4 of the Claude Code engine-development hooks stack. **Targets `hooks-3-test-runner`**
(PR #7242).

## This PR — IntelliJ IDEA formatter (PostToolUse, async)
- `hooks/format-idea.sh`: after editing a `.groovy` file, run IntelliJ IDEA's headless
  formatter to match project code style.
- IDEA is located via the `IDEA_SH` env var or common macOS/Linux/JetBrains-Toolbox paths.
- Runs with **`async: true`** (background, non-blocking) and is fully non-blocking otherwise:
  skips silently when IDEA isn't installed (optional dependency) and only **warns** — never
  blocks — if the formatter errors.
- Most environment-specific of the hooks, so it lands late in the stack — it can be dropped
  without unwinding the others.

## Stack
1. EditorConfig formatting (async) — #7240
2. Build check — #7241
3. Test runner — #7242
4. **(this PR)** IntelliJ IDEA formatter (async)
5. Integration test runner — #7244

🤖 Generated with [Claude Code](https://claude.com/claude-code)