### PR TITLE
Claude Code hooks (5/5): integration test runner

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -52,6 +52,20 @@ understood on its own. This file documents the hooks that are currently wired up
 - **`async: true`**: runs in the background; non-blocking — skips silently if IDEA is not
   installed and only warns (never blocks) if the formatter errors
 
+### 5. Integration test runner (PostToolUse, asyncRewake)
+- **Script**: `hooks/run-integration-test.sh`
+- **Trigger**: editing an integration case `tests/<name>.nf` (scoped declaratively via
+  `if: "Edit(tests/*.nf)"` / `Write(...)` / `MultiEdit(...)` — one entry per edit tool,
+  since `if` patterns are tool-qualified)
+- **Action**: runs just that one case through the existing runner
+  (`tests/checks/run.sh ../<name>.nf`) rather than the full ~115-case suite. Uses the
+  dev launcher (`launch.sh`) and enables Docker only when it is available.
+- **`asyncRewake: true`**: runs in the background (never blocks the conversation) and, on
+  failure (exit code 2), wakes Claude with the failure output so it can react.
+- **Requirements**: a built dev launcher (`make compile`) and, for Docker-only cases,
+  Docker. The runner writes scratch/output dirs under `tests/checks/`; `tests/cleanup.sh`
+  clears them.
+
 ## Enabling / disabling
 
 Hooks are configured in `.claude/settings.json`. Disable one by removing its entry;

--- a/.claude/hooks/run-integration-test.sh
+++ b/.claude/hooks/run-integration-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Integration test hook for Nextflow development.
+#
+# When an integration test case (`tests/<name>.nf`) is edited, run just that one
+# case through the existing integration runner (`tests/checks/run.sh`) instead of
+# the whole ~115-case suite.
+#
+# Wired with `asyncRewake: true`: the run happens in the background (so it never
+# blocks the conversation) and, on failure (exit code 2), wakes Claude with the
+# failure output. The `if` filter in settings.json already scopes this to
+# `tests/*.nf` edits; the checks below repeat that scoping because the `if`
+# filter is best-effort and fails open.
+#
+# Reads the Claude Code hook payload as JSON on stdin (requires `jq`).
+
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+tool_name=$(jq -r '.tool_name // ""' <<<"$input")
+file_path=$(jq -r '.tool_input.file_path // ""' <<<"$input")
+
+case "$tool_name" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+# Only integration cases: a *.nf file directly under tests/.
+[[ -n "$file_path" ]] || exit 0
+case "$file_path" in *.nf) ;; *) exit 0 ;; esac
+[[ "$(basename "$(dirname "$file_path")")" == "tests" ]] || exit 0
+
+root="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null)}"
+[[ -n "$root" && -f "$root/tests/checks/run.sh" ]] || exit 0
+
+name=$(basename "$file_path")
+
+# Use the development launcher; enable Docker only when it is available
+# (run.sh skips Docker-only cases when WITH_DOCKER is empty).
+export NXF_CMD="$root/launch.sh"
+command -v docker >/dev/null 2>&1 && export WITH_DOCKER="-with-docker"
+
+out=$(cd "$root/tests/checks" && bash run.sh "../$name" 2>&1)
+status=$?
+
+if [[ $status -ne 0 ]]; then
+  {
+    echo "Integration test failed: $name"
+    printf '%s\n' "$out" | tail -n 30
+  } >&2
+  exit 2   # asyncRewake: wake Claude with the stderr above
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,27 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-tests.sh",
             "timeout": 300
+          },
+          {
+            "type": "command",
+            "if": "Edit(tests/*.nf)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-integration-test.sh",
+            "timeout": 600,
+            "asyncRewake": true
+          },
+          {
+            "type": "command",
+            "if": "Write(tests/*.nf)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-integration-test.sh",
+            "timeout": 600,
+            "asyncRewake": true
+          },
+          {
+            "type": "command",
+            "if": "MultiEdit(tests/*.nf)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-integration-test.sh",
+            "timeout": 600,
+            "asyncRewake": true
           }
         ]
       }


### PR DESCRIPTION
Part 5 of the Claude Code engine-development hooks stack. **Targets `hooks-4-idea-format`**
(PR #7243).

## This PR — Integration test runner (PostToolUse, `asyncRewake`)
- `hooks/run-integration-test.sh`: when an integration case `tests/<name>.nf` is edited,
  run **just that one case** through the existing runner (`tests/checks/run.sh ../<name>.nf`)
  instead of the full ~115-case suite.
- Scoped declaratively with **`if`**: `Edit(tests/*.nf)`, `Write(tests/*.nf)`,
  `MultiEdit(tests/*.nf)` — one entry per edit tool, because `if` patterns are
  tool-qualified. The script repeats the path check since the `if` filter is best-effort
  and fails open.
- **`asyncRewake: true`**: runs in the background (never blocks the conversation) and wakes
  Claude on failure (exit 2) with the failure output.
- Uses the dev launcher (`launch.sh`) and enables Docker only when available. Requires a
  built dev launcher (`make compile`); the runner writes scratch dirs under `tests/checks/`
  (`tests/cleanup.sh` clears them).

## Stack
1. EditorConfig formatting (async) — #7240
2. Build check — #7241
3. Test runner — #7242
4. IntelliJ IDEA formatter (async) — #7243
5. **(this PR)** Integration test runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)