### PR TITLE
Fix issues with v2 config parser

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -44,11 +44,11 @@ class ConfigDsl extends Script {
 
     private Path configPath
 
-    private Map paramOverrides
+    private Map cliParams
 
     private List<String> profiles
 
-    private Map target = [:]
+    private Map target = [params: [:]]
 
     private Set<String> declaredProfiles = []
 
@@ -70,9 +70,13 @@ class ConfigDsl extends Script {
         this.configPath = path
     }
 
-    void setParams(Map paramOverrides) {
-        this.paramOverrides = paramOverrides
-        target.params = paramOverrides
+    void setParams(Map params) {
+        this.cliParams = params
+        (target.params as Map).putAll(params)
+    }
+
+    void setConfigParams(Map params) {
+        (target.params as Map).putAll(params)
     }
 
     void setProfiles(List<String> profiles) {
@@ -120,7 +124,7 @@ class ConfigDsl extends Script {
     void assign(List<String> names, Object value) {
         if( names.size() == 2 && names.first() == 'params' ) {
             declareParam(names.last(), value)
-            if( paramOverrides.containsKey(names.last()) )
+            if( cliParams.containsKey(names.last()) )
                 return
         }
         navigate(names.init()).put(names.last(), value)
@@ -196,7 +200,8 @@ class ConfigDsl extends Script {
                 .setRenderClosureAsString(renderClosureAsString)
                 .setStrict(strict)
                 .setBinding(binding.getVariables())
-                .setParams(target.params as Map)
+                .setParams(cliParams)
+                .setConfigParams(target.params as Map)
                 .setProfiles(profiles)
         final config = parser.parse(configText, includePath)
         declaredProfiles.addAll(parser.getDeclaredProfiles())

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
@@ -36,7 +36,9 @@ class ConfigParserV2 implements ConfigParser {
 
     private Map bindingVars = [:]
 
-    private Map paramOverrides = [:]
+    private Map cliParams = [:]
+
+    private Map configParams = [:]
 
     private boolean ignoreIncludes = false
 
@@ -94,7 +96,12 @@ class ConfigParserV2 implements ConfigParser {
     ConfigParserV2 setParams(Map vars) {
         // deep clone the map to prevent side-effect
         // see https://github.com/nextflow-io/nextflow/issues/1923
-        this.paramOverrides = Bolts.deepClone(vars)
+        this.cliParams = Bolts.deepClone(vars)
+        return this
+    }
+
+    ConfigParserV2 setConfigParams(Map params) {
+        this.configParams = params
         return this
     }
 
@@ -127,7 +134,8 @@ class ConfigParserV2 implements ConfigParser {
             if( path )
                 script.setConfigPath(path)
             script.setIgnoreIncludes(ignoreIncludes)
-            script.setParams(paramOverrides)
+            script.setParams(cliParams)
+            script.setConfigParams(configParams)
             script.setProfiles(appliedProfiles)
             script.setRenderClosureAsString(renderClosureAsString)
             script.run()

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
@@ -48,7 +48,7 @@ class ConfigParserV2 implements ConfigParser {
 
     private List<String> appliedProfiles
 
-    private Set<String> declaredProfiles
+    private Set<String> declaredProfiles = new HashSet<>()
 
     private Map<String,Object> declaredParams
 
@@ -133,7 +133,7 @@ class ConfigParserV2 implements ConfigParser {
             script.run()
 
             final target = script.getTarget()
-            declaredProfiles = script.getDeclaredProfiles()
+            declaredProfiles.addAll(script.getDeclaredProfiles())
             declaredParams = script.getDeclaredParams()
             return Bolts.toConfigObject(target)
         }

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -170,6 +170,65 @@ class ConfigParserV2Test extends Specification {
 
     }
 
+    def 'should apply params from an included config even when declared in the parent config' () {
+        // https://github.com/nextflow-io/nextflow/issues/6623
+        // a param declared in the parent config (e.g. given a default) must still be
+        // overridable by an included config. The v2 parser previously passed the parent
+        // config's accumulated params to the include parser as if they were CLI overrides,
+        // so the included assignment was silently skipped and the parent value survived.
+        given:
+        def folder = Files.createTempDirectory('test')
+        def main = folder.resolve('nextflow.config')
+        def snippet = folder.resolve('snippet.config')
+
+        main.text = """
+            params.reads = null
+
+            includeConfig "$snippet"
+            """
+
+        snippet.text = '''
+            params.reads = 'from_included'
+            '''
+
+        when:
+        def config = new ConfigParserV2().parse(main)
+        then:
+        config.params.reads == 'from_included'
+
+        cleanup:
+        folder?.deleteDir()
+
+    }
+
+    def 'should let a real CLI param override win over an included config' () {
+        // the companion invariant to issue #6623: an actual CLI --param override must
+        // still take precedence over a value assigned in an included config file.
+        given:
+        def folder = Files.createTempDirectory('test')
+        def main = folder.resolve('nextflow.config')
+        def snippet = folder.resolve('snippet.config')
+
+        main.text = """
+            params.reads = null
+
+            includeConfig "$snippet"
+            """
+
+        snippet.text = '''
+            params.reads = 'from_included'
+            '''
+
+        when:
+        def config = new ConfigParserV2().setParams([reads: 'from_cli']).parse(main)
+        then:
+        config.params.reads == 'from_cli'
+
+        cleanup:
+        folder?.deleteDir()
+
+    }
+
     def 'should parse multiple relative files' () {
 
         given:

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -375,6 +375,36 @@ class ConfigParserV2Test extends Specification {
         slurper.getDeclaredProfiles() == ['alpha','beta'] as Set
     }
 
+    def 'should accumulate declared profiles across multiple config files' () {
+        // a single parser instance is reused to parse all config files (see ConfigBuilder),
+        // so the set of declared profiles must accumulate rather than be overwritten by the
+        // last file parsed -- otherwise profiles defined in an earlier file are reported as
+        // "Unknown configuration profile" when a later file declares none
+        given:
+        def withProfiles = '''
+            profiles {
+                alpha {
+                    a = 1
+                }
+                beta {
+                    b = 2
+                }
+            }
+            '''
+        def withoutProfiles = '''
+            tower {
+                enabled = true
+            }
+            '''
+
+        when:
+        def slurper = new ConfigParserV2().setProfiles(['alpha'])
+        slurper.parse(withProfiles)
+        slurper.parse(withoutProfiles)
+        then:
+        slurper.getDeclaredProfiles() == ['alpha','beta'] as Set
+    }
+
     def 'should return the map of declared params' () {
 
         given:


### PR DESCRIPTION
### Problem

On the 25.10.x line, the strict (v2) config parser aborts a run at config-build time with `Unknown configuration profile: '<name>'` whenever the `profiles {}` block lives in a config file that is **not the last one parsed**. The legacy (v1) parser handles the same configuration fine.

This surfaces on Seqera Platform launches in particular: Platform writes a config into the launch directory (a `tower {}` scope, no profiles) which is parsed after the pipeline's own `nextflow.config`, so every profile-using pipeline fails under the v2 parser. It reproduces with plain `nextflow config`/`nextflow run` against two config files; `includeConfig` is not involved.

### Root cause

`ConfigBuilder` creates a single `ConfigParser` instance and calls `parse()` for each config file in order, then validates the requested `-profile` against`parser.getDeclaredProfiles()` once at the end.

`ConfigParserV2` **reassigned** its `declaredProfiles` field on every `parse()`call (`declaredProfiles = script.getDeclaredProfiles()`), so the field ended up holding only the profiles from the last file parsed. The v1 parser keeps a `final` set and adds to it, accumulating across all files.

### Fix

Initialise `declaredProfiles` to an empty set and accumulate with `addAll(...)` across `parse()` calls, matching the v1 behaviour. Two lines.

This is already fixed on the default branch as part of the larger #6643 ("enable v2 syntax parser by default"), which can't be cherry-picked cleanly onto 25.10.x; this PR is the minimal extraction of just the profile-accumulation fix.

### Verification

- New regression test `should accumulate declared profiles across multiple config files` reuses one parser across two `parse()` calls (the second declaring no profiles) and asserts the earlier file's profiles are retained.
- Confirmed the test **fails on the unpatched 25.10.x branch** and **passes with the fix**; the rest of `ConfigParserV2Test` is unchanged and green.

### Scope / risk

The only non-test consumer of `getDeclaredProfiles()` is `ConfigBuilder`'s `checkValidProfile` gate, so the blast radius is limited to profile validation. The v2 parser is opt-in on 25.10.x (`NXF_SYNTAX_PARSER=v2`).
