### PR TITLE
Fix flatMap tuple error for dataflow value

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/dataflow/ValueImpl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dataflow/ValueImpl.groovy
@@ -29,6 +29,7 @@ import nextflow.extension.DataflowHelper
 import nextflow.extension.OpCall
 import nextflow.extension.OperatorImpl
 import nextflow.script.DataflowTypeHelper
+import nextflow.script.types.Tuple
 
 /**
  * Implements the Value type for typed workflows.

--- a/modules/nextflow/src/test/groovy/nextflow/dataflow/ValueImplTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/dataflow/ValueImplTest.groovy
@@ -88,6 +88,23 @@ class ValueImplTest extends Specification {
         result.val == CH.stop()
     }
 
+    def testFlatMapError() {
+
+        when:
+        runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow {
+                channel.value(tuple(1,2)).flatMap()
+            }
+            '''
+        )
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains 'Operator `flatMap` expected an Iterable but received a tuple'
+    }
+
     def testMap() {
         when:
         def result = runDataflow {


### PR DESCRIPTION
This PR fixes an issue with `flatMap` for dataflow values. When static typing is enabled, flatMap should error when given a tuple instead of flattening it

This was already implemented for channels but was not properly tested for dataflow values