### PR TITLE
Fix failing unit tests with clean build

### DIFF
--- a/modules/nf-commons/src/main/nextflow/plugin/DevPluginManager.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/DevPluginManager.groovy
@@ -65,13 +65,44 @@ class DevPluginManager extends CustomPluginManager {
         def repos = new CompoundPluginRepository()
         // main dev repo
         log.debug "Add plugin root repository: ${getPluginsRoot()}"
-        repos.add( new DevelopmentPluginRepository(getPluginsRoot()) )
+        repos.add( devRepositoryFor(getPluginsRoot()) )
         // extension repos
         for( Path it : extensionRoots ) {
             log.debug "Add plugin dev repository: $it"
-            repos.add( new DevelopmentPluginRepository(it) )
+            repos.add( devRepositoryFor(it) )
         }
         return repos
+    }
+
+    private DevelopmentPluginRepository devRepositoryFor(Path root) {
+        final repo = new DevelopmentPluginRepository(root)
+        // Only consider plugin directories that have actually been compiled, i.e.
+        // those for which a plugin manifest is available in the dev classpath. This
+        // prevents pf4j from logging spurious "Cannot find the manifest path" errors
+        // (with a full stack trace) for every plugin that has not been built yet in
+        // the local dev environment - e.g. when running unit tests from a clean build.
+        repo.setFilter(new BuiltPluginFilter())
+        return repo
+    }
+
+    /**
+     * Accept only the plugin directories that have been built, that is those holding
+     * a manifest in one of the dev classpath directories.
+     *
+     * The manifest locations are derived from {@link DevPluginClasspath} so they stay
+     * in sync with the directories used by the dev plugin class loader.
+     */
+    @CompileStatic
+    private static class BuiltPluginFilter implements FileFilter {
+
+        private static final Collection<String> CLASSES_DIRS = new DevPluginClasspath().getClassesDirectories()
+
+        @Override
+        boolean accept(File file) {
+            if( !file.isDirectory() || file.isHidden() )
+                return false
+            return CLASSES_DIRS.any { new File(file, "$it/META-INF/MANIFEST.MF").isFile() }
+        }
     }
 
 }


### PR DESCRIPTION
Certain unit tests fail when run individually from a clean build. For example:

```bash
make clean
./gradlew :nextflow:test --tests CmdLogTest
```

A unit test fails with "org.pf4j.PluginRuntimeException: Cannot find the manifest path"

This happens because CmdLog calls `Plugins.init()`, which uses the DevPluginManager, which tries to load every core plugin regardless of whether it has been built

You don't hit this error with `make test` because it happens to build all of the plugins before running any tests

The solution is for the DevPluginManager to only load plugins that have been built