### PR TITLE
Fix path input for exec processes

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskInputResolver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskInputResolver.groovy
@@ -322,9 +322,8 @@ class TaskInputResolver {
         if( type == ScriptType.SCRIPTLET ) {
             return new TaskPath(holder)
         }
-        if( type == ScriptType.GROOVY) {
-            // the real path for the native task needs to be fixed -- see #378
-            return Path.of(holder.stageName)
+        if( type == ScriptType.GROOVY ) {
+            return holder.storePath
         }
         throw new IllegalStateException("Unknown task type: $type")
     }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskInputResolverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskInputResolverTest.groovy
@@ -199,6 +199,34 @@ class TaskInputResolverTest extends Specification {
 
     }
 
+    def 'should return absolute store path for native (exec) tasks'() {
+        // see issue #378: a `path` input in an `exec:` block must resolve to the
+        // absolute, symlink-resolved real path so that e.g. `.exists()` works,
+        // not the relative stage name (which is never materialised for native tasks)
+        given:
+        def file1 = Files.createTempFile('test1', '.txt')
+        def file2 = Files.createTempFile('test2', '.txt')
+
+        when:
+        def list = [ FileHolder.get(file1, 'staged_1.txt') ]
+        def result = TaskInputResolver.singleItemOrList(list, true, ScriptType.GROOVY)
+        then:
+        result == file1.toRealPath()
+        result.isAbsolute()
+        result.exists()
+
+        when:
+        list = [ FileHolder.get(file1, 'staged_1.txt'), FileHolder.get(file2, 'staged_2.txt') ]
+        result = TaskInputResolver.singleItemOrList(list, false, ScriptType.GROOVY)
+        then:
+        result*.toString() == [ file1.toRealPath().toString(), file2.toRealPath().toString() ]
+        result.every { it.isAbsolute() && it.exists() }
+
+        cleanup:
+        Files.deleteIfExists(file1)
+        Files.deleteIfExists(file2)
+    }
+
 
     def 'should expand wildcards'() {
 

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskInputResolverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskInputResolverTest.groovy
@@ -199,10 +199,10 @@ class TaskInputResolverTest extends Specification {
 
     }
 
-    def 'should return absolute store path for native (exec) tasks'() {
+    def 'should return absolute store path for exec processes'() {
         // see issue #378: a `path` input in an `exec:` block must resolve to the
         // absolute, symlink-resolved real path so that e.g. `.exists()` works,
-        // not the relative stage name (which is never materialised for native tasks)
+        // not the relative stage name (which is never materialized for native tasks)
         given:
         def file1 = Files.createTempFile('test1', '.txt')
         def file2 = Files.createTempFile('test2', '.txt')


### PR DESCRIPTION
Fix #378 

This PR fixes an issue with `path` inputs in `exec:` processes. Currently, it doesn't work because it uses the stage name even though exec processes do not stage input files

Instead, we bind the input to the source path so that it can be used as a path:

```groovy
process foo {
  input:
  path fastq

  exec:
  println(fastq.exists())
}
```

This also fixes the provenance for exec processes, which rely on input files to determine the upstream task