### PR TITLE
Bump jackson 2.21.1 to 2.21.4 to fix high-severity CVEs

### DIFF
--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -73,8 +73,10 @@ dependencies {
     api('io.seqera:tower-api:1.158.0') {
         exclude group: 'io.micronaut.servlet'
     }
-    api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.1"
-    api "com.fasterxml.jackson.core:jackson-databind:2.21.1"
+    // jackson 2.21.4 addresses GHSA-rmj7-2vxq-3g9f and GHSA-j3rv-43j4-c7qm
+    // (PolymorphicTypeValidator bypasses)
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4"
+    api "com.fasterxml.jackson.core:jackson-databind:2.21.4"
 
     testImplementation(testFixtures(project(":nextflow")))
     testImplementation "org.apache.groovy:groovy:4.0.31"


### PR DESCRIPTION
## Summary

Bumps `jackson-databind` and `jackson-dataformat-yaml` from `2.21.1` to `2.21.4` in `nf-seqera` to address two **high-severity** Dependabot advisories (alerts #222–#225):

- **GHSA-rmj7-2vxq-3g9f** — array subtype allowlist bypass in `BasicPolymorphicTypeValidator` (`allowIfSubTypeIsArray`)
- **GHSA-j3rv-43j4-c7qm** — `PolymorphicTypeValidator` bypass via generic type parameters allowing arbitrary class instantiation

Both artifacts are kept version-aligned. `jackson-databind` resolves to `2.21.4` (BOM-aligned) on the `nf-seqera` runtime classpath via conflict resolution.

## Verification

- `:plugins:nf-seqera:dependencyInsight` confirms `jackson-databind:2.21.4` on `runtimeClasspath`
- `:plugins:nf-seqera:compileGroovy` and `compileTestGroovy` build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
