### PR TITLE
Fix high-severity form-data CRLF injection in docs site

### DIFF
--- a/.docusaurus_site/package-lock.json
+++ b/.docusaurus_site/package-lock.json
@@ -6937,6 +6937,66 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -12007,16 +12067,16 @@
             "license": "MIT"
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -12029,6 +12089,27 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14.17"
+            }
+        },
+        "node_modules/form-data/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/form-data/node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/format": {
@@ -12493,9 +12574,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"

--- a/.docusaurus_site/package.json
+++ b/.docusaurus_site/package.json
@@ -42,6 +42,9 @@
         "@docusaurus/module-type-aliases": "3.9.2",
         "@docusaurus/types": "3.9.2"
     },
+    "overrides": {
+        "form-data": "^4.0.6"
+    },
     "browserslist": {
         "production": [
             ">0.5%",


### PR DESCRIPTION
## Summary

Addresses the high-severity **form-data CRLF injection** advisory **GHSA-hmw2-7cc7-3qxx** (Dependabot alert #210) in the Docusaurus docs site.

`form-data` is a deep transitive dependency, so this adds an npm `overrides` entry pinning it to `^4.0.6`, bumping the resolved version from `4.0.5` → `4.0.6`.

## Verification

`npm audit` confirms `form-data` is no longer flagged (high count 9 → 8); the resolved lockfile entry is `form-data@4.0.6`.

## The other two high npm advisories are not fixable here

| Alert | Package | Why no fix |
|-------|---------|-----------|
| #204 | **lodash** (GHSA-r5fr-rjxr-66jc) | No patched release exists — `npm audit` reports `fixAvailable: false`; the cited `4.18.0` is unpublished (latest lodash is 4.17.21). |
| #201 | **serialize-javascript** (GHSA-5c6j-r48x-rmvq) | The only available fix is a **breaking downgrade** of `@docusaurus/core` 3.9.2 → 3.5.2, which is not viable. |

Both are pulled transitively via `openapi-to-postmanv2` / Docusaurus tooling and affect only the docs-site build — not the shipped Nextflow runtime. They will clear when the upstream tooling releases patched transitive deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
