### PR TITLE
Fix Kryo deserialization error with enum types

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskContext.groovy
@@ -206,7 +206,9 @@ class TaskContext implements Map<String,Object>, Cloneable {
     }
 
     static TaskContext deserialize(TaskProcessor processor, byte[] buffer) {
-        def map = (Map)KryoHelper.deserialize(buffer)
+        // use the script class loader so that Kryo can resolve user-defined types
+        final loader = processor.ownerScript?.getClass()?.getClassLoader()
+        final map = (Map)KryoHelper.deserialize(buffer, loader)
         new TaskContext(processor, map)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/SerializationHelper.groovy
@@ -182,7 +182,7 @@ class KryoHelper {
         }
         finally {
             if( prev ) {
-                kryo.setClassLoader(loader)
+                kryo.setClassLoader(prev)
             }
         }
     }

--- a/tests/checks/enum.nf/.checks
+++ b/tests/checks/enum.nf/.checks
@@ -1,0 +1,20 @@
+#
+# Verify that a task whose input/output is a user-defined enum declared
+# *inline* in the pipeline script can be resumed from the cache.
+# Regression test for https://github.com/nextflow-io/nextflow/issues/4816
+#
+set -e
+
+#
+# run normal mode
+#
+$NXF_RUN | tee .stdout
+
+[[ `grep INFO .nextflow.log | grep -c 'Submitted process'` == 1 ]] || false
+
+#
+# run resume mode -- the task must be served from the cache
+#
+$NXF_RUN -resume | tee .stdout
+
+[[ `grep INFO .nextflow.log | grep -c 'Cached process'` == 1 ]] || false

--- a/tests/enum.nf
+++ b/tests/enum.nf
@@ -1,0 +1,23 @@
+
+enum MyEnum {
+    A,
+    B
+}
+
+workflow {
+    ch = channel.of( tuple([:], MyEnum.B) )
+    SomeTask(ch)
+}
+
+process SomeTask {
+    input:
+    tuple val(meta), val(myEnum)
+
+    output:
+    tuple val(meta), path('out.txt')
+
+    script:
+    """
+    echo "hello $myEnum" > out.txt
+    """
+}


### PR DESCRIPTION
Fix #4816 

This PR fixes an issue with caching tasks that use user-defined enum values

The linked issue used an enum in the `lib` directory, but the same issue happens with an enum in a Nextflow script. TaskContext does not provide the script class loader to Kryo, so it doesn't know about user-defined types when deserializing them

Both cases are fixed, but I only added a test for the Nextflow-native enum since that is best practice