### PR TITLE
docs: deslop semantics reference

### DIFF
--- a/docs/reference/semantics.mdx
+++ b/docs/reference/semantics.mdx
@@ -5,7 +5,7 @@ description: Reference for the semantics of Nextflow language constructs.
 
 # Semantics
 
-This page describes the *semantics* of the Nextflow language -- that is, the meaning and behavior of each language construct. It is a companion to the [Syntax][syntax-page] reference, which describes the *grammar* of the language (how constructs are written). See the [Scripts][script-page] page for a practical introduction to the language.
+The *semantics* of the Nextflow language are the meaning and behavior of each language construct. This page is a companion to the [Syntax][syntax-page] reference, which describes the *grammar* of the language (how constructs are written). See the [Scripts][script-page] page for a practical introduction to the language.
 
 ## Values
 
@@ -105,7 +105,7 @@ See [String][stdlib-types-string] for the available operations.
 
 ### Null
 
-The special value `null` represents the absence of a value. Accessing a property or calling a method on `null` raises a *null reference* error, so `null` is best avoided where possible. The [safe navigation operator](#navigation-operators) can be used to access a property that may be `null`.
+The special value `null` represents the absence of a value. Accessing a property or calling a method on `null` raises a *null reference* error. Avoid `null` where possible. The [safe navigation operator](#navigation-operators) can be used to access a property that may be `null`.
 
 ### Collections
 
@@ -246,7 +246,7 @@ The primary use of a closure is as an argument to a *higher-order function* -- a
 
 ## Operators
 
-An *operator* is a symbol that performs an operation on one or two operands. The full set of operators and their grammar is listed in the [Syntax][syntax-operators] reference; this section describes their semantics, grouped by category.
+An *operator* is a symbol that performs an operation on one or two operands. The full set of operators and their grammar is listed in the [Syntax][syntax-operators] reference. This section describes their semantics, grouped by category.
 
 :::note
 The operators described here are language operators, which apply to ordinary values. They are different from *channel operators*, which are functions for manipulating [channels](#workflows). See [Operators][operator-page] for channel operators.
@@ -296,7 +296,7 @@ assert [1, 2, 3] == [1, 2, 3]
 assert 'hello' == 'hello'
 ```
 
-Ordering operators (`<`, `>`, `<=`, `>=`) compare values according to their natural order: numbers numerically, strings alphabetically, and so on. The spaceship operator `<=>` returns `-1`, `0`, or `1` depending on whether the left operand is less than, equal to, or greater than the right operand, and is useful for defining custom sort comparators:
+Ordering operators (`<`, `>`, `<=`, `>=`) compare values according to their natural order: numbers numerically and strings alphabetically. The spaceship operator `<=>` returns `-1`, `0`, or `1` depending on whether the left operand is less than, equal to, or greater than the right operand, and is useful for defining custom sort comparators:
 
 ```nextflow
 def items = ['banana', 'apple', 'cherry']
@@ -314,7 +314,7 @@ Logical operators combine boolean values. Their operands are coerced based on [t
 | `\|\|`   | logical OR  |
 | `!`      | logical NOT |
 
-The `&&` and `||` operators *short-circuit*: the right operand is evaluated only if necessary. For `&&`, the right operand is evaluated only if the left is truthy; for `||`, only if the left is falsy. This allows the right operand to safely depend on the left:
+The `&&` and `||` operators *short-circuit*: the right operand is evaluated only if necessary. For `&&`, the right operand is evaluated only if the left is truthy. For `||`, it is evaluated only if the left is falsy. This allows the right operand to safely depend on the left:
 
 ```nextflow
 if( reads != null && reads.size() > 0 )
@@ -627,7 +627,7 @@ numbers.inject(0) { acc, v -> acc + v }     // -> 15
 numbers.every { v -> v > 0 }                // -> true
 ```
 
-A higher-order function returns a value rather than mutating external state, which makes it easier to reason about and avoids common sources of error. For example, `inject` accumulates a result without an external accumulator variable:
+A higher-order function returns a value rather than mutating external state. This makes it easier to reason about and avoids common errors. For example, `inject` accumulates a result without an external accumulator variable:
 
 ```nextflow
 // instead of mutating an external variable
@@ -648,7 +648,7 @@ An [assert statement](./syntax#assert) evaluates a boolean condition and raises 
 assert params.input != null : 'The --input parameter is required'
 ```
 
-If the condition is false, an error is raised. The optional message after the colon is included in the error. If no message is given, Nextflow reports the values of the sub-expressions in the condition (a *power assertion*), which makes it easy to see why the assertion failed:
+If the condition is false, an error is raised. The optional message after the colon is included in the error. If no message is given, Nextflow reports the values of the sub-expressions in the condition (a *power assertion*). This makes it easy to see why the assertion failed:
 
 ```nextflow
 assert 2 + 2 == 5
@@ -734,7 +734,7 @@ println items   // -> [1, 2, 3]
 
 To avoid this, create a copy before mutating, or use operations that return a new value (e.g. `list + [item]` instead of `list.add(item)`).
 
-*Reassigning* a parameter, on the other hand, does not affect the caller. The parameter is a separate reference to the same object, so assigning a new value to it changes only the function's local reference:
+*Reassigning* a parameter, on the other hand, does not affect the caller. The parameter is a separate reference to the same object. Assigning a new value to it changes only the function's local reference:
 
 ```nextflow
 def replace(list) {
@@ -831,7 +831,7 @@ A Nextflow workflow describes a *dataflow* -- a graph of [processes][process-pag
 
 ### Definition vs execution
 
-A workflow body is not executed step by step like an ordinary function. Instead, it is evaluated *once*, up front, to *construct* the dataflow graph. The statements in a workflow body declare how processes, operators, and channels are wired together; the actual computation happens *afterward*, asynchronously, as data flows through the graph.
+A workflow body is not executed step by step like an ordinary function. Instead, it is evaluated *once*, up front, to *construct* the dataflow graph. The statements in a workflow body declare how processes, operators, and channels are wired together. The actual computation happens *afterward*, asynchronously, as data flows through the graph.
 
 In this sense, a workflow definition behaves like a *compile-time macro*: it runs once to build the dataflow graph, and the operations it describes (process tasks, operator logic) execute later as data becomes available.
 
@@ -853,7 +853,7 @@ When the workflow body runs:
 
 Only after the entire graph is constructed does Nextflow begin executing it: the channel emits its values, the `map` closure runs for each value, and `view` prints each result.
 
-This has several important consequences:
+This has several consequences:
 
 - **Channel contents cannot be accessed directly.** Because the workflow body runs before any data flows, you cannot inspect the values in a channel from within the workflow body. You must use an operator or process to act on each value:
 

--- a/docs/reference/semantics.mdx
+++ b/docs/reference/semantics.mdx
@@ -627,7 +627,7 @@ numbers.inject(0) { acc, v -> acc + v }     // -> 15
 numbers.every { v -> v > 0 }                // -> true
 ```
 
-A higher-order function returns a value rather than mutating external state. This makes it easier to reason about and avoids common errors. For example, `inject` accumulates a result without an external accumulator variable:
+A higher-order function returns a value rather than mutating external state, which makes it easier to reason about and avoids common errors. For example, `inject` accumulates a result without an external accumulator variable:
 
 ```nextflow
 // instead of mutating an external variable
@@ -648,7 +648,7 @@ An [assert statement](./syntax#assert) evaluates a boolean condition and raises 
 assert params.input != null : 'The --input parameter is required'
 ```
 
-If the condition is false, an error is raised. The optional message after the colon is included in the error. If no message is given, Nextflow reports the values of the sub-expressions in the condition (a *power assertion*). This makes it easy to see why the assertion failed:
+If the condition is false, an error is raised. The optional message after the colon is included in the error. If no message is given, Nextflow reports the values of the sub-expressions in the condition:
 
 ```nextflow
 assert 2 + 2 == 5
@@ -734,7 +734,7 @@ println items   // -> [1, 2, 3]
 
 To avoid this, create a copy before mutating, or use operations that return a new value (e.g. `list + [item]` instead of `list.add(item)`).
 
-*Reassigning* a parameter, on the other hand, does not affect the caller. The parameter is a separate reference to the same object. Assigning a new value to it changes only the function's local reference:
+*Reassigning* a parameter, on the other hand, does not affect the caller. The parameter is a separate reference to the same object, so assigning a new value to it changes only the function's local reference:
 
 ```nextflow
 def replace(list) {

--- a/docs/reference/syntax.mdx
+++ b/docs/reference/syntax.mdx
@@ -624,7 +624,7 @@ A *slashy string* is enclosed by slashes instead of quotes:
 A slashy string cannot be empty because it would become a line comment.
 :::
 
-In single- and double-quoted strings (including their triple-quoted forms), the backslash character (`\`) can be used to escape characters that would otherwise have special meaning, or to insert special characters:
+In single- and double-quoted strings (including their triple-quoted forms), the backslash character (`\`) escapes characters that would otherwise have special meaning, or inserts special characters:
 
 | Escape | Character |
 | ------ | --------- |

--- a/docs/script.mdx
+++ b/docs/script.mdx
@@ -7,7 +7,7 @@ description: A practical introduction to writing Nextflow scripts with variables
 
 Nextflow is a workflow language that runs on the Java virtual machine (JVM). Nextflow's syntax is very similar to [Groovy](https://groovy-lang.org/), a scripting language for the JVM. However, Nextflow is specialized for writing computational pipelines in a declarative manner.
 
-This page is a practical introduction to the Nextflow language. See [Syntax][syntax-page] for the language grammar, [Semantics][semantics-page] for a comprehensive description of language behavior, and [Standard library][stdlib-page] for the built-in types and functions available to every script.
+This page is a practical introduction to the Nextflow language. See [Syntax][syntax-page] for the language grammar, [Semantics][semantics-page] for the meaning and behavior of each language construct, and [Standard library][stdlib-page] for the built-in types and functions available to every script.
 
 :::warning
 Nextflow uses UTF-8 as the default character encoding for source files. Make sure to use UTF-8 encoding when editing Nextflow scripts with your preferred text editor.
@@ -160,7 +160,7 @@ assert [2, 2] != [4]
 ```
 
 :::tip
-The `assert` keyword simply tests a condition and raises an error if the condition is false. Every assert that you see on this page will succeed if executed.
+The `assert` keyword tests a condition and raises an error if the condition is false. Every assert on this page succeeds when executed.
 :::
 
 Comparison operators compare two values:
@@ -178,7 +178,7 @@ assert (true || false) == true    // logical OR
 assert (!true) == false           // logical NOT
 ```
 
-The `in` operator tests *membership*, i.e. whether a collection contains a value:
+The `in` operator tests *membership*, i.e., whether a collection contains a value:
 
 ```nextflow
 assert 2 in [1, 2, 3]
@@ -298,11 +298,11 @@ See [Closures][semantics-closures] and [Iteration][semantics-iteration] for more
 
 ## Script definitions
 
-So far, we have been focusing on the basic building blocks of Nextflow code, like variables, strings, collections, and closures.
+The previous sections covered the basic building blocks of Nextflow code: variables, strings, collections, and closures.
 
-In practice, however, Nextflow scripts are composed of *workflows*, *processes*, and *functions* (collectively known as *definitions*), and can *include* definitions from other scripts.
+In practice, Nextflow scripts are composed of *workflows*, *processes*, and *functions* (collectively known as *definitions*), and can *include* definitions from other scripts.
 
-To transition a code snippet into a proper workflow script, simply wrap it in a `workflow` block:
+To turn a code snippet into a workflow script, wrap it in a `workflow` block:
 
 ```nextflow
 workflow {
@@ -310,7 +310,7 @@ workflow {
 }
 ```
 
-This block is called the *entry workflow*. It serves as the entrypoint when the script is executed. Whenever a script contains only simple statements like `println 'Hello!'`, Nextflow simply treats it as an entry workflow.
+This block is called the *entry workflow*. It is the entrypoint when the script is executed. Whenever a script contains only simple statements like `println 'Hello!'`, Nextflow treats it as an entry workflow.
 
 You can break up code into functions, for example:
 

--- a/docs/script.mdx
+++ b/docs/script.mdx
@@ -300,7 +300,7 @@ See [Closures][semantics-closures] and [Iteration][semantics-iteration] for more
 
 The previous sections covered the basic building blocks of Nextflow code: variables, strings, collections, and closures.
 
-In practice, Nextflow scripts are composed of *workflows*, *processes*, and *functions* (collectively known as *definitions*), and can *include* definitions from other scripts.
+In practice, Nextflow scripts are composed of *workflows*, *processes*, *functions*, and *types* (collectively known as *definitions*), and can *include* definitions from other scripts.
 
 To turn a code snippet into a workflow script, wrap it in a `workflow` block:
 


### PR DESCRIPTION
I pulled this down and ran the Seqera deslop skill we are developing over this PR.

In this PR, it mostly removes prose and shortens/shortens sentences. I've run it leniently, so it looks at the pages as a whole and aligns changes with the Nextflow in-house style (so it's a similar tone/style to other pages in this docs set). It was already pretty good, so changes are minimal.

Otherwise, it reads well and looks good.