### PR TITLE
docs: clarify Bitbucket API token auth requirements

### DIFF
--- a/docs/git.mdx
+++ b/docs/git.mdx
@@ -32,7 +32,7 @@ User name required to access private repositories on the SCM server.
 
 ##### `providers.<provider>.password`
 
-User password required to access private repositories on the SCM server. For BitBucket, use your API token as the `token` value instead — app passwords are deprecated.
+User password required to access private repositories on the SCM server. For BitBucket, use your API token as the `token` value instead. App passwords are deprecated.
 
 ##### `providers.<provider>.token`
 
@@ -74,10 +74,10 @@ providers {
 ```
 
 :::warning
-For the Bitbucket Cloud REST API, `user` must be your **Atlassian account email** (listed under *Personal settings > Email aliases* in Bitbucket), *not* your Bitbucket username. Using the username results in a `401 Not authorized` error.
+For the Bitbucket Cloud REST API, `user` must be your **Atlassian account email** (listed under *Personal settings > Email aliases* in Bitbucket), not your Bitbucket username. Using the username results in a `401 Not authorized` error.
 :::
 
-When creating the [API token](https://id.atlassian.com/manage-profile/security/api-tokens), select **Create API token with scopes** and grant at least `read:repository:bitbucket` (add `write:repository:bitbucket` if you also push). A token without Bitbucket scopes — for example one created only for Jira or Confluence — is rejected with `401 Not authorized`.
+When you create the [API token](https://id.atlassian.com/manage-profile/security/api-tokens), select **Create API token with scopes** and grant at least `read:repository:bitbucket`. Add `write:repository:bitbucket` if you also push. A token without Bitbucket scopes (for example, one created only for Jira or Confluence) is rejected with `401 Not authorized`.
 
 <AddedInVersion version="25.10">
 API tokens are supported for BitBucket authentication. When both `token` and `password` are provided, the API token takes priority over the app password.

--- a/docs/git.mdx
+++ b/docs/git.mdx
@@ -30,17 +30,13 @@ The following configuration properties are supported for each provider configura
 
 User name required to access private repositories on the SCM server.
 
-##### `providers.<provider>.token`
+##### `providers.<provider>.password`
 
-*Required only for private Gitlab servers and supported for BitBucket*
-
-Private API access token.
-
-User password required to access private repositories on the SCM server.
+User password required to access private repositories on the SCM server. For BitBucket, use your API token as the `token` value instead — app passwords are deprecated.
 
 ##### `providers.<provider>.token`
 
-*Required only for private Gitlab servers.*
+*Required only for private Gitlab servers and supported for BitBucket.*
 
 Private API access token.
 
@@ -66,23 +62,29 @@ SCM API `endpoint` URL, e.g., `https://api.github.com` (default: the same as `pr
 
 ### Bitbucket
 
-Create a `bitbucket` entry in the [SCM configuration file](#git-configuration) specifying your user name and either an API token or app password, as shown below:
+Create a `bitbucket` entry in the [SCM configuration file](#git-configuration) specifying your credentials and an API token, as shown below:
 
 ```groovy
 providers {
     bitbucket {
-        user = 'me'
+        user = 'me@my-email.com'
         token = 'my-api-token'
     }
 }
 ```
+
+:::warning
+For the Bitbucket Cloud REST API, `user` must be your **Atlassian account email** (listed under *Personal settings > Email aliases* in Bitbucket), *not* your Bitbucket username. Using the username results in a `401 Not authorized` error.
+:::
+
+When creating the [API token](https://id.atlassian.com/manage-profile/security/api-tokens), select **Create API token with scopes** and grant at least `read:repository:bitbucket` (add `write:repository:bitbucket` if you also push). A token without Bitbucket scopes — for example one created only for Jira or Confluence — is rejected with `401 Not authorized`.
 
 <AddedInVersion version="25.10">
 API tokens are supported for BitBucket authentication. When both `token` and `password` are provided, the API token takes priority over the app password.
 </AddedInVersion>
 
 :::note
-API tokens are substitute passwords for a user account which you can use for scripts and integrating tools in order to avoid putting your real password into configuration files. Learn more about [app passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) and [API tokens](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/).
+[App passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) are deprecated and stop working on June 9, 2026. Use [API tokens](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/) instead. An API token is a substitute password you can use in scripts and tools to avoid putting your real password into configuration files.
 :::
 
 ### Bitbucket Server


### PR DESCRIPTION
## Why

CI on master intermittently fails because the `BitbucketRepositoryProviderTest` integration tests can't authenticate against the Bitbucket Cloud API. Bitbucket Cloud is [deprecating app passwords](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation) (removed **June 9, 2026**) in favor of API tokens, and the token requirements are easy to get wrong:

- The REST API requires the **Atlassian account email** as the `user` (not the Bitbucket username) — using the username returns `401 Not authorized`.
- The API token must be created **with Bitbucket scopes** (`read:repository:bitbucket`, plus `write:` for push). A token scoped only for Jira/Confluence is rejected with `401`.

## What

- Update the **Bitbucket** section of `docs/git.mdx`: example now uses an email as `user`, plus a warning about the email requirement and a note about required token scopes.
- Note that app passwords are deprecated and stop working June 9, 2026.
- Fix a pre-existing bug in the credential-field reference list where `token` was documented twice and the `password` header was missing (its description was orphaned).

Docs-only change (`[ci skip]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
