### PR TITLE
Propagate Seqera Intelligent Compute scheduler run identifier to Platform (#7228)

### DIFF
--- a/adr/20260609-scheduler-run-identifier-propagation.md
+++ b/adr/20260609-scheduler-run-identifier-propagation.md
@@ -1,0 +1,126 @@
+# Propagate the Seqera Intelligent Compute scheduler run identifier to Platform
+
+- Authors: Jorge Ejarque
+- Status: draft
+- Deciders: Jorge Ejarque, Paolo Di Tommaso
+- Date: 2026-06-09
+- Tags: nf-seqera, nf-tower, intelligent-compute, scheduler, platform, trace, accounting
+
+## Summary
+
+When a workflow runs on the Seqera Intelligent Compute scheduler (the `seqera` executor),
+the scheduler assigns a run identifier that Platform currently has no way to associate with
+its workflow record. This ADR covers the **Nextflow side**: capturing that run identifier and
+propagating it to Platform via a dedicated `PATCH /workflow/{workflowId}` request.
+
+## Problem Statement
+
+Platform needs the scheduler's run identifier, per workflow, to retrieve authoritative cost and
+resource-usage metrics (settled cost, VM types, etc.) from the scheduler after completion. Today
+the scheduler `runId` is created inside `SeqeraExecutor` (lazily, on the first task submission) and
+never leaves the executor.
+
+## Goals or Decision Drivers
+
+- Make the run identifier available to Platform **as early as possible** — the first task
+  submission both assigns the id and drives the trace sender loop, so it is reported (via the
+  `PATCH /workflow/{id}` endpoint) at the earliest moment it exists, well before completion.
+- Keep `nextflow` core free of any dependency on the `nf-seqera` plugin.
+- Reuse existing patterns (`WorkflowMetadata`, the `TowerObserver` sender loop, `TowerClient`)
+  rather than introducing new mechanisms.
+
+## Non-goals
+
+- The Platform-side changes (the `tw_workflow_ext` satellite table, the
+  `PATCH /workflow/{workflowId}` endpoint, and the cost-retrieval cron). Those are the Platform
+  half of this work.
+- Per-task cost or VM attribution and workspace-level rollups (out of scope for the consumer
+  feature's v1).
+- A separate "scheduler enabled" flag. An earlier iteration carried a config-derived `enabled`
+  boolean on the workflow object; it was dropped because (a) it is never consumed inside Nextflow,
+  (b) deriving it from run-level config is unreliable (it misses per-process `withName:{ executor }`
+  overrides, so it could report `false` for a run that does use the scheduler and sends a `runId`),
+  and (c) the presence of `schedRunId` already tells Platform the run is scheduler-managed.
+
+## Solution or decision outcome
+
+The scheduler run id is held on `PlatformMetadata` as a single `volatile String schedRunId` field —
+i.e. `workflow.platform.schedRunId`, grouped with the other Platform identifiers (`workflowId`,
+`workflowUrl`) rather than promoted to a top-level `workflow.schedRunId` attribute. It is delivered to
+Platform via a one-off `PATCH /workflow/{workflowId}` request with body `{ "schedRunId": "…" }`.
+
+- `SeqeraExecutor.createRun()` assigns the run id on the first task submission and publishes it to
+  `PlatformMetadata.schedRunId` (`session.workflowMetadata?.platform?.setSchedRunId(runId)`).
+- `TowerObserver` reads it and sends the `PATCH` exactly once, at the earliest moment the id exists.
+
+## Rationale & discussion
+
+### Where the `runId` lives
+
+The run id is held on `PlatformMetadata` (`workflow.platform.schedRunId`), next to the other
+Platform identifiers, rather than as a top-level `WorkflowMetadata.schedRunId` field. This is a
+deliberate choice:
+
+- **It is not a general workflow property.** The run id is meaningless outside a Seqera Platform /
+  Intelligent Compute run — it is a Platform-assigned identifier, conceptually a sibling of
+  `platform.workflowId`. Promoting it to a top-level `workflow` attribute would advertise it to every
+  pipeline as if it were portable run metadata (like `workflow.runName` or `workflow.sessionId`),
+  which it is not.
+- **It keeps the serialization behaviour coherent for free.** `TowerObserver.makeCompleteReq()`
+  already strips the whole `platform` sub-object before sending, and at `onFlowBegin` (when the begin
+  and lineage records capture `toMap()`) the id is always still null — it is assigned later, on the
+  first task submission. So nesting under `platform` means the id is never carried as a real value on
+  the begin/complete/lineage workflow object, **without** needing a special-case exclusion in
+  `WorkflowMetadata.toMap()`. Platform receives the actual value only through the dedicated `PATCH`
+  endpoint.
+
+`schedRunId` is written by `SeqeraExecutor.createRun()` on the executor thread and read by the
+`TowerObserver` reporting thread, so the field is `volatile` to publish that write across threads.
+
+The `TowerObserver` delivers the id via `PATCH /workflow/{workflowId}` (`client.updateWorkflow`) with
+body `{ schedRunId }`. It is sent **exactly once**: the sender thread (`sendTasks0`) calls
+`sendSchedRunId()` each loop iteration, which fires the PATCH the first time the id is non-null and
+then latches. The id is assigned on the first task submission — the same trigger that starts the
+sender loop — so it is propagated at the earliest moment it exists, well before completion. (The run
+id is stable for the life of the run, so re-sending is unnecessary; Platform also treats an identical
+re-supply as idempotent and rejects a *conflicting* value with `400`.)
+
+### Best-effort delivery
+
+Propagating the run id is best-effort telemetry. `TowerClient.updateWorkflow` returns the HTTP
+`Response` rather than throwing, and `sendSchedRunId()` logs a failed update and lets the run carry
+on instead of aborting. Transient failures are already retried at the HTTP-client layer
+(`retryConfig`), so the single attempt latches only once that retry policy is exhausted.
+
+### Resulting wire contract
+
+```
+# PATCH /workflow/{workflowId} — sole carrier, sent once when the id is assigned
+{ schedRunId: "run-xyz" }      // not sent when not scheduler-managed / not yet assigned
+```
+
+The begin/complete (and lineage) workflow object carries no scheduler run id: it is either stripped
+with the `platform` sub-object (complete) or still null at capture time (begin/lineage).
+
+### Components changed (Nextflow side)
+
+- `modules/nextflow` — `PlatformMetadata.schedRunId` (`volatile`) field, grouped with the other
+  Platform identifiers. No change to `WorkflowMetadata.toMap()`.
+- `nf-seqera` — `SeqeraExecutor.createRun()` publishes `runId` to
+  `session.workflowMetadata.platform.schedRunId`.
+- `nf-tower` — `TowerObserver` sends the run id once via `PATCH /workflow/{workflowId}`
+  (`TowerClient.updateWorkflow`, best-effort); `TowerClient` gains the `updateWorkflow` method, its
+  URL builder, and `PATCH` support in `makeRequest`.
+
+### Platform-side dependency / risk
+
+Platform stores the `runId` in a `tw_workflow_ext` workflow-extension satellite table written by the
+new `PATCH /workflow/{workflowId}` endpoint. Until that endpoint ships, the PATCH request would be
+rejected — but because delivery is best-effort (the failure is logged and the run continues), this no
+longer creates a hard Nextflow ↔ Platform version dependency. The change should still be coordinated
+with the Platform endpoint so the id is actually persisted.
+
+## Links
+
+- The Platform-side cost-alignment feature is the consumer of this change; it requires the
+  scheduler run identifier on the Platform side.

--- a/modules/nextflow/src/main/groovy/nextflow/script/PlatformMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/PlatformMetadata.groovy
@@ -125,6 +125,18 @@ class PlatformMetadata {
      */
     volatile List<String> labels
 
+    /**
+     * The Seqera Intelligent Compute scheduler run identifier.
+     *
+     * <p>Assigned lazily by {@code SeqeraExecutor.createRun} on the first task submission (executor
+     * thread) and read by the {@code TowerObserver} reporting thread — hence {@code volatile}. It is
+     * null until the first task is submitted, and for runs not managed by the Intelligent Compute
+     * scheduler. Propagated to Platform via a dedicated {@code PATCH /workflow/{workflowId}} request;
+     * it is grouped here with the other Platform identifiers rather than exposed as a top-level
+     * {@code workflow} attribute.
+     */
+    volatile String schedRunId
+
     PlatformMetadata() {}
 
     PlatformMetadata(String workflowId) {

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
@@ -142,6 +142,8 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
         log.debug "[SEQERA] Creating run: ${request}"
         final response = client.createRun(request)
         this.runId = response.getRunId()
+        // publish the scheduler run id so the Tower observer can propagate it to Platform
+        session.workflowMetadata?.platform?.setSchedRunId(runId)
         log.debug "[SEQERA] Run created id: ${runId}; workflowId: '${workflowId}'; workflowUrl: '${workflowUrl}'"
         // Initialize and start batch submitter with error callback to abort on fatal errors
         this.batchSubmitter = new SeqeraBatchSubmitter(

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
@@ -293,6 +293,40 @@ class SeqeraExecutorTest extends Specification {
         executor.batchSubmitter?.shutdown()
     }
 
+    def 'createRun publishes the run id to the platform metadata'() {
+        given:
+        SysEnv.push([:])
+        def mockClient = Mock(SchedClient) {
+            createRun(_) >> new CreateRunResponse().runId('run-xyz')
+        }
+        def platformMeta = Mock(nextflow.script.PlatformMetadata)
+        def workflowMeta = Mock(WorkflowMetadata) {
+            getPlatform() >> platformMeta
+        }
+        def session = Mock(Session) {
+            getConfig() >> [tower: [:]]
+            getWorkflowMetadata() >> workflowMeta
+            getWorkDir() >> java.nio.file.Paths.get('/work')
+            getRunName() >> 'test-run'
+        }
+        def seqeraOpts = new ExecutorOpts(endpoint: 'https://sched.example.com', provider: 'aws', region: 'eu-west-1')
+        def executor = new SeqeraExecutor()
+        executor.session = session
+        executor.@seqeraConfig = seqeraOpts
+        executor.@client = mockClient
+
+        when:
+        executor.createRun()
+
+        then:
+        executor.runId == 'run-xyz'
+        and:
+        1 * platformMeta.setSchedRunId('run-xyz')
+
+        cleanup:
+        executor.batchSubmitter?.shutdown()
+    }
+
 
     /**
      * Builds a SchedClientConfig using the same logic as {@link SeqeraExecutor#createClient()}

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -152,6 +152,18 @@ class TowerClient {
         }
     }
 
+    /**
+     * Update workflow-extension metadata via the generic {@code PATCH /workflow/{workflowId}}
+     * endpoint. Used to propagate the Seqera Intelligent Compute scheduler run id.
+     *
+     * <p>Returns the {@link Response} rather than throwing on error so the caller can decide how
+     * to react: propagating the run id is best-effort telemetry and must not abort the run.
+     */
+    Response updateWorkflow(Map req, String workspaceId, String workflowId) {
+        final url = getUrlWorkflowUpdate(workspaceId, workflowId)
+        return sendHttpMessage(url, req, 'PATCH')
+    }
+
     protected Map sendAndProcessRequest(String url, Map req, String method){
         final resp = sendHttpMessage(url, req, method)
         if( resp.error ) {
@@ -196,6 +208,13 @@ class TowerClient {
 
     protected String getUrlTraceProgress(String workspaceId, String workflowId) {
         def result = "$endpoint/trace/$workflowId/progress"
+        if( workspaceId )
+            result += "?workspaceId=$workspaceId"
+        return result
+    }
+
+    protected String getUrlWorkflowUpdate(String workspaceId, String workflowId) {
+        def result = "$endpoint/workflow/$workflowId"
         if( workspaceId )
             result += "?workspaceId=$workspaceId"
         return result
@@ -346,6 +365,9 @@ class TowerClient {
 
         if( verb == 'POST' )
             return builder.POST(HttpRequest.BodyPublishers.ofString(payload)).build()
+
+        if( verb == 'PATCH' )
+            return builder.method('PATCH', HttpRequest.BodyPublishers.ofString(payload)).build()
 
         throw new IllegalArgumentException("Unsupported HTTP verb: $verb")
     }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerObserver.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerObserver.groovy
@@ -105,6 +105,8 @@ class TowerObserver implements TraceObserverV2 {
 
     private Map<String,Boolean> allContainers = new ConcurrentHashMap<>()
 
+    private boolean schedRunIdSent
+
     TowerObserver(Session session, TowerClient client, String workspaceId, Map env) {
         this.session = session
         this.workspaceId = workspaceId
@@ -428,6 +430,36 @@ class TowerObserver implements TraceObserverV2 {
         return result
     }
 
+    /**
+     * @return the Seqera Intelligent Compute scheduler run identifier for the current
+     * execution, or {@code null} when the run is not managed by the scheduler or the
+     * identifier has not been assigned yet (i.e. before the first task is submitted).
+     */
+    protected String getSchedRunId() {
+        return session.workflowMetadata?.platform?.schedRunId
+    }
+
+    /**
+     * Propagate the scheduler run id to Platform via a one-off {@code PATCH /workflow/{workflowId}}
+     * as soon as it is available (assigned on the first task submission). The id is stable for the
+     * life of the run, so it is sent exactly once; Platform stores it as a workflow-extension field
+     * used for cost and resource accounting.
+     *
+     * <p>This is best-effort telemetry: a failure only means Platform shows less information, so the
+     * error is logged and the run carries on instead of aborting. The attempt is made just once.
+     */
+    protected void sendSchedRunId() {
+        if( schedRunIdSent )
+            return
+        final id = getSchedRunId()
+        if( !id )
+            return
+        final resp = client.updateWorkflow([schedRunId: id], workspaceId, workflowId)
+        if( resp.error )
+            log.debug("Unable to propagate Seqera scheduler run id to Platform -- ${resp.code}: ${resp.message}")
+        schedRunIdSent = true
+    }
+
     protected String mapToString(def obj) {
         if( obj == null )
             return null
@@ -547,6 +579,9 @@ class TowerObserver implements TraceObserverV2 {
                     if( ev.completed )
                         complete = true
                 }
+
+                // propagate the scheduler run id once it is available (sent exactly once)
+                sendSchedRunId()
 
                 // check if there's something to send
                 final now = System.currentTimeMillis()

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -153,6 +153,7 @@ class TowerClientTest extends Specification {
         client.getUrlTraceProgress(null, '12345') == 'https://api.cloud.seqera.io/trace/12345/progress'
         client.getUrlTraceHeartbeat(null, '12345') == 'https://api.cloud.seqera.io/trace/12345/heartbeat'
         client.getUrlTraceComplete(null, '12345') == 'https://api.cloud.seqera.io/trace/12345/complete'
+        client.getUrlWorkflowUpdate(null, '12345') == 'https://api.cloud.seqera.io/workflow/12345'
     }
 
     def 'should get trace endpoint with workspace' () {
@@ -166,6 +167,7 @@ class TowerClientTest extends Specification {
         client.getUrlTraceProgress('300', '12345') == 'https://api.cloud.seqera.io/trace/12345/progress?workspaceId=300'
         client.getUrlTraceHeartbeat('300', '12345') == 'https://api.cloud.seqera.io/trace/12345/heartbeat?workspaceId=300'
         client.getUrlTraceComplete('300', '12345') == 'https://api.cloud.seqera.io/trace/12345/complete?workspaceId=300'
+        client.getUrlWorkflowUpdate('300', '12345') == 'https://api.cloud.seqera.io/workflow/12345?workspaceId=300'
     }
 
     def 'should load schema col len' () {
@@ -190,6 +192,19 @@ class TowerClientTest extends Specification {
         request != null
         request.method() == 'POST'
         request.uri().toString() == 'http://example.com/test'
+    }
+
+    def 'should build a PATCH request with content'() {
+        given:
+        def tower = new TowerClient()
+        def content = '{"schedRunId": "run-xyz"}'
+
+        when:
+        def request = tower.makeRequest('http://example.com/workflow/123', content, 'PATCH')
+
+        then:
+        request.method() == 'PATCH'
+        request.uri().toString() == 'http://example.com/workflow/123'
     }
 
     def 'should send http message' () {

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerObserverTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerObserverTest.groovy
@@ -152,6 +152,73 @@ class TowerObserverTest extends Specification {
         aroundNow(req.instant)
     }
 
+    def 'should not add scheduler run id to progress requests' () {
+        given:
+        def platform = Mock(PlatformMetadata) { getSchedRunId() >> 'run-xyz' }
+        def meta = Mock(WorkflowMetadata) { getPlatform() >> platform }
+        def session = Mock(Session) { getWorkflowMetadata() >> meta }
+        def PROGRESS = Mock(WorkflowProgress)
+        def observer = Spy(newObserver(session))
+        observer.getWorkflowProgress(true) >> PROGRESS
+
+        when: 'the run id travels via PATCH /workflow, not on progress/heartbeat'
+        then:
+        !observer.makeTasksReq([]).containsKey('schedRunId')
+        and:
+        !observer.makeHeartbeatReq().containsKey('schedRunId')
+    }
+
+    def 'should send the scheduler run id once via PATCH when assigned' () {
+        given:
+        def platform = Mock(PlatformMetadata) { getSchedRunId() >> 'run-xyz' }
+        def meta = Mock(WorkflowMetadata) { getPlatform() >> platform }
+        def session = Mock(Session) { getWorkflowMetadata() >> meta }
+        def client = Mock(TowerClient)
+        def observer = new TowerObserver(session, client, 'ws-1', [:])
+        observer.@workflowId = 'wf-123'
+
+        when: 'invoked repeatedly (once per sender loop iteration)'
+        observer.sendSchedRunId()
+        observer.sendSchedRunId()
+
+        then: 'the run id is patched exactly once'
+        1 * client.updateWorkflow([schedRunId: 'run-xyz'], 'ws-1', 'wf-123') >> new TowerClient.Response(200, 'ok')
+    }
+
+    def 'should not abort the run when the scheduler run id update fails' () {
+        given:
+        def platform = Mock(PlatformMetadata) { getSchedRunId() >> 'run-xyz' }
+        def meta = Mock(WorkflowMetadata) { getPlatform() >> platform }
+        def session = Mock(Session) { getWorkflowMetadata() >> meta }
+        def client = Mock(TowerClient)
+        def observer = new TowerObserver(session, client, 'ws-1', [:])
+        observer.@workflowId = 'wf-123'
+
+        when: 'the update returns an error and is then invoked again'
+        observer.sendSchedRunId()
+        observer.sendSchedRunId()
+
+        then: 'the error response does not abort the run and the attempt is made just once'
+        1 * client.updateWorkflow([schedRunId: 'run-xyz'], 'ws-1', 'wf-123') >> new TowerClient.Response(500, 'boom')
+        noExceptionThrown()
+    }
+
+    def 'should not send the scheduler run id when not assigned' () {
+        given:
+        def platform = Mock(PlatformMetadata) { getSchedRunId() >> null }  // not scheduler-managed
+        def meta = Mock(WorkflowMetadata) { getPlatform() >> platform }
+        def session = Mock(Session) { getWorkflowMetadata() >> meta }
+        def client = Mock(TowerClient)
+        def observer = new TowerObserver(session, client, 'ws-1', [:])
+        observer.@workflowId = 'wf-123'
+
+        when:
+        observer.sendSchedRunId()
+
+        then:
+        0 * client.updateWorkflow(_, _, _)
+    }
+
     static now_millis = System.currentTimeMillis()
     static now_instant = OffsetDateTime.ofInstant(Instant.ofEpochMilli(now_millis), ZoneId.systemDefault())
 


### PR DESCRIPTION
Backport of #7228 to `STABLE-26.04.x`.

Cherry-picks commit e2a673f8cda8e28fcb365d55fc7827d34b0eb9a7 (Propagate Seqera Intelligent Compute scheduler run identifier to Platform), which applied cleanly with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)