### PR TITLE
Drop dead oss.sonatype.org repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,6 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url 'https://repo.eclipse.org/content/groups/releases' }
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url = "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/releases" }
         maven { url = "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/snapshots" }
     }


### PR DESCRIPTION
## Problem

Builds intermittently fail at the compile step with errors like:

```
Could not resolve io.seqera:lib-trace:0.1.0
  > Could not GET '.../oss.sonatype.org/content/repositories/snapshots/.../lib-trace-0.1.0.pom'.
    Received status code 504 from server: Gateway Time-out
```

(e.g. https://github.com/nextflow-io/nextflow/actions/runs/28508064479)

The legacy OSSRH repository (`oss.sonatype.org`) has been decommissioned by Sonatype and now returns 404/504. Gradle treats a `5xx` response as a **fatal** error and aborts resolution rather than falling through to the next repository — so a timeout there breaks resolution of artifacts that are actually available further down the list (on `maven.seqera.io`). This is why unrelated PRs were failing intermittently across branches.

## Fix

Remove the dead `oss.sonatype.org` snapshots repository.

Nothing in this project consumes a `-SNAPSHOT` from Sonatype:
- the `io.seqera:*` libs are **releases** served from `maven.seqera.io/releases`
- everything else resolves from Maven Central

So the repo can simply be removed rather than repointed to the new Central Portal snapshots URL (`https://central.sonatype.com/repository/maven-snapshots/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)