### PR TITLE
Skip nf-tower when superseded by nf-seqera

### DIFF
--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -27,6 +27,7 @@ import nextflow.SysEnv
 import nextflow.exception.AbortOperationException
 import nextflow.extension.Bolts
 import nextflow.extension.FilesEx
+import nextflow.util.VersionNumber
 import org.pf4j.DefaultPluginManager
 import org.pf4j.PluginManager
 import org.pf4j.PluginState
@@ -463,8 +464,41 @@ class PluginsFacade implements PluginStateListener {
             specs << defaultPlugins.getPlugin('nf-cloudcache')
         }
 
+        // nf-seqera (>=1.0.0) integrates the former standalone nf-tower plugin; when both are
+        // requested (e.g. nf-tower declared in the config while nf-seqera is auto-loaded because
+        // tower is enabled) drop nf-tower to avoid running two Platform observers at the same time
+        specs = dropSupersededTowerPlugin(specs)
+
         log.debug "Plugins resolved requirement=$specs"
         return specs
+    }
+
+    /**
+     * The {@code nf-tower} plugin has been integrated into {@code nf-seqera} since version 1.0.0.
+     * When both plugins are requested, remove {@code nf-tower} so that the Seqera Platform
+     * integration is provided solely by {@code nf-seqera} and it is not reported twice.
+     *
+     * @param specs The list of resolved plugin requirements
+     * @return The plugin requirements with {@code nf-tower} removed when superseded by {@code nf-seqera}
+     */
+    protected List<PluginRef> dropSupersededTowerPlugin(List<PluginRef> specs) {
+        final tower = specs.find { it.id == 'nf-tower' }
+        final seqera = specs.find { it.id == 'nf-seqera' }
+        if( tower && seqera && isSeqeraSupersedingTower(seqera.version) ) {
+            log.warn "Plugin 'nf-tower' is superseded by 'nf-seqera${seqera.version ? '@'+seqera.version : ''}' and will not be loaded -- Seqera Platform integration is now provided by the nf-seqera plugin"
+            return specs.findAll { it.id != 'nf-tower' }
+        }
+        return specs
+    }
+
+    /**
+     * @param version The {@code nf-seqera} plugin version (can be {@code null} when unspecified)
+     * @return {@code true} when the given {@code nf-seqera} version integrates the {@code nf-tower}
+     *      functionality i.e. it's {@code >= 1.0.0} or unspecified (defaulting to the bundled version)
+     */
+    protected boolean isSeqeraSupersedingTower(String version) {
+        // a missing version implies the default bundled plugin, which is always >= 1.0.0
+        return !version || new VersionNumber(version).matches('>=1.0.0')
     }
 
     protected List<PluginRef> defaultPluginsConf(Map config) {

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginsFacadeTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginsFacadeTest.groovy
@@ -206,6 +206,74 @@ class PluginsFacadeTest extends Specification {
 
     }
 
+    def 'should drop nf-tower when superseded by nf-seqera' () {
+        given:
+        def defaults = new DefaultPlugins(plugins: [
+                'nf-seqera': new PluginRef('nf-seqera', '1.0.0'),
+                'nf-tower': new PluginRef('nf-tower', '1.11.0')
+        ])
+
+        // nf-tower explicitly declared while nf-seqera is auto-loaded because tower is enabled
+        when:
+        def handler = new PluginsFacade(defaultPlugins: defaults, env: [NXF_PLUGINS_DEFAULT:'true'])
+        def result = handler.pluginsRequirement([tower:[enabled:true], plugins: ['nf-tower']])
+        then:
+        result == [ new PluginRef('nf-seqera', '1.0.0') ]
+
+        // nf-tower explicitly declared while nf-seqera is auto-loaded because TOWER_ACCESS_TOKEN is set
+        when:
+        handler = new PluginsFacade(defaultPlugins: defaults, env: [TOWER_ACCESS_TOKEN:'xyz'])
+        result = handler.pluginsRequirement([plugins: ['nf-tower']])
+        then:
+        result == [ new PluginRef('nf-seqera', '1.0.0') ]
+
+        // both plugins explicitly declared
+        when:
+        handler = new PluginsFacade(defaultPlugins: defaults, env: [:])
+        result = handler.pluginsRequirement([plugins: ['nf-tower', 'nf-seqera']])
+        then:
+        result == [ new PluginRef('nf-seqera', '1.0.0') ]
+
+        // nf-tower alone is left untouched when nf-seqera is not requested
+        when:
+        handler = new PluginsFacade(defaultPlugins: defaults, env: [:])
+        result = handler.pluginsRequirement([plugins: ['nf-tower']])
+        then:
+        result == [ new PluginRef('nf-tower', '1.11.0') ]
+    }
+
+    def 'should keep nf-tower when nf-seqera version does not supersede it' () {
+        given:
+        def defaults = new DefaultPlugins(plugins: [
+                'nf-seqera': new PluginRef('nf-seqera', '0.1.0'),
+                'nf-tower': new PluginRef('nf-tower', '1.11.0')
+        ])
+
+        when:
+        def handler = new PluginsFacade(defaultPlugins: defaults, env: [:])
+        def result = handler.pluginsRequirement([plugins: ['nf-tower@1.11.0', 'nf-seqera@0.1.0']])
+        then:
+        result == [ new PluginRef('nf-tower', '1.11.0'), new PluginRef('nf-seqera', '0.1.0') ]
+    }
+
+    def 'should detect when nf-seqera supersedes nf-tower' () {
+        given:
+        def handler = new PluginsFacade()
+
+        expect:
+        handler.isSeqeraSupersedingTower(VERSION) == EXPECTED
+
+        where:
+        VERSION  | EXPECTED
+        null     | true
+        ''       | true
+        '1.0.0'  | true
+        '1.2.3'  | true
+        '2.0.0'  | true
+        '0.1.0'  | false
+        '0.9.9'  | false
+    }
+
     def 'should return default plugins given config' () {
         given:
         SysEnv.push([:])


### PR DESCRIPTION
## Problem

Since `nf-seqera@1.0.0` the former standalone `nf-tower` plugin is integrated into `nf-seqera`. Nextflow no longer builds or autostarts `nf-tower` (the autostart path in `PluginsFacade` already points at `nf-seqera`), but many existing pipelines / institutional configs still pin it explicitly via `plugins { id 'nf-tower' }`.

When such a config also enables Platform (any of `tower.enabled`, `fusion.enabled`, `TOWER_ACCESS_TOKEN`, or `process.executor = 'seqera'`), `nf-seqera` is auto-loaded **in addition** to the explicitly declared `nf-tower`. Both register a Platform observer, so the run is reported to Seqera Platform **twice**.

## Change

In `PluginsFacade.pluginsRequirement()`, after the plugin requirements are assembled, drop `nf-tower` whenever `nf-seqera` (>=1.0.0) is also requested. This single chokepoint covers every combination of explicit declaration + the four autostart triggers, since they all feed the same `specs` list.

- `dropSupersededTowerPlugin(specs)` — removes `nf-tower` and logs a `warn` when superseded.
- `isSeqeraSupersedingTower(version)` — true for a null/blank (default bundled) version or `>=1.0.0`; a hypothetical `nf-seqera@0.x` pin leaves `nf-tower` untouched.

## Tests

`PluginsFacadeTest`:
- `nf-tower` + `tower.enabled=true` → `[nf-seqera]`
- `nf-tower` + `TOWER_ACCESS_TOKEN` set → `[nf-seqera]`
- both plugins declared explicitly → `[nf-seqera]`
- `nf-tower` alone → untouched
- `nf-seqera@0.1.0` + `nf-tower` → both kept (version does not supersede)
- data-driven version matrix for `isSeqeraSupersedingTower`

🤖 Generated with [Claude Code](https://claude.com/claude-code)