### PR TITLE
Fix CVE-2025-14813: replace discontinued bcprov-ext with bcprov-jdk18on 1.84

### DIFF
--- a/plugins/nf-k8s/build.gradle
+++ b/plugins/nf-k8s/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
-    api 'org.bouncycastle:bcprov-ext-jdk18on:1.78.1'
+    api 'org.bouncycastle:bcprov-jdk18on:1.84'
     api 'org.bouncycastle:bcpkix-jdk18on:1.84'
 
     testImplementation(testFixtures(project(":nextflow")))


### PR DESCRIPTION
## Problem

The `nf-k8s` plugin depended on `org.bouncycastle:bcprov-ext-jdk18on:1.78.1`, flagged as **critical** by [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479) (GOST 28147 CTR mode keystream reuse).

The `-ext` ("extended") variant was **discontinued at 1.78.1** — Maven Central has no 1.79+, which is why the advisory lists no patched version for any `-ext` package. It therefore cannot simply be version-bumped.

## Fix

Switch to the standard `org.bouncycastle:bcprov-jdk18on:1.84`, which is outside all affected version ranges and aligned with the existing `bcpkix-jdk18on:1.84`.

## Why it's safe

The only BouncyCastle usage is `SSLUtils.java` (PEM key/cert parsing), which uses `PEMParser`/`PEMKeyPair`/`JcaPEMKeyConverter` (from bcpkix) and `BouncyCastleProvider`/`PrivateKeyInfo` (from the standard bcprov). None of the extended algorithms (GOST/DSTU — the actual CVE surface) are used, so this is a no-op functionally. `bcpkix` declares no transitive `bcprov`, so the explicit provider dependency is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
