### PR TITLE
Fix containerOptions --opt=value parsing for AWS Batch (#5190)

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/CmdLineHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/CmdLineHelper.groovy
@@ -28,7 +28,7 @@ import java.util.regex.Pattern
 @CompileStatic
 class CmdLineHelper {
 
-    static private Pattern CLI_OPT = ~/--([a-zA-Z_-]+)(?:\W.*)?$|-([a-zA-Z])(?:\W.*)?$/
+    static private Pattern CLI_OPT = ~/--([a-zA-Z_-]+)(?:=(.*))?$|-([a-zA-Z])(?:=(.*))?$/
 
     private List<String> args
 
@@ -128,7 +128,17 @@ class CmdLineHelper {
                 if( opt ) {
                     result.addOption(opt,'true')
                 }
-                opt = matcher.group(1) ?: matcher.group(2)
+                final name = matcher.group(1) ?: matcher.group(3)
+                final value = matcher.group(1) ? matcher.group(2) : matcher.group(4)
+                if( value ) {
+                    // the value was given inline as `--opt=value` or `-o=value`
+                    result.addOption(name, value)
+                    last = name
+                    opt = null
+                }
+                else {
+                    opt = name
+                }
             }
             else {
                 if( !opt ) {

--- a/modules/nf-commons/src/test/nextflow/util/CmdLineHelperTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/CmdLineHelperTest.groovy
@@ -62,6 +62,11 @@ class CmdLineHelperTest extends Specification{
         '--foo 1 -bar 2'        | '[option{foo: [1, -bar, 2]}]'
         and:
         '--foo-name 1 --bar-opt 2' | '[option{foo-name: [1]}, option{bar-opt: [2]}]'
+        and:
+        // inline value using the `=` separator (GH #5190)
+        '--shm-size=1000000000'    | '[option{shm-size: [1000000000]}]'
+        '--foo=1'                  | '[option{foo: [1]}]'
+        '-a=1'                     | '[option{a: [1]}]'
     }
 
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsContainerOptionsMapperTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsContainerOptionsMapperTest.groovy
@@ -136,6 +136,15 @@ class AwsContainerOptionsMapperTest extends Specification {
         properties.linuxParameters.sharedMemorySize() == 1024
     }
 
+    def 'should set shared memory size using equals syntax'() {
+
+        when:
+        def map = CmdLineHelper.parseGnuArgs('--shm-size=256m')
+        def properties = AwsContainerOptionsMapper.createContainerProperties(map)
+        then:
+        properties.linuxParameters.sharedMemorySize() == 256
+    }
+
     def 'should set memory swappiness'() {
 
         when:


### PR DESCRIPTION
Fix #5190 

`CmdLineHelper.parseGnuArgs` classified the GNU long-option form `--opt=value` as a bare boolean flag: the CLI_OPT regex swallowed the `=value` suffix as opaque trailing text via `(?:\W.*)?$`, so the value was lost and the option defaulted to `'true'`. On AWS Batch this made `containerOptions '--shm-size=1000000000'` fail at task submission with `For input string: "true"` when AwsContainerOptionsMapper cast the value to Integer.

Change CLI_OPT to explicitly capture an optional inline `=value` per alternative and have parseGnuArgs use the captured value immediately (mirroring the space-separated logic). The value is checked for truthiness so quoted forms like `-a='b -1'` keep falling back to the next token, preserving existing behavior.

This fix also addresses a correctness gap in `parseGnuArgs`, since GNU convention includes the `--name=value` form