### PR TITLE
Add docker.cpuLimits config option

### DIFF
--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -824,6 +824,8 @@ The following settings are available:
 
 ##### `docker.cpuLimits`
 
+<AddedInVersion version="26.10" />
+
 Use the `--cpus` flag to limit CPU usage instead of `--cpu-shares` (default`false`).
 
 Unlike `--cpu-shares`, which only affects the relative scheduling weight of a container, `--cpus` enforces a hard limit on the number of CPUs available to it. See the [Docker documentation](https://docs.docker.com/engine/containers/resource_constraints/#cpu) for details.

--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -822,6 +822,12 @@ The `docker` scope controls how [Docker](https://www.docker.com) containers are 
 
 The following settings are available:
 
+##### `docker.cpuLimits`
+
+Use the `--cpus` flag to limit CPU usage instead of `--cpu-shares` (default`false`).
+
+Unlike `--cpu-shares`, which only affects the relative scheduling weight of a container, `--cpus` enforces a hard limit on the number of CPUs available to it. See the [Docker documentation](https://docs.docker.com/engine/containers/resource_constraints/#cpu) for details.
+
 ##### `docker.enabled`
 
 Enable Docker execution (default`false`).

--- a/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/DockerBuilder.groovy
@@ -44,7 +44,7 @@ class DockerBuilder extends ContainerBuilder<DockerBuilder> {
 
     private kill = true
 
-    private boolean legacy = System.getenv('NXF_DOCKER_LEGACY')=='true'
+    private boolean legacy
 
     private String mountFlags0
 
@@ -52,8 +52,12 @@ class DockerBuilder extends ContainerBuilder<DockerBuilder> {
 
     private String capAdd
 
+    private boolean cpuLimits
+
     DockerBuilder(String name, DockerConfig config) {
         this.image = name
+
+        this.cpuLimits = config.cpuLimits
 
         if( config.engineOptions )
             addEngineOptions(config.engineOptions)
@@ -125,7 +129,9 @@ class DockerBuilder extends ContainerBuilder<DockerBuilder> {
 
         result << 'run -i '
 
-        if( cpus && !legacy )
+        if( cpus && cpuLimits )
+            result << "--cpus ${cpus} "
+        else if( cpus && !legacy )
             result << "--cpu-shares ${cpus * 1024} "
 
         if( cpuset ) {

--- a/modules/nextflow/src/main/groovy/nextflow/container/DockerConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/container/DockerConfig.groovy
@@ -34,6 +34,12 @@ class DockerConfig implements ConfigScope, ContainerConfig {
 
     @ConfigOption
     @Description("""
+        Use the `--cpus` flag to limit CPU usage instead of `--cpu-shares` (default: `false`).
+    """)
+    final boolean cpuLimits
+
+    @ConfigOption
+    @Description("""
         Enable Docker execution (default: `false`).
     """)
     boolean enabled
@@ -125,6 +131,7 @@ class DockerConfig implements ConfigScope, ContainerConfig {
     DockerConfig() {}
 
     DockerConfig(Map opts) {
+        cpuLimits = opts.cpuLimits as boolean
         enabled = opts.enabled as boolean
         engineOptions = opts.engineOptions
         envWhitelist = ContainerHelper.parseEnvWhitelist(opts.envWhitelist)

--- a/modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/container/DockerBuilderTest.groovy
@@ -151,6 +151,11 @@ class DockerBuilderTest extends Specification {
                 .build()
                 .runCommand == 'docker run -i -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" fedora'
 
+        new DockerBuilder('fedora', new DockerConfig(cpuLimits: true))
+                .setCpus(2)
+                .build()
+                .runCommand == 'docker run -i --cpus 2 -v "$NXF_TASK_WORKDIR":"$NXF_TASK_WORKDIR" -w "$NXF_TASK_WORKDIR" fedora'
+
         new DockerBuilder('fedora')
                 .setMemory('10g')
                 .build()


### PR DESCRIPTION
Fix #5323 

This PR adds the `docker.cpuLimits` config option, which uses `--cpus` to limit CPU usage of Docker containers instead of `--cpu-shares`. This approach is preferred when using the local executor, as noted in the linked issue

Also removes the `NXF_DOCKER_LEGACY` env var, which no longer works since 25.10 and is undocumented anyway