### PR TITLE
Exclude null config env entries from task environment

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -1606,7 +1606,11 @@ class TaskProcessor {
         // add the taskConfig environment entries
         if( session.config.env instanceof Map ) {
             session.config.env.each { name, value ->
-                result.put( name, value?.toString() )
+                // skip entries with a null value (e.g. `env(HOST_VAR)` referencing a
+                // host environment variable that is not set) instead of exporting
+                // them as an empty string with a spurious warning -- see #5722
+                if( value != null )
+                    result.put( name, value.toString() )
             }
         }
         else {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -73,7 +73,7 @@ class TaskProcessorTest extends Specification {
         binFolder.mkdirs()
 
         when:
-        def session = new Session([env: [X:"1", Y:"2", Z:null]])
+        def session = new Session([env: [X:"1", Y:"2", Z:null, W:'']])
         session.setBaseDir(home)
         def processor = createProcessor('task1', session)
         def builder = new ProcessBuilder()
@@ -84,6 +84,8 @@ class TaskProcessorTest extends Specification {
         builder.environment().Y == '2'
         builder.environment().PATH == "\$PATH:${binFolder.toString()}"
         !builder.environment().containsKey('Z')
+        // explicit empty-string values are retained (unlike null values) -- see #5722
+        builder.environment().W == ''
 
         when:
         session = new Session([env: [X:"1", Y:"2", PATH:'/some']])

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -73,7 +73,7 @@ class TaskProcessorTest extends Specification {
         binFolder.mkdirs()
 
         when:
-        def session = new Session([env: [X:"1", Y:"2"]])
+        def session = new Session([env: [X:"1", Y:"2", Z:null]])
         session.setBaseDir(home)
         def processor = createProcessor('task1', session)
         def builder = new ProcessBuilder()
@@ -83,6 +83,7 @@ class TaskProcessorTest extends Specification {
         builder.environment().X == '1'
         builder.environment().Y == '2'
         builder.environment().PATH == "\$PATH:${binFolder.toString()}"
+        !builder.environment().containsKey('Z')
 
         when:
         session = new Session([env: [X:"1", Y:"2", PATH:'/some']])


### PR DESCRIPTION
Fix #5722 

When an `env` config setting references an unset host environment var via `env('HOST_VAR')`, the resolved value is null.

This PR updates the TaskProcessor to exclude these null values from the task environment instead of adding them with a null value. The current behavior causes a spurious "evaluates to an empty value" warning.

Explicit empty-string values (e.g. `env.FOO = ''`) are unaffected.
