### PR TITLE
Add graceful fallback for array directive with unsupported executors

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -22,7 +22,6 @@ import java.util.concurrent.locks.ReentrantLock
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import nextflow.executor.Executor
 import nextflow.executor.TaskArrayExecutor
 import nextflow.file.FileHelper
 import nextflow.util.CacheHelper
@@ -71,12 +70,9 @@ class TaskArrayCollector {
 
     private boolean closed = false
 
-    TaskArrayCollector(TaskProcessor processor, Executor executor, int arraySize) {
-        if( executor !instanceof TaskArrayExecutor )
-            throw new IllegalArgumentException("Executor '${executor.name}' does not support job arrays")
-
+    TaskArrayCollector(TaskProcessor processor, TaskArrayExecutor executor, int arraySize) {
         this.processor = processor
-        this.executor = (TaskArrayExecutor)executor
+        this.executor = executor
         this.arraySize = arraySize
         this.array = new ArrayList<>(arraySize)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -62,6 +62,7 @@ import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.CachedTaskHandler
 import nextflow.executor.Executor
 import nextflow.executor.StoredTaskHandler
+import nextflow.executor.TaskArrayExecutor
 import nextflow.extension.CH
 import nextflow.extension.DataflowHelper
 import nextflow.file.FileHelper
@@ -298,8 +299,16 @@ class TaskProcessor {
         this.forksCount = maxForks ? new LongAdder() : null
         this.isFair0 = config.getFair()
         final arraySize = config.getArray()
-        this.arrayCollector = arraySize > 0 ? new TaskArrayCollector(this, executor, arraySize) : null
+        this.arrayCollector = createArrayCollector(arraySize)
         log.debug "Creating process '$name': maxForks=${maxForks}; fair=${isFair0}; array=${arraySize}"
+    }
+
+    private TaskArrayCollector createArrayCollector(int arraySize) {
+        if( arraySize > 0 && executor instanceof TaskArrayExecutor )
+            return new TaskArrayCollector(this, executor, arraySize)
+        if( arraySize > 0 )
+            log.warn "Executor '${executor.name}' does not support job arrays -- the array directive will be ignored for process '$name'"
+        return null
     }
 
     /**


### PR DESCRIPTION
Fix #5924 

This PR allows the `array` directive to gracefully degrade when applied to unsupported executors (e.g. `local`)

This makes it easier to enable array jobs across the board with a single setting, instead of having to specify it for each process that can use it. Especially useful when e,g, a pipeline has a mix of local jobs and SLURM jobs.