### PR TITLE
feat: add plugin directory trust guard to harden shared plugin caches

### DIFF
--- a/docs/plugins/using-plugins.mdx
+++ b/docs/plugins/using-plugins.mdx
@@ -80,6 +80,7 @@ To use Nextflow plugins in an offline environment:
     Nextflow will attempt to download newer versions of plugins if their versions are not set. See [Identifiers][using-plugins-identifiers] for more information.
     :::
 
+[env-vars]: ../reference/env-vars
 [install-standalone]: ../install#standalone-distribution
 [using-plugins-config]: ./using-plugins#configuration
 [using-plugins-identifiers]: ./using-plugins#identifiers

--- a/docs/plugins/using-plugins.mdx
+++ b/docs/plugins/using-plugins.mdx
@@ -57,9 +57,9 @@ Plugin declarations in Nextflow configuration files are ignored when specifying 
 When Nextflow downloads plugins, it caches them in the directory specified by `NXF_PLUGINS_DIR` (`$HOME/.nextflow/plugins` by default).
 
 :::warning
-The plugin cache should be a private, per-user directory that is not writable by other users. Nextflow loads and executes cached plugin code without re-verifying its origin, so a shared plugin cache that is writable by other users (or owned by another user) allows a lower-trust user to replace cached plugin code with their own, which would then run inside your Nextflow process.
+The plugin cache should be a private, per-user directory that other users cannot write to. Nextflow loads and executes cached plugin code without re-verifying its origin. If the cache is writable by other users (or owned by another user), a lower-trust user can replace the cached code with their own, and that code then runs inside your Nextflow process.
 
-Keep `NXF_PLUGINS_DIR` owned by you and not world-writable (a group-writable directory owned by you, as created under the common umask 002, is fine). If a shared cache is required, use a directory owned by an administrator or a dedicated service account that regular users cannot modify, and add that owner to [`NXF_PLUGINS_TRUSTED_OWNERS`](../reference/env-vars.mdx). Use [`NXF_PLUGINS_STRICT_MODE`](../reference/env-vars.mdx) to control whether Nextflow warns about or refuses to load plugins from an untrusted directory.
+Keep `NXF_PLUGINS_DIR` owned by you and not world-writable. A group-writable directory owned by you, as created under the common umask 002, is fine. If you need a shared cache, use a directory owned by an administrator or a dedicated service account that regular users cannot modify, and add that owner to [`NXF_PLUGINS_TRUSTED_OWNERS`][env-vars]. Use [`NXF_PLUGINS_STRICT_MODE`][env-vars] to control whether Nextflow warns about or refuses to load plugins from an untrusted directory.
 :::
 
 ## Offline usage

--- a/docs/plugins/using-plugins.mdx
+++ b/docs/plugins/using-plugins.mdx
@@ -56,6 +56,12 @@ Plugin declarations in Nextflow configuration files are ignored when specifying 
 
 When Nextflow downloads plugins, it caches them in the directory specified by `NXF_PLUGINS_DIR` (`$HOME/.nextflow/plugins` by default).
 
+:::warning
+The plugin cache should be a private, per-user directory that is not writable by other users. Nextflow loads and executes cached plugin code without re-verifying its origin, so a shared plugin cache that is writable by other users (or owned by another user) allows a lower-trust user to replace cached plugin code with their own, which would then run inside your Nextflow process.
+
+Keep `NXF_PLUGINS_DIR` private (for example `chmod 700`) and owned by you. If a shared cache is required, use an administrator-owned, **read-only** directory that regular users cannot modify. Use [`NXF_PLUGINS_STRICT_MODE`](../reference/env-vars.mdx) to control whether Nextflow warns about or refuses to load plugins from an untrusted directory.
+:::
+
 ## Offline usage
 
 When running Nextflow in an offline environment, any required plugins must be downloaded and moved into the offline environment prior to any runs.

--- a/docs/plugins/using-plugins.mdx
+++ b/docs/plugins/using-plugins.mdx
@@ -59,7 +59,7 @@ When Nextflow downloads plugins, it caches them in the directory specified by `N
 :::warning
 The plugin cache should be a private, per-user directory that is not writable by other users. Nextflow loads and executes cached plugin code without re-verifying its origin, so a shared plugin cache that is writable by other users (or owned by another user) allows a lower-trust user to replace cached plugin code with their own, which would then run inside your Nextflow process.
 
-Keep `NXF_PLUGINS_DIR` private (for example `chmod 700`) and owned by you. If a shared cache is required, use an administrator-owned, **read-only** directory that regular users cannot modify. Use [`NXF_PLUGINS_STRICT_MODE`](../reference/env-vars.mdx) to control whether Nextflow warns about or refuses to load plugins from an untrusted directory.
+Keep `NXF_PLUGINS_DIR` owned by you and not world-writable (a group-writable directory owned by you, as created under the common umask 002, is fine). If a shared cache is required, use a directory owned by an administrator or a dedicated service account that regular users cannot modify, and add that owner to [`NXF_PLUGINS_TRUSTED_OWNERS`](../reference/env-vars.mdx). Use [`NXF_PLUGINS_STRICT_MODE`](../reference/env-vars.mdx) to control whether Nextflow warns about or refuses to load plugins from an untrusted directory.
 :::
 
 ## Offline usage

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -220,7 +220,13 @@ Specifies the URL of the plugin registry used to download and resolve plugins. T
 
 <AddedInVersion version="26.07" />
 
-Controls how Nextflow reacts when the plugins directory (`NXF_PLUGINS_DIR`) or a cached plugin directory is not a trusted location — i.e. it is owned by another user or writable by group or others. Such a directory could be modified by other users, allowing untrusted plugin code to run in your Nextflow process. Allowed values are `warn` (default, logs a warning and continues), `strict` (aborts the run) and `off` (disables the check). The check is skipped on filesystems that do not support POSIX permissions.
+Controls how Nextflow reacts when the plugins directory (`NXF_PLUGINS_DIR`) or a cached plugin directory is not a trusted location — i.e. it is owned by a user other than the one running Nextflow (compared by UID; `root` and any owner listed in `NXF_PLUGINS_TRUSTED_OWNERS` are trusted) or it is world-writable. Such a directory could be modified by other users, allowing untrusted plugin code to run in your Nextflow process. Allowed values are `warn` (default, logs a warning and continues), `strict` (aborts the run) and `off` (disables the check). The check is skipped on filesystems that do not support POSIX permissions, and when running as `root` only a world-writable directory is flagged.
+
+##### `NXF_PLUGINS_TRUSTED_OWNERS`
+
+<AddedInVersion version="26.07" />
+
+Comma-separated list of additional owners (numeric UIDs or user names) that are trusted to own the plugins directory or cached plugin directories, beyond the current user and `root`. Use this to allow an admin-managed shared plugin cache owned by a service account (e.g. `NXF_PLUGINS_TRUSTED_OWNERS=nextflow`) without triggering [`NXF_PLUGINS_STRICT_MODE`](#nxf_plugins_strict_mode).
 
 ##### `NXF_PLUGINS_TEST_REPOSITORY`
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -216,6 +216,12 @@ The path where the plugin archives are loaded and stored (default: `$NXF_HOME/pl
 
 Specifies the URL of the plugin registry used to download and resolve plugins. This allows using custom or private plugin registries instead of the default public registry.
 
+##### `NXF_PLUGINS_STRICT_MODE`
+
+<AddedInVersion version="26.07" />
+
+Controls how Nextflow reacts when the plugins directory (`NXF_PLUGINS_DIR`) or a cached plugin directory is not a trusted location — i.e. it is owned by another user or writable by group or others. Such a directory could be modified by other users, allowing untrusted plugin code to run in your Nextflow process. Allowed values are `warn` (default, logs a warning and continues), `strict` (aborts the run) and `off` (disables the check). The check is skipped on filesystems that do not support POSIX permissions.
+
 ##### `NXF_PLUGINS_TEST_REPOSITORY`
 
 <AddedInVersion version="23.04" />

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -56,13 +56,27 @@ class PluginSecurity {
     static final String MODE_STRICT = 'strict'
     static final String MODE_OFF = 'off'
 
+    static final Set<String> MODES = [MODE_WARN, MODE_STRICT, MODE_OFF] as Set
+
     /**
      * Resolve the strict mode from the {@code NXF_PLUGINS_STRICT_MODE} environment variable.
+     *
+     * The value is normalised (lower-cased and trimmed) and validated against the known modes.
+     * An unset or blank value falls back to the default silently, while an unrecognised value
+     * (e.g. a typo) falls back to the default and logs a warning so it is not silently ignored.
      *
      * @return one of {@code warn} (default), {@code strict} or {@code off}
      */
     static String getMode() {
-        return SysEnv.get('NXF_PLUGINS_STRICT_MODE', MODE_WARN)
+        final raw = SysEnv.get('NXF_PLUGINS_STRICT_MODE')
+        final mode = raw?.toLowerCase()?.trim()
+        if( !mode )
+            return MODE_WARN
+        if( !MODES.contains(mode) ) {
+            log.warn "Invalid NXF_PLUGINS_STRICT_MODE value '${raw}' - expected one of ${MODES.join(', ')}; using default '${MODE_WARN}'"
+            return MODE_WARN
+        }
+        return mode
     }
 
     /**

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -22,6 +22,8 @@ import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFileAttributes
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -36,15 +38,29 @@ import nextflow.exception.AbortOperationException
  * user can pre-populate an official pinned plugin coordinate (e.g. {@code nf-amazon-3.10.0}) with
  * attacker-controlled code that Nextflow would then load from the cache without any origin check.
  *
- * A directory is considered trusted only when it is owned by the current user (or root) AND it is
- * not writable by group or others. This accepts the two legitimate deployment shapes - a private
- * user cache (e.g. {@code 0700}) and an admin-managed read-only shared cache (e.g. {@code root:root
- * 0755}) - while rejecting an attacker-owned directory or a group/world-writable cache.
+ * A directory is considered untrusted when a principal other than the current user can write to
+ * it, that is:
+ * <ul>
+ *   <li>it is owned by a user other than the one running Nextflow (compared by UID), unless the
+ *       owner is {@code root} or listed in {@code NXF_PLUGINS_TRUSTED_OWNERS}; or</li>
+ *   <li>it is world-writable (the {@code others-write} bit is set).</li>
+ * </ul>
+ *
+ * This accepts the mainstream deployment shapes - a private user cache (including the
+ * group-writable {@code rwxrwxr-x} created under the common umask 002 with a user-private group),
+ * an admin-managed read-only cache owned by {@code root} or a configured service account - while
+ * rejecting an attacker-owned directory or a world-writable cache. When running as {@code root}
+ * (UID 0) the owner is always trusted (the admin's responsibility) but a world-writable cache is
+ * still refused.
+ *
+ * Note: a self-owned cache that is group-writable to a <em>shared</em> primary group is treated as
+ * trusted; this residual risk is accepted because user-private-group is the modern default and
+ * flagging it would produce false positives on almost every run. World-writable is always refused.
  *
  * The behaviour is controlled by the {@code NXF_PLUGINS_STRICT_MODE} environment variable:
  * {@code warn} (default) logs a warning and continues, {@code strict} aborts the run, and
- * {@code off} disables the check. On filesystems that do not support POSIX attributes the check is
- * a no-op.
+ * {@code off} disables the check. On filesystems that do not support POSIX attributes, or when the
+ * owner/current UID cannot be determined, the check is a no-op (fails open).
  *
  * @author Claude <noreply@anthropic.com>
  */
@@ -58,12 +74,21 @@ class PluginSecurity {
 
     static final Set<String> MODES = [MODE_WARN, MODE_STRICT, MODE_OFF] as Set
 
+    private static final long ROOT_UID = 0
+
+    // track dirs already reported so a multi-plugin run emits at most one warning per dir
+    private static final Set<String> reported = ConcurrentHashMap.newKeySet()
+
+    // emit the invalid-mode warning at most once per run
+    private static final AtomicBoolean invalidModeWarned = new AtomicBoolean()
+
     /**
      * Resolve the strict mode from the {@code NXF_PLUGINS_STRICT_MODE} environment variable.
      *
      * The value is normalised (lower-cased and trimmed) and validated against the known modes.
      * An unset or blank value falls back to the default silently, while an unrecognised value
-     * (e.g. a typo) falls back to the default and logs a warning so it is not silently ignored.
+     * (e.g. a typo) falls back to the default and logs a warning (once) so it is not silently
+     * ignored.
      *
      * @return one of {@code warn} (default), {@code strict} or {@code off}
      */
@@ -73,27 +98,46 @@ class PluginSecurity {
         if( !mode )
             return MODE_WARN
         if( !MODES.contains(mode) ) {
-            log.warn "Invalid NXF_PLUGINS_STRICT_MODE value '${raw}' - expected one of ${MODES.join(', ')}; using default '${MODE_WARN}'"
+            if( invalidModeWarned.compareAndSet(false, true) )
+                log.warn "Invalid NXF_PLUGINS_STRICT_MODE value '${raw}' - expected one of ${MODES.join(', ')}; using default '${MODE_WARN}'"
             return MODE_WARN
         }
         return mode
     }
 
     /**
+     * The set of owner identities trusted as plugin cache owners, in addition to the current user
+     * and root, parsed from the {@code NXF_PLUGINS_TRUSTED_OWNERS} environment variable. Each
+     * comma-separated entry is either a numeric UID or a user name.
+     *
+     * @return the trimmed, non-empty trusted-owner tokens (may be empty, never {@code null})
+     */
+    static Set<String> getTrustedOwners() {
+        final list = SysEnv.get('NXF_PLUGINS_TRUSTED_OWNERS')
+        if( !list )
+            return Collections.<String>emptySet()
+        return list.tokenize(',')*.trim().findAll { it } as Set<String>
+    }
+
+    /**
      * Determine whether a plugin directory should be considered untrusted.
      *
-     * A directory is untrusted when it is writable by group or others, or when it is owned by a
-     * principal other than the current user or root.
-     *
      * @param perms The POSIX permissions of the directory
-     * @param owner The name of the directory owner
-     * @param currentUser The name of the user running Nextflow
+     * @param ownerUid The UID of the directory owner
+     * @param currentUid The UID of the user running Nextflow
+     * @param trustedUids Additional owner UIDs trusted beyond the current user and root
      * @return {@code true} if the directory cannot be trusted
      */
-    static boolean isUntrusted(Set<PosixFilePermission> perms, String owner, String currentUser) {
-        final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
-        final untrustedOwner = owner != currentUser && owner != 'root'
-        return writableByOthers || untrustedOwner
+    static boolean isUntrusted(Set<PosixFilePermission> perms, long ownerUid, long currentUid, Set<Long> trustedUids) {
+        final worldWritable = perms.contains(PosixFilePermission.OTHERS_WRITE)
+        // running as root: trust any owner (admin's responsibility) but still flag a world-writable cache
+        if( currentUid == ROOT_UID )
+            return worldWritable
+        final ownerTrusted = ownerUid == currentUid || ownerUid == ROOT_UID || trustedUids.contains(ownerUid)
+        if( !ownerTrusted )
+            return true
+        // owner is trusted; group-write is fine (user-private-group / umask 002), only world-write is a risk
+        return worldWritable
     }
 
     /**
@@ -122,15 +166,23 @@ class PluginSecurity {
                 return
             final PosixFileAttributes attrs = view.readAttributes()
             final perms = attrs.permissions()
-            final owner = attrs.owner().name
-            final me = System.getProperty('user.name')
 
-            if( isUntrusted(perms, owner, me) ) {
+            // resolve owner and current UID; if either is unavailable, fail open to avoid false positives
+            final ownerUid = ownerUid(dir)
+            final currentUid = currentUid()
+            if( ownerUid == null || currentUid == null )
+                return
+
+            final trustedUids = resolveTrustedUids(attrs.owner().name, ownerUid)
+            if( isUntrusted(perms, ownerUid, currentUid, trustedUids) ) {
+                final owner = attrs.owner().name
                 final msg = "Plugin directory '${dir}' is not secure (owner=${owner}, mode=${PosixFilePermissions.toString(perms)}) " +
                         "- it may be modified by other users, which could allow untrusted plugin code to run in your Nextflow process"
                 if( mode == MODE_STRICT )
-                    throw new AbortOperationException("${msg} -- refusing to load plugins. Use a private directory (chmod 700) owned by you, or set NXF_PLUGINS_STRICT_MODE=warn to override")
-                log.warn "${msg} -- set NXF_PLUGINS_STRICT_MODE=strict to refuse loading, or use a private plugins directory owned by you"
+                    throw new AbortOperationException("${msg} -- refusing to load plugins. Use a private directory (chmod 700) owned by you, add the owner to NXF_PLUGINS_TRUSTED_OWNERS, or set NXF_PLUGINS_STRICT_MODE=warn to override")
+                // warn at most once per offending directory
+                if( reported.add(dir.toString()) )
+                    log.warn "${msg} -- set NXF_PLUGINS_STRICT_MODE=strict to refuse loading, add the owner to NXF_PLUGINS_TRUSTED_OWNERS, or use a private plugins directory owned by you"
             }
         }
         catch( AbortOperationException e ) {
@@ -139,6 +191,51 @@ class PluginSecurity {
         catch( Exception e ) {
             // never let a permission-inspection failure break a run
             log.debug "Unable to verify plugin directory permissions for '${dir}' - ${e.message}"
+        }
+    }
+
+    /**
+     * Resolve the trusted owner UIDs from {@code NXF_PLUGINS_TRUSTED_OWNERS}. Numeric entries are
+     * matched by UID; a name entry matching the directory owner name resolves to the owner UID.
+     */
+    private static Set<Long> resolveTrustedUids(String ownerName, long ownerUid) {
+        final tokens = getTrustedOwners()
+        if( !tokens )
+            return Collections.<Long>emptySet()
+        final result = new HashSet<Long>()
+        for( String tok : tokens ) {
+            if( tok.isLong() )
+                result.add(tok.toLong())
+            else if( tok == ownerName )
+                result.add(ownerUid)
+        }
+        return result
+    }
+
+    /**
+     * @return the owner UID of the given path, or {@code null} if it cannot be determined
+     */
+    private static Long ownerUid(Path dir) {
+        try {
+            final uid = Files.getAttribute(dir, 'unix:uid')
+            return uid != null ? ((Number) uid).longValue() : null
+        }
+        catch( Exception e ) {
+            log.debug "Unable to read owner UID for '${dir}' - ${e.message}"
+            return null
+        }
+    }
+
+    /**
+     * @return the UID of the user running Nextflow, or {@code null} if it cannot be determined
+     */
+    private static Long currentUid() {
+        try {
+            return new com.sun.security.auth.module.UnixSystem().getUid()
+        }
+        catch( Throwable e ) {
+            log.debug "Unable to determine current user UID - ${e.message}"
+            return null
         }
     }
 }

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.plugin
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFileAttributes
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.SysEnv
+import nextflow.exception.AbortOperationException
+/**
+ * Validate that a plugin directory can be trusted before its content is loaded and
+ * executed inside the Nextflow process.
+ *
+ * The plugin cache ({@code NXF_PLUGINS_DIR}, {@code $NXF_HOME/plugins}) is expected to be a
+ * per-user, private trust boundary. When it is shared and writable by other users, a lower-trust
+ * user can pre-populate an official pinned plugin coordinate (e.g. {@code nf-amazon-3.10.0}) with
+ * attacker-controlled code that Nextflow would then load from the cache without any origin check.
+ *
+ * A directory is considered trusted only when it is owned by the current user (or root) AND it is
+ * not writable by group or others. This accepts the two legitimate deployment shapes - a private
+ * user cache (e.g. {@code 0700}) and an admin-managed read-only shared cache (e.g. {@code root:root
+ * 0755}) - while rejecting an attacker-owned directory or a group/world-writable cache.
+ *
+ * The behaviour is controlled by the {@code NXF_PLUGINS_STRICT_MODE} environment variable:
+ * {@code warn} (default) logs a warning and continues, {@code strict} aborts the run, and
+ * {@code off} disables the check. On filesystems that do not support POSIX attributes the check is
+ * a no-op.
+ *
+ * @author Claude <noreply@anthropic.com>
+ */
+@Slf4j
+@CompileStatic
+class PluginSecurity {
+
+    static final String MODE_WARN = 'warn'
+    static final String MODE_STRICT = 'strict'
+    static final String MODE_OFF = 'off'
+
+    /**
+     * Resolve the strict mode from the {@code NXF_PLUGINS_STRICT_MODE} environment variable.
+     *
+     * @return one of {@code warn} (default), {@code strict} or {@code off}
+     */
+    static String getMode() {
+        return SysEnv.get('NXF_PLUGINS_STRICT_MODE', MODE_WARN)
+    }
+
+    /**
+     * Verify that the given plugin directory can be trusted, using the mode resolved from the
+     * environment.
+     *
+     * @param dir The plugin directory (the plugins root or a {@code $id-$version} directory)
+     */
+    static void checkTrustedDir(Path dir) {
+        checkTrustedDir(dir, getMode())
+    }
+
+    /**
+     * Verify that the given plugin directory can be trusted.
+     *
+     * @param dir The plugin directory (the plugins root or a {@code $id-$version} directory)
+     * @param mode The strict mode: {@code warn}, {@code strict} or {@code off}
+     */
+    static void checkTrustedDir(Path dir, String mode) {
+        if( mode == MODE_OFF || dir == null )
+            return
+        try {
+            final view = Files.getFileAttributeView(dir, PosixFileAttributeView)
+            // non-POSIX filesystem (e.g. Windows, some object stores) - nothing to check
+            if( view == null )
+                return
+            final PosixFileAttributes attrs = view.readAttributes()
+            final perms = attrs.permissions()
+            final owner = attrs.owner().name
+            final me = System.getProperty('user.name')
+
+            final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
+            final untrustedOwner = owner != me && owner != 'root'
+
+            if( writableByOthers || untrustedOwner ) {
+                final msg = "Plugin directory '${dir}' is not secure (owner=${owner}, mode=${PosixFilePermissions.toString(perms)}) " +
+                        "- it may be modified by other users, which could allow untrusted plugin code to run in your Nextflow process"
+                if( mode == MODE_STRICT )
+                    throw new AbortOperationException("${msg} -- refusing to load plugins. Use a private directory (chmod 700) owned by you, or set NXF_PLUGINS_STRICT_MODE=warn to override")
+                log.warn "${msg} -- set NXF_PLUGINS_STRICT_MODE=strict to refuse loading, or use a private plugins directory owned by you"
+            }
+        }
+        catch( AbortOperationException e ) {
+            throw e
+        }
+        catch( Exception e ) {
+            // never let a permission-inspection failure break a run
+            log.debug "Unable to verify plugin directory permissions for '${dir}' - ${e.message}"
+        }
+    }
+}

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -80,6 +80,23 @@ class PluginSecurity {
     }
 
     /**
+     * Determine whether a plugin directory should be considered untrusted.
+     *
+     * A directory is untrusted when it is writable by group or others, or when it is owned by a
+     * principal other than the current user or root.
+     *
+     * @param perms The POSIX permissions of the directory
+     * @param owner The name of the directory owner
+     * @param currentUser The name of the user running Nextflow
+     * @return {@code true} if the directory cannot be trusted
+     */
+    static boolean isUntrusted(Set<PosixFilePermission> perms, String owner, String currentUser) {
+        final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
+        final untrustedOwner = owner != currentUser && owner != 'root'
+        return writableByOthers || untrustedOwner
+    }
+
+    /**
      * Verify that the given plugin directory can be trusted, using the mode resolved from the
      * environment.
      *
@@ -108,10 +125,7 @@ class PluginSecurity {
             final owner = attrs.owner().name
             final me = System.getProperty('user.name')
 
-            final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
-            final untrustedOwner = owner != me && owner != 'root'
-
-            if( writableByOthers || untrustedOwner ) {
+            if( isUntrusted(perms, owner, me) ) {
                 final msg = "Plugin directory '${dir}' is not secure (owner=${owner}, mode=${PosixFilePermissions.toString(perms)}) " +
                         "- it may be modified by other users, which could allow untrusted plugin code to run in your Nextflow process"
                 if( mode == MODE_STRICT )

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -401,6 +401,10 @@ class PluginUpdater extends UpdateManager {
             log.warn("Plugin '${pluginPath.getFileName()}' installation looks corrupted - Delete the following directory and run nextflow again: $pluginPath")
         }
 
+        // verify the plugin dir is a trusted (private, non-shared) location before loading it,
+        // to avoid executing attacker-controlled content from a shared/writable plugin cache
+        PluginSecurity.checkTrustedDir(pluginPath)
+
         // load the plugin from the file system
         PluginWrapper wrapper = pluginManager.loadPluginFromPath(pluginPath)
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -275,6 +275,9 @@ class PluginsFacade implements PluginStateListener {
         // make sure plugins dir exists
         if( mode!=DEV_MODE && !FilesEx.exists(root) && !FilesEx.mkdirs(root) )
             throw new IOException("Unable to create plugins dir: $root")
+        // verify the plugins dir is a trusted (private, non-shared) location
+        if( mode!=DEV_MODE )
+            PluginSecurity.checkTrustedDir(root)
 
         this.manager = createManager(root, embedded)
         this.updater = createUpdater(root, manager)
@@ -295,6 +298,9 @@ class PluginsFacade implements PluginStateListener {
         this.manager.addPluginStateListener(this)
         // setup the updater
         this.updater = createUpdater(root, manager)
+        // verify the plugins dir is a trusted (private, non-shared) location
+        if( mode!=DEV_MODE )
+            PluginSecurity.checkTrustedDir(root)
         // load plugins
         manager.loadPlugins()
         if( embedded ) {

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -138,4 +138,36 @@ class PluginSecurityTest extends Specification {
         VALUE << ['warn', 'strict', 'off']
     }
 
+    @Unroll
+    def 'should normalise the env value #VALUE to #EXPECTED' () {
+        given:
+        SysEnv.push([NXF_PLUGINS_STRICT_MODE: VALUE])
+        expect:
+        PluginSecurity.getMode() == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE      | EXPECTED
+        'STRICT'   | 'strict'
+        'Warn'     | 'warn'
+        '  off  '  | 'off'
+        ' Strict ' | 'strict'
+    }
+
+    @Unroll
+    def 'should fall back to warn for an unrecognised or blank env value #VALUE' () {
+        given:
+        SysEnv.push([NXF_PLUGINS_STRICT_MODE: VALUE])
+        expect:
+        PluginSecurity.getMode() == 'warn'
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE << ['bogus', 'strictly', '', '   ']
+    }
+
 }

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.plugin
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+
+import nextflow.SysEnv
+import nextflow.exception.AbortOperationException
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import spock.lang.Unroll
+/**
+ *
+ * @author Claude <noreply@anthropic.com>
+ */
+@IgnoreIf({ os.windows })
+class PluginSecurityTest extends Specification {
+
+    private Path tempDirWithPerms(String perms) {
+        final dir = Files.createTempDirectory('test-plugin-sec')
+        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString(perms))
+        return dir
+    }
+
+    @Unroll
+    def 'should accept a private dir owned by current user - mode=#MODE perms=#PERMS' () {
+        given:
+        def dir = tempDirWithPerms(PERMS)
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, MODE)
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        dir?.deleteDir()
+
+        where:
+        MODE     | PERMS
+        'strict' | 'rwx------'
+        'warn'   | 'rwx------'
+        'strict' | 'rwxr-xr-x'
+        'warn'   | 'rwxr-xr-x'
+    }
+
+    @Unroll
+    def 'should reject a group/world-writable dir in strict mode - perms=#PERMS' () {
+        given:
+        def dir = tempDirWithPerms(PERMS)
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, 'strict')
+        then:
+        def e = thrown(AbortOperationException)
+        e.message.contains('is not secure')
+
+        cleanup:
+        dir?.deleteDir()
+
+        where:
+        PERMS << ['rwxrwx---', 'rwxrwxrwx', 'rwx-w----', 'rwx----w-']
+    }
+
+    @Unroll
+    def 'should only warn (not throw) for a group/world-writable dir in warn mode - perms=#PERMS' () {
+        given:
+        def dir = tempDirWithPerms(PERMS)
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, 'warn')
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        dir?.deleteDir()
+
+        where:
+        PERMS << ['rwxrwx---', 'rwxrwxrwx']
+    }
+
+    def 'should skip the check entirely when mode is off' () {
+        given:
+        def dir = tempDirWithPerms('rwxrwxrwx')
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, 'off')
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        dir?.deleteDir()
+    }
+
+    def 'should be a no-op for a null dir' () {
+        when:
+        PluginSecurity.checkTrustedDir(null, 'strict')
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should default to warn mode from the environment' () {
+        given:
+        SysEnv.push([:])
+        expect:
+        PluginSecurity.getMode() == 'warn'
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    @Unroll
+    def 'should resolve mode #VALUE from the environment' () {
+        given:
+        SysEnv.push([NXF_PLUGINS_STRICT_MODE: VALUE])
+        expect:
+        PluginSecurity.getMode() == VALUE
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE << ['warn', 'strict', 'off']
+    }
+
+}

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -60,6 +60,25 @@ class PluginSecurityTest extends Specification {
     }
 
     @Unroll
+    def 'should classify trust by owner and perms - owner=#OWNER user=#USER perms=#PERMS untrusted=#UNTRUSTED' () {
+        expect:
+        PluginSecurity.isUntrusted(PosixFilePermissions.fromString(PERMS), OWNER, USER) == UNTRUSTED
+
+        where:
+        OWNER      | USER     | PERMS       | UNTRUSTED
+        // trusted: private dir owned by the current user
+        'alice'    | 'alice'  | 'rwx------' | false
+        // trusted: admin-managed read-only shared cache (root-owned, not group/other writable)
+        'root'     | 'alice'  | 'rwxr-xr-x' | false
+        // untrusted owner: dir owned by another user, even with safe permissions (the PoC case)
+        'attacker' | 'victim' | 'rwx------' | true
+        'attacker' | 'victim' | 'rwxr-xr-x' | true
+        // untrusted perms: group/world writable even when owned by the current user
+        'alice'    | 'alice'  | 'rwxrwx---' | true
+        'alice'    | 'alice'  | 'rwxrwxrwx' | true
+    }
+
+    @Unroll
     def 'should reject a group/world-writable dir in strict mode - perms=#PERMS' () {
         given:
         def dir = tempDirWithPerms(PERMS)

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -39,7 +39,34 @@ class PluginSecurityTest extends Specification {
     }
 
     @Unroll
-    def 'should accept a private dir owned by current user - mode=#MODE perms=#PERMS' () {
+    def 'should classify trust by uid and perms - owner=#OWNER current=#CUR perms=#PERMS trusted=#TRUSTED untrusted=#UNTRUSTED' () {
+        expect:
+        PluginSecurity.isUntrusted(PosixFilePermissions.fromString(PERMS), OWNER, CUR, TRUSTED) == UNTRUSTED
+
+        where:
+        OWNER  | CUR    | PERMS       | TRUSTED           | UNTRUSTED
+        // self-owned: private, read-only, or umask-002 group-writable -> trusted
+        1000L  | 1000L  | 'rwx------' | ([] as Set)       | false
+        1000L  | 1000L  | 'rwxr-xr-x' | ([] as Set)       | false
+        1000L  | 1000L  | 'rwxrwxr-x' | ([] as Set)       | false   // umask 002 default - the key regression
+        1000L  | 1000L  | 'rwxrwx---' | ([] as Set)       | false
+        // self-owned but world-writable -> untrusted
+        1000L  | 1000L  | 'rwxrwxrwx' | ([] as Set)       | true
+        // root-owned admin cache -> trusted; root-owned world-writable -> untrusted
+        0L     | 1000L  | 'rwxr-xr-x' | ([] as Set)       | false
+        0L     | 1000L  | 'rwxrwxrwx' | ([] as Set)       | true
+        // foreign owner -> untrusted even with safe perms (the PoC case)
+        1201L  | 1202L  | 'rwx------' | ([] as Set)       | true
+        1201L  | 1202L  | 'rwxr-xr-x' | ([] as Set)       | true
+        // foreign owner listed as trusted (service-account cache) -> trusted
+        1201L  | 1202L  | 'rwx------' | ([1201L] as Set)  | false
+        // running as root: trust any owner, but still flag world-writable
+        1201L  | 0L     | 'rwx------' | ([] as Set)       | false
+        1201L  | 0L     | 'rwxrwxrwx' | ([] as Set)       | true
+    }
+
+    @Unroll
+    def 'should accept a self-owned dir that is not world-writable - mode=#MODE perms=#PERMS' () {
         given:
         def dir = tempDirWithPerms(PERMS)
 
@@ -56,30 +83,12 @@ class PluginSecurityTest extends Specification {
         'strict' | 'rwx------'
         'warn'   | 'rwx------'
         'strict' | 'rwxr-xr-x'
-        'warn'   | 'rwxr-xr-x'
+        'strict' | 'rwxrwxr-x'   // umask-002 group-writable, owned by me
+        'warn'   | 'rwxrwx---'
     }
 
     @Unroll
-    def 'should classify trust by owner and perms - owner=#OWNER user=#USER perms=#PERMS untrusted=#UNTRUSTED' () {
-        expect:
-        PluginSecurity.isUntrusted(PosixFilePermissions.fromString(PERMS), OWNER, USER) == UNTRUSTED
-
-        where:
-        OWNER      | USER     | PERMS       | UNTRUSTED
-        // trusted: private dir owned by the current user
-        'alice'    | 'alice'  | 'rwx------' | false
-        // trusted: admin-managed read-only shared cache (root-owned, not group/other writable)
-        'root'     | 'alice'  | 'rwxr-xr-x' | false
-        // untrusted owner: dir owned by another user, even with safe permissions (the PoC case)
-        'attacker' | 'victim' | 'rwx------' | true
-        'attacker' | 'victim' | 'rwxr-xr-x' | true
-        // untrusted perms: group/world writable even when owned by the current user
-        'alice'    | 'alice'  | 'rwxrwx---' | true
-        'alice'    | 'alice'  | 'rwxrwxrwx' | true
-    }
-
-    @Unroll
-    def 'should reject a group/world-writable dir in strict mode - perms=#PERMS' () {
+    def 'should reject a world-writable dir in strict mode - perms=#PERMS' () {
         given:
         def dir = tempDirWithPerms(PERMS)
 
@@ -93,13 +102,12 @@ class PluginSecurityTest extends Specification {
         dir?.deleteDir()
 
         where:
-        PERMS << ['rwxrwx---', 'rwxrwxrwx', 'rwx-w----', 'rwx----w-']
+        PERMS << ['rwxrwxrwx', 'rwx----w-']
     }
 
-    @Unroll
-    def 'should only warn (not throw) for a group/world-writable dir in warn mode - perms=#PERMS' () {
+    def 'should only warn (not throw) for a world-writable dir in warn mode' () {
         given:
-        def dir = tempDirWithPerms(PERMS)
+        def dir = tempDirWithPerms('rwxrwxrwx')
 
         when:
         PluginSecurity.checkTrustedDir(dir, 'warn')
@@ -108,9 +116,6 @@ class PluginSecurityTest extends Specification {
 
         cleanup:
         dir?.deleteDir()
-
-        where:
-        PERMS << ['rwxrwx---', 'rwxrwxrwx']
     }
 
     def 'should skip the check entirely when mode is off' () {
@@ -187,6 +192,25 @@ class PluginSecurityTest extends Specification {
 
         where:
         VALUE << ['bogus', 'strictly', '', '   ']
+    }
+
+    @Unroll
+    def 'should parse NXF_PLUGINS_TRUSTED_OWNERS #VALUE' () {
+        given:
+        SysEnv.push(VALUE != null ? [NXF_PLUGINS_TRUSTED_OWNERS: VALUE] : [:])
+        expect:
+        PluginSecurity.getTrustedOwners() == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE              | EXPECTED
+        null               | ([] as Set)
+        ''                 | ([] as Set)
+        '1000'             | (['1000'] as Set)
+        'nextflow'         | (['nextflow'] as Set)
+        '1000, nextflow ,' | (['1000', 'nextflow'] as Set)
     }
 
 }


### PR DESCRIPTION
## Summary

Nextflow loads and executes plugin code from the local plugin cache (`$id-$version`) **without re-verifying its origin** when the directory already exists — `PluginUpdater.load0()` short-circuits the download (and therefore the `sha512sum`/`CompoundVerifier` path) whenever the cached directory is present, and `PluginsFacade.isAllowed()` only matches plugin IDs, not content.

On a **shared, writable** plugin cache (`NXF_PLUGINS_DIR` or `$NXF_HOME/plugins`), a lower-trust local user can pre-populate an official pinned plugin coordinate (e.g. `nf-amazon@3.10.0`) with attacker-controlled code that then runs inside a victim's Nextflow process.

The plugin cache is expected to be a **per-user, private trust boundary** (default `$HOME/.nextflow/plugins`). This PR adds a defense-in-depth guard that verifies a plugin directory is trusted before loading it, addressing the exact precondition of the issue — write access to a trusted cache — with no network calls, no checksums, and no persisted state (works offline).

## Changes and Reasoning

**New `PluginSecurity` helper** (`modules/nf-commons/.../plugin/PluginSecurity.groovy`)
A directory is considered trusted only when it is **owned by the current user (or root)** *and* **not writable by group or others**. This accepts the two legitimate deployment shapes — a private user cache (e.g. `0700`) and an admin-managed **read-only** shared cache (e.g. `root:root 0755`) — while rejecting an attacker-owned directory or a group/world-writable cache.

> The both-conditions check matters: a permissions-only check would miss the reported scenario, where the poisoned directory was `attacker:attacker 755` (not group/other-writable) — ownership is what made it dangerous.

**Call sites**
- `PluginsFacade.init(...)` — guards the plugins **root** at setup (both `init` overloads), so startup-loaded plugins are covered.
- `PluginUpdater.load0()` — guards each `$id-$version` directory immediately before `loadPluginFromPath`, covering cache reuse and the attacker-owned-subdir case.

**New env var `NXF_PLUGINS_STRICT_MODE`** (`warn` | `strict` | `off`)
- `warn` (default) — logs a warning and continues (zero breakage for existing setups).
- `strict` — aborts the run with `AbortOperationException`.
- `off` — disables the check.

The guard is a no-op on filesystems without POSIX permissions and in **dev mode** (where plugins load from the source tree, not the cache).

**Compatibility / rollout**
Default `warn` means no existing deployment breaks; the default `$HOME/.nextflow/plugins` (user-owned) is silent. `strict` is opt-in now; a future stable release can promote the default.

## Testing

New `PluginSecurityTest` (16 cases) and existing plugin tests pass:

- ✅ private `0700` / read-only `0755` → accepted in all modes
- ✅ group/world-writable → warns in `warn`, throws in `strict`
- ✅ `off` mode → never throws
- ✅ null dir / non-POSIX FS → no-op
- ✅ env-var mode resolution (`warn` default, `strict`, `off`)
- ✅ `:nf-commons:test` full suite — no regression in `PluginsFacadeTest` / `PluginUpdaterTest`

End-to-end (dev launcher, `NXF_PLUGINS_MODE=prod`):

| Scenario | Result |
|---|---|
| `strict` + `0777` cache | Aborts — workflow does not run |
| `warn` + `0777` cache | Warns, workflow proceeds |
| `strict` + private `0700` cache | Silent, workflow proceeds |

## Documentation

- `docs/reference/env-vars.mdx` — new `NXF_PLUGINS_STRICT_MODE` entry.
- `docs/plugins/using-plugins.mdx` — security note in the **Caching** section (keep the cache private; supported shared pattern is admin-owned read-only).