### PR TITLE
feat(nf-seqera): send pipeline-secret references to the Seqera Scheduler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ allprojects {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven { url 'https://repo.eclipse.org/content/groups/releases' }
         maven { url = "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/releases" }

--- a/docs/plugins/using-plugins.mdx
+++ b/docs/plugins/using-plugins.mdx
@@ -56,6 +56,12 @@ Plugin declarations in Nextflow configuration files are ignored when specifying 
 
 When Nextflow downloads plugins, it caches them in the directory specified by `NXF_PLUGINS_DIR` (`$HOME/.nextflow/plugins` by default).
 
+:::warning
+The plugin cache should be a private, per-user directory that is not writable by other users. Nextflow loads and executes cached plugin code without re-verifying its origin, so a shared plugin cache that is writable by other users (or owned by another user) allows a lower-trust user to replace cached plugin code with their own, which would then run inside your Nextflow process.
+
+Keep `NXF_PLUGINS_DIR` private (for example `chmod 700`) and owned by you. If a shared cache is required, use an administrator-owned, **read-only** directory that regular users cannot modify. Use [`NXF_PLUGINS_STRICT_MODE`](../reference/env-vars.mdx) to control whether Nextflow warns about or refuses to load plugins from an untrusted directory.
+:::
+
 ## Offline usage
 
 When running Nextflow in an offline environment, any required plugins must be downloaded and moved into the offline environment prior to any runs.

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -216,6 +216,12 @@ The path where the plugin archives are loaded and stored (default: `$NXF_HOME/pl
 
 Specifies the URL of the plugin registry used to download and resolve plugins. This allows using custom or private plugin registries instead of the default public registry.
 
+##### `NXF_PLUGINS_STRICT_MODE`
+
+<AddedInVersion version="26.07" />
+
+Controls how Nextflow reacts when the plugins directory (`NXF_PLUGINS_DIR`) or a cached plugin directory is not a trusted location — i.e. it is owned by another user or writable by group or others. Such a directory could be modified by other users, allowing untrusted plugin code to run in your Nextflow process. Allowed values are `warn` (default, logs a warning and continues), `strict` (aborts the run) and `off` (disables the check). The check is skipped on filesystems that do not support POSIX permissions.
+
 ##### `NXF_PLUGINS_TEST_REPOSITORY`
 
 <AddedInVersion version="23.04" />

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -56,13 +56,27 @@ class PluginSecurity {
     static final String MODE_STRICT = 'strict'
     static final String MODE_OFF = 'off'
 
+    static final Set<String> MODES = [MODE_WARN, MODE_STRICT, MODE_OFF] as Set
+
     /**
      * Resolve the strict mode from the {@code NXF_PLUGINS_STRICT_MODE} environment variable.
+     *
+     * The value is normalised (lower-cased and trimmed) and validated against the known modes.
+     * An unset or blank value falls back to the default silently, while an unrecognised value
+     * (e.g. a typo) falls back to the default and logs a warning so it is not silently ignored.
      *
      * @return one of {@code warn} (default), {@code strict} or {@code off}
      */
     static String getMode() {
-        return SysEnv.get('NXF_PLUGINS_STRICT_MODE', MODE_WARN)
+        final raw = SysEnv.get('NXF_PLUGINS_STRICT_MODE')
+        final mode = raw?.toLowerCase()?.trim()
+        if( !mode )
+            return MODE_WARN
+        if( !MODES.contains(mode) ) {
+            log.warn "Invalid NXF_PLUGINS_STRICT_MODE value '${raw}' - expected one of ${MODES.join(', ')}; using default '${MODE_WARN}'"
+            return MODE_WARN
+        }
+        return mode
     }
 
     /**

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.plugin
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFileAttributes
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.SysEnv
+import nextflow.exception.AbortOperationException
+/**
+ * Validate that a plugin directory can be trusted before its content is loaded and
+ * executed inside the Nextflow process.
+ *
+ * The plugin cache ({@code NXF_PLUGINS_DIR}, {@code $NXF_HOME/plugins}) is expected to be a
+ * per-user, private trust boundary. When it is shared and writable by other users, a lower-trust
+ * user can pre-populate an official pinned plugin coordinate (e.g. {@code nf-amazon-3.10.0}) with
+ * attacker-controlled code that Nextflow would then load from the cache without any origin check.
+ *
+ * A directory is considered trusted only when it is owned by the current user (or root) AND it is
+ * not writable by group or others. This accepts the two legitimate deployment shapes - a private
+ * user cache (e.g. {@code 0700}) and an admin-managed read-only shared cache (e.g. {@code root:root
+ * 0755}) - while rejecting an attacker-owned directory or a group/world-writable cache.
+ *
+ * The behaviour is controlled by the {@code NXF_PLUGINS_STRICT_MODE} environment variable:
+ * {@code warn} (default) logs a warning and continues, {@code strict} aborts the run, and
+ * {@code off} disables the check. On filesystems that do not support POSIX attributes the check is
+ * a no-op.
+ *
+ * @author Claude <noreply@anthropic.com>
+ */
+@Slf4j
+@CompileStatic
+class PluginSecurity {
+
+    static final String MODE_WARN = 'warn'
+    static final String MODE_STRICT = 'strict'
+    static final String MODE_OFF = 'off'
+
+    /**
+     * Resolve the strict mode from the {@code NXF_PLUGINS_STRICT_MODE} environment variable.
+     *
+     * @return one of {@code warn} (default), {@code strict} or {@code off}
+     */
+    static String getMode() {
+        return SysEnv.get('NXF_PLUGINS_STRICT_MODE', MODE_WARN)
+    }
+
+    /**
+     * Verify that the given plugin directory can be trusted, using the mode resolved from the
+     * environment.
+     *
+     * @param dir The plugin directory (the plugins root or a {@code $id-$version} directory)
+     */
+    static void checkTrustedDir(Path dir) {
+        checkTrustedDir(dir, getMode())
+    }
+
+    /**
+     * Verify that the given plugin directory can be trusted.
+     *
+     * @param dir The plugin directory (the plugins root or a {@code $id-$version} directory)
+     * @param mode The strict mode: {@code warn}, {@code strict} or {@code off}
+     */
+    static void checkTrustedDir(Path dir, String mode) {
+        if( mode == MODE_OFF || dir == null )
+            return
+        try {
+            final view = Files.getFileAttributeView(dir, PosixFileAttributeView)
+            // non-POSIX filesystem (e.g. Windows, some object stores) - nothing to check
+            if( view == null )
+                return
+            final PosixFileAttributes attrs = view.readAttributes()
+            final perms = attrs.permissions()
+            final owner = attrs.owner().name
+            final me = System.getProperty('user.name')
+
+            final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
+            final untrustedOwner = owner != me && owner != 'root'
+
+            if( writableByOthers || untrustedOwner ) {
+                final msg = "Plugin directory '${dir}' is not secure (owner=${owner}, mode=${PosixFilePermissions.toString(perms)}) " +
+                        "- it may be modified by other users, which could allow untrusted plugin code to run in your Nextflow process"
+                if( mode == MODE_STRICT )
+                    throw new AbortOperationException("${msg} -- refusing to load plugins. Use a private directory (chmod 700) owned by you, or set NXF_PLUGINS_STRICT_MODE=warn to override")
+                log.warn "${msg} -- set NXF_PLUGINS_STRICT_MODE=strict to refuse loading, or use a private plugins directory owned by you"
+            }
+        }
+        catch( AbortOperationException e ) {
+            throw e
+        }
+        catch( Exception e ) {
+            // never let a permission-inspection failure break a run
+            log.debug "Unable to verify plugin directory permissions for '${dir}' - ${e.message}"
+        }
+    }
+}

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginSecurity.groovy
@@ -80,6 +80,23 @@ class PluginSecurity {
     }
 
     /**
+     * Determine whether a plugin directory should be considered untrusted.
+     *
+     * A directory is untrusted when it is writable by group or others, or when it is owned by a
+     * principal other than the current user or root.
+     *
+     * @param perms The POSIX permissions of the directory
+     * @param owner The name of the directory owner
+     * @param currentUser The name of the user running Nextflow
+     * @return {@code true} if the directory cannot be trusted
+     */
+    static boolean isUntrusted(Set<PosixFilePermission> perms, String owner, String currentUser) {
+        final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
+        final untrustedOwner = owner != currentUser && owner != 'root'
+        return writableByOthers || untrustedOwner
+    }
+
+    /**
      * Verify that the given plugin directory can be trusted, using the mode resolved from the
      * environment.
      *
@@ -108,10 +125,7 @@ class PluginSecurity {
             final owner = attrs.owner().name
             final me = System.getProperty('user.name')
 
-            final writableByOthers = perms.contains(PosixFilePermission.GROUP_WRITE) || perms.contains(PosixFilePermission.OTHERS_WRITE)
-            final untrustedOwner = owner != me && owner != 'root'
-
-            if( writableByOthers || untrustedOwner ) {
+            if( isUntrusted(perms, owner, me) ) {
                 final msg = "Plugin directory '${dir}' is not secure (owner=${owner}, mode=${PosixFilePermissions.toString(perms)}) " +
                         "- it may be modified by other users, which could allow untrusted plugin code to run in your Nextflow process"
                 if( mode == MODE_STRICT )

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -401,6 +401,10 @@ class PluginUpdater extends UpdateManager {
             log.warn("Plugin '${pluginPath.getFileName()}' installation looks corrupted - Delete the following directory and run nextflow again: $pluginPath")
         }
 
+        // verify the plugin dir is a trusted (private, non-shared) location before loading it,
+        // to avoid executing attacker-controlled content from a shared/writable plugin cache
+        PluginSecurity.checkTrustedDir(pluginPath)
+
         // load the plugin from the file system
         PluginWrapper wrapper = pluginManager.loadPluginFromPath(pluginPath)
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -275,6 +275,9 @@ class PluginsFacade implements PluginStateListener {
         // make sure plugins dir exists
         if( mode!=DEV_MODE && !FilesEx.exists(root) && !FilesEx.mkdirs(root) )
             throw new IOException("Unable to create plugins dir: $root")
+        // verify the plugins dir is a trusted (private, non-shared) location
+        if( mode!=DEV_MODE )
+            PluginSecurity.checkTrustedDir(root)
 
         this.manager = createManager(root, embedded)
         this.updater = createUpdater(root, manager)
@@ -295,6 +298,9 @@ class PluginsFacade implements PluginStateListener {
         this.manager.addPluginStateListener(this)
         // setup the updater
         this.updater = createUpdater(root, manager)
+        // verify the plugins dir is a trusted (private, non-shared) location
+        if( mode!=DEV_MODE )
+            PluginSecurity.checkTrustedDir(root)
         // load plugins
         manager.loadPlugins()
         if( embedded ) {

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -138,4 +138,36 @@ class PluginSecurityTest extends Specification {
         VALUE << ['warn', 'strict', 'off']
     }
 
+    @Unroll
+    def 'should normalise the env value #VALUE to #EXPECTED' () {
+        given:
+        SysEnv.push([NXF_PLUGINS_STRICT_MODE: VALUE])
+        expect:
+        PluginSecurity.getMode() == EXPECTED
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE      | EXPECTED
+        'STRICT'   | 'strict'
+        'Warn'     | 'warn'
+        '  off  '  | 'off'
+        ' Strict ' | 'strict'
+    }
+
+    @Unroll
+    def 'should fall back to warn for an unrecognised or blank env value #VALUE' () {
+        given:
+        SysEnv.push([NXF_PLUGINS_STRICT_MODE: VALUE])
+        expect:
+        PluginSecurity.getMode() == 'warn'
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE << ['bogus', 'strictly', '', '   ']
+    }
+
 }

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.plugin
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+
+import nextflow.SysEnv
+import nextflow.exception.AbortOperationException
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import spock.lang.Unroll
+/**
+ *
+ * @author Claude <noreply@anthropic.com>
+ */
+@IgnoreIf({ os.windows })
+class PluginSecurityTest extends Specification {
+
+    private Path tempDirWithPerms(String perms) {
+        final dir = Files.createTempDirectory('test-plugin-sec')
+        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString(perms))
+        return dir
+    }
+
+    @Unroll
+    def 'should accept a private dir owned by current user - mode=#MODE perms=#PERMS' () {
+        given:
+        def dir = tempDirWithPerms(PERMS)
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, MODE)
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        dir?.deleteDir()
+
+        where:
+        MODE     | PERMS
+        'strict' | 'rwx------'
+        'warn'   | 'rwx------'
+        'strict' | 'rwxr-xr-x'
+        'warn'   | 'rwxr-xr-x'
+    }
+
+    @Unroll
+    def 'should reject a group/world-writable dir in strict mode - perms=#PERMS' () {
+        given:
+        def dir = tempDirWithPerms(PERMS)
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, 'strict')
+        then:
+        def e = thrown(AbortOperationException)
+        e.message.contains('is not secure')
+
+        cleanup:
+        dir?.deleteDir()
+
+        where:
+        PERMS << ['rwxrwx---', 'rwxrwxrwx', 'rwx-w----', 'rwx----w-']
+    }
+
+    @Unroll
+    def 'should only warn (not throw) for a group/world-writable dir in warn mode - perms=#PERMS' () {
+        given:
+        def dir = tempDirWithPerms(PERMS)
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, 'warn')
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        dir?.deleteDir()
+
+        where:
+        PERMS << ['rwxrwx---', 'rwxrwxrwx']
+    }
+
+    def 'should skip the check entirely when mode is off' () {
+        given:
+        def dir = tempDirWithPerms('rwxrwxrwx')
+
+        when:
+        PluginSecurity.checkTrustedDir(dir, 'off')
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        dir?.deleteDir()
+    }
+
+    def 'should be a no-op for a null dir' () {
+        when:
+        PluginSecurity.checkTrustedDir(null, 'strict')
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should default to warn mode from the environment' () {
+        given:
+        SysEnv.push([:])
+        expect:
+        PluginSecurity.getMode() == 'warn'
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    @Unroll
+    def 'should resolve mode #VALUE from the environment' () {
+        given:
+        SysEnv.push([NXF_PLUGINS_STRICT_MODE: VALUE])
+        expect:
+        PluginSecurity.getMode() == VALUE
+
+        cleanup:
+        SysEnv.pop()
+
+        where:
+        VALUE << ['warn', 'strict', 'off']
+    }
+
+}

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginSecurityTest.groovy
@@ -60,6 +60,25 @@ class PluginSecurityTest extends Specification {
     }
 
     @Unroll
+    def 'should classify trust by owner and perms - owner=#OWNER user=#USER perms=#PERMS untrusted=#UNTRUSTED' () {
+        expect:
+        PluginSecurity.isUntrusted(PosixFilePermissions.fromString(PERMS), OWNER, USER) == UNTRUSTED
+
+        where:
+        OWNER      | USER     | PERMS       | UNTRUSTED
+        // trusted: private dir owned by the current user
+        'alice'    | 'alice'  | 'rwx------' | false
+        // trusted: admin-managed read-only shared cache (root-owned, not group/other writable)
+        'root'     | 'alice'  | 'rwxr-xr-x' | false
+        // untrusted owner: dir owned by another user, even with safe permissions (the PoC case)
+        'attacker' | 'victim' | 'rwx------' | true
+        'attacker' | 'victim' | 'rwxr-xr-x' | true
+        // untrusted perms: group/world writable even when owned by the current user
+        'alice'    | 'alice'  | 'rwxrwx---' | true
+        'alice'    | 'alice'  | 'rwxrwxrwx' | true
+    }
+
+    @Unroll
     def 'should reject a group/world-writable dir in strict mode - perms=#PERMS' () {
         given:
         def dir = tempDirWithPerms(PERMS)

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     // intelligent compute scheduler client
-    api 'io.seqera:sched-client:0.63.0'
+    api 'io.seqera:sched-client:0.69.0'
     // Single lib-httpx declaration. Must stay 'api' at 2.3.0 to override the older lib-httpx
     // pulled transitively by sched-client, otherwise the plugin bundles failsafe-3.1.0 which
     // clashes with the failsafe-3.3.2 the plugin is compiled against (java.lang.NoSuchMethodError

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
@@ -65,6 +65,8 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
 
     private volatile String runId
 
+    private volatile String workflowId
+
     private volatile Map<String,String> runResourceLabels = Collections.<String,String>emptyMap()
 
     private SeqeraBatchSubmitter batchSubmitter
@@ -122,6 +124,7 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
     protected void createRun() {
         final towerConfig = session.config.tower as Map ?: Collections.emptyMap()
         final workflowId = session.workflowMetadata?.platform?.workflowId
+        this.workflowId = workflowId
         final workflowUrl = session.workflowMetadata?.platform?.workflowUrl
         final workspaceId = PlatformHelper.getWorkspaceId(towerConfig, SysEnv.get()) as Long
         final computeEnvId = PlatformHelper.getComputeEnvId(towerConfig, SysEnv.get()) ?: seqeraConfig.computeEnvId
@@ -218,6 +221,25 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
 
     String getRunId() {
         return runId
+    }
+
+    /**
+     * The Platform workflow id for this run, used to build pipeline secret store references
+     * ({@code tower-<workflowId>/<name>}). {@code null} when running without a Platform workflow
+     * (bare scheduler), in which case secret references are not built.
+     */
+    String getWorkflowId() {
+        return workflowId
+    }
+
+    /**
+     * The Seqera executor is secret-native: pipeline secret values are resolved at the compute
+     * edge (the scheduler backend), so Nextflow must not emit the local-store {@code source}
+     * snippet. The task carries only the secret <em>reference</em>, never the value.
+     */
+    @Override
+    boolean isSecretNative() {
+        return true
     }
 
     Map<String,String> getRunResourceLabels() {

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -156,9 +156,36 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
         final delta = Labels.delta(taskLabels, executor.runResourceLabels)
         if( delta )
             schedTask.labels(delta)
+        // attach pipeline secret references (never values) — resolved at the compute edge
+        final secretRefs = buildSecretRefs()
+        if( secretRefs )
+            schedTask.secrets(secretRefs)
         log.debug "[SEQERA] Enqueueing task for batch submission: ${schedTask}"
         // Enqueue for batch submission - status will be set by setBatchTaskId callback
         executor.getBatchSubmitter().submit(this, schedTask)
+    }
+
+    /**
+     * Build the map of container environment variable name to the pipeline secret store
+     * reference for each {@code secret} process directive.
+     *
+     * Platform stores the secret value in the cloud secret store under
+     * {@code tower-<workflowId>/<name>}; the executor sends only this reference and the
+     * scheduler backend resolves the value at the compute edge. The secret value never
+     * passes through Nextflow or the scheduler API.
+     *
+     * Returns {@code null} when there are no secret directives or no Platform workflow id
+     * (bare-scheduler usage has no store, so a missing reference is a no-op).
+     */
+    protected Map<String, String> buildSecretRefs() {
+        final names = task.config.getSecret()
+        final workflowId = executor.getWorkflowId()
+        if( !names || !workflowId )
+            return null
+        final result = new LinkedHashMap<String, String>()
+        for( String name : names )
+            result.put(name, "tower-${workflowId}/${name}".toString())
+        return result
     }
 
     /**

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
@@ -145,6 +145,14 @@ class SeqeraExecutorTest extends Specification {
         fusionConfig.targetVersion == null
     }
 
+    def 'should be secret-native so Nextflow suppresses the local-store secrets snippet'() {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        new SeqeraExecutor().isSecretNative()
+    }
+
     def 'should expose run resource labels coerced from config-level process.resourceLabels'() {
         given:
         SysEnv.push([:])

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -863,6 +863,112 @@ class SeqeraTaskHandlerTest extends Specification {
         captured.getLabels() == [region: 'us-east-1']
     }
 
+    def 'submit maps secret directive names to tower-<workflowId> references'() {
+        given:
+        Task captured = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> captured = args[1] as Task }
+        }
+        def taskConfig = Mock(TaskConfig) {
+            getCpus() >> 1
+            getMemory() >> MemoryUnit.of('1 GB')
+            getAccelerator() >> null
+            getResourceLabels() >> [:]
+            getResourceLimit('memory') >> null
+            getResourceLimit('cpus') >> null
+            getDisk() >> null
+            getSecret() >> ['DB_PWD', 'API_KEY']
+        }
+        def taskRun = Mock(TaskRun) {
+            getConfig() >> taskConfig
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getContainer() >> 'docker.io/library/alpine:3'
+            getContainerPlatform() >> 'linux/amd64'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromInt(1)
+            lazyName() >> 'sample_task'
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) {
+                getMachineRequirement() >> null
+                getTaskEnvironment() >> [:]
+            }
+            getRunResourceLabels() >> [:]
+            getWorkflowId() >> 'wf123'
+            ensureRunCreated() >> {}
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) {
+                fusionEnv() >> [:]
+            }
+            fusionSubmitCli() >> ['/bin/sh', '-c', 'true']
+        }
+
+        when:
+        handler.submit()
+
+        then: 'each secret name maps to its cloud-store reference; no value is present'
+        captured != null
+        captured.getSecrets() == [DB_PWD: 'tower-wf123/DB_PWD', API_KEY: 'tower-wf123/API_KEY']
+    }
+
+    def 'submit sets no secrets when the secret directive is empty'() {
+        given:
+        Task captured = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> captured = args[1] as Task }
+        }
+        def taskConfig = Mock(TaskConfig) {
+            getCpus() >> 1
+            getMemory() >> MemoryUnit.of('1 GB')
+            getAccelerator() >> null
+            getResourceLabels() >> [:]
+            getResourceLimit('memory') >> null
+            getResourceLimit('cpus') >> null
+            getDisk() >> null
+            getSecret() >> []
+        }
+        def taskRun = Mock(TaskRun) {
+            getConfig() >> taskConfig
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getContainer() >> 'docker.io/library/alpine:3'
+            getContainerPlatform() >> 'linux/amd64'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromInt(1)
+            lazyName() >> 'sample_task'
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) {
+                getMachineRequirement() >> null
+                getTaskEnvironment() >> [:]
+            }
+            getRunResourceLabels() >> [:]
+            getWorkflowId() >> 'wf123'
+            ensureRunCreated() >> {}
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) {
+                fusionEnv() >> [:]
+            }
+            fusionSubmitCli() >> ['/bin/sh', '-c', 'true']
+        }
+
+        when:
+        handler.submit()
+
+        then:
+        captured != null
+        captured.getSecrets() == null
+    }
+
     def 'submit overlays seqera hints onto config-scope machine requirement'() {
         given:
         Task captured = null


### PR DESCRIPTION
## What this does

Makes the `seqera` executor deliver Seqera Platform pipeline secrets (`secret 'FOO'` directive) to tasks running on the Seqera Scheduler. Companion to the scheduler-side work in seqeralabs/sched#653 (PR seqeralabs/sched#658).

## How it works

- `SeqeraTaskHandler.submit()` maps each `secret` directive name to the cloud secret-store reference `tower-<workflowId>/<name>` and sends it in the task's new `secrets` map. The executor sends **references only** — never the value; the scheduler resolves it at the edge (ECS `valueFrom` / VM agent).
- `SeqeraExecutor` now declares `isSecretNative()=true`, so `BashWrapperBuilder` skips its local-store `source` snippet — which pointed at a `$HOME/.nextflow/secrets/…` file on the head node that does not exist in the remote scheduler task container (the reason `secret` was silently broken here before).

## ⚠️ Temporary — must revert before merge

To compile against the new `Task.secrets` field, this PR:
- adds `mavenLocal()` to the root `build.gradle`, and
- bumps `nf-seqera`'s `sched-client` to `0.69.0`.

The new field currently exists only in Maven-local (from the sched branch). **Once a sched release publishes `sched-client` with the `secrets` field, drop the `mavenLocal()` line.** This is the cross-repo release-ordering dependency; the PR is a draft until then.

## Verification

- ✅ Full `:plugins:nf-seqera:test` passes (added: directive-name → reference mapping, empty-directive no-op, `isSecretNative`).
- ⏳ End-to-end run of a `secret 'FOO'` pipeline pending the sched release.

Ref seqeralabs/sched#653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)