### PR TITLE
feat(nf-seqera): send pipeline-secret references to the Seqera Scheduler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,6 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url 'https://repo.eclipse.org/content/groups/releases' }
         maven { url = "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/releases" }

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ allprojects {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven { url 'https://repo.eclipse.org/content/groups/releases' }
         maven { url = "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/releases" }

--- a/docs/executor.mdx
+++ b/docs/executor.mdx
@@ -422,6 +422,7 @@ Resource requests and other job characteristics can be controlled via the follow
 - [cpus][process-cpus]
 - [disk][process-disk]
 - [memory][process-memory]
+- [secret][process-secret]
 - [time][process-time]
 
 The following [hints][process-hints] are supported:
@@ -604,4 +605,5 @@ process {
 [process-pod]: ./reference/process#pod
 [process-queue]: ./reference/process#queue
 [process-resourcelabels]: ./reference/process#resourcelabels
+[process-secret]: ./reference/process#secret
 [process-time]: ./reference/process#time

--- a/docs/secrets.mdx
+++ b/docs/secrets.mdx
@@ -13,7 +13,7 @@ This feature allows you to decouple the use of secrets in your pipelines from th
 
 When a pipeline is launched, Nextflow injects the secrets into the run without leaking them into temporary execution files. Secrets are provided to tasks as environment variables.
 
-Secrets can be used with the local executor and grid executors (e.g., Slurm or Grid Engine). Secrets can be used with the AWS Batch executor when launched from [Seqera Platform](https://seqera.io/blog/pipeline-secrets-secure-handling-of-sensitive-information-in-tower/).
+Secrets can be used with the local executor and grid executors (e.g., Slurm or Grid Engine). Secrets can be used with the AWS Batch executor when launched from [Seqera Platform](https://seqera.io/blog/pipeline-secrets-secure-handling-of-sensitive-information-in-tower/). Secrets are also supported by the [Seqera executor](./executor#seqera), which resolves the secret value at the compute edge so that only the secret reference — never the value — is carried with the task.
 
 ## Command line
 

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     // intelligent compute scheduler client
-    api 'io.seqera:sched-client:0.71.0-SNAPSHOT'
+    api 'io.seqera:sched-client:0.71.0'
     // Single lib-httpx declaration. Must stay 'api' at 2.3.0 to override the older lib-httpx
     // pulled transitively by sched-client, otherwise the plugin bundles failsafe-3.1.0 which
     // clashes with the failsafe-3.3.2 the plugin is compiled against (java.lang.NoSuchMethodError

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -51,10 +51,13 @@ dependencies {
     compileOnly project(':nextflow')
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
     compileOnly 'org.pf4j:pf4j:3.14.1'
-    api 'io.seqera:sched-client:0.63.0'
-    // Override the old lib-httpx pulled transitively by sched-client, otherwise the plugin
-    // bundles failsafe-3.1.0 which clashes with the failsafe-3.3.2 the plugin is compiled
-    // against (java.lang.NoSuchMethodError on handleIf(CheckedPredicate) at runtime).
+
+    // intelligent compute scheduler client
+    api 'io.seqera:sched-client:0.69.0'
+    // Single lib-httpx declaration. Must stay 'api' at 2.3.0 to override the older lib-httpx
+    // pulled transitively by sched-client, otherwise the plugin bundles failsafe-3.1.0 which
+    // clashes with the failsafe-3.3.2 the plugin is compiled against (java.lang.NoSuchMethodError
+    // on handleIf(CheckedPredicate) at runtime).
     api 'io.seqera:lib-httpx:2.3.0'
 
     testImplementation(testFixtures(project(":nextflow")))

--- a/plugins/nf-seqera/build.gradle
+++ b/plugins/nf-seqera/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     // intelligent compute scheduler client
-    api 'io.seqera:sched-client:0.69.0'
+    api 'io.seqera:sched-client:0.71.0-SNAPSHOT'
     // Single lib-httpx declaration. Must stay 'api' at 2.3.0 to override the older lib-httpx
     // pulled transitively by sched-client, otherwise the plugin bundles failsafe-3.1.0 which
     // clashes with the failsafe-3.3.2 the plugin is compiled against (java.lang.NoSuchMethodError

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
@@ -65,6 +65,8 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
 
     private volatile String runId
 
+    private volatile String workflowId
+
     private volatile Map<String,String> runResourceLabels = Collections.<String,String>emptyMap()
 
     private SeqeraBatchSubmitter batchSubmitter
@@ -122,6 +124,7 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
     protected void createRun() {
         final towerConfig = session.config.tower as Map ?: Collections.emptyMap()
         final workflowId = session.workflowMetadata?.platform?.workflowId
+        this.workflowId = workflowId
         final workflowUrl = session.workflowMetadata?.platform?.workflowUrl
         final workspaceId = PlatformHelper.getWorkspaceId(towerConfig, SysEnv.get()) as Long
         final computeEnvId = PlatformHelper.getComputeEnvId(towerConfig, SysEnv.get()) ?: seqeraConfig.computeEnvId
@@ -218,6 +221,25 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
 
     String getRunId() {
         return runId
+    }
+
+    /**
+     * The Platform workflow id for this run, used to build pipeline secret store references
+     * ({@code tower-<workflowId>/<name>}). {@code null} when running without a Platform workflow
+     * (bare scheduler), in which case secret references are not built.
+     */
+    String getWorkflowId() {
+        return workflowId
+    }
+
+    /**
+     * The Seqera executor is secret-native: pipeline secret values are resolved at the compute
+     * edge (the scheduler backend), so Nextflow must not emit the local-store {@code source}
+     * snippet. The task carries only the secret <em>reference</em>, never the value.
+     */
+    @Override
+    boolean isSecretNative() {
+        return true
     }
 
     Map<String,String> getRunResourceLabels() {

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -156,9 +156,36 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
         final delta = Labels.delta(taskLabels, executor.runResourceLabels)
         if( delta )
             schedTask.labels(delta)
+        // attach pipeline secret references (never values) — resolved at the compute edge
+        final secretRefs = buildSecretRefs()
+        if( secretRefs )
+            schedTask.secrets(secretRefs)
         log.debug "[SEQERA] Enqueueing task for batch submission: ${schedTask}"
         // Enqueue for batch submission - status will be set by setBatchTaskId callback
         executor.getBatchSubmitter().submit(this, schedTask)
+    }
+
+    /**
+     * Build the map of container environment variable name to the pipeline secret store
+     * reference for each {@code secret} process directive.
+     *
+     * Platform stores the secret value in the cloud secret store under
+     * {@code tower-<workflowId>/<name>}; the executor sends only this reference and the
+     * scheduler backend resolves the value at the compute edge. The secret value never
+     * passes through Nextflow or the scheduler API.
+     *
+     * Returns {@code null} when there are no secret directives or no Platform workflow id
+     * (bare-scheduler usage has no store, so a missing reference is a no-op).
+     */
+    protected Map<String, String> buildSecretRefs() {
+        final names = task.config.getSecret()
+        final workflowId = executor.getWorkflowId()
+        if( !names || !workflowId )
+            return null
+        final result = new LinkedHashMap<String, String>()
+        for( String name : names )
+            result.put(name, "tower-${workflowId}/${name}".toString())
+        return result
     }
 
     /**

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
@@ -145,6 +145,14 @@ class SeqeraExecutorTest extends Specification {
         fusionConfig.targetVersion == null
     }
 
+    def 'should be secret-native so Nextflow suppresses the local-store secrets snippet'() {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        new SeqeraExecutor().isSecretNative()
+    }
+
     def 'should expose run resource labels coerced from config-level process.resourceLabels'() {
         given:
         SysEnv.push([:])

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -863,6 +863,112 @@ class SeqeraTaskHandlerTest extends Specification {
         captured.getLabels() == [region: 'us-east-1']
     }
 
+    def 'submit maps secret directive names to tower-<workflowId> references'() {
+        given:
+        Task captured = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> captured = args[1] as Task }
+        }
+        def taskConfig = Mock(TaskConfig) {
+            getCpus() >> 1
+            getMemory() >> MemoryUnit.of('1 GB')
+            getAccelerator() >> null
+            getResourceLabels() >> [:]
+            getResourceLimit('memory') >> null
+            getResourceLimit('cpus') >> null
+            getDisk() >> null
+            getSecret() >> ['DB_PWD', 'API_KEY']
+        }
+        def taskRun = Mock(TaskRun) {
+            getConfig() >> taskConfig
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getContainer() >> 'docker.io/library/alpine:3'
+            getContainerPlatform() >> 'linux/amd64'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromInt(1)
+            lazyName() >> 'sample_task'
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) {
+                getMachineRequirement() >> null
+                getTaskEnvironment() >> [:]
+            }
+            getRunResourceLabels() >> [:]
+            getWorkflowId() >> 'wf123'
+            ensureRunCreated() >> {}
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) {
+                fusionEnv() >> [:]
+            }
+            fusionSubmitCli() >> ['/bin/sh', '-c', 'true']
+        }
+
+        when:
+        handler.submit()
+
+        then: 'each secret name maps to its cloud-store reference; no value is present'
+        captured != null
+        captured.getSecrets() == [DB_PWD: 'tower-wf123/DB_PWD', API_KEY: 'tower-wf123/API_KEY']
+    }
+
+    def 'submit sets no secrets when the secret directive is empty'() {
+        given:
+        Task captured = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> captured = args[1] as Task }
+        }
+        def taskConfig = Mock(TaskConfig) {
+            getCpus() >> 1
+            getMemory() >> MemoryUnit.of('1 GB')
+            getAccelerator() >> null
+            getResourceLabels() >> [:]
+            getResourceLimit('memory') >> null
+            getResourceLimit('cpus') >> null
+            getDisk() >> null
+            getSecret() >> []
+        }
+        def taskRun = Mock(TaskRun) {
+            getConfig() >> taskConfig
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getContainer() >> 'docker.io/library/alpine:3'
+            getContainerPlatform() >> 'linux/amd64'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromInt(1)
+            lazyName() >> 'sample_task'
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) {
+                getMachineRequirement() >> null
+                getTaskEnvironment() >> [:]
+            }
+            getRunResourceLabels() >> [:]
+            getWorkflowId() >> 'wf123'
+            ensureRunCreated() >> {}
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) {
+                fusionEnv() >> [:]
+            }
+            fusionSubmitCli() >> ['/bin/sh', '-c', 'true']
+        }
+
+        when:
+        handler.submit()
+
+        then:
+        captured != null
+        captured.getSecrets() == null
+    }
+
     def 'submit overlays seqera hints onto config-scope machine requirement'() {
         given:
         Task captured = null


### PR DESCRIPTION
## What this does

Makes the `seqera` executor deliver Seqera Platform pipeline secrets (`secret 'FOO'` directive) to tasks running on the Seqera Scheduler. Companion to the scheduler-side work in seqeralabs/sched#653 (PR seqeralabs/sched#658).

## How it works

- `SeqeraTaskHandler.submit()` maps each `secret` directive name to the cloud secret-store reference `tower-<workflowId>/<name>` and sends it in the task's new `secrets` map. The executor sends **references only** — never the value; the scheduler resolves it at the edge (ECS `valueFrom` / VM agent).
- `SeqeraExecutor` now declares `isSecretNative()=true`, so `BashWrapperBuilder` skips its local-store `source` snippet — which pointed at a `$HOME/.nextflow/secrets/…` file on the head node that does not exist in the remote scheduler task container (the reason `secret` was silently broken here before).


## Verification

- ✅ Full `:plugins:nf-seqera:test` passes (added: directive-name → reference mapping, empty-directive no-op, `isSecretNative`).
- ⏳ End-to-end run of a `secret 'FOO'` pipeline pending the sched release.

Ref seqeralabs/sched#653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)