### PR TITLE
Update nf-azure: node communication mode setting, allow Azure Compute Gallery and allow configuration of verification state

### DIFF
--- a/docs/azure.mdx
+++ b/docs/azure.mdx
@@ -597,6 +597,43 @@ azure {
 }
 ```
 
+**Custom images from an Azure Compute Gallery**
+
+You can provision pool nodes from a custom VM image published in an [Azure Compute Gallery](https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery) by setting `virtualMachineImageId` to the image version resource ID. When set, `publisher` and `offer` are ignored, and `sku` must be set to the Batch node agent SKU id that matches the image operating system.
+
+```groovy
+azure {
+    batch {
+        pools {
+            <pool-name> {
+                virtualMachineImageId = '/subscriptions/<subscription>/resourceGroups/<group>/providers/Microsoft.Compute/galleries/<gallery>/images/<definition>/versions/<version>'
+                sku = 'batch.node.ubuntu 22.04'
+            }
+        }
+    }
+}
+```
+
+:::note
+Custom images require Microsoft Entra authentication (service principal or managed identity). The Batch account identity must have read access to the gallery image, and the pool typically requires `virtualNetwork` to be set.
+:::
+
+**Image verification**
+
+By default, Nextflow only selects images that Azure Batch has formally verified. Set `verification` to `unverified` to also allow images that Azure Batch lists but has not verified, or to `any` to accept both. This setting is ignored when `virtualMachineImageId` is set.
+
+```groovy
+azure {
+    batch {
+        pools {
+            <pool-name> {
+                verification = 'unverified'  // 'verified' (default), 'unverified' or 'any'
+            }
+        }
+    }
+}
+```
+
 ### Advanced features
 
 **Virtual networks**
@@ -618,6 +655,14 @@ Nextflow can submit tasks to existing pools that are already attached to a virtu
 :::warning
 Virtual networks require Microsoft Entra authentication (service principal or managed identity).
 :::
+
+**Node communication mode**
+
+Pools can be configured to use [simplified compute node communication](https://learn.microsoft.com/en-us/azure/batch/simplified-compute-node-communication), which changes how the Batch service communicates with the compute nodes and reduces the outbound network access required by the nodes. The default is `simplified`; set it to `classic` to restore the legacy behavior.
+
+```groovy
+azure.batch.pools.<pool-name>.targetCommunicationMode = 'simplified'  // 'simplified' (default) or 'classic'
+```
 
 **Start tasks**
 

--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -537,6 +537,10 @@ The mount options for mounting the file shares (default`-o vers=3.0,dir_mode=077
 
 The offer type of the virtual machine type used by the pool identified with `<name>` (default`centos-container`).
 
+##### `azure.batch.pools.<name>.osType`
+
+The OS type of the pool nodes. Can be either `linux` or `windows` (default`linux`).
+
 ##### `azure.batch.pools.<name>.privileged`
 
 Enable the task to run with elevated access. Ignored if `runAs` is set (default`false`).
@@ -576,6 +580,18 @@ Enable the `startTask` to run with elevated access (default`false`).
 <AddedInVersion version="25.04" />
 
 The `startTask` that is executed as the node joins the Azure Batch node pool.
+
+##### `azure.batch.pools.<name>.targetCommunicationMode`
+
+The node communication mode used by the pool. Can be either `classic` or `simplified` (default`simplified`). In `simplified` mode the Batch service initiates communication with the compute nodes, reducing the outbound network access required by the nodes.
+
+##### `azure.batch.pools.<name>.verification`
+
+The image verification type to match when resolving the VM image from the Batch supported-images list. Can be `verified`, `unverified`, or `any` (default`verified`). Ignored when `virtualMachineImageId` is set.
+
+##### `azure.batch.pools.<name>.virtualMachineImageId`
+
+The resource ID of a custom VM image from an Azure Compute Gallery to use for the pool nodes (e.g. `/subscriptions/<id>/resourceGroups/<group>/providers/Microsoft.Compute/galleries/<gallery>/images/<definition>/versions/<version>`). When set, `publisher` and `offer` are ignored, and `sku` must be set to the Batch node agent SKU id that matches the image OS (e.g. `batch.node.ubuntu 22.04`).
 
 ##### `azure.batch.pools.<name>.virtualNetwork`
 

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -51,6 +51,7 @@ import com.azure.compute.batch.models.ContainerConfiguration
 import com.azure.compute.batch.models.ContainerRegistryReference
 import com.azure.compute.batch.models.ContainerType
 import com.azure.compute.batch.models.ElevationLevel
+import com.azure.compute.batch.models.ImageReference
 import com.azure.compute.batch.models.MetadataItem
 import com.azure.compute.batch.models.MountConfiguration
 import com.azure.compute.batch.models.NetworkConfiguration
@@ -704,7 +705,7 @@ class AzBatchService implements Closeable {
                 continue
             if( it.osType != opts.osType )
                 continue
-            if( it.verificationType != opts.verification )
+            if( opts.verification != null && it.verificationType != opts.verification )
                 continue
             if( !it.imageReference.publisher.equalsIgnoreCase(opts.publisher) )
                 continue
@@ -712,8 +713,14 @@ class AzBatchService implements Closeable {
                 return it
         }
 
-        log.debug "[AZURE BATCH] No VM image matching sku=$opts.sku; publisher=$opts.publisher; offer=$opts.offer; OS type=$opts.osType; verification type=$opts.verification - supported images: $available"
-        throw new IllegalStateException("Cannot find a matching VM image with publisher=$opts.publisher; offer=$opts.offer; OS type=$opts.osType; verification type=$opts.verification")
+        log.debug "[AZURE BATCH] No VM image matching sku=$opts.sku; publisher=$opts.publisher; offer=$opts.offer; OS type=$opts.osType; verification type=${opts.verification ?: 'any'} - supported images: $available"
+        throw new IllegalStateException("Cannot find a matching VM image with publisher=$opts.publisher; offer=$opts.offer; OS type=$opts.osType; verification type=${opts.verification ?: 'any'}")
+    }
+
+    protected ImageReference customImageReference(AzPoolOpts opts) {
+        if( !opts.sku )
+            throw new IllegalArgumentException("Azure Batch pool option 'sku' is required when 'virtualMachineImageId' is set - it must be a valid node agent SKU id (e.g. 'batch.node.ubuntu 22.04')")
+        return new ImageReference().setVirtualMachineImageId(opts.virtualMachineImageId)
     }
 
     protected AzVmPoolSpec specFromPoolConfig(String poolId) {
@@ -883,9 +890,20 @@ class AzBatchService implements Closeable {
             log.debug "[AZURE BATCH] Connecting Azure Batch pool to Container Registry '$registryOpts.server'"
         }
 
-        final image = getImage(opts)
+        final ImageReference imageRef
+        final String nodeAgentSkuId
+        if( opts.virtualMachineImageId ) {
+            imageRef = customImageReference(opts)
+            nodeAgentSkuId = opts.sku
+            log.debug "[AZURE BATCH] Using custom VM image from Compute Gallery: $opts.virtualMachineImageId (node agent SKU: $nodeAgentSkuId)"
+        }
+        else {
+            final image = getImage(opts)
+            imageRef = image.imageReference
+            nodeAgentSkuId = image.nodeAgentSkuId
+        }
 
-        new VirtualMachineConfiguration(image.imageReference, image.nodeAgentSkuId)
+        new VirtualMachineConfiguration(imageRef, nodeAgentSkuId)
                 .setContainerConfiguration(containerConfig)
     }
 
@@ -951,6 +969,10 @@ class AzBatchService implements Closeable {
             if( !pol ) throw new IllegalArgumentException("Unknown Azure Batch scheduling policy: ${spec.opts.schedulePolicy}")
             poolParams.setTaskSchedulingPolicy( new BatchTaskSchedulingPolicy(pol) )
         }
+
+        // node communication mode
+        if( spec.opts.targetCommunicationMode )
+            poolParams.setTargetNodeCommunicationMode( spec.opts.targetCommunicationMode )
 
         // mount points
         if ( config.storage().fileShares ) {

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzPoolOpts.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.cloud.azure.config
 
+import com.azure.compute.batch.models.BatchNodeCommunicationMode
 import com.azure.compute.batch.models.ImageVerificationType
 import com.azure.compute.batch.models.OSType
 import com.google.common.hash.Hasher
@@ -144,8 +145,31 @@ class AzPoolOpts implements CacheFunnel, ConfigScope {
     """)
     final String vmType
 
-    OSType osType = DEFAULT_OS_TYPE
-    ImageVerificationType verification = ImageVerificationType.VERIFIED
+    @ConfigOption
+    @Description("""
+        The resource ID of a custom VM image from an Azure Compute Gallery to use for the pool nodes
+        (e.g. `/subscriptions/<id>/resourceGroups/<group>/providers/Microsoft.Compute/galleries/<gallery>/images/<definition>/versions/<version>`).
+        When set, `publisher` and `offer` are ignored, and `sku` must be set to the Batch node agent SKU id that matches the image OS (e.g. `batch.node.ubuntu 22.04`).
+    """)
+    final String virtualMachineImageId
+
+    @ConfigOption
+    @Description("""
+        The OS type of the pool nodes. Can be either `linux` or `windows` (default: `linux`).
+    """)
+    final OSType osType
+
+    @ConfigOption
+    @Description("""
+        The image verification type to match when resolving the VM image from the Batch supported-images list. Can be `verified`, `unverified`, or `any` (default: `verified`). Ignored when `virtualMachineImageId` is set.
+    """)
+    final ImageVerificationType verification
+
+    @ConfigOption
+    @Description("""
+        The node communication mode used by the pool. Can be either `classic` or `simplified` (default: `simplified`). In `simplified` mode the Batch service initiates communication with the compute nodes, reducing the outbound network access required by the nodes.
+    """)
+    final BatchNodeCommunicationMode targetCommunicationMode
 
     String registry
     String userName
@@ -175,6 +199,44 @@ class AzPoolOpts implements CacheFunnel, ConfigScope {
         this.password = opts.password
         this.virtualNetwork = opts.virtualNetwork
         this.lowPriority = opts.lowPriority as boolean
+        this.virtualMachineImageId = opts.virtualMachineImageId ?: null
+        this.osType = parseOsType(opts.osType)
+        this.verification = parseVerification(opts.verification)
+        this.targetCommunicationMode = parseCommunicationMode(opts.targetCommunicationMode)
+    }
+
+    protected static OSType parseOsType(value) {
+        if( value == null )
+            return DEFAULT_OS_TYPE
+        if( value instanceof OSType )
+            return value
+        final str = value.toString().toLowerCase()
+        if( str == 'linux' ) return OSType.LINUX
+        if( str == 'windows' ) return OSType.WINDOWS
+        throw new IllegalArgumentException("Invalid azure.batch.pools.<name>.osType value: '$value' - expected 'linux' or 'windows'")
+    }
+
+    protected static ImageVerificationType parseVerification(value) {
+        if( value == null )
+            return ImageVerificationType.VERIFIED
+        if( value instanceof ImageVerificationType )
+            return value
+        final str = value.toString().toLowerCase()
+        if( str == 'verified' ) return ImageVerificationType.VERIFIED
+        if( str == 'unverified' ) return ImageVerificationType.UNVERIFIED
+        if( str == 'any' ) return null
+        throw new IllegalArgumentException("Invalid azure.batch.pools.<name>.verification value: '$value' - expected 'verified', 'unverified' or 'any'")
+    }
+
+    protected static BatchNodeCommunicationMode parseCommunicationMode(value) {
+        if( value == null )
+            return BatchNodeCommunicationMode.SIMPLIFIED
+        if( value instanceof BatchNodeCommunicationMode )
+            return value
+        final str = value.toString().toLowerCase()
+        if( str == 'simplified' ) return BatchNodeCommunicationMode.SIMPLIFIED
+        if( str == 'classic' ) return BatchNodeCommunicationMode.CLASSIC
+        throw new IllegalArgumentException("Invalid azure.batch.pools.<name>.targetCommunicationMode value: '$value' - expected 'simplified' or 'classic'")
     }
 
     @Override
@@ -195,6 +257,10 @@ class AzPoolOpts implements CacheFunnel, ConfigScope {
         hasher.putUnencodedChars(schedulePolicy ?: '')
         hasher.putUnencodedChars(virtualNetwork ?: '')
         hasher.putBoolean(lowPriority)
+        hasher.putUnencodedChars(virtualMachineImageId ?: '')
+        hasher.putUnencodedChars(osType.toString())
+        hasher.putUnencodedChars(verification?.toString() ?: 'any')
+        hasher.putUnencodedChars(targetCommunicationMode.toString())
         hasher.putUnencodedChars(startTask.script ?: '')
         hasher.putBoolean(startTask.privileged)
         return hasher

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -519,7 +519,7 @@ class AzBatchServiceTest extends Specification {
         then:
         1 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
         and:
-        spec.poolId == 'nf-pool-42f3635f3fb8b71160900efa959f7809-Standard_X1'
+        spec.poolId == 'nf-pool-1e1fb78a0107f3a7c1ee451fadcbaf08-Standard_X1'
         spec.metadata == [foo: 'bar']
 
     }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzPoolOptsTest.groovy
@@ -16,6 +16,11 @@
 
 package nextflow.cloud.azure.config
 
+import com.azure.compute.batch.models.BatchNodeCommunicationMode
+import com.azure.compute.batch.models.ImageVerificationType
+import com.azure.compute.batch.models.OSType
+import com.google.common.hash.Hashing
+import nextflow.util.CacheHelper
 import nextflow.util.Duration
 import spock.lang.Specification
 /**
@@ -48,6 +53,104 @@ class AzPoolOptsTest extends Specification {
         !opts.lowPriority
         !opts.startTask.script
         !opts.startTask.privileged
+        !opts.virtualMachineImageId
+        opts.osType == OSType.LINUX
+        opts.verification == ImageVerificationType.VERIFIED
+        opts.targetCommunicationMode == BatchNodeCommunicationMode.SIMPLIFIED
+    }
+
+    def 'should configure a custom compute gallery image' () {
+        when:
+        def opts = new AzPoolOpts([
+            virtualMachineImageId: '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/galleries/g/images/d/versions/1.0.0',
+            sku: 'batch.node.ubuntu 22.04',
+            verification: 'unverified',
+            osType: 'linux',
+        ])
+        then:
+        opts.virtualMachineImageId == '/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/galleries/g/images/d/versions/1.0.0'
+        opts.sku == 'batch.node.ubuntu 22.04'
+        opts.verification == ImageVerificationType.UNVERIFIED
+        opts.osType == OSType.LINUX
+    }
+
+    def 'should parse the verification value' () {
+        expect:
+        new AzPoolOpts([verification: VALUE]).verification == EXPECTED
+        where:
+        VALUE        | EXPECTED
+        null         | ImageVerificationType.VERIFIED
+        'verified'   | ImageVerificationType.VERIFIED
+        'unverified' | ImageVerificationType.UNVERIFIED
+        'any'        | null
+    }
+
+    def 'should reject an invalid verification value' () {
+        when:
+        new AzPoolOpts([verification: 'bogus'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('verification')
+    }
+
+    def 'should parse the osType value' () {
+        expect:
+        new AzPoolOpts([osType: VALUE]).osType == EXPECTED
+        where:
+        VALUE     | EXPECTED
+        null      | OSType.LINUX
+        'linux'   | OSType.LINUX
+        'windows' | OSType.WINDOWS
+    }
+
+    def 'should reject an invalid osType value' () {
+        when:
+        new AzPoolOpts([osType: 'macos'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('osType')
+    }
+
+    def 'should parse the target communication mode' () {
+        expect:
+        new AzPoolOpts([targetCommunicationMode: VALUE]).targetCommunicationMode == EXPECTED
+        where:
+        VALUE        | EXPECTED
+        null         | BatchNodeCommunicationMode.SIMPLIFIED
+        'simplified' | BatchNodeCommunicationMode.SIMPLIFIED
+        'classic'    | BatchNodeCommunicationMode.CLASSIC
+        'SIMPLIFIED' | BatchNodeCommunicationMode.SIMPLIFIED
+        'CLASSIC'    | BatchNodeCommunicationMode.CLASSIC
+    }
+
+    def 'should reject an invalid target communication mode' () {
+        when:
+        new AzPoolOpts([targetCommunicationMode: 'bogus'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('targetCommunicationMode')
+    }
+
+    private static String hash(AzPoolOpts opts) {
+        opts.funnel(Hashing.murmur3_128().newHasher(), CacheHelper.HashMode.STANDARD).hash().toString()
+    }
+
+    def 'pool hash should differ when image config differs' () {
+        given:
+        def base = new AzPoolOpts()
+        def gallery = new AzPoolOpts([virtualMachineImageId: '/subscriptions/x/resourceGroups/rg/providers/Microsoft.Compute/galleries/g/images/d/versions/1'])
+        def unverified = new AzPoolOpts([verification: 'unverified'])
+        expect:
+        hash(base) != hash(gallery)
+        hash(base) != hash(unverified)
+    }
+
+    def 'pool hash should differ when communication mode differs' () {
+        given:
+        def base = new AzPoolOpts()
+        def classic = new AzPoolOpts([targetCommunicationMode: 'classic'])
+        expect:
+        hash(base) != hash(classic)
     }
 
     def 'should create pool with custom options' () {


### PR DESCRIPTION
### **Overview**

**Node Communication Mode**
In our environment, Azure Batch is configured within a virtual network. However, Nextflow does not expose a configuration item for the Node Communication Mode. The Classic mode has been deprecated for a while, but Nextflow pools still default to it because they use an older API version. Without a configuration item, we cannot explictly tell it to use "simplified" mode.

This PR adds `azure.batch.pools.<name>.targetCommunicationMode` (named to match the Azure Batch API and SDKs). Accepted values are `simplified` and `classic`, defaulting to **`simplified`** since classic is deprecated and should no longer be used.

This only affects users running Nextflow on Azure in a networked environment.

Reference: https://learn.microsoft.com/en-us/azure/batch/simplified-compute-node-communication

**Azure Compute Gallery**
Last year we had a major outage when an update to the Microsoft Marketplace Ubuntu 22.04 HPC image flipped its verification state to `unverified`. Because Nextflow only targets `verified` images, new pools could no longer be created. Our pipeline tooling did not support Ubuntu 24.04 yet, so we had to scramble to restore service.

In order to avoid such an event again, Microsoft suggested that we switch to Azure Compute Gallery images. Within Azure Compute Gallery, we have full control over the images. However, Nextflow did not support the usage of them yet.

Two new options (virtualMachineImageId and osType) have been introduced to support usage of the Azure Compute Gallery. 

**Image verification state**
For non-production and testing purposes we occasionally need to use unverified Marketplace images, but Nextflow always forced `verified`.

This PR adds `azure.batch.pools.<name>.verification` with values `verified` (default), `unverified`, or `any` - where `any` ignores the verification state entirely. This setting is ignored when `virtualMachineImageId` is set.

### Expected Impact

We have been running these changes as a custom `nf-azure` fork (based on the upstream plugin) in production for a while, so we are confident they behave as intended.

- **Networked Azure users:** pools created by Nextflow will now use `simplified` communication mode by default instead of `classic`. The effect is generally positive, but users should be aware of the change.
- **Everyone else:** the new options are no-ops unless explicitly set. Verification still defaults to `verified` (unchanged behavior), and the Compute Gallery options are ignored when not configured.

### Tests

Unit tests added/updated in `nf-azure`:

- **`AzPoolOptsTest`**
  - Defaults: `verification=verified`, `osType=linux`, `targetCommunicationMode=simplified`, `virtualMachineImageId=null`.
  - Compute Gallery image configuration (`virtualMachineImageId` + `sku`).
  - Parsing/validation of `verification` (`verified`/`unverified`/`any`, case-insensitive), with an error on invalid values.
  - Parsing/validation of `targetCommunicationMode` and `osType`, with errors on invalid values.
  - Cache-key (`funnel`) sensitivity: the pool hash changes when the image config or communication mode changes.
- **`AzBatchServiceTest`**
  - Updated the auto-pool id hash to reflect the new pool options now included in the cache key.

Docs updated: `docs/azure.mdx` and `docs/reference/config.mdx`.