### PR TITLE
Add ast-grep Groovy lint foundations

### DIFF
--- a/.config/astgrep/.gitignore
+++ b/.config/astgrep/.gitignore
@@ -1,0 +1,3 @@
+# ast-grep build artifacts (rebuilt locally by build.sh)
+.grammar-build/
+groovy.dylib

--- a/.config/astgrep/README.md
+++ b/.config/astgrep/README.md
@@ -16,6 +16,17 @@ ast-grep scan -c .config/astgrep/sgconfig.yml # scan the repo
 Requires [`ast-grep`](https://ast-grep.github.io/guide/quick-start.html) (>= 0.44) and a
 C compiler (`gcc`/`clang`).
 
+## Testing
+
+Each rule has a test file in `rule-tests/` with `valid` (should not match) and
+`invalid` (should match) cases. Run them with:
+
+```bash
+cd .config/astgrep && ast-grep test
+```
+
+After changing a rule, refresh the captured output with `ast-grep test -U`.
+
 ## How it works
 
 - **`build.sh`** fetches [dekobon/tree-sitter-groovy](https://github.com/dekobon/tree-sitter-groovy)
@@ -26,6 +37,8 @@ C compiler (`gcc`/`clang`).
 - **`sgconfig.yml`** registers `groovy` as an ast-grep custom language (`expandoChar: _`
   because Groovy uses `$` for GString interpolation; metavariables are still `$NAME` / `$$$`).
 - **`rules/`** holds one YAML lint rule per file.
+- **`rule-tests/`** holds one test file per rule (`valid` / `invalid` cases), with
+  captured output under `rule-tests/__snapshots__/`.
 
 `groovy.dylib` and `.grammar-build/` are gitignored; each checkout rebuilds the library locally.
 

--- a/.config/astgrep/README.md
+++ b/.config/astgrep/README.md
@@ -1,0 +1,36 @@
+# ast-grep lint rules for Groovy
+
+Structural (AST-based) lint rules for Nextflow's Groovy sources, using
+[ast-grep](https://ast-grep.github.io/) with a compiled tree-sitter Groovy grammar
+registered as a custom language.
+
+## Usage
+
+```bash
+cd .config/astgrep
+./build.sh                                    # fetch pinned grammar + compile groovy.dylib (run once)
+cd -
+ast-grep scan -c .config/astgrep/sgconfig.yml # scan the repo
+```
+
+Requires [`ast-grep`](https://ast-grep.github.io/guide/quick-start.html) (>= 0.44) and a
+C compiler (`gcc`/`clang`).
+
+## How it works
+
+- **`build.sh`** fetches [dekobon/tree-sitter-groovy](https://github.com/dekobon/tree-sitter-groovy)
+  at a pinned immutable commit (`8c70dc6`, release v0.2.2) into `.grammar-build/` (gitignored,
+  not vendored), asserts the resolved SHA matches the pin, and compiles the parser into
+  `groovy.dylib`. The library is native code compiled on each machine, so it works on macOS
+  (Mach-O) and Linux (ELF) alike — no per-platform binary is committed.
+- **`sgconfig.yml`** registers `groovy` as an ast-grep custom language (`expandoChar: _`
+  because Groovy uses `$` for GString interpolation; metavariables are still `$NAME` / `$$$`).
+- **`rules/`** holds one YAML lint rule per file.
+
+`groovy.dylib` and `.grammar-build/` are gitignored; each checkout rebuilds the library locally.
+
+## Rules
+
+| id | severity | flags |
+|---|---|---|
+| `no-wildcard-import` | warning | `import foo.bar.*` — import specific classes |

--- a/.config/astgrep/build.sh
+++ b/.config/astgrep/build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetch the pinned tree-sitter Groovy grammar and compile it into groovy.dylib.
+#
+# The grammar is NOT vendored: it is fetched at a pinned, immutable commit
+# (git's SHA is a content hash, so the build is deterministic) into a gitignored
+# build dir, then compiled with the system C compiler. Run once; the resulting
+# groovy.dylib is reused by ast-grep via sgconfig.yml. Portable: compiles native
+# on each host (Mach-O on macOS, ELF on Linux) — no committed per-platform binary.
+#
+#   ./build.sh
+#   ast-grep scan -c .config/astgrep/sgconfig.yml
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# dekobon/tree-sitter-groovy, release v0.2.2, pinned by immutable commit SHA.
+GRAMMAR_REPO="https://github.com/dekobon/tree-sitter-groovy.git"
+GRAMMAR_COMMIT="8c70dc650be128673efd6f53bdc0ffba3ba4ce7d"
+BUILD_DIR=".grammar-build"
+OUT="groovy.dylib"
+
+if [ ! -d "$BUILD_DIR/.git" ]; then
+  rm -rf "$BUILD_DIR"
+  git clone --quiet "$GRAMMAR_REPO" "$BUILD_DIR"
+fi
+git -C "$BUILD_DIR" fetch --quiet --tags origin
+git -C "$BUILD_DIR" checkout --quiet "$GRAMMAR_COMMIT"
+
+# Assert the checkout resolved to the exact pinned SHA (immutable content hash),
+# not a moved tag/branch. If this ever fails, determinism is compromised — stop.
+RESOLVED="$(git -C "$BUILD_DIR" rev-parse HEAD)"
+if [ "$RESOLVED" != "$GRAMMAR_COMMIT" ]; then
+  echo "error: expected $GRAMMAR_COMMIT but got $RESOLVED" >&2
+  exit 1
+fi
+
+SRC="$BUILD_DIR/src"
+[ -f "$SRC/parser.c" ] || { echo "error: $SRC/parser.c missing" >&2; exit 1; }
+
+# scanner.c is plain C (not C++); compile parser + external scanner together.
+# Drop -std=c11 if the compiler rejects it (clang defaults suffice).
+gcc -std=c11 -shared -fPIC -O2 -I "$SRC" \
+  "$SRC/parser.c" "$SRC/scanner.c" \
+  -o "$OUT"
+
+echo "built $OUT from ${GRAMMAR_COMMIT:0:7}"

--- a/.config/astgrep/rule-tests/__snapshots__/no-wildcard-import-snapshot.yml
+++ b/.config/astgrep/rule-tests/__snapshots__/no-wildcard-import-snapshot.yml
@@ -1,0 +1,20 @@
+id: no-wildcard-import
+snapshots:
+  import java.awt.*:
+    labels:
+    - source: import java.awt.*
+      style: primary
+      start: 0
+      end: 17
+  import javax.swing.*:
+    labels:
+    - source: import javax.swing.*
+      style: primary
+      start: 0
+      end: 20
+  import nextflow.processor.*:
+    labels:
+    - source: import nextflow.processor.*
+      style: primary
+      start: 0
+      end: 27

--- a/.config/astgrep/rule-tests/no-wildcard-import-test.yml
+++ b/.config/astgrep/rule-tests/no-wildcard-import-test.yml
@@ -1,0 +1,11 @@
+id: no-wildcard-import
+valid:
+  - import javax.swing.JButton
+  - import java.awt.Color
+  - import static java.nio.file.StandardOpenOption.WRITE
+  # static wildcard imports are intentionally not flagged by this rule
+  - import static nextflow.processor.TaskStatus.*
+invalid:
+  - import javax.swing.*
+  - import java.awt.*
+  - import nextflow.processor.*

--- a/.config/astgrep/rules/no-star-import.yml
+++ b/.config/astgrep/rules/no-star-import.yml
@@ -1,0 +1,13 @@
+id: no-wildcard-import
+language: groovy
+severity: warning
+message: Avoid wildcard imports; import specific classes.
+note: |
+  Nextflow's developer style guide mandates single-class imports (the IntelliJ
+  setup raises the "class count to use import with star" thresholds to 99, which
+  effectively disables star imports). Wildcard imports also invite name collisions
+  as the codebase evolves; a recent illustration (in Java, nextflow-io/nextflow#7100)
+  was a clash between the AWS SDK's and the JDK's AccessDeniedException when both
+  packages were star-imported. Import the specific classes instead.
+rule:
+  pattern: import $X.*

--- a/.config/astgrep/sgconfig.yml
+++ b/.config/astgrep/sgconfig.yml
@@ -1,5 +1,7 @@
 ruleDirs:
   - rules
+testConfigs:
+  - testDir: rule-tests
 customLanguages:
   groovy:
     libraryPath: groovy.dylib

--- a/.config/astgrep/sgconfig.yml
+++ b/.config/astgrep/sgconfig.yml
@@ -1,0 +1,7 @@
+ruleDirs:
+  - rules
+customLanguages:
+  groovy:
+    libraryPath: groovy.dylib
+    extensions: [groovy, gradle]
+    expandoChar: _


### PR DESCRIPTION
## What

Adds a small [ast-grep](https://ast-grep.github.io/) setup for **structural (AST-based) linting of Groovy sources**, under `.config/astgrep/`. This is the foundation PR: it wires up the tooling and ships a **single, advisory (warning-severity) starter rule** so the mechanism can be reviewed in isolation. Further rules are intended to stack as follow-up PRs.

## Why lead with `no-wildcard-import`

It maps directly to an **already-documented house style**: the [Nextflow developer docs](https://docs.seqera.io/nextflow/developer/) mandate single-class imports (the recommended IntelliJ setup raises the "class count to use import with `*`" thresholds to 99, effectively disabling star imports). So this rule encodes an existing written convention rather than introducing a new opinion.

As a secondary motivation, wildcard imports invite name collisions as the codebase evolves — a recent *illustration* (in Java, not Groovy) was #7100, where the AWS SDK's and the JDK's `AccessDeniedException` clashed because both packages were star-imported. Note this Groovy-only linter would **not** have caught that `.java` case; it's cited only to show the class of problem wildcards create.

Scoped to plain `import foo.bar.*` — **2 findings** today:
- `plugins/nf-console/src/main/nextflow/ui/console/Nextflow.groovy:19` — `import javax.swing.*`
- `plugins/nf-tower/src/main/io/seqera/tower/plugin/auth/AuthCommandImpl.groovy:24` — `import java.awt.*`

(Static wildcard imports — `import static ...*` — are idiomatic for enums/constants and Spock tests, ~106 occurrences; intentionally **not** flagged here. A separate rule for those could be a follow-up if desired.)

## How it works

- `.config/astgrep/build.sh` fetches [dekobon/tree-sitter-groovy](https://github.com/dekobon/tree-sitter-groovy) at a **pinned immutable commit** (`8c70dc6`, v0.2.2) into a gitignored `.grammar-build/` (not vendored), asserts the resolved SHA matches the pin, and compiles `groovy.dylib` locally. The library is native code built on each machine, so it works on macOS (Mach-O) and Linux (ELF) — nothing binary is committed.
- `.config/astgrep/sgconfig.yml` registers `groovy` as an ast-grep custom language.
- `.config/astgrep/rules/` holds one YAML lint rule per file.

## Usage

```bash
cd .config/astgrep && ./build.sh          # once
ast-grep scan -c .config/astgrep/sgconfig.yml
```

Requires `ast-grep` (>= 0.44) and a C compiler.

## Notes

- **Advisory only** — `severity: warning`; not wired into CI, nothing blocks.
- Intended follow-up rules (separate PRs): `no-print-stack-trace`, `no-system-out-println` (both tie to the `@Slf4j` logger convention), `no-thread-sleep`, and optionally static-wildcard imports.
