### PR TITLE
Fix URL percent-encoding lost on resume for http/ftp paths

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/util/KryoHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/KryoHelperTest.groovy
@@ -177,6 +177,24 @@ class KryoHelperTest extends  Specification {
         KryoHelper.deserialize(buffer).toUri() == new URI('http://host.com/foo.txt')
     }
 
+    def 'should serialise xpath preserving percent-encoding' () {
+        // regression test for https://github.com/nextflow-io/nextflow/issues/6109
+        // a percent-encoded URL (e.g. %23 for '#') must survive a serialize/deserialize
+        // round-trip without being decoded, otherwise the URL is corrupted on -resume
+        given:
+        def url = 'http://host.com/41741_2%237.sub.cram'
+        def file = FileHelper.asPath(url)
+
+        when:
+        def buffer = KryoHelper.serialize(file)
+        def copy = KryoHelper.deserialize(buffer)
+
+        then:
+        copy.getClass().getName() == 'nextflow.file.http.XPath'
+        copy == file
+        copy.toUri().toString() == url
+    }
+
     def 'should serialise xfilesystem' () {
         when:
         def uri = new URI('https://host.com/path/foo.txt')

--- a/modules/nf-httpfs/src/main/nextflow/file/http/XPathSerializer.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XPathSerializer.groovy
@@ -44,6 +44,10 @@ class XPathSerializer extends Serializer<XPath> {
     XPath read(Kryo kryo, Input input, Class<XPath> type) {
         final uri = input.readString()
         log.trace "Path de-serialization > uri=$uri"
-        (XPath) FileHelper.asPath(new URI(uri))
+        // note: pass the raw string (not a pre-parsed URI) so that percent-encoded
+        // characters (e.g. %23 for '#') go through the same string-based parsing
+        // used when the path is first created via file(), instead of being decoded
+        // by java.net.URI#getPath() -- see https://github.com/nextflow-io/nextflow/issues/6109
+        (XPath) FileHelper.asPath(uri)
     }
 }


### PR DESCRIPTION
Fix #6109 

This PR fixes a bug where URLs containing special characters like `#` were not deserialized correctly on resume. The deserialization path did not match the construction path used by `file()`, so it produced the wrong URL on resume, truncating the request at the '#' and failing to stage the foreign file.