### PR TITLE
Guard trace log against string formatting errors

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowBinding.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowBinding.groovy
@@ -27,6 +27,7 @@ import nextflow.exception.IllegalInvocationException
 import nextflow.exception.ScriptRuntimeException
 import nextflow.extension.CH
 import nextflow.extension.OpCall
+import org.codehaus.groovy.runtime.InvokerHelper
 /**
  * Models the execution context of a workflow component
  *
@@ -100,7 +101,7 @@ class WorkflowBinding extends Binding  {
     @Override
     Object invokeMethod(String name, Object args) {
         if( meta ) {
-            log.trace "Trying to invoke component: $name - args=${args}"
+            log.trace "Trying to invoke component: $name - args=${renderArgs(args)}"
             final component = getComponent0(name)
             if( component ) {
                 checkScope0(component)
@@ -113,6 +114,15 @@ class WorkflowBinding extends Binding  {
         }
 
         throw new MissingMethodException(name,this.getClass())
+    }
+
+    private static String renderArgs(Object args) {
+        try {
+            return InvokerHelper.toString(args)
+        }
+        catch( Throwable t ) {
+            return "<unable to render args: ${t.class.simpleName}>"
+        }
     }
 
     private Object invoke0(ComponentDef component, Object args) {

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowBindingTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowBindingTest.groovy
@@ -16,9 +16,9 @@
 
 package nextflow.script
 
-import spock.lang.Specification
-
+import nextflow.NF
 import nextflow.extension.OpCall
+import spock.lang.Specification
 
 /**
  *
@@ -27,7 +27,7 @@ import nextflow.extension.OpCall
 class WorkflowBindingTest extends Specification {
 
     def setupSpec() {
-        WorkflowBinding.init()
+        NF.init()
     }
 
     def 'should lookup variables' () {
@@ -76,6 +76,21 @@ class WorkflowBindingTest extends Specification {
         1 * binding.getComponent0('foo') >> null
         thrown(MissingMethodException)
 
+    }
+
+    def 'should not fail when tracing a method call' () {
+        given:
+        def BOOM = new Object() {
+            @Override
+            String toString() { throw new MissingPropertyException('task', Object) }
+        }
+        def ARGS = [BOOM] as Object[]
+
+        when:
+        def result = WorkflowBinding.renderArgs(ARGS)
+        then:
+        noExceptionThrown()
+        result == '<unable to render args: MissingPropertyException>'
     }
 
     def 'should get an extension method as variable' () {


### PR DESCRIPTION
Fix #6600 

This PR fixes a trace log that can cause the pipeline to fail. It logs every method call invoked by WorkflowBinding, which serializes arbitrary method call arguments that can fail

Rather than trying to patch specific cases, we simply guard the trace log so that it doesn't affect the run