### PR TITLE
docs: Clarify behavior of withName selectors

### DIFF
--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -201,22 +201,25 @@ You can use the `withName` selector to configure a specific process by its name:
 ```groovy
 process {
     withName: hello {
-cpus = 4
-memory = 8.GB
-queue = 'short'
+        cpus = 4
+        memory = 8.GB
+        queue = 'short'
     }
 }
 ```
 
-The `withName` selector matches both:
+When the selector is an unqualified process name, it matches both processes *defined* with than name and processes *included* under that alias. Selectors for an alias take priority over selectors for the original name. For example, if you define a process as `hello` and include it as `sayHello`, both `withName: hello` and `withName: sayHello` apply, with `withName: sayHello` taking priority.
 
-- Processes defined with that name
-- Processes included under that alias
+When the selector is a qualified process name, it matches only processes invoked with the exact fully-qualified name. For example, `withName: 'PARENT:hello'` matches `hello` invoked by `PARENT`. It does not match:
 
-When you include a process with an alias, selectors for the alias take priority over selectors for the original name. For example, if you define a process as `hello` and include it as `sayHello`, both `withName: hello` and `withName: sayHello` apply, with `withName: sayHello` taking priority.
+- `GRANDPARENT:PARENT:hello` (nested invocation)
+- `PARENT:sayHello` (different process alias)
+- `PARENT2:hello` (different workflow alias)
+
+In each case, use the fully-qualified process name instead.
 
 :::tip
-You don't need to enclose label and process names in quotes unless they contain special characters (`-`, `!`, etc.) or are keywords or built-in type identifiers.
+You don't need to enclose label and process names in quotes unless they contain special characters (`-`, `:`, `!`, etc.) or are keywords or built-in type identifiers.
 :::
 
 ### Selector expressions

--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -216,7 +216,7 @@ When the selector is a qualified process name, it matches only processes invoked
 - `PARENT:sayHello` (different process alias)
 - `PARENT2:hello` (different workflow alias)
 
-In each case, use the fully-qualified process name instead.
+In each case, use the fully-qualified process name instead. Alternatively, use a regular expression (e.g. `.*:PARENT:hello`) to match multiple variants.
 
 :::tip
 You don't need to enclose label and process names in quotes unless they contain special characters (`-`, `:`, `!`, etc.) or are keywords or built-in type identifiers.

--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -224,7 +224,9 @@ You don't need to enclose label and process names in quotes unless they contain 
 
 ### Selector expressions
 
-You can use regular expressions in process selectors to apply the same configuration to all processes matching the pattern:
+You can use regular expressions in process selectors to apply the same configuration to all processes matching the pattern.
+
+Use the `|` operator to select multiple names or labels:
 
 ```groovy
 process {
@@ -237,7 +239,7 @@ process {
 
 This configuration requests 2 CPUs and 4 GB of memory for processes labeled as `hello` or `bye`.
 
-You can negate a selector expression by prefixing it with the special character `!`:
+Use the `!` operator to negate a selector expression:
 
 ```groovy
 process {
@@ -247,7 +249,7 @@ process {
 }
 ```
 
-This configuration sets 2 CPUs for processes labeled as `hello` and 4 CPUs for all processes *not* labeled as `hello`. It also specifies the `long` queue for processes whose name does *not* start with `align`.
+This configuration requests 2 CPUs for processes labeled as `hello` and 4 CPUs for all processes *not* labeled as `hello`. It also specifies the `long` queue for processes whose name does *not* start with `align`.
 
 ### Selector priority
 

--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -208,7 +208,7 @@ process {
 }
 ```
 
-When the selector is an unqualified process name, it matches both processes *defined* with than name and processes *included* under that alias. Selectors for an alias take priority over selectors for the original name. For example, if you define a process as `hello` and include it as `sayHello`, both `withName: hello` and `withName: sayHello` apply, with `withName: sayHello` taking priority.
+When the selector is an unqualified process name, it matches both processes *defined* with that name and processes *included* under that alias. Selectors for an alias take priority over selectors for the original name. For example, if you define a process as `hello` and include it as `sayHello`, both `withName: hello` and `withName: sayHello` apply, with `withName: sayHello` taking priority.
 
 When the selector is a qualified process name, it matches only processes invoked with the exact fully-qualified name. For example, `withName: 'PARENT:hello'` matches `hello` invoked by `PARENT`. It does not match:
 


### PR DESCRIPTION
Close #6682 

This PR updates the withName selector docs to explain how they work with  fully qualified names -- selectors that use a qualified name must match the fully-qualified name exactly.