### PR TITLE
Fix plugin blocks incorrectly merged in v2 config parser

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -321,14 +321,19 @@ class ConfigDsl extends Script {
     }
 
     private static class PluginsDsl extends ConfigBlockDsl {
+        private Set<String> plugins = new LinkedHashSet<>()
+
         PluginsDsl(ConfigDsl dsl) {
             super(dsl, Collections.<String>emptyList())
         }
 
         void id(String value) {
-            final target = dsl.getTarget()
-            final plugins = (Set) target.computeIfAbsent('plugins', (k) -> new LinkedHashSet<>())
             plugins.add(value)
+        }
+
+        @Override
+        void apply() {
+            dsl.getTarget().put('plugins', plugins)
         }
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -87,14 +87,6 @@ class ConfigParserV2Test extends Specification {
         def main = folder.resolve('nextflow.config')
         def snippet = folder.resolve('other.config')
 
-        main.text = """
-            includeConfig 'other.config'
-
-            plugins {
-                id 'nf-schema@2.6.1'
-            }
-            """
-
         snippet.text = '''
             plugins {
                 id 'nf-boost'
@@ -103,11 +95,28 @@ class ConfigParserV2Test extends Specification {
             '''
 
         when:
-        def config = new ConfigParserV2().parse(main)
+        main.text = """
+            includeConfig 'other.config'
 
+            plugins {
+                id 'nf-schema@2.6.1'
+            }
+            """
+        def config = new ConfigParserV2().parse(main)
         then:
-        // the last `plugins` block wins
         config.plugins == ['nf-schema@2.6.1'] as Set
+
+        when:
+        main.text = """
+            plugins {
+                id 'nf-schema@2.6.1'
+            }
+
+            includeConfig 'other.config'
+            """
+        config = new ConfigParserV2().parse(main)
+        then:
+        config.plugins == ['nf-boost', 'nf-schema@2.5.1'] as Set
 
         cleanup:
         folder?.deleteDir()

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -81,6 +81,38 @@ class ConfigParserV2Test extends Specification {
         config.process.cpus == 1
     }
 
+    def 'should resolve multiple plugins block by replacement' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def main = folder.resolve('nextflow.config')
+        def snippet = folder.resolve('other.config')
+
+        main.text = """
+            includeConfig 'other.config'
+
+            plugins {
+                id 'nf-schema@2.6.1'
+            }
+            """
+
+        snippet.text = '''
+            plugins {
+                id 'nf-boost'
+                id 'nf-schema@2.5.1'
+            }
+            '''
+
+        when:
+        def config = new ConfigParserV2().parse(main)
+
+        then:
+        // the last `plugins` block wins
+        config.plugins == ['nf-schema@2.6.1'] as Set
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'should parse composed config files' () {
 
         given:


### PR DESCRIPTION
Fix #6754

The v2 config parser currently merges subsequent `plugins` blocks when it should simply use the last defined block

This is already how the v1 parser behaves and the v2 parser in most scenarios, except the case of a main config including another config and both defining a `plugins` block

Regardless of whether we allow plugins merging in the future, this fix ensures that the current behavior is consistent