### PR TITLE
Fix negative duration error on short run

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/Duration.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/Duration.groovy
@@ -219,7 +219,8 @@ class Duration implements IDuration, TemporalAmount, Comparable<Duration>, Seria
     }
 
     static Duration between( Temporal start, Temporal end ) {
-        new Duration(java.time.Duration.between(start, end).toMillis())
+        final millis = java.time.Duration.between(start, end).toMillis()
+        new Duration(Math.max(0L, millis))
     }
 
     @Override

--- a/modules/nf-commons/src/test/nextflow/util/DurationTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/DurationTest.groovy
@@ -193,10 +193,11 @@ class DurationTest extends Specification {
 
         given:
         def start = Instant.now()
-        def end = start.plusMillis(1000)
 
         expect:
-        Duration.between(start, end) == Duration.of('1sec')
+        Duration.between(start, start.plusMillis(1000)) == Duration.of('1sec')
+        and: 'guard against non-monotonic wall clock'
+        Duration.between(start, start.minusMillis(228)) == Duration.of(0)
     }
 
     // TemporalAmount interface tests


### PR DESCRIPTION
Fix #6757 and #1384 

`WorkflowMetadata` uses `OffsetDateTime.now()` to record the start and stop timestamps. However, these timestamps are not monotonic, which means it is possible for `complete - start < 0` in certain cases, e.g. when the wall clock is corrected (NTP, WSL, etc) and the run is very short (e.g. cached run)

This causes a runtime error because `Duration` does not allow a negative duration value

This PR fixes it by updating `Duration.between()` to gate negative intervals to 0.