### PR TITLE
Report syntax error for unexpected character in gstring

### DIFF
--- a/modules/nf-lang/src/main/antlr/ConfigLexer.g4
+++ b/modules/nf-lang/src/main/antlr/ConfigLexer.g4
@@ -170,6 +170,10 @@ GStringExprStart
     :   '${' -> pushMode(DEFAULT_MODE)
     ;
 
+GStringUnexpectedChar
+    :   . { require(errorIgnored, "Unexpected character: '" + getText().replace("'", "\\'") + "'", -1, false); }
+    ;
+
 mode TDQ_GSTRING_MODE;
 TdqGStringEnd
     :   TdqStringQuotationMark -> popMode
@@ -185,6 +189,10 @@ TdqGStringText
 
 TdqGStringExprStart
     :   '${' -> pushMode(DEFAULT_MODE)
+    ;
+
+TdqGStringUnexpectedChar
+    :   . { require(errorIgnored, "Unexpected character: '" + getText().replace("'", "\\'") + "'", -1, false); }
     ;
 
 mode DEFAULT_MODE;

--- a/modules/nf-lang/src/main/antlr/ScriptLexer.g4
+++ b/modules/nf-lang/src/main/antlr/ScriptLexer.g4
@@ -172,6 +172,10 @@ GStringExprStart
     :   '${' -> pushMode(DEFAULT_MODE)
     ;
 
+GStringUnexpectedChar
+    :   . { require(errorIgnored, "Unexpected character: '" + getText().replace("'", "\\'") + "'", -1, false); }
+    ;
+
 mode TDQ_GSTRING_MODE;
 TdqGStringEnd
     :   TdqStringQuotationMark -> popMode
@@ -187,6 +191,10 @@ TdqGStringText
 
 TdqGStringExprStart
     :   '${' -> pushMode(DEFAULT_MODE)
+    ;
+
+TdqGStringUnexpectedChar
+    :   . { require(errorIgnored, "Unexpected character: '" + getText().replace("'", "\\'") + "'", -1, false); }
     ;
 
 mode DEFAULT_MODE;

--- a/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
@@ -523,4 +523,73 @@ class ScriptAstBuilderTest extends Specification {
         errors[0].getOriginalMessage() == "Missing field type"
     }
 
+    def 'should report an error for an unexpected character in a gstring' () {
+        when:
+        // bare `$` not followed by an identifier or `{` in a triple-quoted gstring
+        def errors = check(
+            '''\
+            """
+            echo "$/"
+            """
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 2
+        errors[0].getStartColumn() == 7
+        errors[0].getOriginalMessage() == "Unexpected character: '\$'"
+
+        when:
+        // bare `$` in a double-quoted gstring
+        errors = check(
+            '''\
+            "abc $/ def"
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 6
+        errors[0].getOriginalMessage() == "Unexpected character: '\$'"
+
+        when:
+        // invalid escape sequence in a gstring (the `\\` matches no rule)
+        errors = check(
+            '''\
+            "abc \\q def"
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 6
+        errors[0].getOriginalMessage() == "Unexpected character: '\\'"
+    }
+
+    def 'should allow escaped and interpolated gstring characters' () {
+        when:
+        // escaped `\\$` renders as a literal `$`
+        def errors = check(
+            '''\
+            """
+            echo "\\$/"
+            """
+            '''
+        )
+        then:
+        errors.size() == 0
+
+        when:
+        // normal `${...}` interpolation
+        errors = check(
+            '''\
+            """
+            echo "${'hello'}"
+            """
+            '''
+        )
+        then:
+        errors.size() == 0
+    }
+
 }


### PR DESCRIPTION
Fix #6883 

Long ago, I simplified the lexer rules for GStrings to remove a hack inherited from the Groovy grammar. However, that caused certain syntax errors to not be caught, leading to weird runtime behavior

This PR adds the lexer rules necessary to complete the GString handling, so that cases like `"$/"` are reported as invalid syntax rather than leading to silently incorrect behavior