### PR TITLE
Fix lint reporting of excluded paths

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -42,6 +42,7 @@ import nextflow.script.parser.v2.ErrorSummary
 import nextflow.script.parser.v2.StandardErrorListener
 import nextflow.util.ClassLoaderFactory
 import nextflow.util.PathUtils
+import nextflow.util.TestOnly
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.control.messages.SyntaxErrorMessage
 import org.codehaus.groovy.control.messages.WarningMessage
@@ -120,6 +121,9 @@ class CmdLint extends CmdBase {
 
     private ErrorSummary summary = new ErrorSummary()
 
+    @TestOnly
+    protected Path root
+
     @Override
     String getName() { 'lint' }
 
@@ -156,8 +160,9 @@ class CmdLint extends CmdBase {
         final List<File> files = []
 
         for( final input : inputs ) {
+            final start = root != null ? root.resolve(input) : Path.of(input)
             PathUtils.visitFiles(
-                Path.of(input),
+                start,
                 (path) -> !PathUtils.isExcluded(path, excludePatterns),
                 (path) -> files.add(path.toFile()))
         }
@@ -229,6 +234,7 @@ class CmdLint extends CmdBase {
         compiler.getSources()
             .values()
             .stream()
+            .filter((source) -> !isExcludedSource(source))
             .sorted(Comparator.comparing((SourceUnit source) -> source.getSource().getURI()))
             .forEach((source) -> {
                 final errorCollector = source.getErrorCollector()
@@ -247,16 +253,42 @@ class CmdLint extends CmdBase {
             })
     }
 
+    /**
+     * Determine whether a source file should be excluded from lint
+     * reporting. Sources can be added to the compiler indirectly, e.g.
+     * by resolving an `include` statement into a script that lives
+     * under an excluded directory, so exclusion can't be determined
+     * solely from the initial file listing.
+     *
+     * @param source
+     */
+    private boolean isExcludedSource(SourceUnit source) {
+        final uri = source.getSource().getURI()
+        if( uri == null || uri.getScheme() != 'file' )
+            return false
+        for( Path path = Path.of(uri); path != null; path = path.getParent() ) {
+            if( PathUtils.isExcluded(path, excludePatterns) )
+                return true
+        }
+        return false
+    }
+
+    /**
+     * Report all errors and warnings for a source file.
+     *
+     * @param source
+     */
     private void printErrors(SourceUnit source) {
         errorListener.beforeErrors()
 
+        final name = relativeName(source)
         final errors = source.getErrorCollector().getErrors() ?: []
         errors.stream()
             .filter(message -> message instanceof SyntaxErrorMessage)
             .map(message -> ((SyntaxErrorMessage) message).getCause())
             .sorted(ERROR_COMPARATOR)
             .forEach((cause) -> {
-                errorListener.onError(cause, source.getName(), source)
+                errorListener.onError(cause, name, source)
                 summary.errors += 1
             })
 
@@ -265,11 +297,23 @@ class CmdLint extends CmdBase {
             .filter(warning -> warning !instanceof ParanoidWarning)
             .sorted(WARNING_COMPARATOR)
             .forEach((warning) -> {
-                errorListener.onWarning(warning, source.getName(), source)
+                errorListener.onWarning(warning, name, source)
                 summary.warnings += 1
             })
 
         errorListener.afterErrors()
+    }
+
+    /**
+     * Resolve the path for a source file, relative to the
+     * current working directory.
+     *
+     * @param source
+     */
+    private String relativeName(SourceUnit source) {
+        final uri = source.getSource().getURI()
+        final cwd = root ?: Path.of('.').toAbsolutePath().normalize()
+        return cwd.relativize(Path.of(uri)).toString()
     }
 
     private static final Comparator<SyntaxException> ERROR_COMPARATOR = (SyntaxException a, SyntaxException b) -> {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -257,8 +257,10 @@ class CmdLint extends CmdBase {
      * Determine whether a source file should be excluded from lint
      * reporting. Sources can be added to the compiler indirectly, e.g.
      * by resolving an `include` statement into a script that lives
-     * under an excluded directory, so exclusion can't be determined
-     * solely from the initial file listing.
+     * under an excluded directory.
+     *
+     * Match exclude patterns only against path components *within* the
+     * project directory.
      *
      * @param source
      */
@@ -266,7 +268,10 @@ class CmdLint extends CmdBase {
         final uri = source.getSource().getURI()
         if( uri == null || uri.getScheme() != 'file' )
             return false
-        for( Path path = Path.of(uri); path != null; path = path.getParent() ) {
+        final base = cwd()
+        final absolute = Path.of(uri)
+        final start = absolute.startsWith(base) ? base.relativize(absolute) : absolute
+        for( Path path = start; path != null; path = path.getParent() ) {
             if( PathUtils.isExcluded(path, excludePatterns) )
                 return true
         }
@@ -312,8 +317,15 @@ class CmdLint extends CmdBase {
      */
     private String relativeName(SourceUnit source) {
         final uri = source.getSource().getURI()
-        final cwd = root ?: Path.of('.').toAbsolutePath().normalize()
-        return cwd.relativize(Path.of(uri)).toString()
+        return cwd().relativize(Path.of(uri)).toString()
+    }
+
+    /**
+     * The directory that source paths are resolved and reported against.
+     * Defaults to the current working directory; overridable in tests.
+     */
+    private Path cwd() {
+        return root ?: Path.of('.').toAbsolutePath().normalize()
     }
 
     private static final Comparator<SyntaxException> ERROR_COMPARATOR = (SyntaxException a, SyntaxException b) -> {

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdLintTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdLintTest.groovy
@@ -17,8 +17,11 @@
 package nextflow.cli
 
 import java.nio.file.Files
+import java.nio.file.Path
 
 import nextflow.exception.AbortOperationException
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.SourceUnit
 import org.junit.Rule
 import spock.lang.Specification
 import test.OutputCapture
@@ -37,6 +40,10 @@ class CmdLintTest extends Specification {
             options: new CliOptions(opts ?: [ansiLog: false])
         )
         return cmd
+    }
+
+    SourceUnit fileSource(Path path) {
+        return new SourceUnit(path.toFile(), new CompilerConfiguration(), null, null)
     }
 
     def 'should read files from positional args and -files-from option' () {
@@ -112,16 +119,17 @@ class CmdLintTest extends Specification {
 
         when:
         def cmd = createCmdLint()
-        cmd.args = [dir.toFile().toString()]
+        cmd.args = ['.']
+        cmd.root = dir
         cmd.run()
 
         then:
         thrown(AbortOperationException)
         and:
-        capture.toString().contains("Error $dir/main.nf:5:19: Unexpected input: '\\n'")
+        capture.toString().contains("Error main.nf:5:19: Unexpected input: '\\n'")
         capture.toString().contains("│   5 |                 \${")
         capture.toString().contains("╰     |                   ^")
-        capture.toString().contains("Error $dir/nextflow.config:2:27: Unexpected input: '\\n'")
+        capture.toString().contains("Error nextflow.config:2:27: Unexpected input: '\\n'")
         capture.toString().contains("│   2 |                 withLabel:")
         capture.toString().contains("╰     |                           ^")
 
@@ -207,6 +215,55 @@ class CmdLintTest extends Specification {
         capture.toString().contains("Error")
         capture.toString().contains("`printx` is not defined")
         capture.toString().contains("Nextflow linting complete")
+
+        cleanup:
+        dir?.deleteDir()
+    }
+
+    def 'should exclude sources under an excluded directory' () {
+
+        given:
+        def dir = Files.createTempDirectory('test')
+        def included = dir.resolve('modules/local/foo/main.nf')
+        def excluded = dir.resolve('modules/nf-core/bar/main.nf')
+        Files.createDirectories(included.parent)
+        Files.createDirectories(excluded.parent)
+        included.text = ''
+        excluded.text = ''
+        and:
+        def cmd = createCmdLint()
+        cmd.excludePatterns = ['nf-core']
+
+        expect:
+        // a file directly under a non-excluded directory is kept
+        !cmd.isExcludedSource(fileSource(included))
+        // a file reached indirectly (e.g. via include) under an excluded
+        // ancestor directory is excluded, even with an absolute path
+        cmd.isExcludedSource(fileSource(excluded))
+
+        cleanup:
+        dir?.deleteDir()
+    }
+
+    def 'should report indirectly-included sources with a relative path' () {
+
+        given:
+        def cwd = Path.of('.').toAbsolutePath()
+        // create the file under the working directory so it can be relativized
+        def dir = Files.createTempDirectory(cwd, 'test')
+        def file = dir.resolve('modules/nf-core/bar/main.nf')
+        Files.createDirectories(file.parent)
+        file.text = ''
+        and:
+        def cmd = createCmdLint()
+        def source = fileSource(file)
+
+        expect:
+        // the source is backed by an absolute file, as if resolved from an include
+        source.getName() == file.toString()
+        and:
+        // but it is reported relative to the working directory
+        cmd.relativeName(source) == cwd.relativize(file).toString()
 
         cleanup:
         dir?.deleteDir()

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdLintTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdLintTest.groovy
@@ -245,6 +245,29 @@ class CmdLintTest extends Specification {
         dir?.deleteDir()
     }
 
+    def 'should exclude sources based on their relative path in the project root' () {
+
+        given:
+        // simulate a project checked out under a directory named `work`,
+        // which is one of the default exclude patterns
+        def base = Files.createTempDirectory('test').resolve('work/myproject')
+        def file = base.resolve('modules/local/foo/main.nf')
+        Files.createDirectories(file.parent)
+        file.text = ''
+        and:
+        def cmd = createCmdLint()
+        cmd.root = base
+        // excludePatterns keeps the default value, which includes `work`
+
+        expect:
+        // the `work` ancestor is above the project root and must be ignored;
+        // only path components within the project should be matched
+        !cmd.isExcludedSource(fileSource(file))
+
+        cleanup:
+        base?.parent?.parent?.deleteDir()
+    }
+
     def 'should report indirectly-included sources with a relative path' () {
 
         given:


### PR DESCRIPTION
Fix #6945 

The `lint` command `-exclude` option did not account for the fact that the linting process can pick up additional files via includes. These included files were not filtered against the exclude patterns. Additionally, they were reported by absolute path instead of relative path

This PR fixes both issues. Source files are filtered again after linting and prior to reporting, and they are reported by relative path