### PR TITLE
Fix workflow metadata when failOnIgnore is true

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowMetadata.groovy
@@ -400,7 +400,7 @@ class WorkflowMetadata {
             errorReport = msg
         }
         else {
-            exitStatus = 0
+            exitStatus = session.isSuccess() ? 0 : 1
         }
     }
 
@@ -411,7 +411,7 @@ class WorkflowMetadata {
     void invokeOnComplete() {
         this.complete = OffsetDateTime.now()
         this.duration = Duration.between( start, complete )
-        this.success = !(session.aborted || session.cancelled)
+        this.success = session.isSuccess()
         this.stats = getWorkflowStats()
 
         setErrorAttributes()

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowMetadataTest.groovy
@@ -47,7 +47,7 @@ class WorkflowMetadataTest extends Specification {
     def 'should capture the abort cause in errorReport and errorMessage' () {
         given:
         def script = Mock(ScriptFile)
-        Session session = Spy(Session, constructorArgs: [[:]])
+        Session session = Spy(Session)
         session.getStatsObserver() >> Mock(WorkflowStatsObserver) { getStats() >> new WorkflowStats() }
         // simulate a background abort (e.g. a Tower 502 telemetry failure): error set, no task fault
         session.getError() >> new AbortRunException('Unexpected HTTP response\n- status code : 502\n- response msg: 502 Bad Gateway')
@@ -336,6 +336,44 @@ class WorkflowMetadataTest extends Specification {
 
         cleanup:
         SysEnv.pop()
+    }
+
+    def 'should report failure when the run is unsuccessful due to failOnIgnore' () {
+        given:
+        def script = Mock(ScriptFile)
+        Session session = Spy(Session)
+        session.getStatsObserver() >> Mock(WorkflowStatsObserver) { getStats() >> new WorkflowStats() }
+        session.getFault() >> null
+        session.getError() >> null
+        session.isSuccess() >> false
+        and:
+        def metadata = new WorkflowMetadata(session, script)
+
+        when:
+        metadata.invokeOnComplete()
+
+        then:
+        !metadata.success
+        metadata.exitStatus == 1
+    }
+
+    def 'should report success when the run is successful' () {
+        given:
+        def script = Mock(ScriptFile)
+        Session session = Spy(Session)
+        session.getStatsObserver() >> Mock(WorkflowStatsObserver) { getStats() >> new WorkflowStats() }
+        session.getFault() >> null
+        session.getError() >> null
+        session.isSuccess() >> true
+        and:
+        def metadata = new WorkflowMetadata(session, script)
+
+        when:
+        metadata.invokeOnComplete()
+
+        then:
+        metadata.success
+        metadata.exitStatus == 0
     }
 
 }


### PR DESCRIPTION
## Summary

- derive `WorkflowMetadata.success` from `Session.isSuccess()`
- report exit status `1` when `failOnIgnore` makes the workflow unsuccessful without a task fault
- preserve explicit task and Nextflow exit statuses, with regression coverage for status `137`

## Why

`Session.isSuccess()` accounts for `workflow.failOnIgnore`, but `WorkflowMetadata` only checked whether the session was aborted or cancelled. As a result, `onComplete` and reporting integrations could see `workflow.success=true` and `workflow.exitStatus=0` while the Nextflow process exited with status 1.

Fixes #7304

## Validation

- `./gradlew --no-daemon :nextflow:test --rerun-tasks`
- `make compile`
- reproduced the issue workflow with the development launcher and verified `workflow.success=false`, `workflow.exitStatus=1`, and process exit status `1`