### PR TITLE
Bound lint exclude matching to the project directory

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -266,7 +266,15 @@ class CmdLint extends CmdBase {
         final uri = source.getSource().getURI()
         if( uri == null || uri.getScheme() != 'file' )
             return false
-        for( Path path = Path.of(uri); path != null; path = path.getParent() ) {
+        // Match exclude patterns only against path components *within* the
+        // project directory. Walking the absolute path would incorrectly match
+        // an ancestor directory above the project root, e.g. a project checked
+        // out under a directory named `work` (a default exclude pattern) or a
+        // CI checkout under `/home/runner/work/...`.
+        final base = cwd()
+        final absolute = Path.of(uri)
+        final start = absolute.startsWith(base) ? base.relativize(absolute) : absolute
+        for( Path path = start; path != null; path = path.getParent() ) {
             if( PathUtils.isExcluded(path, excludePatterns) )
                 return true
         }
@@ -312,8 +320,15 @@ class CmdLint extends CmdBase {
      */
     private String relativeName(SourceUnit source) {
         final uri = source.getSource().getURI()
-        final cwd = root ?: Path.of('.').toAbsolutePath().normalize()
-        return cwd.relativize(Path.of(uri)).toString()
+        return cwd().relativize(Path.of(uri)).toString()
+    }
+
+    /**
+     * The directory that source paths are resolved and reported against.
+     * Defaults to the current working directory; overridable in tests.
+     */
+    private Path cwd() {
+        return root ?: Path.of('.').toAbsolutePath().normalize()
     }
 
     private static final Comparator<SyntaxException> ERROR_COMPARATOR = (SyntaxException a, SyntaxException b) -> {

--- a/modules/nextflow/src/test/groovy/nextflow/cli/CmdLintTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/CmdLintTest.groovy
@@ -245,6 +245,30 @@ class CmdLintTest extends Specification {
         dir?.deleteDir()
     }
 
+    def 'should not exclude sources when the project root is under a directory matching an exclude pattern' () {
+
+        given:
+        // simulate a project checked out under a directory named `work`,
+        // which is one of the default exclude patterns (e.g. ~/work/myproject
+        // or a CI checkout under /home/runner/work/...)
+        def base = Files.createTempDirectory('test').resolve('work/myproject')
+        def file = base.resolve('modules/local/foo/main.nf')
+        Files.createDirectories(file.parent)
+        file.text = ''
+        and:
+        def cmd = createCmdLint()
+        cmd.root = base
+        // excludePatterns keeps the default value, which includes `work`
+
+        expect:
+        // the `work` ancestor is above the project root and must be ignored;
+        // only path components within the project should be matched
+        !cmd.isExcludedSource(fileSource(file))
+
+        cleanup:
+        base?.parent?.parent?.deleteDir()
+    }
+
     def 'should report indirectly-included sources with a relative path' () {
 
         given:


### PR DESCRIPTION
Follow-up fix for #7354.

### Problem

`CmdLint.isExcludedSource()` (added in #7354) walks the **absolute** path of each source up to the filesystem root and excludes the file if *any* ancestor directory name matches an `-exclude` pattern. Because the walk climbs above the project root into the absolute prefix, any pattern that coincides with an ancestor directory name silently excludes the file.

The default exclude list contains `work`, an extremely common ancestor-directory name:

- a repo cloned under `~/work/...`
- a GitHub Actions checkout under `/home/runner/work/<repo>/<repo>/...`

In those layouts **every** source resolves to an absolute path containing `/work/`, so all files are silently skipped and `nextflow lint` reports no issues and exits 0 even when the files contain real errors.

### Fix

Relativize each source against the project directory before matching, so only path components **within** the project are considered against exclude patterns. The intended behaviour from #7354 (excluding e.g. `nf-core` scripts pulled in indirectly via `include`) is preserved — verified below.

| Scenario | Before | After |
|---|---|---|
| `nf-core` pulled in via `include` | excluded | excluded ✅ |
| `local` include (must be kept) | kept | kept ✅ |
| project under `~/work` | **all files silently skipped** | linted correctly ✅ |
| `include nf-core` **and** project under `~/work` | excluded (wrong prefix reason) | `nf-core` excluded, project kept ✅ |

### Tests

Adds a regression test (`should not exclude sources when the project root is under a directory matching an exclude pattern`) that fails on the current #7354 code and passes with this fix. `./gradlew :nextflow:test --tests "nextflow.cli.CmdLintTest"` → 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
