### PR TITLE
Accept http requesting-protocol for https proxy CONNECT tunnel auth

### DIFF
--- a/modules/nf-commons/src/main/nextflow/util/ProxyConfig.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/ProxyConfig.groovy
@@ -75,7 +75,7 @@ class ProxyConfig {
                     // protocol regardless of the destination scheme, so an https proxy config
                     // must also accept an http requesting protocol, otherwise credentials for an
                     // HTTPS CONNECT tunnel are discarded.
-                    final isHttpsTunnel = protocol.equalsIgnoreCase('https') && getRequestingProtocol().equalsIgnoreCase('http')
+                    final isHttpsTunnel = protocol.equalsIgnoreCase('https') && 'http'.equalsIgnoreCase(getRequestingProtocol())
                     if( !isHttpsTunnel )
                         return null
                 }

--- a/modules/nf-commons/src/main/nextflow/util/ProxyConfig.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/ProxyConfig.groovy
@@ -70,8 +70,16 @@ class ProxyConfig {
                     return null
                 if( !getRequestingHost().equalsIgnoreCase(host) )
                     return null
-                if( protocol && !protocol.equalsIgnoreCase(getRequestingProtocol()) )
-                    return null
+                if( protocol && !protocol.equalsIgnoreCase(getRequestingProtocol()) ) {
+                    // For Basic proxy authentication the JDK hard-codes "http" as the requesting
+                    // protocol regardless of the destination scheme (see the Basic branch of
+                    // sun.net.www.protocol.http.HttpURLConnection#getHttpProxyAuthentication),
+                    // so an https proxy config must also accept an http requesting protocol,
+                    // otherwise credentials for an HTTPS CONNECT tunnel are discarded (see #5634).
+                    final isHttpsTunnel = protocol.equalsIgnoreCase('https') && getRequestingProtocol().equalsIgnoreCase('http')
+                    if( !isHttpsTunnel )
+                        return null
+                }
                 if( port && getRequestingPort() != Integer.parseInt(port) ) {
                     return null
                 }

--- a/modules/nf-commons/src/main/nextflow/util/ProxyConfig.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/ProxyConfig.groovy
@@ -72,10 +72,9 @@ class ProxyConfig {
                     return null
                 if( protocol && !protocol.equalsIgnoreCase(getRequestingProtocol()) ) {
                     // For Basic proxy authentication the JDK hard-codes "http" as the requesting
-                    // protocol regardless of the destination scheme (see the Basic branch of
-                    // sun.net.www.protocol.http.HttpURLConnection#getHttpProxyAuthentication),
-                    // so an https proxy config must also accept an http requesting protocol,
-                    // otherwise credentials for an HTTPS CONNECT tunnel are discarded (see #5634).
+                    // protocol regardless of the destination scheme, so an https proxy config
+                    // must also accept an http requesting protocol, otherwise credentials for an
+                    // HTTPS CONNECT tunnel are discarded.
                     final isHttpsTunnel = protocol.equalsIgnoreCase('https') && getRequestingProtocol().equalsIgnoreCase('http')
                     if( !isHttpsTunnel )
                         return null

--- a/modules/nf-commons/src/test/nextflow/util/ProxyConfigTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/ProxyConfigTest.groovy
@@ -102,15 +102,6 @@ class ProxyConfigTest extends Specification {
         invokeAuth(authenticator, Authenticator.RequestorType.PROXY, 'proxy.example.com', 8080, 'https') == null
     }
 
-    def 'authenticator is null-safe when the requesting protocol is missing'() {
-        given: 'an https_proxy-derived config'
-        def proxy = new ProxyConfig(protocol: 'https', host: 'proxy.example.com', port: '8080', username: 'foo', password: 'bar')
-        def authenticator = proxy.authenticator()
-
-        expect: 'a null requesting protocol does not throw and yields no credentials'
-        invokeAuth(authenticator, Authenticator.RequestorType.PROXY, 'proxy.example.com', 8080, null) == null
-    }
-
     def 'proxyConfig should return null when no proxy is registered'() {
         expect:
         ProxyConfig.proxyConfig() == null

--- a/modules/nf-commons/src/test/nextflow/util/ProxyConfigTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/ProxyConfigTest.groovy
@@ -79,6 +79,20 @@ class ProxyConfigTest extends Specification {
         invokeAuth(authenticator, Authenticator.RequestorType.PROXY, 'other.example.com', 8080, 'https') == null
     }
 
+    def 'authenticator should release credentials for an https proxy over an http CONNECT tunnel'() {
+        given: 'an https_proxy-derived config (Launcher sets protocol=https from HTTPS_PROXY)'
+        def proxy = new ProxyConfig(protocol: 'https', host: 'proxy.example.com', port: '8080', username: 'foo', password: 'bar')
+        def authenticator = proxy.authenticator()
+
+        when: 'the JDK authenticates an HTTPS CONNECT tunnel — it reports requestingProtocol="http", not "https" (see #5634)'
+        def auth = invokeAuth(authenticator, Authenticator.RequestorType.PROXY, 'proxy.example.com', 8080, 'http')
+
+        then: 'credentials must still be released, otherwise HTTPS targets 407 behind an authenticating proxy'
+        auth != null
+        auth.userName == 'foo'
+        new String(auth.password) == 'bar'
+    }
+
     def 'proxyConfig should return null when no proxy is registered'() {
         expect:
         ProxyConfig.proxyConfig() == null

--- a/modules/nf-commons/src/test/nextflow/util/ProxyConfigTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/ProxyConfigTest.groovy
@@ -93,6 +93,24 @@ class ProxyConfigTest extends Specification {
         new String(auth.password) == 'bar'
     }
 
+    def 'authenticator relaxation is one-directional: http proxy config rejects an https request'() {
+        given: 'an http_proxy-derived config'
+        def proxy = new ProxyConfig(protocol: 'http', host: 'proxy.example.com', port: '8080', username: 'foo', password: 'bar')
+        def authenticator = proxy.authenticator()
+
+        expect: 'an https requesting-protocol against an http config is still rejected'
+        invokeAuth(authenticator, Authenticator.RequestorType.PROXY, 'proxy.example.com', 8080, 'https') == null
+    }
+
+    def 'authenticator is null-safe when the requesting protocol is missing'() {
+        given: 'an https_proxy-derived config'
+        def proxy = new ProxyConfig(protocol: 'https', host: 'proxy.example.com', port: '8080', username: 'foo', password: 'bar')
+        def authenticator = proxy.authenticator()
+
+        expect: 'a null requesting protocol does not throw and yields no credentials'
+        invokeAuth(authenticator, Authenticator.RequestorType.PROXY, 'proxy.example.com', 8080, null) == null
+    }
+
     def 'proxyConfig should return null when no proxy is registered'() {
         expect:
         ProxyConfig.proxyConfig() == null


### PR DESCRIPTION
Fix #5634

For Basic proxy authentication the JDK hard-codes "http" as the
requesting protocol regardless of the destination scheme,
which passes the string literal "http". ProxyConfig.authenticator()'s guard therefore never matched for an https_proxy-derived config authenticating an HTTPS CONNECT tunnel (protocol="https" != requesting "http"), silently discarding valid proxy credentials and causing a 407.

Relax the guard to also accept an http requesting-protocol when the
configured protocol is https (the CONNECT-tunnel case), keeping the
host/port/requestor-type checks intact. Adds a regression test driving
the real authenticator with the exact field values the JDK supplies for
an HTTPS tunnel.

This complements #7331 (which cleared `jdk.http.auth.tunneling.disabledSchemes` so the authenticator is consulted at all); without this fix the consulted authenticator still rejected the credentials.