### PR TITLE
Split CLI config handling out of ConfigBuilder

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdAuth.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdAuth.groovy
@@ -22,7 +22,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Const
 import nextflow.SysEnv
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.exception.AbortOperationException
 import nextflow.platform.PlatformHelper
 import nextflow.plugin.Plugins
@@ -283,7 +283,7 @@ class CmdAuth extends CmdBase implements UsageAware {
         @Override
         void usage(List<String> result) {
             // Read config to get the actual resolved endpoint value
-            final builder = new ConfigBuilder().setHomeDir(Const.APP_HOME_DIR).setCurrentDir(Const.APP_HOME_DIR)
+            final builder = new ConfigCmdAdapter().setHomeDir(Const.APP_HOME_DIR).setCurrentDir(Const.APP_HOME_DIR)
             final config = builder.buildConfigObject().flatten()
             final towerConfig = config.findAll { it.key.toString().startsWith('tower.') }
                 .collectEntries { k, v -> [(k.toString().substring(6)): v] }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdClean.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdClean.groovy
@@ -20,7 +20,6 @@ import java.nio.file.FileVisitor
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.nio.file.attribute.BasicFileAttributes
 
 import com.beust.jcommander.Parameter
@@ -33,6 +32,7 @@ import nextflow.Global
 import nextflow.ISession
 import nextflow.Session
 import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.exception.AbortOperationException
 import nextflow.file.FileHelper
 import nextflow.plugin.Plugins
@@ -107,11 +107,11 @@ class CmdClean extends CmdBase implements CacheBase {
         Global.setLazySession {
             final builder = new ConfigBuilder()
                     .setShowClosures(true)
-                    .showMissingVariables(true)
+                    .setShowMissingVariables(true)
+            final config = new ConfigCmdAdapter(builder)
                     .setOptions(launcher.options)
-                    .setBaseDir(Paths.get('.'))
-
-            final config = builder.buildConfigObject()
+                    .setBaseDir(Path.of('.'))
+                    .buildConfigObject()
             return (ISession) new Session(config)
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdConfig.groovy
@@ -26,6 +26,7 @@ import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import nextflow.NF
 import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.ConfigValidator
 import nextflow.exception.AbortOperationException
 import nextflow.plugin.Plugins
@@ -113,12 +114,13 @@ class CmdConfig extends CmdBase {
         final builder = new ConfigBuilder()
                 .setShowClosures(true)
                 .setStripSecrets(true)
-                .showMissingVariables(true)
+                .setShowMissingVariables(true)
+
+        final config = new ConfigCmdAdapter(builder)
                 .setOptions(launcher.options)
                 .setBaseDir(base)
                 .setCmdConfig(this)
-
-        final config = builder.buildConfigObject()
+                .buildConfigObject()
 
         // -- validate config options
         if( NF.isSyntaxParserV2() ) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdFs.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdFs.groovy
@@ -30,7 +30,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Global
 import nextflow.Session
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.exception.AbortOperationException
 import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
@@ -202,7 +202,7 @@ class CmdFs extends CmdBase implements UsageAware {
 
     private Session createSession() {
         // create the config
-        final config = new ConfigBuilder()
+        final config = new ConfigCmdAdapter()
                 .setOptions(getLauncher().getOptions())
                 .setBaseDir(Paths.get('.'))
                 .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLineage.groovy
@@ -21,7 +21,7 @@ import java.nio.file.Paths
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import groovy.transform.CompileStatic
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.ConfigMap
 import nextflow.exception.AbortOperationException
 import nextflow.plugin.Plugins
@@ -86,7 +86,7 @@ class CmdLineage extends CmdBase implements UsageAware {
         // setup the plugins system and load the secrets provider
         Plugins.init()
         // load the config
-        this.config = new ConfigBuilder()
+        this.config = new ConfigCmdAdapter()
             .setOptions(launcher.options)
             .setBaseDir(Paths.get('.'))
             .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdNode.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdNode.groovy
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.daemon.DaemonLauncher
 import nextflow.plugin.Plugins
 import nextflow.util.ServiceName
@@ -65,10 +65,10 @@ class CmdNode extends CmdBase {
     protected launchDaemon(String name = null) {
 
         // create the config object
-        def config = new ConfigBuilder()
-                            .setOptions(launcher.options)
-                            .setCmdNode(this)
-                            .build()
+        final config = new ConfigCmdAdapter()
+                .setOptions(launcher.options)
+                .setCmdNode(this)
+                .build()
 
         DaemonLauncher instance
         if( name ) {

--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy
@@ -36,6 +36,7 @@ import nextflow.NF
 import nextflow.NextflowMeta
 import nextflow.SysEnv
 import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.ConfigMap
 import nextflow.config.ConfigValidator
 import nextflow.config.Manifest
@@ -360,12 +361,13 @@ class CmdRun extends CmdBase implements HubOptions {
         // -- PHASE 1: Load config with mock secrets provider
         final secretsProvider = new EmptySecretProvider()
         ConfigBuilder builder = new ConfigBuilder()
+            .setCliParams(cliParams)
+            .setSecretsProvider(secretsProvider)  // Mock provider returns empty strings
+        ConfigCmdAdapter adapter = new ConfigCmdAdapter(builder)
             .setOptions(launcher.options)
             .setCmdRun(this)
             .setBaseDir(scriptFile.parent)
-            .setCliParams(cliParams)
-            .setSecretsProvider(secretsProvider)  // Mock provider returns empty strings
-        ConfigMap config = builder.build()
+        ConfigMap config = adapter.build()
         Map configParams = builder.getConfigParams()
 
         // -- Check Nextflow version
@@ -388,12 +390,13 @@ class CmdRun extends CmdBase implements HubOptions {
         if( secretsProvider.usedSecrets() ) {
             log.debug "Config file used secrets -- reloading config with secrets provider"
             builder = new ConfigBuilder()
+                .setCliParams(cliParams)
+                // No .setSecretsProvider() - uses real secrets system now
+            adapter = new ConfigCmdAdapter(builder)
                 .setOptions(launcher.options)
                 .setCmdRun(this)
                 .setBaseDir(scriptFile.parent)
-                .setCliParams(cliParams)
-                // No .setSecretsProvider() - uses real secrets system now
-            config = builder.build()
+            config = adapter.build()
             configParams = builder.getConfigParams()
         }
 
@@ -419,7 +422,7 @@ class CmdRun extends CmdBase implements HubOptions {
         final isTowerEnabled = config.navigate('tower.enabled') as Boolean
         final isDataEnabled = config.navigate("lineage.enabled") as Boolean
         if( isTowerEnabled || isDataEnabled || log.isTraceEnabled() )
-            runner.session.resolvedConfig = ConfigBuilder.resolveConfig(scriptFile.parent, this, cliParams)
+            runner.session.resolvedConfig = ConfigCmdAdapter.resolveConfig(scriptFile.parent, this, cliParams)
         // note config files are collected during the build process
         // this line should be after `ConfigBuilder#build`
         runner.session.configFiles = builder.parsedConfigFiles

--- a/modules/nextflow/src/main/groovy/nextflow/cli/PluginAbstractExec.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/PluginAbstractExec.groovy
@@ -21,6 +21,7 @@ import java.nio.file.Paths
 import groovy.transform.CompileStatic
 import nextflow.Session
 import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.exception.AbortOperationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -49,7 +50,7 @@ trait PluginAbstractExec implements PluginExecAware {
     final int exec(Launcher launcher1, String pluginId, String cmd, List<String> args) {
         this.launcher = launcher1
         // create the config
-        final config = new ConfigBuilder()
+        final config = new ConfigCmdAdapter(new ConfigBuilder())
                 .setOptions(launcher1.options)
                 .setBaseDir(Paths.get('.'))
                 .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleInstall.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleInstall.groovy
@@ -22,7 +22,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.seqera.npr.client.RegistryClient
 import nextflow.cli.CmdBase
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.RegistryConfig
 import nextflow.exception.AbortOperationException
 import nextflow.module.ModuleReference
@@ -75,7 +75,7 @@ class CmdModuleInstall extends CmdBase {
 
         // Get config
         def baseDir = root ?: Paths.get('.').toAbsolutePath().normalize()
-        def config = new ConfigBuilder()
+        def config = new ConfigCmdAdapter()
             .setOptions(launcher.options)
             .setBaseDir(baseDir)
             .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModulePublish.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModulePublish.groovy
@@ -22,7 +22,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.seqera.npr.client.RegistryClient
 import nextflow.cli.CmdBase
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.RegistryConfig
 import nextflow.exception.AbortOperationException
 import nextflow.module.ModuleChecksum
@@ -102,7 +102,7 @@ class CmdModulePublish extends CmdBase {
         }
 
         // Step 3: Get authentication token
-        def config = new ConfigBuilder()
+        def config = new ConfigCmdAdapter()
             .setOptions(launcher.options)
             .setBaseDir(moduleDir)
             .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleRun.groovy
@@ -24,7 +24,7 @@ import groovy.transform.CompileStatic
 import io.seqera.npr.client.RegistryClient
 import nextflow.Const
 import nextflow.cli.CmdRun
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.RegistryConfig
 import nextflow.exception.AbortOperationException
 import nextflow.module.ModuleReference
@@ -96,7 +96,7 @@ class CmdModuleRun extends CmdRun {
 
         // Get config
         final baseDir = root ?: Path.of('.').toAbsolutePath().normalize()
-        final config = new ConfigBuilder()
+        final config = new ConfigCmdAdapter()
             .setOptions(launcher.options)
             .setBaseDir(baseDir)
             .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleSearch.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleSearch.groovy
@@ -27,7 +27,7 @@ import io.seqera.npr.api.schema.v1.ModuleSearchResult
 import io.seqera.npr.api.schema.v1.SearchModulesResponse
 import io.seqera.npr.client.RegistryClient
 import nextflow.cli.CmdBase
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.RegistryConfig
 import nextflow.exception.AbortOperationException
 import nextflow.module.RegistryClientFactory
@@ -86,7 +86,7 @@ class CmdModuleSearch extends CmdBase {
 
         // Get config
         def baseDir = Paths.get('.').toAbsolutePath().normalize()
-        def config = new ConfigBuilder()
+        def config = new ConfigCmdAdapter()
             .setOptions(launcher.options)
             .setBaseDir(baseDir)
             .build()

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleView.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleView.groovy
@@ -30,7 +30,7 @@ import io.seqera.npr.api.schema.v1.ModuleMetadata
 import io.seqera.npr.api.schema.v1.ModuleRelease
 import io.seqera.npr.api.schema.v1.ModuleTool
 import nextflow.cli.CmdBase
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.config.RegistryConfig
 import nextflow.exception.AbortOperationException
 import nextflow.module.ModuleReference
@@ -100,7 +100,7 @@ class CmdModuleView extends CmdBase {
 
         // Get config
         def baseDir = root ?: Paths.get('.').toAbsolutePath().normalize()
-        def config = new ConfigBuilder()
+        def config = new ConfigCmdAdapter()
             .setOptions(launcher.options)
             .setBaseDir(baseDir)
             .build()

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -16,94 +16,88 @@
 
 package nextflow.config
 
-import static nextflow.util.ConfigHelper.*
-
 import java.nio.file.Path
-import java.nio.file.Paths
 
+import groovy.transform.CompileStatic
 import groovy.transform.Memoized
-import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
-import nextflow.Const
 import nextflow.NF
 import nextflow.SysEnv
-import nextflow.cli.CliOptions
-import nextflow.cli.CmdConfig
-import nextflow.cli.CmdNode
-import nextflow.cli.CmdRun
 import nextflow.exception.AbortOperationException
 import nextflow.exception.ConfigParseException
 import nextflow.secret.SecretsLoader
 import nextflow.secret.SecretsProvider
-import nextflow.util.HistoryFile
-import nextflow.util.SecretHelper
 /**
  * Builds up the Nextflow configuration object
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
+@CompileStatic
 class ConfigBuilder {
 
-    static final public String DEFAULT_PROFILE = 'standard'
+    public static final String DEFAULT_PROFILE = 'standard'
 
-    CliOptions options
+    protected Path baseDir
 
-    CmdRun cmdRun
+    protected Path currentDir
 
-    CmdNode cmdNode
+    protected Map<String,?> cliParams
 
-    Path baseDir
+    protected String profile = DEFAULT_PROFILE
 
-    Path homeDir
+    protected boolean validateProfile
 
-    Path currentDir
+    protected boolean ignoreIncludes
 
-    Map<String,?> cliParams
+    protected boolean ansiLog
 
-    boolean showAllProfiles
+    protected SecretsProvider secretsProvider
 
-    String profile = DEFAULT_PROFILE
+    protected boolean showAllProfiles
 
-    boolean validateProfile
+    protected boolean showClosures
 
-    List<Path> userConfigFiles = []
+    protected boolean showMissingVariables
 
-    List<Path> parsedConfigFiles = []
+    protected boolean stripSecrets
 
-    boolean showClosures
+    protected List<Path> parsedConfigFiles = []
 
-    boolean stripSecrets
+    protected Map<String,Object> declaredParams = [:]
 
-    boolean showMissingVariables
+    protected Map<ConfigObject, String> emptyVariables = [:]
 
-    SecretsProvider secretsProvider
+    protected List<String> warnings = []
 
-    Map<ConfigObject, String> emptyVariables = new LinkedHashMap<>(10)
-
-    Map<String,String> env = new HashMap<>(SysEnv.get())
-
-    List<String> warnings = new ArrayList<>(10)
-
-    Map<String,Object> declaredParams
-
-    ConfigBuilder() {
-        setHomeDir(Const.APP_HOME_DIR)
-        setCurrentDir(Paths.get('.'))
-    }
-
-    ConfigBuilder setShowClosures(boolean value) {
-        this.showClosures = value
+    ConfigBuilder setBaseDir(Path path) {
+        this.baseDir = path.complete()
         return this
     }
 
-    ConfigBuilder setStripSecrets(boolean value) {
-        this.stripSecrets = value
+    ConfigBuilder setCurrentDir(Path path) {
+        this.currentDir = path.complete()
         return this
     }
 
-    ConfigBuilder showMissingVariables(boolean value) {
-        this.showMissingVariables = value
+    ConfigBuilder setIgnoreIncludes(boolean value) {
+        this.ignoreIncludes = value
+        return this
+    }
+
+    ConfigBuilder setAnsiLog(boolean value) {
+        this.ansiLog = value
+        return this
+    }
+
+    ConfigBuilder setCliParams(Map<String,?> cliParams) {
+        this.cliParams = cliParams
+        return this
+    }
+
+    ConfigBuilder setProfile(String value) {
+        this.profile = value ?: DEFAULT_PROFILE
+        this.validateProfile = value as boolean
         return this
     }
 
@@ -112,236 +106,43 @@ class ConfigBuilder {
         return this
     }
 
-    ConfigBuilder setOptions( CliOptions options ) {
-        this.options = options
-        return this
-    }
-
-    ConfigBuilder setCmdRun( CmdRun cmdRun ) {
-        this.cmdRun = cmdRun
-        setProfile(cmdRun.profile)
-        return this
-    }
-
-    ConfigBuilder setCliParams( Map<String,?> cliParams ) {
-        this.cliParams = cliParams
-        return this
-    }
-
-    ConfigBuilder setBaseDir( Path path ) {
-        this.baseDir = path.complete()
-        return this
-    }
-
-    ConfigBuilder setCurrentDir( Path path ) {
-        this.currentDir = path.complete()
-        return this
-    }
-
-    ConfigBuilder setHomeDir( Path path ) {
-        this.homeDir = path.complete()
-        return this
-    }
-
-    ConfigBuilder setCmdNode( CmdNode node ) {
-        this.cmdNode = node
-        return this
-    }
-
-    ConfigBuilder setCmdConfig( CmdConfig cmdConfig ) {
-        showAllProfiles = cmdConfig.showAllProfiles
-        setProfile(cmdConfig.profile)
-        return this
-    }
-
-    ConfigBuilder setProfile( String value ) {
-        profile = value ?: DEFAULT_PROFILE
-        validateProfile = value as boolean
-        return this
-    }
-
     ConfigBuilder setShowAllProfiles(boolean value) {
         this.showAllProfiles = value
         return this
     }
 
-    ConfigBuilder setUserConfigFiles( Path... files )  {
-        setUserConfigFiles(files as List)
+    ConfigBuilder setShowClosures(boolean value) {
+        this.showClosures = value
         return this
     }
 
-    ConfigBuilder setUserConfigFiles( List<Path> files ) {
-        if( files )
-            userConfigFiles.addAll(files)
+    ConfigBuilder setShowMissingVariables(boolean value) {
+        this.showMissingVariables = value
         return this
+    }
+
+    ConfigBuilder setStripSecrets(boolean value) {
+        this.stripSecrets = value
+        return this
+    }
+
+    List<Path> getParsedConfigFiles() {
+        return parsedConfigFiles
+    }
+
+    Map<String,Object> getCliParams() {
+        return cliParams
     }
 
     Map<String,Object> getConfigParams() {
         return declaredParams
     }
 
-    static private wrapValue( value ) {
-        if( !value )
-            return ''
-
-        value = value.toString().trim()
-        if( value == 'true' || value == 'false')
-            return value
-
-        if( value.isNumber() )
-            return value
-
-        return "'$value'"
+    List<String> getWarnings() {
+        return warnings
     }
 
-    /**
-     * Transform the specified list of string to a list of files, verifying their existence.
-     * <p>
-     *     If a file in the list does not exist an exception of type {@code CliArgumentException} is thrown.
-     * <p>
-     *     If the specified list is empty it tries to return of default configuration files located at:
-     *     <li>$HOME/.nextflow/taskConfig
-     *     <li>$PWD/nextflow.taskConfig
-     *
-     * @param files
-     * @return
-     */
-    @PackageScope
-    List<Path> validateConfigFiles( List<String> files ) {
-
-        def result = []
-        if ( files ) {
-            for( String fileName : files ) {
-                def thisFile = currentDir.resolve(fileName)
-                if(!thisFile.exists()) {
-                    throw new AbortOperationException("The specified configuration file does not exist: $thisFile -- check the name or choose another file")
-                }
-                result << thisFile
-            }
-            return result
-        }
-
-        /*
-         * config file in the nextflow home
-         */
-        def home = homeDir.resolve('config')
-        if( home.exists() ) {
-            log.debug "Found config home: $home"
-            result << home
-        }
-
-        /**
-         * Config file in the pipeline base dir
-         * This config file name should be predictable, therefore cannot be overridden
-         */
-        def base = null
-        if( baseDir && baseDir != currentDir ) {
-            base = baseDir.resolve('nextflow.config')
-            if( base.exists() ) {
-                log.debug "Found config base: $base"
-                result << base
-            }
-        }
-
-        /**
-         * Local or user provided file
-         * Default config file name can be overridden with `NXF_CONFIG_FILE` env variable
-         */
-        def configFileName = env.get('NXF_CONFIG_FILE') ?: 'nextflow.config'
-        def local = currentDir.resolve(configFileName)
-        if( local.exists() && local != base ) {
-            log.debug "Found config local: $local"
-            result << local
-        }
-
-        def customConfigs = []
-        if( userConfigFiles ) customConfigs.addAll(userConfigFiles)
-        if( options?.userConfig ) customConfigs.addAll(options.userConfig)
-        if( cmdRun?.runConfig ) customConfigs.addAll(cmdRun.runConfig)
-        if( customConfigs ) {
-            for( def item : customConfigs ) {
-                def configFile = item instanceof Path ? item : currentDir.resolve(item.toString())
-                if(!configFile.exists()) {
-                    throw new AbortOperationException("The specified configuration file does not exist: $configFile -- check the name or choose another file")
-                }
-
-                log.debug "User config file: $configFile"
-                result << configFile
-            }
-        }
-
-        return result
-    }
-
-    /**
-     * Create the nextflow configuration {@link ConfigObject} given a one or more
-     * config files
-     *
-     * @param files A list of config files {@link Path}
-     * @return The resulting {@link ConfigObject} instance
-     */
-    @PackageScope
-    ConfigObject buildGivenFiles(List<Path> files) {
-
-        final Map<String,String> vars = cmdRun?.env
-        final boolean exportSysEnv = cmdRun?.exportSysEnv
-
-        def items = []
-        if( files ) for( Path file : files ) {
-            log.debug "Parsing config file: ${file.complete()}"
-            if (!file.exists()) {
-                log.warn "The specified configuration file cannot be found: $file"
-            }
-            else {
-                items << file
-            }
-        }
-
-        Map env = [:]
-        if( exportSysEnv ) {
-            log.debug "Adding current system environment to session environment"
-            env.putAll(SysEnv.get())
-        }
-        if( vars ) {
-            log.debug "Adding the following variables to session environment: $vars"
-            env.putAll(vars)
-        }
-
-        // set the cluster options for the node command
-        if( cmdNode?.clusterOptions )  {
-            def str = new StringBuilder()
-            cmdNode.clusterOptions.each { k, v ->
-                str << "cluster." << k << '=' << wrapValue(v) << '\n'
-            }
-            items << str
-        }
-
-        // -- add the executor obj from the command line args
-        if( cmdRun?.clusterOptions )  {
-            def str = new StringBuilder()
-            cmdRun.clusterOptions.each { k, v ->
-                str << "cluster." << k << '=' << wrapValue(v) << '\n'
-            }
-            items << str
-        }
-
-        if( cmdRun?.executorOptions )  {
-            def str = new StringBuilder()
-            cmdRun.executorOptions.each { k, v ->
-                str << "executor." << k << '=' << wrapValue(v) << '\n'
-            }
-            items << str
-        }
-
-        buildConfig0( env, items )
-    }
-
-    @PackageScope
-    ConfigObject buildGivenFiles(Path... files) {
-        buildGivenFiles(files as List<Path>)
-    }
-
-    protected Map configVars() {
+    Map configVars() {
         // this is needed to make sure to reuse the same
         // instance of the config vars across different instances of the ConfigBuilder
         // and prevent multiple parsing of the same params file (which can even be remote resource)
@@ -356,43 +157,56 @@ class ConfigBuilder {
         final binding = new HashMap(10)
         binding.put('baseDir', base)
         binding.put('projectDir', base)
-        binding.put('launchDir', Paths.get('.').toRealPath())
-        binding.put('outputDir', Paths.get('results').complete())
+        binding.put('launchDir', Path.of('.').toRealPath())
+        binding.put('outputDir', Path.of('results').complete())
         binding.put('secrets', secretContext)
         return binding
     }
 
-    protected ConfigObject buildConfig0( Map env, List configEntries )  {
+    /**
+     * Build a config object from the given config entries and
+     * environment variables. Each entry can be either a file (Path)
+     * or a snippet (String).
+     *
+     * @param env
+     * @param configEntries
+     */
+    ConfigObject build(Map<String,String> env=[:], List configEntries)  {
         assert env != null
 
-        final ignoreIncludes = options ? options.ignoreConfigIncludes : false
-        final ansiLog = options ? options.ansiLog : false
         final parser = ConfigParserFactory.create()
                 .setRenderClosureAsString(showClosures)
                 .setStripSecrets(stripSecrets)
                 .setIgnoreIncludes(ignoreIncludes)
                 .setAnsiLog(ansiLog)
-        ConfigObject result = new ConfigObject()
 
         if( cliParams )
             parser.setParams(cliParams)
 
+        final result = new ConfigObject()
+        result.put('env', new ConfigObject())
+
         // add the user specified environment to the session env
-        env.sort().each { name, value -> result.env.put(name,value) }
+        final resultEnv = (Map) result.env
+        env.sort().forEach((name, value) -> {
+            resultEnv.put(name, value)
+        })
 
         if( configEntries ) {
+            final binding = [:]
             // the configuration object binds always the current environment
             // so that in the configuration file may be referenced any variable
             // in the current environment
-            final binding = new HashMap(SysEnv.get())
-            binding.putAll(env)
+            if( NF.getSyntaxParserVersion() == 'v1' ) {
+                binding.putAll(SysEnv.get())
+                binding.putAll(env)
+            }
             binding.putAll(configVars())
 
             parser.setBinding(binding)
 
             // merge of the provided configuration files
-            for( def entry : configEntries ) {
-
+            for( final entry : configEntries ) {
                 try {
                     merge0(result, parser, entry)
                 }
@@ -400,11 +214,14 @@ class ConfigBuilder {
                     throw e
                 }
                 catch( Exception e ) {
-                    def message = (entry instanceof Path ? "Unable to parse config file: '$entry'" : "Unable to parse configuration ")
-                    throw new ConfigParseException(message,e)
+                    final message = entry instanceof Path
+                        ? "Unable to parse config file: '$entry'".toString()
+                        : "Unable to parse configuration "
+                    throw new ConfigParseException(message, e)
                 }
             }
 
+            // validate profiles if specified
             if( validateProfile ) {
                 checkValidProfile(parser.getDeclaredProfiles())
             }
@@ -413,20 +230,20 @@ class ConfigBuilder {
         }
 
         // guarantee top scopes
-        for( String name : ['env','session','params','process','executor']) {
-            if( !result.isSet(name) ) result.put(name, new ConfigObject())
+        for( final name : List.of('env','executor','params','process') ) {
+            if( !result.isSet(name) )
+                result.put(name, new ConfigObject())
         }
 
         return result
     }
 
     /**
-     * Merge the main config with a separate config file
+     * Merge a config entry into an accumulated config object.
      *
      * @param result The main {@link ConfigObject}
      * @param parser The {@ConfigParser} instance
-     * @param entry The next config snippet/file to be parsed
-     * @return
+     * @param entry The next config file or snippet to parse
      */
     protected void merge0(ConfigObject result, ConfigParser parser, entry) {
         if( !entry )
@@ -438,17 +255,21 @@ class ConfigBuilder {
             parser.setProfiles(profile.tokenize(','))
         }
 
-        final config = parse0(parser, entry)
+        final config = parse0(parser,entry)
         if( NF.getSyntaxParserVersion() == 'v1' )
-            validate(config, entry)
+            checkUnresolvedConfig(config, entry)
         result.merge(config)
     }
 
+    /**
+     * Parse a config file or snippet.
+     *
+     * @param parser
+     * @param entry
+     */
     protected ConfigObject parse0(ConfigParser parser, entry) {
         if( entry instanceof File ) {
-            final path = entry.toPath()
-            parsedConfigFiles << path
-            return parser.parse(path)
+            return parse0(parser, entry.toPath())
         }
 
         if( entry instanceof Path ) {
@@ -464,17 +285,18 @@ class ConfigBuilder {
     }
 
     /**
-     * Validate a config object verifying is does not contains unresolved attributes
+     * Verify that a config object does not contain any unresolved attributes.
      *
      * @param config The {@link ConfigObject} to verify
      * @param file The source config file/snippet
-     * @return
      */
-    protected void validate(ConfigObject config, file, String parent=null, List stack = new ArrayList()) {
+    protected void checkUnresolvedConfig(ConfigObject config, file, String parent=null, List<ConfigObject> stack = []) {
         for( String key : new ArrayList<>(config.keySet()) ) {
             final value = config.get(key)
             if( value instanceof ConfigObject ) {
-                final fqKey = parent ? "${parent}.${key}": key as String
+                final fqKey = parent
+                    ? "${parent}.${key}".toString()
+                    : key as String
                 if( value.isEmpty() ) {
                     final msg = "Unknown config attribute `$fqKey` -- check config file: $file".toString()
                     if( showMissingVariables ) {
@@ -490,7 +312,7 @@ class ConfigBuilder {
                     stack.push(config)
                     try {
                         if( !stack.contains(value)) {
-                            validate(value, file, fqKey, stack)
+                            checkUnresolvedConfig(value, file, fqKey, stack)
                         }
                         else {
                             log.debug("Found a recursive config property: `$fqKey`")
@@ -514,18 +336,23 @@ class ConfigBuilder {
         }
     }
 
-    protected void checkValidProfile(Collection<String> validNames) {
+    /**
+     * Validate that each specified profile exists in the merged config.
+     *
+     * @param declaredProfiles
+     */
+    protected void checkValidProfile(Collection<String> declaredProfiles) {
         if( !profile || profile == DEFAULT_PROFILE ) {
             return
         }
 
-        log.debug "Available config profiles: $validNames"
+        log.debug "Available config profiles: $declaredProfiles"
         for( String name : profile.tokenize(',') ) {
-            if( name in validNames )
+            if( name in declaredProfiles )
                 continue
 
             def message = "Unknown configuration profile: '${name}'"
-            def choices = validNames.closest(name)
+            def choices = declaredProfiles.closest(name)
             if( choices ) {
                 message += "\n\nDid you mean one of these?\n"
                 choices.each { message += "    ${it}\n" }
@@ -536,381 +363,4 @@ class ConfigBuilder {
         }
     }
 
-    private String normalizeResumeId( String uniqueId ) {
-        if( !uniqueId )
-            return null
-        if( uniqueId == 'last' || uniqueId == 'true' ) {
-            if( HistoryFile.disabled() )
-                throw new AbortOperationException("The resume session id should be specified via `-resume` option when history file tracking is disabled")
-            uniqueId = HistoryFile.DEFAULT.getLast()?.sessionId
-
-            if( !uniqueId ) {
-                log.warn "It appears you have never run this project before -- Option `-resume` is ignored"
-            }
-        }
-
-        return uniqueId
-    }
-
-    @PackageScope
-    void configRunOptions(ConfigObject config, Map env, CmdRun cmdRun) {
-
-        // -- set config options
-        if( cmdRun.cacheable != null )
-            config.cacheable = cmdRun.cacheable
-
-        // -- set the run name
-        if( cmdRun.runName )
-            config.runName = cmdRun.runName
-
-        if( cmdRun.stubRun )
-            config.stubRun = cmdRun.stubRun
-
-        // -- set the output directory
-        if( cmdRun.outputDir )
-            config.outputDir = cmdRun.outputDir
-
-        if( cmdRun.outputFormat )
-            config.outputFormat = cmdRun.outputFormat
-
-        if( cmdRun.preview )
-            config.preview = cmdRun.preview
-
-        if( cmdRun.plugins )
-            config.plugins = cmdRun.plugins.tokenize(',')
-
-        // -- sets the working directory
-        if( cmdRun.workDir )
-            config.workDir = cmdRun.workDir
-
-        else if( !config.workDir )
-            config.workDir = env.get('NXF_WORK') ?: 'work'
-
-        if( cmdRun.bucketDir )
-            config.bucketDir = cmdRun.bucketDir
-
-        // -- sets the library path
-        if( cmdRun.libPath )
-            config.libDir = cmdRun.libPath
-
-        else if ( !config.isSet('libDir') && env.get('NXF_LIB') )
-            config.libDir = env.get('NXF_LIB')
-
-        // -- override 'process' parameters defined on the cmd line
-        cmdRun.process.each { name, value ->
-            config.process[name] = parseValue(value)
-        }
-
-        if( cmdRun.withoutConda && config.conda instanceof Map ) {
-            // disable conda execution
-            log.debug "Disabling execution with Conda as requested by command-line option `-without-conda`"
-            config.conda.enabled = false
-        }
-
-        // -- apply the conda environment
-        if( cmdRun.withConda ) {
-            if( cmdRun.withConda != '-' )
-                config.process.conda = cmdRun.withConda
-            config.conda.enabled = true
-        }
-
-        if( cmdRun.withoutSpack && config.spack instanceof Map ) {
-            // disable spack execution
-            log.debug "Disabling execution with Spack as requested by command-line option `-without-spack`"
-            config.spack.enabled = false
-        }
-
-        // -- apply the spack environment
-        if( cmdRun.withSpack ) {
-            if( cmdRun.withSpack != '-' )
-                config.process.spack = cmdRun.withSpack
-            config.spack.enabled = true
-        }
-
-        // -- sets the resume option
-        if( cmdRun.resume )
-            config.resume = cmdRun.resume
-
-        if( config.isSet('resume') )
-            config.resume = normalizeResumeId(config.resume as String)
-
-        // -- sets `dumpHashes` option
-        if( cmdRun.dumpHashes ) {
-            config.dumpHashes = cmdRun.dumpHashes != '-' ? cmdRun.dumpHashes : 'default'
-        }
-
-        if( cmdRun.dumpChannels )
-            config.dumpChannels = cmdRun.dumpChannels.tokenize(',')
-
-        // -- other configuration parameters
-        if( cmdRun.poolSize ) {
-            config.poolSize = cmdRun.poolSize
-        }
-        if( cmdRun.queueSize ) {
-            config.executor.queueSize = cmdRun.queueSize
-        }
-        if( cmdRun.pollInterval ) {
-            config.executor.pollInterval = cmdRun.pollInterval
-        }
-
-        // -- sets trace file options
-        if( cmdRun.withTrace ) {
-            if( !(config.trace instanceof Map) )
-                config.trace = [:]
-            config.trace.enabled = true
-            if( cmdRun.withTrace != '-' )
-                config.trace.file = cmdRun.withTrace
-        }
-
-        // -- sets report report options
-        if( cmdRun.withReport ) {
-            if( !(config.report instanceof Map) )
-                config.report = [:]
-            config.report.enabled = true
-            if( cmdRun.withReport != '-' )
-                config.report.file = cmdRun.withReport
-        }
-
-        // -- sets timeline report options
-        if( cmdRun.withTimeline ) {
-            if( !(config.timeline instanceof Map) )
-                config.timeline = [:]
-            config.timeline.enabled = true
-            if( cmdRun.withTimeline != '-' )
-                config.timeline.file = cmdRun.withTimeline
-        }
-
-        // -- sets DAG report options
-        if( cmdRun.withDag ) {
-            if( !(config.dag instanceof Map) )
-                config.dag = [:]
-            config.dag.enabled = true
-            if( cmdRun.withDag != '-' )
-                config.dag.file = cmdRun.withDag
-        }
-
-        if( cmdRun.withNotification ) {
-            if( !(config.notification instanceof Map) )
-                config.notification = [:]
-            if( cmdRun.withNotification in ['true','false']) {
-                config.notification.enabled = cmdRun.withNotification == 'true'
-            }
-            else {
-                config.notification.enabled = true
-                config.notification.to = cmdRun.withNotification
-            }
-        }
-
-        // -- sets the messages options
-        if( cmdRun.withWebLog ) {
-            log.warn "The command line option '-with-weblog' is deprecated - consider enabling this feature by setting 'weblog.enabled=true' in your configuration file"
-            if( !(config.weblog instanceof Map) )
-                config.weblog = [:]
-            config.weblog.enabled = true
-            if( cmdRun.withWebLog != '-' )
-                config.weblog.url = cmdRun.withWebLog
-            else if( !config.weblog.url )
-                config.weblog.url = 'http://localhost'
-        }
-
-        // -- sets tower options
-        if( cmdRun.withTower ) {
-            if( !(config.tower instanceof Map) )
-                config.tower = [:]
-            config.tower.enabled = true
-            if( cmdRun.withTower != '-' )
-                config.tower.endpoint = cmdRun.withTower
-        }
-
-        // -- set wave options
-        if( cmdRun.withWave ) {
-            if( !(config.wave instanceof Map) )
-                config.wave = [:]
-            config.wave.enabled = true
-            if( cmdRun.withWave != '-' )
-                config.wave.endpoint = cmdRun.withWave
-        }
-
-        // -- set fusion options
-        if( cmdRun.withFusion ) {
-            if( !(config.fusion instanceof Map) )
-                config.fusion = [:]
-            config.fusion.enabled = cmdRun.withFusion == 'true'
-        }
-
-        // -- set cloudcache options
-        final envCloudPath = env.get('NXF_CLOUDCACHE_PATH')
-        if( cmdRun.cloudCachePath || envCloudPath ) {
-            if( !(config.cloudcache instanceof Map) )
-                config.cloudcache = [:]
-            if( !config.cloudcache.isSet('enabled') )
-                config.cloudcache.enabled = true
-            if( cmdRun.cloudCachePath && cmdRun.cloudCachePath != '-' )
-                config.cloudcache.path = cmdRun.cloudCachePath
-            else if( !config.cloudcache.isSet('path') && envCloudPath )
-                config.cloudcache.path = envCloudPath
-        }
-
-        // -- add the command line parameters to the 'taskConfig' object
-        if( cliParams )
-            config.params = mergeMaps( (Map)config.params, cliParams, NF.strictMode )
-
-        if( cmdRun.withoutDocker && config.docker instanceof Map ) {
-            // disable docker execution
-            log.debug "Disabling execution in Docker container as requested by command-line option `-without-docker`"
-            config.docker.enabled = false
-        }
-
-        if( cmdRun.withDocker ) {
-            configContainer(config, 'docker', cmdRun.withDocker)
-        }
-
-        if( cmdRun.withPodman ) {
-            configContainer(config, 'podman', cmdRun.withPodman)
-        }
-
-        if( cmdRun.withSingularity ) {
-            configContainer(config, 'singularity', cmdRun.withSingularity)
-        }
-
-        if( cmdRun.withApptainer ) {
-            configContainer(config, 'apptainer', cmdRun.withApptainer)
-        }
-
-        if( cmdRun.withCharliecloud ) {
-            configContainer(config, 'charliecloud', cmdRun.withCharliecloud)
-        }
-    }
-
-    private void configContainer(ConfigObject config, String engine, def cli) {
-        log.debug "Enabling execution in ${engine.capitalize()} container as requested by command-line option `-with-$engine ${cmdRun.withDocker}`"
-
-        if( !config.containsKey(engine) )
-            config.put(engine, [:])
-
-        if( !(config.get(engine) instanceof Map) )
-            throw new AbortOperationException("Invalid `$engine` definition in the config file")
-
-        def containerConfig = (Map)config.get(engine)
-        containerConfig.enabled = true
-        if( cli != '-' ) {
-            // this is supposed to be a docker image name
-            config.process.container = cli
-        }
-        else if( containerConfig.image ) {
-            config.process.container = containerConfig.image
-        }
-    }
-
-    ConfigObject buildConfigObject() {
-        // -- configuration file(s)
-        def configFiles = validateConfigFiles(options?.config)
-        def config = buildGivenFiles(configFiles)
-
-        if( cmdRun )
-            configRunOptions(config, SysEnv.get(), cmdRun)
-
-        return config
-    }
-
-
-    /**
-     * @return A the application options hold in a {@code ConfigObject} instance
-     */
-    ConfigMap build() {
-        toConfigMap(buildConfigObject())
-    }
-
-    protected static ConfigMap toConfigMap(ConfigObject config) {
-        assert config != null
-        (ConfigMap)normalize0((Map)config)
-    }
-
-    static private normalize0( config ) {
-
-        if( config instanceof Map ) {
-            ConfigMap result = new ConfigMap(config.size())
-            for( String name : config.keySet() ) {
-                def value = (config as Map).get(name)
-                result.put(name, normalize0(value))
-            }
-            return result
-        }
-        else if( config instanceof Collection ) {
-            List result = new ArrayList(config.size())
-            for( entry in config ) {
-                result << normalize0(entry)
-            }
-            return result
-        }
-        else {
-            return config
-        }
-    }
-
-    /**
-     * Merge two maps recursively avoiding keys to be overwritten
-     *
-     * @param config
-     * @param params
-     * @return a map resulting of merging result and right maps
-     */
-    protected Map mergeMaps(Map config, Map params, boolean strict, List keys=[]) {
-        if( config==null )
-            config = new LinkedHashMap()
-
-        for( Map.Entry entry : params ) {
-            final key = entry.key.toString()
-            final value = entry.value
-            final previous = getConfigVal0(config, key)
-            keys << entry.key
-
-            if( previous==null ) {
-                config[key] = value
-            }
-            else if( previous instanceof Map && value instanceof Map ) {
-                mergeMaps(previous, value, strict, keys)
-            }
-            else {
-                if( previous instanceof Map || value instanceof Map ) {
-                    final msg = "Configuration setting type with key '${keys.join('.')}' does not match the parameter with the same key - Config value=$previous; parameter value=$value"
-                    if(strict)
-                        throw new AbortOperationException(msg)
-                    log.warn(msg)
-                }
-                config[key] = value
-            }
-        }
-
-        return config
-    }
-
-    private Object getConfigVal0(Map config, String key) {
-        if( config instanceof ConfigObject ) {
-            return config.isSet(key) ? config.get(key) : null
-        }
-        else {
-            return config.get(key)
-        }
-    }
-
-    static String resolveConfig(Path baseDir, CmdRun cmdRun, Map cliParams) {
-
-        final config = new ConfigBuilder()
-                .setShowClosures(true)
-                .setStripSecrets(true)
-                .setOptions(cmdRun.launcher.options)
-                .setCmdRun(cmdRun)
-                .setCliParams(cliParams)
-                .setBaseDir(baseDir)
-                .buildConfigObject()
-
-        // strip secrets
-        SecretHelper.hideSecrets(config)
-        // compute config
-        final result = toCanonicalString(config, false)
-        // dump config for debugging
-        log.trace "Resolved config:\n${result.indent('\t')}"
-        return result
-    }
 }

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
@@ -1,0 +1,684 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.config
+
+import java.nio.file.Path
+
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.Const
+import nextflow.NF
+import nextflow.SysEnv
+import nextflow.cli.CliOptions
+import nextflow.cli.CmdConfig
+import nextflow.cli.CmdNode
+import nextflow.cli.CmdRun
+import nextflow.exception.AbortOperationException
+import nextflow.trace.GraphObserver
+import nextflow.trace.ReportObserver
+import nextflow.trace.TimelineObserver
+import nextflow.trace.TraceFileObserver
+import nextflow.util.HistoryFile
+import nextflow.util.SecretHelper
+
+import static nextflow.util.ConfigHelper.parseValue
+import static nextflow.util.ConfigHelper.toCanonicalString
+/**
+ * Adapter for building a Nextflow config with CLI overrides
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+class ConfigCmdAdapter {
+
+    ConfigBuilder builder
+
+    CliOptions options
+
+    CmdRun cmdRun
+
+    CmdNode cmdNode
+
+    Path baseDir
+
+    Path currentDir
+
+    Path homeDir
+
+    List<Path> userConfigFiles = []
+
+    ConfigCmdAdapter(ConfigBuilder builder) {
+        this.builder = builder
+        setHomeDir(Const.APP_HOME_DIR)
+        setCurrentDir(Path.of('.'))
+    }
+
+    ConfigCmdAdapter() {
+        this(new ConfigBuilder())
+    }
+
+    ConfigCmdAdapter setOptions(CliOptions options) {
+        this.options = options
+        builder.setIgnoreIncludes(options?.ignoreConfigIncludes)
+        builder.setAnsiLog(options?.ansiLog)
+        return this
+    }
+
+    ConfigCmdAdapter setCmdConfig(CmdConfig cmdConfig) {
+        builder.setShowAllProfiles(cmdConfig.showAllProfiles)
+        builder.setProfile(cmdConfig.profile)
+        return this
+    }
+
+    ConfigCmdAdapter setCmdNode(CmdNode cmdNode) {
+        this.cmdNode = cmdNode
+        return this
+    }
+
+    ConfigCmdAdapter setCmdRun(CmdRun cmdRun) {
+        this.cmdRun = cmdRun
+        builder.setProfile(cmdRun.profile)
+        return this
+    }
+
+    ConfigCmdAdapter setBaseDir(Path path) {
+        this.baseDir = path.complete()
+        builder.setBaseDir(baseDir)
+        return this
+    }
+
+    ConfigCmdAdapter setCurrentDir(Path path) {
+        this.currentDir = path.complete()
+        builder.setCurrentDir(currentDir)
+        return this
+    }
+
+    ConfigCmdAdapter setHomeDir(Path path) {
+        this.homeDir = path.complete()
+        return this
+    }
+
+    ConfigCmdAdapter setUserConfigFiles(Path... files)  {
+        setUserConfigFiles(files as List<Path>)
+        return this
+    }
+
+    ConfigCmdAdapter setUserConfigFiles(List<Path> files) {
+        userConfigFiles.addAll(files)
+        return this
+    }
+
+    /**
+     * Build the configuration as a ConfigMap.
+     */
+    ConfigMap build() {
+        toConfigMap(buildConfigObject())
+    }
+
+    /**
+     * Build the configuration as a ConfigObject.
+     */
+    ConfigObject buildConfigObject() {
+        // -- configuration file(s)
+        final configFiles = resolveConfigFiles(options?.config)
+        validateConfigFiles(configFiles)
+        final config = buildGivenFiles(configFiles)
+
+        if( cmdRun )
+            configRunOptions(config, SysEnv.get(), cmdRun)
+
+        return config
+    }
+
+    /**
+     * Transform the specified list of string to a list of files.
+     *
+     * The following default configuration files are used if no files are specified:
+     * - $HOME/.nextflow/config
+     * - $PWD/nextflow.config
+     *
+     * @param files
+     * @return
+     */
+    @CompileDynamic
+    protected List<Path> resolveConfigFiles(List<String> files) {
+
+        if( files ) {
+            return files.stream()
+                .map(filename -> currentDir.resolve(filename))
+                .toList()
+        }
+
+        final List<Path> result = []
+
+        /*
+         * config file in the nextflow home
+         */
+        final home = homeDir.resolve('config')
+        if( home.exists() ) {
+            log.debug "Found config home: $home"
+            result << home
+        }
+
+        /**
+         * Config file in the pipeline base dir
+         * This config file name should be predictable, therefore cannot be overridden
+         */
+        def base = null
+        if( baseDir && baseDir != currentDir ) {
+            base = baseDir.resolve('nextflow.config')
+            if( base.exists() ) {
+                log.debug "Found config base: $base"
+                result << base
+            }
+        }
+
+        /**
+         * Local or user provided file
+         * Default config file name can be overridden with `NXF_CONFIG_FILE` env variable
+         */
+        final configFileName = SysEnv.get('NXF_CONFIG_FILE') ?: 'nextflow.config'
+        final local = currentDir.resolve(configFileName)
+        if( local.exists() && local != base ) {
+            log.debug "Found config local: $local"
+            result << local
+        }
+
+        final customConfigs = []
+        if( userConfigFiles )
+            customConfigs.addAll(userConfigFiles)
+        if( options?.userConfig )
+            customConfigs.addAll(options.userConfig)
+        if( cmdRun?.runConfig )
+            customConfigs.addAll(cmdRun.runConfig)
+        for( final item : customConfigs ) {
+            final configFile = item instanceof Path ? item : currentDir.resolve(item.toString())
+            log.debug "User config file: $configFile"
+            result << configFile
+        }
+
+        return result
+    }
+
+    /**
+     * Validate the existence of a list of config files.
+     *
+     * @param files
+     */
+    @CompileDynamic
+    protected void validateConfigFiles(List<Path> files) {
+        for( final file : files ) {
+            // note: use the path's own `exists()` so that remote config files backed by
+            // a custom provider (e.g. ProviderPath for pipelines resolved from a Git repo)
+            // are checked via their provider rather than the default filesystem
+            if( !file.exists() )
+                throw new AbortOperationException("The specified configuration file does not exist: $file -- check the name or choose another file")
+        }
+    }
+
+    /**
+     * Create the nextflow configuration {@link ConfigObject} given a one or more
+     * config files
+     *
+     * @param files A list of config files {@link Path}
+     * @return The resulting {@link ConfigObject} instance
+     */
+    @CompileDynamic
+    protected ConfigObject buildGivenFiles(List<Path> files) {
+
+        def items = []
+        if( files ) for( Path file : files ) {
+            log.debug "Parsing config file: ${file.complete()}"
+            if (!file.exists()) {
+                log.warn "The specified configuration file cannot be found: $file"
+            }
+            else {
+                items << file
+            }
+        }
+
+        final Map<String,String> env = [:]
+        if( cmdRun?.exportSysEnv ) {
+            log.debug "Adding current system environment to session environment"
+            env.putAll(SysEnv.get())
+        }
+
+        final envVars = cmdRun?.env
+        if( envVars ) {
+            log.debug "Adding the following variables to session environment: $envVars"
+            env.putAll(envVars)
+        }
+
+        // set the cluster options for the node command
+        if( cmdNode?.clusterOptions )  {
+            def str = new StringBuilder()
+            cmdNode.clusterOptions.each { k, v ->
+                str << "cluster." << k << '=' << wrapValue(v) << '\n'
+            }
+            items << str
+        }
+
+        // -- add the executor obj from the command line args
+        if( cmdRun?.clusterOptions )  {
+            def str = new StringBuilder()
+            cmdRun.clusterOptions.each { k, v ->
+                str << "cluster." << k << '=' << wrapValue(v) << '\n'
+            }
+            items << str
+        }
+
+        if( cmdRun?.executorOptions )  {
+            def str = new StringBuilder()
+            cmdRun.executorOptions.each { k, v ->
+                str << "executor." << k << '=' << wrapValue(v) << '\n'
+            }
+            items << str
+        }
+
+        return builder.build(env, items)
+    }
+
+    protected ConfigObject buildGivenFiles(Path... files) {
+        return buildGivenFiles(files as List<Path>)
+    }
+
+    private static String wrapValue( value ) {
+        if( !value )
+            return ''
+
+        value = value.toString().trim()
+        if( value == 'true' || value == 'false')
+            return value
+
+        if( value.isNumber() )
+            return value
+
+        return "'$value'"
+    }
+
+    /**
+     * Apply command-line arguments to the config.
+     *
+     * @param config
+     * @param env
+     * @param cmdRun
+     */
+    @CompileDynamic
+    protected void configRunOptions(ConfigObject config, Map env, CmdRun cmdRun) {
+
+        // -- set config options
+        if( cmdRun.cacheable != null )
+            config.cacheable = cmdRun.cacheable
+
+        // -- set the run name
+        if( cmdRun.runName )
+            config.runName = cmdRun.runName
+
+        if( cmdRun.stubRun )
+            config.stubRun = cmdRun.stubRun
+
+        // -- set the output directory
+        if( cmdRun.outputDir )
+            config.outputDir = cmdRun.outputDir
+
+        if( cmdRun.outputFormat )
+            config.outputFormat = cmdRun.outputFormat
+
+        if( cmdRun.preview )
+            config.preview = cmdRun.preview
+
+        if( cmdRun.plugins )
+            config.plugins = cmdRun.plugins.tokenize(',')
+
+        // -- sets the working directory
+        if( cmdRun.workDir )
+            config.workDir = cmdRun.workDir
+
+        else if( !config.workDir )
+            config.workDir = env.get('NXF_WORK') ?: 'work'
+
+        if( cmdRun.bucketDir )
+            config.bucketDir = cmdRun.bucketDir
+
+        // -- sets the library path
+        if( cmdRun.libPath )
+            config.libDir = cmdRun.libPath
+
+        else if ( !config.isSet('libDir') && env.get('NXF_LIB') )
+            config.libDir = env.get('NXF_LIB')
+
+        // -- override 'process' parameters defined on the cmd line
+        cmdRun.process.each { name, value ->
+            config.process[name] = parseValue(value)
+        }
+
+        if( cmdRun.withoutConda && config.conda instanceof Map ) {
+            // disable conda execution
+            log.debug "Disabling execution with Conda as requested by command-line option `-without-conda`"
+            config.conda.enabled = false
+        }
+
+        // -- apply the conda environment
+        if( cmdRun.withConda ) {
+            if( cmdRun.withConda != '-' )
+                config.process.conda = cmdRun.withConda
+            config.conda.enabled = true
+        }
+
+        if( cmdRun.withoutSpack && config.spack instanceof Map ) {
+            // disable spack execution
+            log.debug "Disabling execution with Spack as requested by command-line option `-without-spack`"
+            config.spack.enabled = false
+        }
+
+        // -- apply the spack environment
+        if( cmdRun.withSpack ) {
+            if( cmdRun.withSpack != '-' )
+                config.process.spack = cmdRun.withSpack
+            config.spack.enabled = true
+        }
+
+        // -- sets the resume option
+        if( cmdRun.resume )
+            config.resume = cmdRun.resume
+
+        if( config.isSet('resume') )
+            config.resume = normalizeResumeId(config.resume as String)
+
+        // -- sets `dumpHashes` option
+        if( cmdRun.dumpHashes ) {
+            config.dumpHashes = cmdRun.dumpHashes != '-' ? cmdRun.dumpHashes : 'default'
+        }
+
+        if( cmdRun.dumpChannels )
+            config.dumpChannels = cmdRun.dumpChannels.tokenize(',')
+
+        // -- other configuration parameters
+        if( cmdRun.poolSize ) {
+            config.poolSize = cmdRun.poolSize
+        }
+        if( cmdRun.queueSize ) {
+            config.executor.queueSize = cmdRun.queueSize
+        }
+        if( cmdRun.pollInterval ) {
+            config.executor.pollInterval = cmdRun.pollInterval
+        }
+
+        // -- sets trace file options
+        if( cmdRun.withTrace ) {
+            if( !(config.trace instanceof Map) )
+                config.trace = [:]
+            config.trace.enabled = true
+            if( cmdRun.withTrace != '-' )
+                config.trace.file = cmdRun.withTrace
+        }
+
+        // -- sets report report options
+        if( cmdRun.withReport ) {
+            if( !(config.report instanceof Map) )
+                config.report = [:]
+            config.report.enabled = true
+            if( cmdRun.withReport != '-' )
+                config.report.file = cmdRun.withReport
+        }
+
+        // -- sets timeline report options
+        if( cmdRun.withTimeline ) {
+            if( !(config.timeline instanceof Map) )
+                config.timeline = [:]
+            config.timeline.enabled = true
+            if( cmdRun.withTimeline != '-' )
+                config.timeline.file = cmdRun.withTimeline
+        }
+
+        // -- sets DAG report options
+        if( cmdRun.withDag ) {
+            if( !(config.dag instanceof Map) )
+                config.dag = [:]
+            config.dag.enabled = true
+            if( cmdRun.withDag != '-' )
+                config.dag.file = cmdRun.withDag
+        }
+
+        if( cmdRun.withNotification ) {
+            if( !(config.notification instanceof Map) )
+                config.notification = [:]
+            if( cmdRun.withNotification in ['true','false']) {
+                config.notification.enabled = cmdRun.withNotification == 'true'
+            }
+            else {
+                config.notification.enabled = true
+                config.notification.to = cmdRun.withNotification
+            }
+        }
+
+        // -- sets the messages options
+        if( cmdRun.withWebLog ) {
+            log.warn "The command line option '-with-weblog' is deprecated - consider enabling this feature by setting 'weblog.enabled=true' in your configuration file"
+            if( !(config.weblog instanceof Map) )
+                config.weblog = [:]
+            config.weblog.enabled = true
+            if( cmdRun.withWebLog != '-' )
+                config.weblog.url = cmdRun.withWebLog
+            else if( !config.weblog.url )
+                config.weblog.url = 'http://localhost'
+        }
+
+        // -- sets tower options
+        if( cmdRun.withTower ) {
+            if( !(config.tower instanceof Map) )
+                config.tower = [:]
+            config.tower.enabled = true
+            if( cmdRun.withTower != '-' )
+                config.tower.endpoint = cmdRun.withTower
+        }
+
+        // -- set wave options
+        if( cmdRun.withWave ) {
+            if( !(config.wave instanceof Map) )
+                config.wave = [:]
+            config.wave.enabled = true
+            if( cmdRun.withWave != '-' )
+                config.wave.endpoint = cmdRun.withWave
+        }
+
+        // -- set fusion options
+        if( cmdRun.withFusion ) {
+            if( !(config.fusion instanceof Map) )
+                config.fusion = [:]
+            config.fusion.enabled = cmdRun.withFusion == 'true'
+        }
+
+        // -- set cloudcache options
+        final envCloudPath = env.get('NXF_CLOUDCACHE_PATH')
+        if( cmdRun.cloudCachePath || envCloudPath ) {
+            if( !(config.cloudcache instanceof Map) )
+                config.cloudcache = [:]
+            if( !config.cloudcache.isSet('enabled') )
+                config.cloudcache.enabled = true
+            if( cmdRun.cloudCachePath && cmdRun.cloudCachePath != '-' )
+                config.cloudcache.path = cmdRun.cloudCachePath
+            else if( !config.cloudcache.isSet('path') && envCloudPath )
+                config.cloudcache.path = envCloudPath
+        }
+
+        // -- add the command line parameters to the config
+        final cliParams = builder.getCliParams()
+        if( cliParams )
+            config.params = mergeMaps( (Map)config.params, cliParams, NF.strictMode )
+
+        if( cmdRun.withoutDocker && config.docker instanceof Map ) {
+            // disable docker execution
+            log.debug "Disabling execution in Docker container as requested by command-line option `-without-docker`"
+            config.docker.enabled = false
+        }
+
+        if( cmdRun.withDocker ) {
+            configContainer(config, 'docker', cmdRun.withDocker)
+        }
+
+        if( cmdRun.withPodman ) {
+            configContainer(config, 'podman', cmdRun.withPodman)
+        }
+
+        if( cmdRun.withSingularity ) {
+            configContainer(config, 'singularity', cmdRun.withSingularity)
+        }
+
+        if( cmdRun.withApptainer ) {
+            configContainer(config, 'apptainer', cmdRun.withApptainer)
+        }
+
+        if( cmdRun.withCharliecloud ) {
+            configContainer(config, 'charliecloud', cmdRun.withCharliecloud)
+        }
+    }
+
+    private String normalizeResumeId( String uniqueId ) {
+        if( !uniqueId )
+            return null
+        if( uniqueId == 'last' || uniqueId == 'true' ) {
+            if( HistoryFile.disabled() )
+                throw new AbortOperationException("The resume session id should be specified via `-resume` option when history file tracking is disabled")
+            uniqueId = HistoryFile.DEFAULT.getLast()?.sessionId
+
+            if( !uniqueId ) {
+                log.warn "It appears you have never run this project before -- Option `-resume` is ignored"
+            }
+        }
+
+        return uniqueId
+    }
+
+    @CompileDynamic
+    private void configContainer(ConfigObject config, String engine, def cli) {
+        log.debug "Enabling execution in ${engine.capitalize()} container as requested by command-line option `-with-$engine ${cmdRun.withDocker}`"
+
+        if( !config.containsKey(engine) )
+            config.put(engine, [:])
+
+        if( !(config.get(engine) instanceof Map) )
+            throw new AbortOperationException("Invalid `$engine` definition in the config file")
+
+        def containerConfig = (Map)config.get(engine)
+        containerConfig.enabled = true
+        if( cli != '-' ) {
+            // this is supposed to be a docker image name
+            config.process.container = cli
+        }
+        else if( containerConfig.image ) {
+            config.process.container = containerConfig.image
+        }
+    }
+
+    /**
+     * Merge two maps recursively avoiding keys to be overwritten
+     *
+     * @param config
+     * @param params
+     * @return a map resulting of merging result and right maps
+     */
+    protected Map mergeMaps(Map config, Map params, boolean strict, List keys=[]) {
+        if( config==null )
+            config = new LinkedHashMap()
+
+        for( Map.Entry entry : params ) {
+            final key = entry.key.toString()
+            final value = entry.value
+            final previous = getConfigVal0(config, key)
+            keys << entry.key
+
+            if( previous==null ) {
+                config[key] = value
+            }
+            else if( previous instanceof Map && value instanceof Map ) {
+                mergeMaps(previous, value, strict, keys)
+            }
+            else {
+                if( previous instanceof Map || value instanceof Map ) {
+                    final msg = "Configuration setting type with key '${keys.join('.')}' does not match the parameter with the same key - Config value=$previous; parameter value=$value"
+                    if(strict)
+                        throw new AbortOperationException(msg)
+                    log.warn(msg)
+                }
+                config[key] = value
+            }
+        }
+
+        return config
+    }
+
+    private Object getConfigVal0(Map config, String key) {
+        if( config instanceof ConfigObject ) {
+            return config.isSet(key) ? config.get(key) : null
+        }
+        else {
+            return config.get(key)
+        }
+    }
+
+    static String resolveConfig(Path baseDir, CmdRun cmdRun, Map cliParams) {
+
+        final builder = new ConfigBuilder()
+                .setShowClosures(true)
+                .setStripSecrets(true)
+                .setCliParams(cliParams)
+
+        final config = new ConfigCmdAdapter(builder)
+                .setOptions(cmdRun.launcher.options)
+                .setCmdRun(cmdRun)
+                .setBaseDir(baseDir)
+                .buildConfigObject()
+
+        // strip secrets
+        SecretHelper.hideSecrets(config)
+        // compute config
+        final result = toCanonicalString(config, false)
+        // dump config for debugging
+        log.trace "Resolved config:\n${result.indent('\t')}"
+        return result
+    }
+
+    protected static ConfigMap toConfigMap(ConfigObject config) {
+        assert config != null
+        (ConfigMap)normalize0((Map)config)
+    }
+
+    private static Object normalize0( config ) {
+
+        if( config instanceof Map ) {
+            ConfigMap result = new ConfigMap(config.size())
+            for( String name : config.keySet() ) {
+                def value = (config as Map).get(name)
+                result.put(name, normalize0(value))
+            }
+            return result
+        }
+        else if( config instanceof Collection ) {
+            List result = new ArrayList(config.size())
+            for( entry in config ) {
+                result << normalize0(entry)
+            }
+            return result
+        }
+        else {
+            return config
+        }
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/module/DefaultRemoteModuleResolver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/module/DefaultRemoteModuleResolver.groovy
@@ -18,6 +18,7 @@ package nextflow.module
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.Const
 import nextflow.Global
 import nextflow.config.ConfigBuilder
 
@@ -47,7 +48,7 @@ class DefaultRemoteModuleResolver implements RemoteModuleResolver {
     @Override
     Path resolve(String moduleName, Path projectDir) {
         final baseDir = projectDir ?: Path.of('.').toAbsolutePath()
-        final config = Global.config ?: new ConfigBuilder().setBaseDir(baseDir).build()
+        final config = Global.config ?: buildConfig(baseDir)
         final registryConfig = config.navigate('registry') as RegistryConfig
 
         // Create module resolver
@@ -72,5 +73,20 @@ class DefaultRemoteModuleResolver implements RemoteModuleResolver {
     @Override
     int getPriority() {
         return 0  // Default implementation has lowest priority
+    }
+
+    /**
+     * Build a minimal config from the default config files (Nextflow home and the
+     * project base directory) when no global config is available.
+     */
+    protected static Map buildConfig(Path baseDir) {
+        final files = new ArrayList<Path>()
+        final home = Const.APP_HOME_DIR.resolve('config')
+        if( home.exists() )
+            files.add(home)
+        final base = baseDir.resolve('nextflow.config')
+        if( base.exists() )
+            files.add(base)
+        return new ConfigBuilder().setBaseDir(baseDir).build(files)
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -20,11 +20,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import nextflow.SysEnv
-import nextflow.cli.CliOptions
-import nextflow.cli.CmdConfig
-import nextflow.cli.CmdNode
-import nextflow.cli.CmdRun
-import nextflow.cli.Launcher
 import nextflow.exception.AbortOperationException
 import nextflow.exception.ConfigParseException
 import nextflow.extension.FilesEx
@@ -39,32 +34,6 @@ import spock.lang.Unroll
  */
 class ConfigBuilderTest extends Specification {
 
-    def setupSpec() {
-        SysEnv.push([:])
-    }
-
-    def cleanupSpec() {
-        SysEnv.pop()
-    }
-
-    ConfigObject configWithParams(Path file, Map runOpts, Path baseDir=null) {
-        def run = new CmdRun(runOpts)
-        return new ConfigBuilder()
-            .setOptions(new CliOptions())
-            .setCmdRun(run)
-            .setCliParams(run.parsedParams(ConfigBuilder.getConfigVars(baseDir, null)))
-            .buildGivenFiles(file)
-    }
-
-    ConfigObject configWithParams(Map config, Map runOpts, Map cliOpts=[:]) {
-        def run = new CmdRun(runOpts)
-        return new ConfigBuilder(config)
-            .setOptions(new CliOptions(cliOpts))
-            .setCmdRun(run)
-            .setCliParams(run.parsedParams(ConfigBuilder.getConfigVars(null, null)))
-            .build()
-    }
-
     def 'build config object' () {
 
         setup:
@@ -72,7 +41,7 @@ class ConfigBuilderTest extends Specification {
         def builder = [:] as ConfigBuilder
 
         when:
-        def config = builder.buildConfig0(env,null)
+        def config = builder.build(env,null)
 
         then:
         ('PATH' in config.env )
@@ -120,8 +89,8 @@ class ConfigBuilderTest extends Specification {
 
         when:
         def env = SysEnv.get()
-        def config1 = builder.buildConfig0(env, [text1])
-        def config2 = builder.buildConfig0(env, [text1, text2])
+        def config1 = builder.build(env, [text1])
+        def config2 = builder.build(env, [text1, text2])
 
         // note: configuration object can be modified like any map
         config2.env ['ZZZ'] = '99'
@@ -173,10 +142,9 @@ class ConfigBuilderTest extends Specification {
         params.test = 2
         '''
 
-
         when:
         def env = SysEnv.get()
-        def config1 = builder.buildConfig0(env, [text1])
+        def config1 = builder.build(env, [text1])
 
         then:
         config1.task.field1 == 1
@@ -208,1303 +176,13 @@ class ConfigBuilderTest extends Specification {
         '''
 
         when:
-        def cfg = builder.buildConfig0([:], [text])
+        def cfg = builder.build([:], [text])
         then:
         cfg.params.p == '/base/path/1'
         cfg.params.q == '/base/path/2'
         cfg.params.x == '/base/path/3'
         cfg.params.y == "${Path.of('.').toRealPath()}/4"
 
-    }
-
-    def 'CLI params should override the ones defined in the config file' () {
-        setup:
-        def file = Files.createTempFile('test',null)
-        file.text = '''
-        params {
-          alpha = 'x'
-        }
-        params.beta = 'y'
-        params.delta = 'Foo'
-        params.gamma = params.alpha
-        params {
-            omega = 'Bar'
-        }
-
-        process {
-          publishDir = [path: params.alpha]
-        }
-        '''
-        when:
-        def result = configWithParams(file, [params: [alpha: 'Hello', beta: 'World', omega: 'Last']])
-
-        then:
-        result.params.alpha == 'Hello'  // <-- params defined as CLI options override the ones in the config file
-        result.params.beta == 'World'   // <--   as above
-        result.params.gamma == 'Hello'  // <--   as above
-        result.params.omega == 'Last'
-        result.params.delta == 'Foo'
-        result.process.publishDir == [path: 'Hello']
-
-        cleanup:
-        file?.delete()
-    }
-
-    def 'CLI params should override the ones defined in the config file [2]' () {
-        setup:
-        def file = Files.createTempFile('test',null)
-        file.text = '''
-        params {
-          alpha = 'x'
-          beta = 'y'
-          delta = 'Foo'
-          gamma = params.alpha
-          omega = 'Bar'
-        }
-
-        process {
-          publishDir = [path: params.alpha]
-        }
-        '''
-        when:
-        def result = configWithParams(file, [params: [alpha: 'Hello', beta: 'World', omega: 'Last']])
-
-        then:
-        result.params.alpha == 'Hello'  // <-- params defined as CLI options override the ones in the config file
-        result.params.beta == 'World'   // <--   as above
-        result.params.gamma == 'Hello'  // <--   as above
-        result.params.omega == 'Last'
-        result.params.delta == 'Foo'
-        result.process.publishDir == [path: 'Hello']
-
-        cleanup:
-        file?.delete()
-    }
-
-
-    def 'CLI params should override the ones in one or more config files' () {
-        given:
-        def folder = File.createTempDir()
-        def configMain = new File(folder,'nextflow.config').absoluteFile
-        def snippet1 = new File(folder,'config1.txt').absoluteFile
-        def snippet2 = new File(folder,'config2.txt').absoluteFile
-
-
-        configMain.text = """
-        process.name = 'alpha'
-        params.one = 'a'
-        params.xxx = 'x'
-        includeConfig "$snippet1"
-        """
-
-        snippet1.text = """
-        params.two = 'b'
-        params.yyy = 'y'
-
-        process.cpus = 4
-        process.memory = '8GB'
-
-        includeConfig("$snippet2")
-        """
-
-        snippet2.text = '''
-        params.three = 'c'
-        params.zzz = 'z'
-
-        process { disk = '1TB' }
-        process.resources.foo = 1
-        process.resources.bar = 2
-        '''
-
-        when:
-        def config = configWithParams(configMain.toPath(), [params: [one: '1', two: 'dos', three: 'tres']])
-
-        then:
-        config.params.one == '1'
-        config.params.two == 'dos'
-        config.params.three == 'tres'
-        config.process.name == 'alpha'
-        config.params.xxx == 'x'
-        config.params.yyy == 'y'
-        config.params.zzz == 'z'
-
-        config.process.cpus == 4
-        config.process.memory == '8GB'
-        config.process.disk == '1TB'
-        config.process.resources.foo == 1
-        config.process.resources.bar == 2
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-    def 'should include config with params' () {
-        given:
-        def folder = File.createTempDir()
-        def configMain = new File(folder,'nextflow.config').absoluteFile
-        def snippet1 = new File(folder,'igenomes.config').absoluteFile
-
-
-        configMain.text = '''
-        includeConfig 'igenomes.config'
-        '''
-
-        snippet1.text = '''
-        params {
-          genomes {
-            'GRCh37' {
-              fasta = "${params.igenomes_base}/genome.fa"
-              bwa   = "${params.igenomes_base}/BWAIndex/genome.fa"
-            }
-          }
-        }
-        '''
-
-        when:
-        def config = configWithParams(configMain.toPath(), [params: [igenomes_base: 'test']])
-
-        then:
-        config.params.genomes.GRCh37 == [fasta:'test/genome.fa', bwa:'test/BWAIndex/genome.fa']
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-
-    def 'should fetch the config path from env var' () {
-        given:
-        def folder = File.createTempDir()
-        def configMain = new File(folder,'my.config').absoluteFile
-
-        configMain.text = """
-        process.name = 'alpha'
-        params.one = 'a'
-        params.two = 'b'
-        """
-
-        // relative path to current dir
-        when:
-        def config = new ConfigBuilder(env: [NXF_CONFIG_FILE: 'my.config']) .setCurrentDir(folder.toPath()) .build()
-        then:
-        config.params.one == 'a'
-        config.params.two == 'b'
-        config.process.name == 'alpha'
-
-        // absolute path
-        when:
-        config = new ConfigBuilder(env: [NXF_CONFIG_FILE: configMain.toString()]) .build()
-        then:
-        config.params.one == 'a'
-        config.params.two == 'b'
-        config.process.name == 'alpha'
-
-        // default should not find it
-        when:
-        config = new ConfigBuilder() .build()
-        then:
-        config.params == [:]
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-    def 'CLI params should override params in profiles' () {
-
-        setup:
-        def file = Files.createTempFile('test',null)
-        file.text = '''
-        params.alpha = 'a'
-        params.beta = 'b'
-        params.delta = 'Foo'
-        params.gamma = params.alpha
-
-        params {
-            genomes {
-                'GRCh37' {
-                    bed12   = '/data/genes.bed'
-                    bismark = '/data/BismarkIndex'
-                    bowtie  = '/data/genome'
-                }
-            }
-        }
-
-        profiles {
-            first {
-                params.alpha = 'Alpha'
-                params.omega = 'Omega'
-                params.gamma = 'First'
-                process.name = 'Bar'
-            }
-
-            second {
-                params.alpha = 'xxx'
-                params.gamma = 'Second'
-                process {
-                    publishDir = [path: params.alpha]
-                }
-            }
-        }
-        '''
-
-        when:
-        def config = configWithParams(file, [params: [alpha: 'AAA', beta: 'BBB']])
-        then:
-        config.params.alpha == 'AAA'
-        config.params.beta == 'BBB'
-        config.params.delta == 'Foo'
-        config.params.gamma == 'AAA'
-        config.params.genomes.'GRCh37'.bed12 == '/data/genes.bed'
-        config.params.genomes.'GRCh37'.bismark == '/data/BismarkIndex'
-        config.params.genomes.'GRCh37'.bowtie  == '/data/genome'
-
-        when:
-        config = configWithParams(file, [params: [alpha: 'AAA', beta: 'BBB'], profile: 'first'])
-        then:
-        config.params.alpha == 'AAA'
-        config.params.beta == 'BBB'
-        config.params.delta == 'Foo'
-        config.params.gamma == 'First'
-        config.process.name == 'Bar'
-        config.params.genomes.'GRCh37'.bed12 == '/data/genes.bed'
-        config.params.genomes.'GRCh37'.bismark == '/data/BismarkIndex'
-        config.params.genomes.'GRCh37'.bowtie  == '/data/genome'
-
-        cleanup:
-        file?.delete()
-    }
-
-    def 'params-file should override params in the config file' () {
-        setup:
-        def baseDir = Path.of('/my/base/dir')
-        and:
-        def paramsFile = Files.createTempFile('test', '.yml')
-        paramsFile.text = '''
-            alpha: "Hello"
-            beta: "World"
-            omega: "Last"
-            theta: "${baseDir}/something"
-            '''.stripIndent()
-        and:
-        def file = Files.createTempFile('test',null)
-        file.text = '''
-        params {
-          alpha = 'x'
-        }
-        params.beta = 'y'
-        params.delta = 'Foo'
-        params.gamma = params.alpha
-        params {
-            omega = 'Bar'
-        }
-
-        process {
-          publishDir = [path: params.alpha]
-        }
-        '''
-        when:
-        def result = configWithParams(file, [paramsFile: paramsFile], baseDir)
-
-        then:
-        result.params.alpha == 'Hello'  // <-- params defined in the params-file overrides the ones in the config file
-        result.params.beta == 'World'   // <--   as above
-        result.params.gamma == 'Hello'  // <--   as above
-        result.params.omega == 'Last'
-        result.params.delta == 'Foo'
-        result.params.theta == "$baseDir/something"
-        result.process.publishDir == [path: 'Hello']
-
-        cleanup:
-        file?.delete()
-        paramsFile?.delete()
-    }
-
-    def 'params should override params-file and override params in the config file' () {
-        setup:
-        def params = Files.createTempFile('test', '.yml')
-        params.text = '''
-            alpha: "Hello"
-            beta: "World"
-            omega: "Last"
-            '''.stripIndent()
-        and:
-        def file = Files.createTempFile('test',null)
-        file.text = '''
-        params {
-          alpha = 'x'
-        }
-        params.beta = 'y'
-        params.delta = 'Foo'
-        params.gamma = "I'm gamma"
-        params.omega = "I'm the last"
-
-        process {
-          publishDir = [path: params.alpha]
-        }
-        '''
-        when:
-        def result = configWithParams(file, [paramsFile: params, params: [alpha: 'Hola', beta: 'Mundo']])
-
-        then:
-        result.params.alpha == 'Hola'   // <-- this comes from the CLI
-        result.params.beta == 'Mundo'   // <-- this comes from the CLI as well
-        result.params.omega == 'Last'   // <-- this comes from the params-file
-        result.params.gamma == "I'm gamma"   // <-- from the config
-        result.params.delta == 'Foo'         // <-- from the config
-        result.process.publishDir == [path: 'Hola']
-
-        cleanup:
-        file?.delete()
-        params?.delete()
-    }
-
-    def 'valid config files' () {
-
-        given:
-        def folder = Files.createTempDirectory('test')
-        def f1 = folder.resolve('file1')
-        def f2 = folder.resolve('file2')
-
-        when:
-        new ConfigBuilder()
-                    .validateConfigFiles([f1.toString(), f2.toString()])
-        then:
-        thrown(AbortOperationException)
-
-
-        when:
-        f1.text = '1'; f2.text = '2'
-        def files = new ConfigBuilder()
-                    .validateConfigFiles([f1.toString(), f2.toString()])
-        then:
-        files == [f1, f2]
-
-
-        when:
-        files = new ConfigBuilder(homeDir: folder, currentDir: folder)
-                    .setUserConfigFiles(f1,f2)
-                    .validateConfigFiles()
-        then:
-        files == [f1, f2]
-
-        cleanup:
-        folder.deleteDir()
-
-    }
-
-    def 'should discover default config files' () {
-        given:
-        def homeDir = Files.createTempDirectory('home')
-        def baseDir = Files.createTempDirectory('work')
-        def workDir = Files.createTempDirectory('work')
-
-        when:
-        def homeConfig = homeDir.resolve('config')
-        homeConfig.text = 'foo=1'
-        def files1 = new ConfigBuilder(homeDir: homeDir, baseDir: workDir, currentDir: workDir).validateConfigFiles()
-        then:
-        files1 == [homeConfig]
-
-        when:
-        def workConfig = workDir.resolve('nextflow.config')
-        workConfig.text = 'bar=2'
-        def files2 = new ConfigBuilder(homeDir: homeDir, baseDir: workDir, currentDir: workDir).validateConfigFiles()
-        then:
-        files2 == [homeConfig, workConfig]
-
-        when:
-        def baseConfig = baseDir.resolve('nextflow.config')
-        baseConfig.text = 'ciao=3'
-        def files3 = new ConfigBuilder(homeDir: homeDir, baseDir: baseDir, currentDir: workDir).validateConfigFiles()
-        then:
-        files3 == [homeConfig, baseConfig, workConfig]
-
-
-        cleanup:
-        homeDir?.deleteDir()
-        workDir?.deleteDir()
-    }
-
-    def 'command executor options'() {
-
-        when:
-        def opt = new CliOptions()
-        def run = new CmdRun(executorOptions: [ alpha: 1, 'beta.x': 'hola', 'beta.y': 'ciao' ])
-        def result = new ConfigBuilder().setOptions(opt).setCmdRun(run).buildGivenFiles()
-        then:
-        result.executor.alpha == 1
-        result.executor.beta.x == 'hola'
-        result.executor.beta.y == 'ciao'
-
-    }
-
-    def 'run command cluster options'() {
-
-        when:
-        def opt = new CliOptions()
-        def run = new CmdRun(clusterOptions: [ alpha: 1, 'beta.x': 'hola', 'beta.y': 'ciao' ])
-        def result = new ConfigBuilder().setOptions(opt).setCmdRun(run).buildGivenFiles()
-        then:
-        result.cluster.alpha == 1
-        result.cluster.beta.x == 'hola'
-        result.cluster.beta.y == 'ciao'
-
-    }
-
-    def 'run with docker'() {
-
-        when:
-        def opt = new CliOptions()
-        def run = new CmdRun(withDocker: 'cbcrg/piper')
-        def config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-
-        then:
-        config.docker.enabled
-        config.process.container == 'cbcrg/piper'
-
-    }
-
-    def 'run with docker 2'() {
-
-        given:
-        def file = Files.createTempFile('test','config')
-        file.deleteOnExit()
-        file.text =
-                '''
-                docker {
-                    image = 'busybox'
-                    enabled = false
-                }
-                '''
-
-        when:
-        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
-        def run = new CmdRun(withDocker: '-')
-        def config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        config.docker.enabled
-        config.docker.image == 'busybox'
-        config.process.container == 'busybox'
-
-        when:
-        opt = new CliOptions(config: [file.toFile().canonicalPath] )
-        run = new CmdRun(withDocker: 'cbcrg/mybox')
-        config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        config.docker.enabled
-        config.process.container == 'cbcrg/mybox'
-
-    }
-
-    def 'run with docker 3'() {
-        given:
-        def file = Files.createTempFile('test','config')
-        file.deleteOnExit()
-
-        when:
-        file.text =
-                '''
-                process.'withName:test'.container = 'busybox'
-                '''
-        def opt = new CliOptions(config: [file.toFile().canonicalPath])
-        def run = new CmdRun(withDocker: '-')
-        def config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        config.docker.enabled
-        config.process.'withName:test'.container == 'busybox'
-
-        when:
-        file.text =
-                '''
-                process.container = 'busybox'
-                '''
-        opt = new CliOptions(config: [file.toFile().canonicalPath])
-        run = new CmdRun(withDocker: '-')
-        config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        config.docker.enabled
-        config.process.container == 'busybox'
-
-        when:
-        opt = new CliOptions()
-        run = new CmdRun(withDocker: '-')
-        config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        config.docker.enabled
-        !config.process.container
-
-        when:
-        file.text =
-                '''
-                process.'withName:test'.tag = 'tag'
-                '''
-        opt = new CliOptions(config: [file.toFile().canonicalPath])
-        run = new CmdRun(withDocker: '-')
-        config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        config.docker.enabled
-        !config.process.container
-
-    }
-
-    def 'run without docker'() {
-
-        given:
-        def file = Files.createTempFile('test','config')
-        file.deleteOnExit()
-        file.text =
-                '''
-                docker {
-                    image = 'busybox'
-                    enabled = true
-                }
-                '''
-
-        when:
-        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
-        def run = new CmdRun(withoutDocker: true)
-        def config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        !config.docker.enabled
-        config.docker.image == 'busybox'
-        !config.process.container
-
-    }
-
-    def 'config with cluster options'() {
-
-        when:
-        def opt = new CliOptions()
-        def cmd = new CmdNode(clusterOptions: [join: 'x', group: 'y', interface: 'abc', slots: 10, 'tcp.alpha':'uno', 'tcp.beta': 'due'])
-
-        def config = new ConfigBuilder()
-                .setOptions(opt)
-                .setCmdNode(cmd)
-                .build()
-
-        then:
-        config.cluster.join == 'x'
-        config.cluster.group == 'y'
-        config.cluster.interface == 'abc'
-        config.cluster.slots == 10
-        config.cluster.tcp.alpha == 'uno'
-        config.cluster.tcp.beta == 'due'
-
-    }
-
-    def 'should set session trace options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-
-        then:
-        config.trace instanceof Map
-        !config.trace.enabled
-        !config.trace.file
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withTrace: 'some-file'))
-        then:
-        config.trace instanceof Map
-        config.trace.enabled
-        config.trace.file == 'some-file'
-
-        when:
-        config = new ConfigObject()
-        config.trace.file = 'foo.txt'
-        builder.configRunOptions(config, env, new CmdRun(withTrace: 'bar.txt'))
-        then: // command line should override the config file
-        config.trace instanceof Map
-        config.trace.enabled
-        config.trace.file == 'bar.txt'
-
-        when:
-        config = new ConfigObject()
-        config.trace.file = 'foo.txt'
-        builder.configRunOptions(config, env, new CmdRun(withTrace: '-'))
-        then: // command line should override the config file
-        config.trace instanceof Map
-        config.trace.enabled
-        config.trace.file == 'foo.txt'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withTrace: '-'))
-        then: // command line should override the config file
-        config.trace instanceof Map
-        config.trace.enabled
-        !config.trace.file
-    }
-
-    def 'should set session report options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.report
-
-        when:
-        config = new ConfigObject()
-        config.report.file = 'foo.html'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.report instanceof Map
-        !config.report.enabled
-        config.report.file == 'foo.html'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withReport: 'my-report.html'))
-        then:
-        config.report instanceof Map
-        config.report.enabled
-        config.report.file == 'my-report.html'
-
-        when:
-        config = new ConfigObject()
-        config.report.file = 'this-report.html'
-        builder.configRunOptions(config, env, new CmdRun(withReport: 'my-report.html'))
-        then:
-        config.report instanceof Map
-        config.report.enabled
-        config.report.file == 'my-report.html'
-
-        when:
-        config = new ConfigObject()
-        config.report.file = 'this-report.html'
-        builder.configRunOptions(config, env, new CmdRun(withReport: '-'))
-        then:
-        config.report instanceof Map
-        config.report.enabled
-        config.report.file == 'this-report.html'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withReport: '-'))
-        then:
-        config.report instanceof Map
-        config.report.enabled
-        !config.report.file
-    }
-
-
-    def 'should set session dag options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.dag
-
-        when:
-        config = new ConfigObject()
-        config.dag.file = 'foo-dag.html'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.dag instanceof Map
-        !config.dag.enabled
-        config.dag.file == 'foo-dag.html'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withDag: 'my-dag.html'))
-        then:
-        config.dag instanceof Map
-        config.dag.enabled
-        config.dag.file == 'my-dag.html'
-
-        when:
-        config = new ConfigObject()
-        config.dag.file = 'this-dag.html'
-        builder.configRunOptions(config, env, new CmdRun(withDag: 'my-dag.html'))
-        then:
-        config.dag instanceof Map
-        config.dag.enabled
-        config.dag.file == 'my-dag.html'
-
-        when:
-        config = new ConfigObject()
-        config.dag.file = 'this-dag.html'
-        builder.configRunOptions(config, env, new CmdRun(withDag: '-'))
-        then:
-        config.dag instanceof Map
-        config.dag.enabled
-        config.dag.file == 'this-dag.html'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withDag: '-'))
-        then:
-        config.dag instanceof Map
-        config.dag.enabled
-        !config.dag.file
-    }
-
-    def 'should set session weblog options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.weblog
-
-        when:
-        config = new ConfigObject()
-        config.weblog.url = 'http://bar.com'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.weblog instanceof Map
-        !config.weblog.enabled
-        config.weblog.url == 'http://bar.com'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withWebLog: 'http://foo.com'))
-        then:
-        config.weblog instanceof Map
-        config.weblog.enabled
-        config.weblog.url == 'http://foo.com'
-
-        when:
-        config = new ConfigObject()
-        config.weblog.enabled = true
-        config.weblog.url = 'http://bar.com'
-        builder.configRunOptions(config, env, new CmdRun(withWebLog: 'http://foo.com'))
-        then:
-        config.weblog instanceof Map
-        config.weblog.enabled
-        config.weblog.url == 'http://foo.com'
-
-        when:
-        config = new ConfigObject()
-        config.weblog.enabled = true
-        config.weblog.url = 'http://bar.com'
-        builder.configRunOptions(config, env, new CmdRun(withWebLog: '-'))
-        then:
-        config.weblog instanceof Map
-        config.weblog.enabled
-        config.weblog.url == 'http://bar.com'
-
-        when:
-        config = new ConfigObject()
-        config.weblog.enabled = true
-        builder.configRunOptions(config, env, new CmdRun(withWebLog: '-'))
-        then:
-        config.weblog instanceof Map
-        config.weblog.enabled
-        config.weblog.url == 'http://localhost'
-
-    }
-
-    def 'should set session timeline options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.timeline
-
-        when:
-        config = new ConfigObject()
-        config.timeline.file = 'my-file.html'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.timeline instanceof Map
-        !config.timeline.enabled
-        config.timeline.file == 'my-file.html'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withTimeline: 'my-timeline.html'))
-        then:
-        config.timeline instanceof Map
-        config.timeline.enabled
-        config.timeline.file == 'my-timeline.html'
-
-        when:
-        config = new ConfigObject()
-        config.timeline.enabled = true
-        config.timeline.file = 'this-timeline.html'
-        builder.configRunOptions(config, env, new CmdRun(withTimeline: 'my-timeline.html'))
-        then:
-        config.timeline instanceof Map
-        config.timeline.enabled
-        config.timeline.file == 'my-timeline.html'
-
-        when:
-        config = new ConfigObject()
-        config.timeline.enabled = true
-        config.timeline.file = 'my-timeline.html'
-        builder.configRunOptions(config, env, new CmdRun(withTimeline: '-'))
-        then:
-        config.timeline instanceof Map
-        config.timeline.enabled
-        config.timeline.file == 'my-timeline.html'
-
-        when:
-        config = new ConfigObject()
-        config.timeline.enabled = true
-        builder.configRunOptions(config, env, new CmdRun(withTimeline: '-'))
-        then:
-        config.timeline instanceof Map
-        config.timeline.enabled
-        !config.timeline.file
-    }
-
-    def 'should set tower options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.tower
-
-        when:
-        config = new ConfigObject()
-        config.tower.endpoint = 'http://foo.com'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.tower instanceof Map
-        !config.tower.enabled
-        config.tower.endpoint == 'http://foo.com'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withTower: 'http://bar.com'))
-        then:
-        config.tower instanceof Map
-        config.tower.enabled
-        config.tower.endpoint == 'http://bar.com'
-
-        when:
-        config = new ConfigObject()
-        config.tower.endpoint = 'http://foo.com'
-        builder.configRunOptions(config, env, new CmdRun(withTower: '-'))
-        then:
-        config.tower instanceof Map
-        config.tower.enabled
-        config.tower.endpoint == 'http://foo.com'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withTower: '-'))
-        then:
-        config.tower instanceof Map
-        config.tower.enabled
-        !config.tower.endpoint
-    }
-
-    def 'should set wave options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.wave
-
-        when:
-        config = new ConfigObject()
-        config.wave.endpoint = 'http://foo.com'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.wave instanceof Map
-        !config.wave.enabled
-        config.wave.endpoint == 'http://foo.com'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withWave: 'http://bar.com'))
-        then:
-        config.wave instanceof Map
-        config.wave.enabled
-        config.wave.endpoint == 'http://bar.com'
-
-        when:
-        config = new ConfigObject()
-        config.wave.endpoint = 'http://foo.com'
-        builder.configRunOptions(config, env, new CmdRun(withWave: '-'))
-        then:
-        config.wave instanceof Map
-        config.wave.enabled
-        config.wave.endpoint == 'http://foo.com'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withWave: '-'))
-        then:
-        config.wave instanceof Map
-        config.wave.enabled
-        !config.wave.endpoint
-    }
-
-    def 'should set cloudcache options' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.cloudcache
-
-        when:
-        config = new ConfigObject()
-        config.cloudcache.path = 's3://foo/bar'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.cloudcache instanceof Map
-        !config.cloudcache.enabled
-        config.cloudcache.path == 's3://foo/bar'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: 's3://this/that'))
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        config.cloudcache.path == 's3://this/that'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: '-'))
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        !config.cloudcache.path
-
-        when:
-        config = new ConfigObject()
-        config.cloudcache.path = 's3://alpha/delta'
-        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: '-'))
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        config.cloudcache.path == 's3://alpha/delta'
-
-        when:
-        config = new ConfigObject()
-        config.cloudcache.path = 's3://alpha/delta'
-        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: 's3://should/override/config'))
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        config.cloudcache.path == 's3://should/override/config'
-
-        when:
-        config = new ConfigObject()
-        config.cloudcache.enabled = false
-        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: 's3://should/override/config'))
-        then:
-        config.cloudcache instanceof Map
-        !config.cloudcache.enabled
-        config.cloudcache.path == 's3://should/override/config'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, [NXF_CLOUDCACHE_PATH:'s3://foo'], new CmdRun(cloudCachePath: 's3://should/override/env'))
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        config.cloudcache.path == 's3://should/override/env'
-
-        when:
-        config = new ConfigObject()
-        config.cloudcache.path = 's3://config/path'
-        builder.configRunOptions(config, [NXF_CLOUDCACHE_PATH:'s3://foo'], new CmdRun())
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        config.cloudcache.path == 's3://config/path'
-
-        when:
-        config = new ConfigObject()
-        config.cloudcache.path = 's3://config/path'
-        builder.configRunOptions(config, [NXF_CLOUDCACHE_PATH:'s3://foo'], new CmdRun(cloudCachePath: 's3://should/override/config'))
-        then:
-        config.cloudcache instanceof Map
-        config.cloudcache.enabled
-        config.cloudcache.path == 's3://should/override/config'
-
-    }
-
-    def 'should enable conda env' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.conda
-
-        when:
-        config = new ConfigObject()
-        config.conda.createOptions = 'something'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.conda instanceof Map
-        !config.conda.enabled
-        config.conda.createOptions == 'something'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withConda: 'my-recipe.yml'))
-        then:
-        config.conda instanceof Map
-        config.conda.enabled
-        config.process.conda == 'my-recipe.yml'
-
-        when:
-        config = new ConfigObject()
-        config.conda.enabled = true
-        builder.configRunOptions(config, env, new CmdRun(withConda: 'my-recipe.yml'))
-        then:
-        config.conda instanceof Map
-        config.conda.enabled
-        config.process.conda == 'my-recipe.yml'
-
-        when:
-        config = new ConfigObject()
-        config.process.conda = 'my-recipe.yml'
-        builder.configRunOptions(config, env, new CmdRun(withConda: '-'))
-        then:
-        config.conda instanceof Map
-        config.conda.enabled
-        config.process.conda == 'my-recipe.yml'
-    }
-
-    def 'should disable conda env' () {
-        given:
-        def file = Files.createTempFile('test','config')
-        file.deleteOnExit()
-        file.text =
-                '''
-                conda {
-                    enabled = true
-                }
-                '''
-
-        when:
-        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
-        def run = new CmdRun(withoutConda: true)
-        def config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        !config.conda.enabled
-        !config.process.conda
-    }
-
-    def 'should enable spack env' () {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.spack
-
-        when:
-        config = new ConfigObject()
-        config.spack.createOptions = 'something'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.spack instanceof Map
-        !config.spack.enabled
-        config.spack.createOptions == 'something'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(withSpack: 'my-recipe.yaml'))
-        then:
-        config.spack instanceof Map
-        config.spack.enabled
-        config.process.spack == 'my-recipe.yaml'
-
-        when:
-        config = new ConfigObject()
-        config.spack.enabled = true
-        builder.configRunOptions(config, env, new CmdRun(withSpack: 'my-recipe.yaml'))
-        then:
-        config.spack instanceof Map
-        config.spack.enabled
-        config.process.spack == 'my-recipe.yaml'
-
-        when:
-        config = new ConfigObject()
-        config.process.spack = 'my-recipe.yaml'
-        builder.configRunOptions(config, env, new CmdRun(withSpack: '-'))
-        then:
-        config.spack instanceof Map
-        config.spack.enabled
-        config.process.spack == 'my-recipe.yaml'
-    }
-
-    def 'should disable spack env' () {
-        given:
-        def file = Files.createTempFile('test','config')
-        file.deleteOnExit()
-        file.text =
-                '''
-                spack {
-                    enabled = true
-                }
-                '''
-
-        when:
-        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
-        def run = new CmdRun(withoutSpack: true)
-        def config = new ConfigBuilder().setOptions(opt).setCmdRun(run).build()
-        then:
-        !config.spack.enabled
-        !config.process.spack
-    }
-
-    def 'SHOULD SET `RESUME` OPTION'() {
-
-        given:
-        def env = [:]
-        def builder = [:] as ConfigBuilder
-
-        when:
-        def config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.isSet('resume')
-
-        when:
-        config = new ConfigObject()
-        config.resume ='alpha-beta-delta'
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        config.resume == 'alpha-beta-delta'
-
-        when:
-        config = new ConfigObject()
-        config.resume ='alpha-beta-delta'
-        builder.configRunOptions(config, env, new CmdRun(resume: 'xxx-yyy'))
-        then:
-        config.resume == 'xxx-yyy'
-
-        when:
-        config = new ConfigObject()
-        config.resume ='this-that'
-        builder.configRunOptions(config, env, new CmdRun(resume: 'xxx-yyy'))
-        then:
-        config.resume == 'xxx-yyy'
-    }
-
-    def 'should set `workDir`' () {
-
-        given:
-        def config = new ConfigObject()
-        def builder = [:] as ConfigBuilder
-
-        when:
-        builder.configRunOptions(config, [:], new CmdRun())
-        then:
-        config.workDir == 'work'
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, [NXF_WORK: '/foo/bar'], new CmdRun())
-        then:
-        config.workDir == '/foo/bar'
-
-        when:
-        config = new ConfigObject()
-        config.workDir = 'hello/there'
-        builder.configRunOptions(config, [:], new CmdRun())
-        then:
-        config.workDir == 'hello/there'
-
-        when:
-        config = new ConfigObject()
-        config.workDir = 'hello/there'
-        builder.configRunOptions(config, [:], new CmdRun(workDir: 'my/work/dir'))
-        then:
-        config.workDir == 'my/work/dir'
-    }
-
-    def 'should set `libDir`' () {
-        given:
-        def config = new ConfigObject()
-        def builder = [:] as ConfigBuilder
-
-        when:
-        builder.configRunOptions(config, [:], new CmdRun())
-        then:
-        !config.isSet('libDir')
-
-        when:
-        builder.configRunOptions(config, [NXF_LIB:'/foo/bar'], new CmdRun())
-        then:
-        config.libDir == '/foo/bar'
-
-        when:
-        builder.configRunOptions(config, [:], new CmdRun(libPath: 'my/lib/dir'))
-        then:
-        config.libDir == 'my/lib/dir'
-    }
-
-    def 'should set `cacheable`' () {
-        given:
-        def env = [:]
-        def config
-        def builder = [:] as ConfigBuilder
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun())
-        then:
-        !config.isSet('cacheable')
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(cacheable: false))
-        then:
-        config.cacheable == false
-
-        when:
-        config = new ConfigObject()
-        builder.configRunOptions(config, env, new CmdRun(cacheable: true))
-        then:
-        config.cacheable == true
     }
 
     def 'should check for a valid profile' () {
@@ -1533,7 +211,6 @@ class ConfigBuilderTest extends Specification {
             """
             .stripIndent().leftTrim()
 
-
         when:
         builder.profile = 'delta'
         builder.checkValidProfile(['alpha','delta','omega'])
@@ -1555,156 +232,118 @@ class ConfigBuilderTest extends Specification {
 
     }
 
-    def 'should set profile options' () {
-
-        def builder
-
-        when:
-        builder = new ConfigBuilder().setCmdRun(new CmdRun(profile: 'foo'))
-        then:
-        builder.profile == 'foo'
-        builder.validateProfile
-
-        when:
-        builder = new ConfigBuilder().setCmdRun(new CmdRun())
-        then:
-        builder.profile == 'standard'
-        !builder.validateProfile
-
-        when:
-        builder = new ConfigBuilder().setCmdRun(new CmdRun(profile: 'standard'))
-        then:
-        builder.profile == 'standard'
-        builder.validateProfile
-    }
-
-    def 'should set config options' () {
-        def builder
-
-        when:
-        builder = new ConfigBuilder().setCmdConfig(new CmdConfig())
-        then:
-        !builder.showAllProfiles
-
-        when:
-        builder = new ConfigBuilder().setCmdConfig(new CmdConfig(showAllProfiles: true))
-        then:
-        builder.showAllProfiles
-
-        when:
-        builder = new ConfigBuilder().setCmdConfig(new CmdConfig(profile: 'foo'))
-        then:
-        builder.profile == 'foo'
-        builder.validateProfile
-
-    }
-
-    def 'should set params into config object' () {
+    def 'should warn about missing attribute' () {
 
         given:
-        def emptyFile = Files.createTempFile('empty','config').toFile()
-        def EMPTY = [emptyFile.toString()]
-
-        def configFile = Files.createTempFile('test','config').toFile()
-        configFile.deleteOnExit()
-        configFile.text = '''
-          params.foo = 1
-          params.bar = 2
-          params.data = '/some/path'
-        '''
-        configFile = configFile.toString()
-
-        def jsonFile = Files.createTempFile('test','.json').toFile()
-        jsonFile.text = '''
-          {
-            "foo": 10,
-            "bar": 20
-          }
-        '''
-        jsonFile = jsonFile.toString()
-
-        def yamlFile = Files.createTempFile('test','.yaml').toFile()
-        yamlFile.text = '''
-          {
-            "foo": 100,
-            "bar": 200
-          }
-        '''
-        yamlFile = yamlFile.toString()
-
-        def config
+        SysEnv.push('NXF_SYNTAX_PARSER': 'v1', HOME: '/home/user')
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+        file.text =
+                '''
+                params.foo = HOME
+                '''
 
         when:
-        config = configWithParams([:], [:], [config: EMPTY])
+        def cfg = new ConfigBuilder().build([file])
         then:
-        config.params == [:]
+        cfg.params.foo == '/home/user'
 
-        // get params for the CLI
         when:
-        config = configWithParams([:], [params: [foo:'one', bar:'two']], [config: EMPTY])
+        file.text =
+                '''
+                params.foo = bar
+                '''
+        new ConfigBuilder().build([file])
         then:
-        config.params == [foo:'one', bar:'two']
+        def e = thrown(ConfigParseException)
+        e.message == "Unknown config attribute `bar` -- check config file: ${file.toRealPath()}".toString()
 
-        // get params from config file
-        when:
-        config = configWithParams([:], [:], [config: [configFile]])
-        then:
-        config.params == [foo:1, bar:2, data: '/some/path']
-
-        // get params form JSON file
-        when:
-        config = configWithParams([:], [paramsFile: jsonFile], [config: EMPTY])
-        then:
-        config.params == [foo:10, bar:20]
-
-        // get params from YAML file
-        when:
-        config = configWithParams([:], [paramsFile: yamlFile], [config: EMPTY])
-        then:
-        config.params == [foo:100, bar:200]
-
-        // cli override config
-        when:
-        config = configWithParams([:], [params: [foo:'hello', baz:'world']], [config: [configFile]])
-        then:
-        config.params == [foo:'hello', bar:2, baz: 'world', data: '/some/path']
-
-        // CLI override JSON
-        when:
-        config = configWithParams([:], [params: [foo:'hello', baz:'world'], paramsFile: jsonFile], [config: EMPTY])
-        then:
-        config.params == [foo:'hello', bar:20, baz: 'world']
-
-        // JSON override config
-        when:
-        config = configWithParams([:], [paramsFile: jsonFile], [config: [configFile]])
-        then:
-        config.params == [foo:10, bar:20, data: '/some/path']
-
-
-        // CLI override JSON that override config
-        when:
-        config = configWithParams([:], [paramsFile: jsonFile, params: [foo:'Ciao']], [config: [configFile]])
-        then:
-        config.params == [foo:'Ciao', bar:20, data: '/some/path']
+        cleanup:
+        SysEnv.pop()
     }
 
-    def 'should run with conda' () {
-
+    def 'should guarantee top scopes without a session scope' () {
         when:
-        def config = new ConfigBuilder().setCmdRun(new CmdRun(withConda: '/some/path/env.yml')).build()
+        def config = new ConfigBuilder().build([])
         then:
-        config.process.conda == '/some/path/env.yml'
-
+        config.containsKey('env')
+        config.containsKey('process')
+        config.containsKey('executor')
+        config.containsKey('params')
+        and:
+        // `session` is not a config scope and must not be created implicitly
+        !config.containsKey('session')
     }
 
-    def 'should run with spack' () {
+    def 'should not expose environment variables to the config binding with v2 parser' () {
+        given:
+        SysEnv.push('NXF_SYNTAX_PARSER': 'v2', HOME: '/home/user')
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+        file.text =
+                '''
+                params.foo = HOME
+                '''
 
         when:
-        def config = new ConfigBuilder().setCmdRun(new CmdRun(withSpack: '/some/path/env.yaml')).build()
+        // unlike the v1 parser, the v2 parser does not bind environment variables,
+        // so `HOME` is an unknown attribute rather than resolving to the env value
+        new ConfigBuilder().build([file])
         then:
-        config.process.spack == '/some/path/env.yaml'
+        thrown(ConfigParseException)
 
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should render missing variables' () {
+        given:
+        SysEnv.push('NXF_SYNTAX_PARSER': 'v1')
+        def file = Files.createTempFile('test',null)
+
+        file.text =
+                '''
+                foo = 'xyz'
+                bar = "$SCRATCH/singularity_images_nextflow"
+                '''
+
+        when:
+        def builder = new ConfigBuilder()
+                .setShowMissingVariables(true)
+        def cfg = builder.build([file])
+        def str = ConfigHelper.toCanonicalString(cfg)
+        then:
+        str == '''\
+            foo = 'xyz'
+            bar = '$SCRATCH/singularity_images_nextflow'
+            '''.stripIndent()
+
+        and:
+        builder.warnings[0].startsWith('Unknown config attribute `SCRATCH`')
+        cleanup:
+        SysEnv.pop()
+        file?.delete()
+    }
+
+    def 'should report fully qualified missing attribute'  () {
+
+        given:
+        SysEnv.push('NXF_SYNTAX_PARSER': 'v1')
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+
+        when:
+        file.text =
+                '''
+                params.x = foo.bar
+                '''
+        new ConfigBuilder().build([file])
+        then:
+        def e = thrown(ConfigParseException)
+        e.message == "Unknown config attribute `foo.bar` -- check config file: ${file.toRealPath()}".toString()
+
+        cleanup:
+        SysEnv.pop()
     }
 
     def 'should collect config files' () {
@@ -1732,91 +371,6 @@ class ConfigBuilderTest extends Specification {
         file2?.delete()
     }
 
-
-    def 'should configure notification' () {
-
-        given:
-        Map config
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun()).build()
-        then:
-        !config.notification
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(withNotification: true)).build()
-        then:
-        config.notification.enabled == true
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(withNotification: false)).build()
-        then:
-        config.notification.enabled == false
-        config.notification.to == null
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(withNotification: 'yo@nextflow.com')).build()
-        then:
-        config.notification.enabled == true
-        config.notification.to == 'yo@nextflow.com'
-    }
-
-    def 'should configure fusion' () {
-
-        given:
-        Map config
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun()).build()
-        then:
-        !config.fusion
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(withFusion: true)).build()
-        then:
-        config.fusion.enabled == true
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(withFusion: false)).build()
-        then:
-        config.fusion == [enabled: false]
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(withFusion: true)).build()
-        then:
-        config.fusion == [enabled: true]
-    }
-
-    def 'should configure stub run mode' () {
-        given:
-        Map config
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun()).build()
-        then:
-        !config.stubRun
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(stubRun: true)).build()
-        then:
-        config.stubRun == true
-    }
-
-    def 'should configure preview mode' () {
-        given:
-        Map config
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun()).build()
-        then:
-        !config.preview
-
-        when:
-        config = new ConfigBuilder().setCmdRun(new CmdRun(preview: true)).build()
-        then:
-        config.preview == true
-    }
-
     def 'should merge profiles' () {
         given:
         def ENV = [:]
@@ -1826,7 +380,7 @@ class ConfigBuilderTest extends Specification {
         def CONFIG = '''
                 process.container = 'base'
                 process.executor = 'local'
-
+                
                 profiles {
                     cfg1 {
                       process.executor = 'sge'
@@ -1853,7 +407,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.profile = 'cfg1'
-        result = builder.buildConfig0(ENV, [CONFIG])
+        result = builder.build(ENV, [CONFIG])
         then:
         result.process.container == 'base'
         result.process.executor == 'sge'
@@ -1861,7 +415,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.profile = 'cfg2'
-        result = builder.buildConfig0(ENV, [CONFIG])
+        result = builder.build(ENV, [CONFIG])
         then:
         result.process.container == 'base'
         result.process.executor == 'batch'
@@ -1869,7 +423,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.profile = 'cfg1,docker'
-        result = builder.buildConfig0(ENV, [CONFIG])
+        result = builder.build(ENV, [CONFIG])
         then:
         result.process.container ==  'foo/1'
         result.process.executor == 'sge'
@@ -1879,7 +433,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.profile = 'cfg1,singularity'
-        result = builder.buildConfig0(ENV, [CONFIG])
+        result = builder.build(ENV, [CONFIG])
         then:
         result.process.container ==  'bar-2.img'
         result.process.executor == 'sge'
@@ -1889,7 +443,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.profile = 'cfg2,singularity'
-        result = builder.buildConfig0(ENV, [CONFIG])
+        result = builder.build(ENV, [CONFIG])
         then:
         result.process.container ==  'bar-2.img'
         result.process.executor == 'batch'
@@ -1899,7 +453,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.profile = 'missing'
-        builder.buildConfig0(ENV, [CONFIG])
+        builder.build(ENV, [CONFIG])
         then:
         thrown(AbortOperationException)
     }
@@ -1938,7 +492,7 @@ class ConfigBuilderTest extends Specification {
 
         when:
         builder.showAllProfiles = true
-        result = builder.buildConfig0(ENV, [CONFIG])
+        result = builder.build(ENV, [CONFIG])
         then:
         result.profiles.cfg1.process.executor == 'sge'
         result.profiles.cfg1.process.queue == 'short'
@@ -1955,7 +509,7 @@ class ConfigBuilderTest extends Specification {
 
         given:
         def folder = Files.createTempDirectory('test')
-        def file1 = folder.resolve('test.config')
+        def file1 = folder.resolve('test.conf')
         file1.text = '''
             process {
                 cpus = 2
@@ -1971,7 +525,7 @@ class ConfigBuilderTest extends Specification {
             '''
 
         when:
-        def cfg1 = new ConfigBuilder().buildConfig0([:], [file1])
+        def cfg1 = new ConfigBuilder().build([file1])
         then:
         cfg1.process.cpus == 2
         cfg1.process.'withName:bar'.cpus == 4
@@ -1982,10 +536,10 @@ class ConfigBuilderTest extends Specification {
         when:
         def file2 = folder.resolve('nextflow.config')
         file2.text = """
-            includeConfig "$file1"
+            includeConfig "$file1" 
             """
 
-        def cfg2 = new ConfigBuilder().buildConfig0([:], [file2])
+        def cfg2 = new ConfigBuilder().build([file2])
         then:
         cfg1 == cfg2
 
@@ -1998,20 +552,20 @@ class ConfigBuilderTest extends Specification {
 
         given:
         def folder = Files.createTempDirectory('test')
-        def file1 = folder.resolve('test.config')
+        def file1 = folder.resolve('test.conf')
         file1.text = '''
             process {
-                ext { args = "Hello World!" }
-                cpus = 1
+                ext { args = "Hello World!" } 
+                cpus = 1 
                 withName:BAR {
-                    ext { args = "Ciao mondo!" }
+                    ext { args = "Ciao mondo!" } 
                     cpus = 2
                 }
             }
             '''
 
         when:
-        def cfg1 = new ConfigBuilder().buildConfig0([:], [file1])
+        def cfg1 = new ConfigBuilder().build([file1])
         then:
         cfg1.process.cpus == 1
         cfg1.process.ext.args == 'Hello World!'
@@ -2029,11 +583,11 @@ class ConfigBuilderTest extends Specification {
 
         given:
         def folder = Files.createTempDirectory('test')
-        def file1 = folder.resolve('test.config')
+        def file1 = folder.resolve('test.conf')
         file1.text = '''
             process {
-                ext.args = "Hello World!"
-                cpus = 1
+                ext.args = "Hello World!" 
+                cpus = 1 
                 withName:BAR {
                     ext.args = "Ciao mondo!"
                     cpus = 2
@@ -2042,7 +596,7 @@ class ConfigBuilderTest extends Specification {
             '''
 
         when:
-        def cfg1 = new ConfigBuilder().buildConfig0([:], [file1])
+        def cfg1 = new ConfigBuilder().build([file1])
         then:
         cfg1.process.cpus == 1
         cfg1.process.ext.args == 'Hello World!'
@@ -2056,18 +610,18 @@ class ConfigBuilderTest extends Specification {
     def 'should access top params from profile' () {
         given:
         def folder = Files.createTempDirectory('test')
-        def file1 = folder.resolve('file1.config')
+        def file1 = folder.resolve('file1.conf')
 
         file1.text = """
-            params.alpha = 1
-            params.delta = 2
-
+            params.alpha = 1 
+            params.delta = 2 
+            
             profiles {
                 foo {
-                    params.delta = 20
-                    params.gamma = 30
-
-                    process {
+                    params.delta = 20 
+                    params.gamma = 30 
+                    
+                    process {  
                         cpus = params.alpha
                     }
                 }
@@ -2075,7 +629,7 @@ class ConfigBuilderTest extends Specification {
             """
 
         when:
-        def cfg = new ConfigBuilder().setProfile('foo').buildConfig0([:], [file1])
+        def cfg = new ConfigBuilder().setProfile('foo').build([file1])
         then:
         cfg.process == [cpus: 1]
         cfg.params == [alpha: 1, delta: 20, gamma: 30]
@@ -2087,31 +641,30 @@ class ConfigBuilderTest extends Specification {
     def 'should access top params from profile [2]' () {
         given:
         def folder = Files.createTempDirectory('test')
-        def file1 = folder.resolve('file1.config')
+        def file1 = folder.resolve('file1.conf')
 
         file1.text = """
             params {
-                alpha = 1
-                delta = 2
+                alpha = 1 
+                delta = 2 
             }
-
+            
             profiles {
                 foo {
                     params {
-                        delta = 20
+                        delta = 20 
                         gamma = 30
                     }
 
-                    process {
+                    process {  
                         cpus = params.alpha
                     }
                 }
             }
             """
 
-
         when:
-        def cfg = new ConfigBuilder().setProfile('foo').buildConfig0([:], [file1])
+        def cfg = new ConfigBuilder().setProfile('foo').build([file1])
         then:
         cfg.process == [cpus: 1]
         cfg.params == [alpha: 1, delta: 20, gamma: 30]
@@ -2123,33 +676,32 @@ class ConfigBuilderTest extends Specification {
     def 'should merge params two profiles' () {
         given:
         def folder = Files.createTempDirectory('test')
-        def file1 = folder.resolve('file1.config')
+        def file1 = folder.resolve('file1.conf')
 
-        file1.text = '''
+        file1.text = '''    
             profiles {
                 foo {
                     params {
-                        alpha = 1
-                        delta = 2
+                        alpha = 1 
+                        delta = 2 
                     }
                 }
 
                 bar {
                     params {
-                        delta = 20
-                        gamma = 30
+                        delta = 20 
+                        gamma = 30 
                     }
-
+                    
                     process {
                         cpus = params.alpha
-                    }
+                    }                
                 }
             }
             '''
 
-
         when:
-        def cfg = new ConfigBuilder().setProfile('foo,bar') .buildConfig0([:], [file1])
+        def cfg = new ConfigBuilder().setProfile('foo,bar') .build([file1])
         then:
         cfg.process.cpus == 1
         cfg.params.alpha == 1
@@ -2158,236 +710,6 @@ class ConfigBuilderTest extends Specification {
 
         cleanup:
         folder?.deleteDir()
-    }
-
-    def 'CLI params should overwrite only the key provided when nested'() {
-        given:
-        def folder = File.createTempDir()
-        def configMain = new File(folder, 'nextflow.config').absoluteFile
-
-        configMain.text = """
-        params {
-            foo = 'Hello'
-            bar = "Monde"
-            baz {
-                x = "Ciao"
-                y = "mundo"
-                z {
-                    alpha = "Hallo"
-                    beta  = "World"
-                }
-            }
-
-        }
-        """
-
-        when:
-        def config = configWithParams(
-            [env: [NXF_CONFIG_FILE: configMain.toString()]],
-            [params: [bar: "world", 'baz.y': "mondo", 'baz.z.beta': "Welt"]] )
-
-        then:
-        config.params.foo == 'Hello'
-        config.params.bar == 'world'
-        config.params.baz.x == 'Ciao'
-        config.params.baz.y == 'mondo'
-        //tests recursion
-        config.params.baz.z.alpha == 'Hallo'
-        config.params.baz.z.beta == 'Welt'
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-    @Unroll
-    def 'should merge config params' () {
-        given:
-        def builder = new ConfigBuilder()
-
-        expect:
-        def cfg = new ConfigObject(); if(CONFIG) cfg.putAll(CONFIG)
-        and:
-        builder.mergeMaps(cfg, PARAMS, false) == EXPECTED
-
-        where:
-        CONFIG                      | PARAMS | EXPECTED
-        [foo:1]                     | null                          | [foo:1]
-        null                        | [bar:2]                       | [bar:2]
-        [foo:1]                     | [bar:2]                       | [foo: 1, bar: 2]
-        [foo:1]                     | [bar:null]                    | [foo: 1, bar: null]
-        [foo:1]                     | [foo:null]                    | [foo: null]
-        [foo:1, bar:[:]]            | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
-        [foo:1, bar:[x:1, y:2]]     | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
-        [foo:1, bar:[x:1, y:2]]     | [foo: 2, bar: [x:10, y:20]]   | [foo: 2, bar: [x:10, y:20]]
-        [foo:1, bar:null]           | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
-        [foo:1, bar:2]              | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
-        [foo:1, bar:[x:1, y:2]]     | [bar: 2]                      | [foo: 1, bar: 2]
-    }
-
-    @Unroll
-    def 'should merge config strict params' () {
-        given:
-        def builder = new ConfigBuilder()
-
-        expect:
-        def cfg = new ConfigObject(); if(CONFIG) cfg.putAll(CONFIG)
-        and:
-        builder.mergeMaps(cfg, PARAMS, true) == EXPECTED
-
-        where:
-        CONFIG                      | PARAMS                        | EXPECTED
-        [:]                         | [bar:2]                       | [bar:2]
-        [foo:1]                     | null                          | [foo:1]
-        null                        | [bar:2]                       | [bar:2]
-        [foo:1]                     | [bar:2]                       | [foo: 1, bar: 2]
-        [foo:1]                     | [bar:null]                    | [foo: 1, bar: null]
-        [foo:1]                     | [foo:null]                    | [foo: null]
-        [foo:1, bar:[:]]            | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
-        [foo:1, bar:[x:1, y:2]]     | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
-        [foo:1, bar:[x:1, y:2]]     | [foo: 2, bar: [x:10, y:20]]   | [foo: 2, bar: [x:10, y:20]]
-    }
-
-    def 'prevent side effects with with nested params' () {
-        given:
-        def folder = Files.createTempDirectory('test')
-        and:
-        def config = folder.resolve('nf.config')
-        config.text = '''\
-        params.test.foo = "foo_def"
-        params.test.bar = "bar_def"
-        '''.stripIndent()
-
-        when:
-        def cfg1 = new ConfigBuilder()
-                .setOptions( new CliOptions(userConfig: [config.toString()]))
-                .build()
-        then:
-        cfg1.params.test.foo == "foo_def"
-        cfg1.params.test.bar == "bar_def"
-
-
-        when:
-        def cfg2 = configWithParams([:], [params: ['test.foo': 'CLI_FOO']], [userConfig: [config.toString()]])
-        then:
-        cfg2.params.test.foo == "CLI_FOO"
-        cfg2.params.test.bar == "bar_def"
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-    def 'parse nested json' () {
-        given:
-        def folder = Files.createTempDirectory('test')
-        and:
-        def config = folder.resolve('nf.json')
-        config.text = '''\
-        {
-            "title": "something",
-            "nested": {
-                "name": "Mike",
-                "and": {
-                    "more": "nesting",
-                    "still": {
-                        "another": "layer"
-                    }
-                }
-            }
-        }
-        '''.stripIndent()
-
-        when:
-        def cfg1 = configWithParams([:], [paramsFile: config.toString()])
-
-        then:
-        cfg1.params.title == "something"
-        cfg1.params.nested.name == 'Mike'
-        cfg1.params.nested.and.more == 'nesting'
-        cfg1.params.nested.and.still.another == 'layer'
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-    def 'parse nested yaml' () {
-        given:
-        def folder = Files.createTempDirectory('test')
-        and:
-        def config = folder.resolve('nf.yaml')
-        config.text = '''\
-            title: "something"
-            nested:
-              name: "Mike"
-              and:
-                more: nesting
-                still:
-                  another: layer
-        '''.stripIndent()
-
-        when:
-        def cfg1 = configWithParams([:], [paramsFile: config.toString()])
-
-        then:
-        cfg1.params.title == "something"
-        cfg1.params.nested.name == 'Mike'
-        cfg1.params.nested.and.more == 'nesting'
-        cfg1.params.nested.and.still.another == 'layer'
-
-        cleanup:
-        folder?.deleteDir()
-    }
-
-
-    def 'should return parsed config' () {
-        given:
-        def base = Files.createTempDirectory('test')
-        def configFile = base.resolve('nextflow.config')
-        configFile.text = '''
-        profiles {
-            first {
-                params {
-                  foo = 'Hello world'
-                  awsKey = 'xyz'
-                }
-                process {
-                    executor = { 'local' }
-                }
-                outputDir = params.outdir
-            }
-            second {
-                params.none = 'Blah'
-            }
-        }
-        '''
-        when:
-        def opt = new CliOptions(config: [configFile.toFile().canonicalPath])
-        def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: new Launcher(options: opt))
-        def cliParams = [foo: 'Hola', outdir: 'output_folder']
-        def txt = ConfigBuilder.resolveConfig(base, cmd, cliParams)
-        then:
-        txt == '''\
-            params {
-               foo = 'Hola'
-               outdir = 'output_folder'
-               awsKey = '[secret]'
-            }
-
-            process {
-               executor = { 'local' }
-            }
-
-            outputDir = 'output_folder'
-            outputFormat = 'text'
-            workDir = 'work'
-
-            tower {
-               enabled = true
-               endpoint = 'http://foo.com'
-            }
-            '''.stripIndent()
-
-        cleanup:
-        base?.deleteDir()
     }
 
     def 'should merge profiles with conditions' () {
@@ -2428,7 +750,7 @@ class ConfigBuilderTest extends Specification {
         '''
 
         when:
-        def cfg = new ConfigBuilder().setProfile('test').buildConfig0([:], [main])
+        def cfg = new ConfigBuilder().setProfile('test').build([:], [main])
         then:
         cfg.process.'withName:FOO'
         cfg.params.load_config == true
@@ -2438,7 +760,6 @@ class ConfigBuilderTest extends Specification {
         cleanup:
         folder?.deleteDir()
     }
-
 
     def 'should build config object with secrets' () {
         given:
@@ -2465,7 +786,7 @@ class ConfigBuilderTest extends Specification {
         '''
 
         when:
-        def cfg = new ConfigBuilder().setBaseDir(folder).buildConfig0([:], [text])
+        def cfg = new ConfigBuilder().setBaseDir(folder).build([text])
         then:
         cfg.params.p == "$folder/1"
         cfg.params.s == 'ciao/2'
@@ -2514,7 +835,7 @@ class ConfigBuilderTest extends Specification {
 
         snippet1.text = """
         p2 = secrets.DELTA
-        includeConfig "$snippet2"
+        includeConfig "$snippet2" 
         """
 
         snippet2.text = '''
@@ -2523,8 +844,7 @@ class ConfigBuilderTest extends Specification {
         '''
 
         when:
-        def opt = new CliOptions()
-        def config = new ConfigBuilder().setBaseDir(folder).setOptions(opt).buildGivenFiles(configMain)
+        def config = new ConfigBuilder().setBaseDir(folder).build([configMain])
         then:
         config.p1 == 'one'
         config.p2 == 'two'
@@ -2571,7 +891,7 @@ class ConfigBuilderTest extends Specification {
 
         snippet1.text = '''
         p2 = 'two'
-        // include config via string interpolation using a secret
+        // include config via string interpolation using a secret 
         includeConfig "$secrets.SECRET_FILE2"
         '''
 
@@ -2580,8 +900,7 @@ class ConfigBuilderTest extends Specification {
         '''
 
         when:
-        def opt = new CliOptions()
-        def config = new ConfigBuilder().setBaseDir(folder).setOptions(opt).buildGivenFiles(configMain)
+        def config = new ConfigBuilder().setBaseDir(folder).build([configMain])
         then:
         config.p1 == 'one'
         config.p2 == 'two'
@@ -2633,9 +952,9 @@ class ConfigBuilderTest extends Specification {
         and:
         configMain.text = '''
         p1 = secrets.ALPHA
-        foo.p1 = secrets.ALPHA
+        foo.p1 = secrets.ALPHA 
         bar {
-          p1 = secrets.ALPHA
+          p1 = secrets.ALPHA 
         }
         // include config via a secret property
         includeConfig secrets.SECRET_FILE1
@@ -2647,7 +966,7 @@ class ConfigBuilderTest extends Specification {
         bar {
           p2 = "$secrets.DELTA"
         }
-        // include config via string interpolation using a secret
+        // include config via string interpolation using a secret 
         includeConfig "$secrets.SECRET_FILE2"
         '''
 
@@ -2660,12 +979,10 @@ class ConfigBuilderTest extends Specification {
         '''
 
         when:
-        def opt = new CliOptions()
         def config = new ConfigBuilder()
-                            .setBaseDir(folder)
-                            .setOptions(opt)
-                            .setStripSecrets(true)
-                            .buildGivenFiles(configMain)
+                .setBaseDir(folder)
+                .setStripSecrets(true)
+                .build([configMain])
         then:
         config.p1 == 'secrets.ALPHA'
         config.p2 == 'secrets.DELTA'
@@ -2685,4 +1002,3 @@ class ConfigBuilderTest extends Specification {
     }
 
 }
-

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigCmdAdapterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigCmdAdapterTest.groovy
@@ -1,0 +1,1828 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.config
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import nextflow.SysEnv
+import nextflow.cli.CliOptions
+import nextflow.cli.CmdConfig
+import nextflow.cli.CmdNode
+import nextflow.cli.CmdRun
+import nextflow.cli.Launcher
+import nextflow.exception.AbortOperationException
+import spock.lang.Specification
+import spock.lang.Unroll
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class ConfigCmdAdapterTest extends Specification {
+
+    def setupSpec() {
+        SysEnv.push([:])
+    }
+
+    def cleanupSpec() {
+        SysEnv.pop()
+    }
+
+    ConfigObject configWithParams(Path file, Map runOpts, Path baseDir=null) {
+        def run = new CmdRun(runOpts)
+        def cliParams = run.parsedParams(ConfigBuilder.getConfigVars(baseDir, null))
+        def builder = new ConfigBuilder()
+            .setCliParams(cliParams)
+        return new ConfigCmdAdapter(builder)
+            .setOptions(new CliOptions())
+            .setCmdRun(run)
+            .buildGivenFiles(file)
+    }
+
+    ConfigObject configWithParams(Map runOpts, Map cliOpts=[:]) {
+        def run = new CmdRun(runOpts)
+        def cliParams = run.parsedParams(ConfigBuilder.getConfigVars(null, null))
+        def builder = new ConfigBuilder()
+            .setCliParams(cliParams)
+        return new ConfigCmdAdapter(builder)
+            .setOptions(new CliOptions(cliOpts))
+            .setCmdRun(run)
+            .build()
+    }
+
+    def 'CLI params should override the ones defined in the config file' () {
+        setup:
+        def file = Files.createTempFile('test',null)
+        file.text = '''
+        params {
+          alpha = 'x'
+        }
+        params.beta = 'y'
+        params.delta = 'Foo'
+        params.gamma = params.alpha
+        params {
+            omega = 'Bar'
+        }
+
+        process {
+          publishDir = [path: params.alpha]
+        }
+        '''
+        when:
+        def result = configWithParams(file, [params: [alpha: 'Hello', beta: 'World', omega: 'Last']])
+
+        then:
+        result.params.alpha == 'Hello'  // <-- params defined as CLI options override the ones in the config file
+        result.params.beta == 'World'   // <--   as above
+        result.params.gamma == 'Hello'  // <--   as above
+        result.params.omega == 'Last'
+        result.params.delta == 'Foo'
+        result.process.publishDir == [path: 'Hello']
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'CLI params should override the ones defined in the config file [2]' () {
+        setup:
+        def file = Files.createTempFile('test',null)
+        file.text = '''
+        params {
+          alpha = 'x'
+          beta = 'y'
+          delta = 'Foo'
+          gamma = params.alpha
+          omega = 'Bar'
+        }
+
+        process {
+          publishDir = [path: params.alpha]
+        }
+        '''
+        when:
+        def result = configWithParams(file, [params: [alpha: 'Hello', beta: 'World', omega: 'Last']])
+
+        then:
+        result.params.alpha == 'Hello'  // <-- params defined as CLI options override the ones in the config file
+        result.params.beta == 'World'   // <--   as above
+        result.params.gamma == 'Hello'  // <--   as above
+        result.params.omega == 'Last'
+        result.params.delta == 'Foo'
+        result.process.publishDir == [path: 'Hello']
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'CLI params should override the ones in one or more config files' () {
+        given:
+        def folder = File.createTempDir()
+        def configMain = new File(folder,'nextflow.config').absoluteFile
+        def snippet1 = new File(folder,'config1.txt').absoluteFile
+        def snippet2 = new File(folder,'config2.txt').absoluteFile
+
+
+        configMain.text = """
+        process.name = 'alpha'
+        params.one = 'a'
+        params.xxx = 'x'
+        includeConfig "$snippet1"
+        """
+
+        snippet1.text = """
+        params.two = 'b'
+        params.yyy = 'y'
+
+        process.cpus = 4
+        process.memory = '8GB'
+
+        includeConfig("$snippet2")
+        """
+
+        snippet2.text = '''
+        params.three = 'c'
+        params.zzz = 'z'
+
+        process { disk = '1TB' }
+        process.resources.foo = 1
+        process.resources.bar = 2
+        '''
+
+        when:
+        def config = configWithParams(configMain.toPath(), [params: [one: '1', two: 'dos', three: 'tres']])
+
+        then:
+        config.params.one == '1'
+        config.params.two == 'dos'
+        config.params.three == 'tres'
+        config.process.name == 'alpha'
+        config.params.xxx == 'x'
+        config.params.yyy == 'y'
+        config.params.zzz == 'z'
+
+        config.process.cpus == 4
+        config.process.memory == '8GB'
+        config.process.disk == '1TB'
+        config.process.resources.foo == 1
+        config.process.resources.bar == 2
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'should include config with params' () {
+        given:
+        def folder = File.createTempDir()
+        def configMain = new File(folder,'nextflow.config').absoluteFile
+        def snippet1 = new File(folder,'igenomes.config').absoluteFile
+
+
+        configMain.text = '''
+        includeConfig 'igenomes.config'
+        '''
+
+        snippet1.text = '''
+        params {
+          genomes {
+            'GRCh37' {
+              fasta = "${params.igenomes_base}/genome.fa"
+              bwa   = "${params.igenomes_base}/BWAIndex/genome.fa"
+            }
+          }
+        }
+        '''
+
+        when:
+        def config = configWithParams(configMain.toPath(), [params: [igenomes_base: 'test']])
+
+        then:
+        config.params.genomes.'GRCh37' == [fasta:'test/genome.fa', bwa:'test/BWAIndex/genome.fa']
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'should fetch the config path from env var' () {
+        given:
+        def folder = File.createTempDir()
+        def configMain = new File(folder,'my.config').absoluteFile
+
+
+        configMain.text = """
+        process.name = 'alpha'
+        params.one = 'a'
+        params.two = 'b'
+        """
+
+        // relative path to current dir
+        when:
+        SysEnv.push(NXF_CONFIG_FILE: 'my.config')
+        def config = new ConfigCmdAdapter() .setCurrentDir(folder.toPath()) .build()
+        SysEnv.pop()
+        then:
+        config.params.one == 'a'
+        config.params.two == 'b'
+        config.process.name == 'alpha'
+
+        // absolute path
+        when:
+        SysEnv.push(NXF_CONFIG_FILE: configMain.toString())
+        config = new ConfigCmdAdapter() .build()
+        SysEnv.pop()
+        then:
+        config.params.one == 'a'
+        config.params.two == 'b'
+        config.process.name == 'alpha'
+
+        // default should not find it
+        when:
+        config = new ConfigCmdAdapter() .build()
+        then:
+        config.params == [:]
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'CLI params should overrides the ones in one or more profiles' () {
+
+        setup:
+        def file = Files.createTempFile('test',null)
+        file.text = '''
+        params.alpha = 'a'
+        params.beta = 'b'
+        params.delta = 'Foo'
+        params.gamma = params.alpha
+
+        params {
+            genomes {
+                'GRCh37' {
+                  bed12   = '/data/genes.bed'
+                  bismark = '/data/BismarkIndex'
+                  bowtie  = '/data/genome'
+                }
+            }
+        }
+
+        profiles {
+          first {
+            params.alpha = 'Alpha'
+            params.omega = 'Omega'
+            params.gamma = 'First'
+            process.name = 'Bar'
+          }
+
+          second {
+            params.alpha = 'xxx'
+            params.gamma = 'Second'
+            process {
+                publishDir = [path: params.alpha]
+            }
+          }
+
+        }
+
+        '''
+
+        when:
+        def config = configWithParams(file, [params: [alpha: 'AAA', beta: 'BBB']])
+        then:
+        config.params.alpha == 'AAA'
+        config.params.beta == 'BBB'
+        config.params.delta == 'Foo'
+        config.params.gamma == 'AAA'
+        config.params.genomes.'GRCh37'.bed12 == '/data/genes.bed'
+        config.params.genomes.'GRCh37'.bismark == '/data/BismarkIndex'
+        config.params.genomes.'GRCh37'.bowtie  == '/data/genome'
+
+        when:
+        config = configWithParams(file, [params: [alpha: 'AAA', beta: 'BBB'], profile: 'first'])
+        then:
+        config.params.alpha == 'AAA'
+        config.params.beta == 'BBB'
+        config.params.delta == 'Foo'
+        config.params.gamma == 'First'
+        config.process.name == 'Bar'
+        config.params.genomes.'GRCh37'.bed12 == '/data/genes.bed'
+        config.params.genomes.'GRCh37'.bismark == '/data/BismarkIndex'
+        config.params.genomes.'GRCh37'.bowtie  == '/data/genome'
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'params-file should override params in the config file' () {
+        setup:
+        def baseDir = Path.of('/my/base/dir')
+        and:
+        def paramsFile = Files.createTempFile('test', '.yml')
+        paramsFile.text = '''
+            alpha: "Hello" 
+            beta: "World" 
+            omega: "Last"
+            theta: "${baseDir}/something"
+            '''.stripIndent()
+        and:
+        def file = Files.createTempFile('test',null)
+        file.text = '''
+        params {
+          alpha = 'x'
+        }
+        params.beta = 'y'
+        params.delta = 'Foo'
+        params.gamma = params.alpha
+        params {
+            omega = 'Bar'
+        }
+
+        process {
+          publishDir = [path: params.alpha]
+        }
+        '''
+        when:
+        def result = configWithParams(file, [paramsFile: paramsFile], baseDir)
+
+        then:
+        result.params.alpha == 'Hello'  // <-- params defined in the params-file overrides the ones in the config file
+        result.params.beta == 'World'   // <--   as above
+        result.params.gamma == 'Hello'  // <--   as above
+        result.params.omega == 'Last'
+        result.params.delta == 'Foo'
+        result.params.theta == "$baseDir/something"
+        result.process.publishDir == [path: 'Hello']
+
+        cleanup:
+        file?.delete()
+        paramsFile?.delete()
+    }
+
+    def 'params should override params-file and override params in the config file' () {
+        setup:
+        def params = Files.createTempFile('test', '.yml')
+        params.text = '''
+            alpha: "Hello" 
+            beta: "World" 
+            omega: "Last"
+            '''.stripIndent()
+        and:
+        def file = Files.createTempFile('test',null)
+        file.text = '''
+        params {
+          alpha = 'x'
+        }
+        params.beta = 'y'
+        params.delta = 'Foo'
+        params.gamma = "I'm gamma"
+        params.omega = "I'm the last"
+        
+        process {
+          publishDir = [path: params.alpha]
+        }
+        '''
+        when:
+        def result = configWithParams(file, [paramsFile: params, params: [alpha: 'Hola', beta: 'Mundo']])
+
+        then:
+        result.params.alpha == 'Hola'   // <-- this comes from the CLI
+        result.params.beta == 'Mundo'   // <-- this comes from the CLI as well
+        result.params.omega == 'Last'   // <-- this comes from the params-file
+        result.params.gamma == "I'm gamma"   // <-- from the config
+        result.params.delta == 'Foo'         // <-- from the config
+        result.process.publishDir == [path: 'Hola']
+
+        cleanup:
+        file?.delete()
+        params?.delete()
+    }
+
+    def 'should validate config files' () {
+
+        given:
+        def folder = Files.createTempDirectory('test')
+        def f1 = folder.resolve('file1')
+        def f2 = folder.resolve('file2')
+
+        when:
+        new ConfigCmdAdapter()
+                    .validateConfigFiles([f1, f2])
+        then:
+        thrown(AbortOperationException)
+
+        when:
+        f1.text = '1'; f2.text = '2'
+        def files = new ConfigCmdAdapter()
+                    .resolveConfigFiles([f1.toString(), f2.toString()])
+        then:
+        files == [f1, f2]
+
+        when:
+        files = new ConfigCmdAdapter()
+                    .setHomeDir(folder)
+                    .setCurrentDir(folder)
+                    .setUserConfigFiles(f1,f2)
+                    .resolveConfigFiles([])
+        then:
+        files == [f1, f2]
+
+        cleanup:
+        folder.deleteDir()
+
+    }
+
+    def 'should discover default config files' () {
+        given:
+        def homeDir = Files.createTempDirectory('home')
+        def baseDir = Files.createTempDirectory('work')
+        def workDir = Files.createTempDirectory('work')
+
+        when:
+        def homeConfig = homeDir.resolve('config')
+        homeConfig.text = 'foo=1'
+        def files1 = new ConfigCmdAdapter(homeDir: homeDir, baseDir: workDir, currentDir: workDir).resolveConfigFiles()
+        then:
+        files1 == [homeConfig]
+
+        when:
+        def workConfig = workDir.resolve('nextflow.config')
+        workConfig.text = 'bar=2'
+        def files2 = new ConfigCmdAdapter(homeDir: homeDir, baseDir: workDir, currentDir: workDir).resolveConfigFiles()
+        then:
+        files2 == [homeConfig, workConfig]
+
+        when:
+        def baseConfig = baseDir.resolve('nextflow.config')
+        baseConfig.text = 'ciao=3'
+        def files3 = new ConfigCmdAdapter(homeDir: homeDir, baseDir: baseDir, currentDir: workDir).resolveConfigFiles()
+        then:
+        files3 == [homeConfig, baseConfig, workConfig]
+
+        cleanup:
+        homeDir?.deleteDir()
+        workDir?.deleteDir()
+    }
+
+    def 'command executor options'() {
+
+        when:
+        def opt = new CliOptions()
+        def run = new CmdRun(executorOptions: [ alpha: 1, 'beta.x': 'hola', 'beta.y': 'ciao' ])
+        def result = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).buildGivenFiles()
+        then:
+        result.executor.alpha == 1
+        result.executor.beta.x == 'hola'
+        result.executor.beta.y == 'ciao'
+
+    }
+
+    def 'run command cluster options'() {
+
+        when:
+        def opt = new CliOptions()
+        def run = new CmdRun(clusterOptions: [ alpha: 1, 'beta.x': 'hola', 'beta.y': 'ciao' ])
+        def result = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).buildGivenFiles()
+        then:
+        result.cluster.alpha == 1
+        result.cluster.beta.x == 'hola'
+        result.cluster.beta.y == 'ciao'
+
+    }
+
+    def 'run with docker'() {
+
+        when:
+        def opt = new CliOptions()
+        def run = new CmdRun(withDocker: 'cbcrg/piper')
+        def config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+
+        then:
+        config.docker.enabled
+        config.process.container == 'cbcrg/piper'
+
+    }
+
+    def 'run with docker 2'() {
+
+        given:
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+        file.text =
+                '''
+                docker {
+                    image = 'busybox'
+                    enabled = false
+                }
+                '''
+
+        when:
+        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
+        def run = new CmdRun(withDocker: '-')
+        def config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        config.docker.enabled
+        config.docker.image == 'busybox'
+        config.process.container == 'busybox'
+
+        when:
+        opt = new CliOptions(config: [file.toFile().canonicalPath] )
+        run = new CmdRun(withDocker: 'cbcrg/mybox')
+        config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        config.docker.enabled
+        config.process.container == 'cbcrg/mybox'
+
+    }
+
+    def 'run with docker 3'() {
+        given:
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+
+        when:
+        file.text =
+                '''
+                process.'withName:test'.container = 'busybox'
+                '''
+        def opt = new CliOptions(config: [file.toFile().canonicalPath])
+        def run = new CmdRun(withDocker: '-')
+        def config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        config.docker.enabled
+        config.process.'withName:test'.container == 'busybox'
+
+        when:
+        file.text =
+                '''
+                process.container = 'busybox'
+                '''
+        opt = new CliOptions(config: [file.toFile().canonicalPath])
+        run = new CmdRun(withDocker: '-')
+        config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        config.docker.enabled
+        config.process.container == 'busybox'
+
+        when:
+        opt = new CliOptions()
+        run = new CmdRun(withDocker: '-')
+        config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        config.docker.enabled
+        !config.process.container
+
+        when:
+        file.text =
+                '''
+                process.'withName:test'.tag = 'tag'
+                '''
+        opt = new CliOptions(config: [file.toFile().canonicalPath])
+        run = new CmdRun(withDocker: '-')
+        config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        config.docker.enabled
+        !config.process.container
+
+    }
+
+    def 'run without docker'() {
+
+        given:
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+        file.text =
+                '''
+                docker {
+                    image = 'busybox'
+                    enabled = true
+                }
+                '''
+
+        when:
+        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
+        def run = new CmdRun(withoutDocker: true)
+        def config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        !config.docker.enabled
+        config.docker.image == 'busybox'
+        !config.process.container
+
+    }
+
+    def 'config with cluster options'() {
+
+        when:
+        def opt = new CliOptions()
+        def cmd = new CmdNode(clusterOptions: [join: 'x', group: 'y', interface: 'abc', slots: 10, 'tcp.alpha':'uno', 'tcp.beta': 'due'])
+
+        def config = new ConfigCmdAdapter()
+                .setOptions(opt)
+                .setCmdNode(cmd)
+                .build()
+
+        then:
+        config.cluster.join == 'x'
+        config.cluster.group == 'y'
+        config.cluster.interface == 'abc'
+        config.cluster.slots == 10
+        config.cluster.tcp.alpha == 'uno'
+        config.cluster.tcp.beta == 'due'
+
+    }
+
+    def 'should set session trace options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+
+        then:
+        config.trace instanceof Map
+        !config.trace.enabled
+        !config.trace.file
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withTrace: 'some-file'))
+        then:
+        config.trace instanceof Map
+        config.trace.enabled
+        config.trace.file == 'some-file'
+
+        when:
+        config = new ConfigObject()
+        config.trace.file = 'foo.txt'
+        builder.configRunOptions(config, env, new CmdRun(withTrace: 'bar.txt'))
+        then: // command line should override the config file
+        config.trace instanceof Map
+        config.trace.enabled
+        config.trace.file == 'bar.txt'
+
+        when:
+        config = new ConfigObject()
+        config.trace.file = 'foo.txt'
+        builder.configRunOptions(config, env, new CmdRun(withTrace: '-'))
+        then: // command line should override the config file
+        config.trace instanceof Map
+        config.trace.enabled
+        config.trace.file == 'foo.txt'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withTrace: '-'))
+        then: // command line should override the config file
+        config.trace instanceof Map
+        config.trace.enabled
+    }
+
+    def 'should set session report options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.report
+
+        when:
+        config = new ConfigObject()
+        config.report.file = 'foo.html'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.report instanceof Map
+        !config.report.enabled
+        config.report.file == 'foo.html'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withReport: 'my-report.html'))
+        then:
+        config.report instanceof Map
+        config.report.enabled
+        config.report.file == 'my-report.html'
+
+        when:
+        config = new ConfigObject()
+        config.report.file = 'this-report.html'
+        builder.configRunOptions(config, env, new CmdRun(withReport: 'my-report.html'))
+        then:
+        config.report instanceof Map
+        config.report.enabled
+        config.report.file == 'my-report.html'
+
+        when:
+        config = new ConfigObject()
+        config.report.file = 'this-report.html'
+        builder.configRunOptions(config, env, new CmdRun(withReport: '-'))
+        then:
+        config.report instanceof Map
+        config.report.enabled
+        config.report.file == 'this-report.html'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withReport: '-'))
+        then:
+        config.report instanceof Map
+        config.report.enabled
+    }
+
+    def 'should set session dag options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.dag
+
+        when:
+        config = new ConfigObject()
+        config.dag.file = 'foo-dag.html'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.dag instanceof Map
+        !config.dag.enabled
+        config.dag.file == 'foo-dag.html'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withDag: 'my-dag.html'))
+        then:
+        config.dag instanceof Map
+        config.dag.enabled
+        config.dag.file == 'my-dag.html'
+
+        when:
+        config = new ConfigObject()
+        config.dag.file = 'this-dag.html'
+        builder.configRunOptions(config, env, new CmdRun(withDag: 'my-dag.html'))
+        then:
+        config.dag instanceof Map
+        config.dag.enabled
+        config.dag.file == 'my-dag.html'
+
+        when:
+        config = new ConfigObject()
+        config.dag.file = 'this-dag.html'
+        builder.configRunOptions(config, env, new CmdRun(withDag: '-'))
+        then:
+        config.dag instanceof Map
+        config.dag.enabled
+        config.dag.file == 'this-dag.html'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withDag: '-'))
+        then:
+        config.dag instanceof Map
+        config.dag.enabled
+    }
+
+    def 'should set session weblog options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.weblog
+
+        when:
+        config = new ConfigObject()
+        config.weblog.url = 'http://bar.com'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.weblog instanceof Map
+        !config.weblog.enabled
+        config.weblog.url == 'http://bar.com'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withWebLog: 'http://foo.com'))
+        then:
+        config.weblog instanceof Map
+        config.weblog.enabled
+        config.weblog.url == 'http://foo.com'
+
+        when:
+        config = new ConfigObject()
+        config.weblog.enabled = true
+        config.weblog.url = 'http://bar.com'
+        builder.configRunOptions(config, env, new CmdRun(withWebLog: 'http://foo.com'))
+        then:
+        config.weblog instanceof Map
+        config.weblog.enabled
+        config.weblog.url == 'http://foo.com'
+
+        when:
+        config = new ConfigObject()
+        config.weblog.enabled = true
+        config.weblog.url = 'http://bar.com'
+        builder.configRunOptions(config, env, new CmdRun(withWebLog: '-'))
+        then:
+        config.weblog instanceof Map
+        config.weblog.enabled
+        config.weblog.url == 'http://bar.com'
+
+        when:
+        config = new ConfigObject()
+        config.weblog.enabled = true
+        builder.configRunOptions(config, env, new CmdRun(withWebLog: '-'))
+        then:
+        config.weblog instanceof Map
+        config.weblog.enabled
+        config.weblog.url == 'http://localhost'
+
+    }
+
+    def 'should set session timeline options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.timeline
+
+        when:
+        config = new ConfigObject()
+        config.timeline.file = 'my-file.html'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.timeline instanceof Map
+        !config.timeline.enabled
+        config.timeline.file == 'my-file.html'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withTimeline: 'my-timeline.html'))
+        then:
+        config.timeline instanceof Map
+        config.timeline.enabled
+        config.timeline.file == 'my-timeline.html'
+
+        when:
+        config = new ConfigObject()
+        config.timeline.enabled = true
+        config.timeline.file = 'this-timeline.html'
+        builder.configRunOptions(config, env, new CmdRun(withTimeline: 'my-timeline.html'))
+        then:
+        config.timeline instanceof Map
+        config.timeline.enabled
+        config.timeline.file == 'my-timeline.html'
+
+        when:
+        config = new ConfigObject()
+        config.timeline.enabled = true
+        config.timeline.file = 'my-timeline.html'
+        builder.configRunOptions(config, env, new CmdRun(withTimeline: '-'))
+        then:
+        config.timeline instanceof Map
+        config.timeline.enabled
+        config.timeline.file == 'my-timeline.html'
+
+        when:
+        config = new ConfigObject()
+        config.timeline.enabled = true
+        builder.configRunOptions(config, env, new CmdRun(withTimeline: '-'))
+        then:
+        config.timeline instanceof Map
+        config.timeline.enabled
+    }
+
+    def 'should set tower options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.tower
+
+        when:
+        config = new ConfigObject()
+        config.tower.endpoint = 'http://foo.com'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.tower instanceof Map
+        !config.tower.enabled
+        config.tower.endpoint == 'http://foo.com'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withTower: 'http://bar.com'))
+        then:
+        config.tower instanceof Map
+        config.tower.enabled
+        config.tower.endpoint == 'http://bar.com'
+
+        when:
+        config = new ConfigObject()
+        config.tower.endpoint = 'http://foo.com'
+        builder.configRunOptions(config, env, new CmdRun(withTower: '-'))
+        then:
+        config.tower instanceof Map
+        config.tower.enabled
+        config.tower.endpoint == 'http://foo.com'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withTower: '-'))
+        then:
+        config.tower instanceof Map
+        config.tower.enabled
+        !config.tower.endpoint
+    }
+
+    def 'should set wave options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.wave
+
+        when:
+        config = new ConfigObject()
+        config.wave.endpoint = 'http://foo.com'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.wave instanceof Map
+        !config.wave.enabled
+        config.wave.endpoint == 'http://foo.com'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withWave: 'http://bar.com'))
+        then:
+        config.wave instanceof Map
+        config.wave.enabled
+        config.wave.endpoint == 'http://bar.com'
+
+        when:
+        config = new ConfigObject()
+        config.wave.endpoint = 'http://foo.com'
+        builder.configRunOptions(config, env, new CmdRun(withWave: '-'))
+        then:
+        config.wave instanceof Map
+        config.wave.enabled
+        config.wave.endpoint == 'http://foo.com'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withWave: '-'))
+        then:
+        config.wave instanceof Map
+        config.wave.enabled
+        !config.wave.endpoint
+    }
+
+    def 'should set cloudcache options' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.cloudcache
+
+        when:
+        config = new ConfigObject()
+        config.cloudcache.path = 's3://foo/bar'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.cloudcache instanceof Map
+        !config.cloudcache.enabled
+        config.cloudcache.path == 's3://foo/bar'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: 's3://this/that'))
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        config.cloudcache.path == 's3://this/that'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: '-'))
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        !config.cloudcache.path
+
+        when:
+        config = new ConfigObject()
+        config.cloudcache.path = 's3://alpha/delta'
+        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: '-'))
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        config.cloudcache.path == 's3://alpha/delta'
+
+        when:
+        config = new ConfigObject()
+        config.cloudcache.path = 's3://alpha/delta'
+        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: 's3://should/override/config'))
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        config.cloudcache.path == 's3://should/override/config'
+
+        when:
+        config = new ConfigObject()
+        config.cloudcache.enabled = false
+        builder.configRunOptions(config, env, new CmdRun(cloudCachePath: 's3://should/override/config'))
+        then:
+        config.cloudcache instanceof Map
+        !config.cloudcache.enabled
+        config.cloudcache.path == 's3://should/override/config'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, [NXF_CLOUDCACHE_PATH:'s3://foo'], new CmdRun(cloudCachePath: 's3://should/override/env'))
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        config.cloudcache.path == 's3://should/override/env'
+
+        when:
+        config = new ConfigObject()
+        config.cloudcache.path = 's3://config/path'
+        builder.configRunOptions(config, [NXF_CLOUDCACHE_PATH:'s3://foo'], new CmdRun())
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        config.cloudcache.path == 's3://config/path'
+
+        when:
+        config = new ConfigObject()
+        config.cloudcache.path = 's3://config/path'
+        builder.configRunOptions(config, [NXF_CLOUDCACHE_PATH:'s3://foo'], new CmdRun(cloudCachePath: 's3://should/override/config'))
+        then:
+        config.cloudcache instanceof Map
+        config.cloudcache.enabled
+        config.cloudcache.path == 's3://should/override/config'
+
+    }
+
+    def 'should enable conda env' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.conda
+
+        when:
+        config = new ConfigObject()
+        config.conda.createOptions = 'something'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.conda instanceof Map
+        !config.conda.enabled
+        config.conda.createOptions == 'something'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withConda: 'my-recipe.yml'))
+        then:
+        config.conda instanceof Map
+        config.conda.enabled
+        config.process.conda == 'my-recipe.yml'
+
+        when:
+        config = new ConfigObject()
+        config.conda.enabled = true
+        builder.configRunOptions(config, env, new CmdRun(withConda: 'my-recipe.yml'))
+        then:
+        config.conda instanceof Map
+        config.conda.enabled
+        config.process.conda == 'my-recipe.yml'
+
+        when:
+        config = new ConfigObject()
+        config.process.conda = 'my-recipe.yml'
+        builder.configRunOptions(config, env, new CmdRun(withConda: '-'))
+        then:
+        config.conda instanceof Map
+        config.conda.enabled
+        config.process.conda == 'my-recipe.yml'
+    }
+
+    def 'should disable conda env' () {
+        given:
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+        file.text =
+                '''
+                conda {
+                    enabled = true
+                }
+                '''
+
+        when:
+        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
+        def run = new CmdRun(withoutConda: true)
+        def config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        !config.conda.enabled
+        !config.process.conda
+    }
+
+    def 'should enable spack env' () {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.spack
+
+        when:
+        config = new ConfigObject()
+        config.spack.createOptions = 'something'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.spack instanceof Map
+        !config.spack.enabled
+        config.spack.createOptions == 'something'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(withSpack: 'my-recipe.yaml'))
+        then:
+        config.spack instanceof Map
+        config.spack.enabled
+        config.process.spack == 'my-recipe.yaml'
+
+        when:
+        config = new ConfigObject()
+        config.spack.enabled = true
+        builder.configRunOptions(config, env, new CmdRun(withSpack: 'my-recipe.yaml'))
+        then:
+        config.spack instanceof Map
+        config.spack.enabled
+        config.process.spack == 'my-recipe.yaml'
+
+        when:
+        config = new ConfigObject()
+        config.process.spack = 'my-recipe.yaml'
+        builder.configRunOptions(config, env, new CmdRun(withSpack: '-'))
+        then:
+        config.spack instanceof Map
+        config.spack.enabled
+        config.process.spack == 'my-recipe.yaml'
+    }
+
+    def 'should disable spack env' () {
+        given:
+        def file = Files.createTempFile('test','config')
+        file.deleteOnExit()
+        file.text =
+                '''
+                spack {
+                    enabled = true
+                }
+                '''
+
+        when:
+        def opt = new CliOptions(config: [file.toFile().canonicalPath] )
+        def run = new CmdRun(withoutSpack: true)
+        def config = new ConfigCmdAdapter().setOptions(opt).setCmdRun(run).build()
+        then:
+        !config.spack.enabled
+        !config.process.spack
+    }
+
+    def 'SHOULD SET `RESUME` OPTION'() {
+
+        given:
+        def env = [:]
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        def config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.isSet('resume')
+
+        when:
+        config = new ConfigObject()
+        config.resume ='alpha-beta-delta'
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        config.resume == 'alpha-beta-delta'
+
+        when:
+        config = new ConfigObject()
+        config.resume ='alpha-beta-delta'
+        builder.configRunOptions(config, env, new CmdRun(resume: 'xxx-yyy'))
+        then:
+        config.resume == 'xxx-yyy'
+
+        when:
+        config = new ConfigObject()
+        config.resume ='this-that'
+        builder.configRunOptions(config, env, new CmdRun(resume: 'xxx-yyy'))
+        then:
+        config.resume == 'xxx-yyy'
+    }
+
+    def 'should set `workDir`' () {
+
+        given:
+        def config = new ConfigObject()
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        builder.configRunOptions(config, [:], new CmdRun())
+        then:
+        config.workDir == 'work'
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, [NXF_WORK: '/foo/bar'], new CmdRun())
+        then:
+        config.workDir == '/foo/bar'
+
+        when:
+        config = new ConfigObject()
+        config.workDir = 'hello/there'
+        builder.configRunOptions(config, [:], new CmdRun())
+        then:
+        config.workDir == 'hello/there'
+
+        when:
+        config = new ConfigObject()
+        config.workDir = 'hello/there'
+        builder.configRunOptions(config, [:], new CmdRun(workDir: 'my/work/dir'))
+        then:
+        config.workDir == 'my/work/dir'
+    }
+
+    def 'should set `libDir`' () {
+        given:
+        def config = new ConfigObject()
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        builder.configRunOptions(config, [:], new CmdRun())
+        then:
+        !config.isSet('libDir')
+
+        when:
+        builder.configRunOptions(config, [NXF_LIB:'/foo/bar'], new CmdRun())
+        then:
+        config.libDir == '/foo/bar'
+
+        when:
+        builder.configRunOptions(config, [:], new CmdRun(libPath: 'my/lib/dir'))
+        then:
+        config.libDir == 'my/lib/dir'
+    }
+
+    def 'should set `cacheable`' () {
+        given:
+        def env = [:]
+        def config
+        def builder = [:] as ConfigCmdAdapter
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun())
+        then:
+        !config.isSet('cacheable')
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(cacheable: false))
+        then:
+        config.cacheable == false
+
+        when:
+        config = new ConfigObject()
+        builder.configRunOptions(config, env, new CmdRun(cacheable: true))
+        then:
+        config.cacheable == true
+    }
+
+    def 'should set profile options' () {
+        def builder
+        def adapter
+
+        when:
+        builder = new ConfigBuilder()
+        adapter = new ConfigCmdAdapter(builder).setCmdRun(new CmdRun(profile: 'foo'))
+        then:
+        builder.profile == 'foo'
+        builder.validateProfile
+
+        when:
+        builder = new ConfigBuilder()
+        adapter = new ConfigCmdAdapter(builder).setCmdRun(new CmdRun())
+        then:
+        builder.profile == 'standard'
+        !builder.validateProfile
+
+        when:
+        builder = new ConfigBuilder()
+        adapter = new ConfigCmdAdapter(builder).setCmdRun(new CmdRun(profile: 'standard'))
+        then:
+        builder.profile == 'standard'
+        builder.validateProfile
+    }
+
+    def 'should set config options' () {
+        def builder
+        def adapter
+
+        when:
+        builder = new ConfigBuilder()
+        adapter = new ConfigCmdAdapter(builder).setCmdConfig(new CmdConfig())
+        then:
+        !builder.showAllProfiles
+
+        when:
+        builder = new ConfigBuilder()
+        adapter = new ConfigCmdAdapter(builder).setCmdConfig(new CmdConfig(showAllProfiles: true))
+        then:
+        builder.showAllProfiles
+
+        when:
+        builder = new ConfigBuilder()
+        adapter = new ConfigCmdAdapter(builder).setCmdConfig(new CmdConfig(profile: 'foo'))
+        then:
+        builder.profile == 'foo'
+        builder.validateProfile
+
+    }
+
+    def 'should set params into config object' () {
+
+        given:
+        def emptyFile = Files.createTempFile('empty','config').toFile()
+        def EMPTY = [emptyFile.toString()]
+
+        def configFile = Files.createTempFile('test','config').toFile()
+        configFile.deleteOnExit()
+        configFile.text = '''
+          params.foo = 1
+          params.bar = 2
+          params.data = '/some/path'
+        '''
+        configFile = configFile.toString()
+
+        def jsonFile = Files.createTempFile('test','.json').toFile()
+        jsonFile.text = '''
+          {
+            "foo": 10,
+            "bar": 20
+          }
+        '''
+        jsonFile = jsonFile.toString()
+
+        def yamlFile = Files.createTempFile('test','.yaml').toFile()
+        yamlFile.text = '''
+          {
+            "foo": 100,
+            "bar": 200
+          }
+        '''
+        yamlFile = yamlFile.toString()
+
+        def config
+
+        when:
+        config = configWithParams([:], [config: EMPTY])
+        then:
+        config.params == [:]
+
+        // get params for the CLI
+        when:
+        config = configWithParams([params: [foo:'one', bar:'two']], [config: EMPTY])
+        then:
+        config.params == [foo:'one', bar:'two']
+
+        // get params from config file
+        when:
+        config = configWithParams([:], [config: [configFile]])
+        then:
+        config.params == [foo:1, bar:2, data: '/some/path']
+
+        // get params form JSON file
+        when:
+        config = configWithParams([paramsFile: jsonFile], [config: EMPTY])
+        then:
+        config.params == [foo:10, bar:20]
+
+        // get params from YAML file
+        when:
+        config = configWithParams([paramsFile: yamlFile], [config: EMPTY])
+        then:
+        config.params == [foo:100, bar:200]
+
+        // cli override config
+        when:
+        config = configWithParams([params: [foo:'hello', baz:'world']], [config: [configFile]])
+        then:
+        config.params == [foo:'hello', bar:2, baz: 'world', data: '/some/path']
+
+        // CLI override JSON
+        when:
+        config = configWithParams([params: [foo:'hello', baz:'world'], paramsFile: jsonFile], [config: EMPTY])
+        then:
+        config.params == [foo:'hello', bar:20, baz: 'world']
+
+        // JSON override config
+        when:
+        config = configWithParams([paramsFile: jsonFile], [config: [configFile]])
+        then:
+        config.params == [foo:10, bar:20, data: '/some/path']
+
+        // CLI override JSON that override config
+        when:
+        config = configWithParams([paramsFile: jsonFile, params: [foo:'Ciao']], [config: [configFile]])
+        then:
+        config.params == [foo:'Ciao', bar:20, data: '/some/path']
+    }
+
+    def 'should run with conda' () {
+
+        when:
+        def config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withConda: '/some/path/env.yml')).build()
+        then:
+        config.process.conda == '/some/path/env.yml'
+
+    }
+
+    def 'should run with spack' () {
+
+        when:
+        def config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withSpack: '/some/path/env.yaml')).build()
+        then:
+        config.process.spack == '/some/path/env.yaml'
+
+    }
+
+    def 'should configure notification' () {
+
+        given:
+        Map config
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun()).build()
+        then:
+        !config.notification
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withNotification: true)).build()
+        then:
+        config.notification.enabled == true
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withNotification: false)).build()
+        then:
+        config.notification.enabled == false
+        config.notification.to == null
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withNotification: 'yo@nextflow.com')).build()
+        then:
+        config.notification.enabled == true
+        config.notification.to == 'yo@nextflow.com'
+    }
+
+    def 'should configure fusion' () {
+
+        given:
+        Map config
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun()).build()
+        then:
+        !config.fusion
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withFusion: true)).build()
+        then:
+        config.fusion.enabled == true
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withFusion: false)).build()
+        then:
+        config.fusion == [enabled: false]
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(withFusion: true)).build()
+        then:
+        config.fusion == [enabled: true]
+    }
+
+    def 'should configure stub run mode' () {
+        given:
+        Map config
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun()).build()
+        then:
+        !config.stubRun
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(stubRun: true)).build()
+        then:
+        config.stubRun == true
+    }
+
+    def 'should configure preview mode' () {
+        given:
+        Map config
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun()).build()
+        then:
+        !config.preview
+
+        when:
+        config = new ConfigCmdAdapter().setCmdRun(new CmdRun(preview: true)).build()
+        then:
+        config.preview == true
+    }
+
+    def 'CLI params should overwrite only the key provided when nested'() {
+        given:
+        def folder = File.createTempDir()
+        def configMain = new File(folder, 'nextflow.config').absoluteFile
+
+        configMain.text = """
+        params {
+            foo = 'Hello'
+            bar = "Monde"
+            baz {
+                x = "Ciao"
+                y = "mundo"
+                z { 
+                    alpha = "Hallo"
+                    beta  = "World"
+                }
+            }
+            
+        }        
+        """
+
+        when:
+        SysEnv.push(NXF_CONFIG_FILE: configMain.toString())
+        def config = configWithParams( [params: [bar: "world", 'baz.y': "mondo", 'baz.z.beta': "Welt"]] )
+        SysEnv.pop()
+
+        then:
+        config.params.foo == 'Hello'
+        config.params.bar == 'world'
+        config.params.baz.x == 'Ciao'
+        config.params.baz.y == 'mondo'
+        //tests recursion
+        config.params.baz.z.alpha == 'Hallo'
+        config.params.baz.z.beta == 'Welt'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    @Unroll
+    def 'should merge config params' () {
+        given:
+        def builder = new ConfigCmdAdapter()
+
+        expect:
+        def cfg = new ConfigObject(); if(CONFIG) cfg.putAll(CONFIG)
+        and:
+        builder.mergeMaps(cfg, PARAMS, false) == EXPECTED
+
+        where:
+        CONFIG                      | PARAMS | EXPECTED
+        [foo:1]                     | null                          | [foo:1]
+        null                        | [bar:2]                       | [bar:2]
+        [foo:1]                     | [bar:2]                       | [foo: 1, bar: 2]
+        [foo:1]                     | [bar:null]                    | [foo: 1, bar: null]
+        [foo:1]                     | [foo:null]                    | [foo: null]
+        [foo:1, bar:[:]]            | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
+        [foo:1, bar:[x:1, y:2]]     | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
+        [foo:1, bar:[x:1, y:2]]     | [foo: 2, bar: [x:10, y:20]]   | [foo: 2, bar: [x:10, y:20]]
+        [foo:1, bar:null]           | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
+        [foo:1, bar:2]              | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
+        [foo:1, bar:[x:1, y:2]]     | [bar: 2]                      | [foo: 1, bar: 2]
+    }
+
+    @Unroll
+    def 'should merge config strict params' () {
+        given:
+        def builder = new ConfigCmdAdapter()
+
+        expect:
+        def cfg = new ConfigObject(); if(CONFIG) cfg.putAll(CONFIG)
+        and:
+        builder.mergeMaps(cfg, PARAMS, true) == EXPECTED
+
+        where:
+        CONFIG                      | PARAMS                        | EXPECTED
+        [:]                         | [bar:2]                       | [bar:2]
+        [foo:1]                     | null                          | [foo:1]
+        null                        | [bar:2]                       | [bar:2]
+        [foo:1]                     | [bar:2]                       | [foo: 1, bar: 2]
+        [foo:1]                     | [bar:null]                    | [foo: 1, bar: null]
+        [foo:1]                     | [foo:null]                    | [foo: null]
+        [foo:1, bar:[:]]            | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
+        [foo:1, bar:[x:1, y:2]]     | [bar: [x:10, y:20]]           | [foo: 1, bar: [x:10, y:20]]
+        [foo:1, bar:[x:1, y:2]]     | [foo: 2, bar: [x:10, y:20]]   | [foo: 2, bar: [x:10, y:20]]
+    }
+
+    def 'prevent config side effects' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        and:
+        def config = folder.resolve('nf.config')
+        config.text = '''\
+        params.test.foo = "foo_def"
+        params.test.bar = "bar_def"        
+        '''.stripIndent()
+
+        when:
+        def cfg1 = new ConfigCmdAdapter()
+                .setOptions( new CliOptions(userConfig: [config.toString()]))
+                .build()
+        then:
+        cfg1.params.test.foo == "foo_def"
+        cfg1.params.test.bar == "bar_def"
+
+        
+        when:
+        def cfg2 = configWithParams([params: ['test.foo': 'CLI_FOO']], [userConfig: [config.toString()]])
+        then:
+        cfg2.params.test.foo == "CLI_FOO"
+        cfg2.params.test.bar == "bar_def"
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'parse nested json' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        and:
+        def config = folder.resolve('nf.json')
+        config.text = '''\
+        {
+            "title": "something",
+            "nested": {
+                "name": "Mike",
+                "and": {
+                    "more": "nesting",
+                    "still": {
+                        "another": "layer"
+                    }
+                }
+            }
+        }
+        '''.stripIndent()
+
+        when:
+        def cfg1 = configWithParams([paramsFile: config.toString()])
+
+        then:
+        cfg1.params.title == "something"
+        cfg1.params.nested.name == 'Mike'
+        cfg1.params.nested.and.more == 'nesting'
+        cfg1.params.nested.and.still.another == 'layer'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'parse nested yaml' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        and:
+        def config = folder.resolve('nf.yaml')
+        config.text = '''\
+            title: "something"
+            nested: 
+              name: "Mike"
+              and:
+                more: nesting
+                still:
+                  another: layer      
+        '''.stripIndent()
+
+        when:
+        def cfg1 = configWithParams([paramsFile: config.toString()])
+
+        then:
+        cfg1.params.title == "something"
+        cfg1.params.nested.name == 'Mike'
+        cfg1.params.nested.and.more == 'nesting'
+        cfg1.params.nested.and.still.another == 'layer'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'should return parsed config' () {
+        given:
+        def base = Files.createTempDirectory('test')
+        def configFile = base.resolve('nextflow.config')
+        configFile.text = '''
+        profiles {
+            first {
+                params {
+                  foo = 'Hello world'
+                  awsKey = 'xyz'
+                }
+                process {
+                    executor = { 'local' }
+                }
+                outputDir = params.outdir
+            }
+            second {
+                params.none = 'Blah'
+            }
+        }
+        '''
+        when:
+        def opt = new CliOptions(config: [configFile.toFile().canonicalPath])
+        def cmd = new CmdRun(profile: 'first', withTower: 'http://foo.com', launcher: new Launcher(options: opt))
+        def cliParams = [foo: 'Hola', outdir: 'output_folder']
+        def txt = ConfigCmdAdapter.resolveConfig(base, cmd, cliParams)
+        then:
+        txt == '''\
+            params {
+               foo = 'Hola'
+               outdir = 'output_folder'
+               awsKey = '[secret]'
+            }
+
+            process {
+               executor = { 'local' }
+            }
+
+            outputDir = 'output_folder'
+            outputFormat = 'text'
+            workDir = 'work'
+
+            tower {
+               enabled = true
+               endpoint = 'http://foo.com'
+            }
+            '''.stripIndent()
+
+        cleanup:
+        base?.deleteDir()
+    }
+
+}
+

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v1/ConfigParserV1Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v1/ConfigParserV1Test.groovy
@@ -575,7 +575,7 @@ class ConfigParserV1Test extends Specification {
 
         when:
         def url = 'http://localhost:9900/nextflow.config' as Path
-        def cfg = new ConfigBuilder().buildGivenFiles(url)
+        def cfg = new ConfigBuilder().build([url])
         then:
         cfg.params.foo == 'Hello'
         cfg.params.bar == 'world!'

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -591,7 +591,7 @@ class ConfigParserV2Test extends Specification {
 
         when:
         def url = 'http://localhost:9900/nextflow.config' as Path
-        def cfg = new ConfigBuilder().buildGivenFiles(url)
+        def cfg = new ConfigBuilder().build([url])
         then:
         cfg.params.foo == 'Hello'
         cfg.params.bar == 'world!'

--- a/modules/nextflow/src/test/groovy/nextflow/scm/ProviderPathTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/ProviderPathTest.groovy
@@ -48,7 +48,7 @@ class ProviderPathTest extends Specification {
             '''
 
         when:
-        def cfg = new ConfigBuilder().buildGivenFiles(path)
+        def cfg = new ConfigBuilder().build([path])
         then:
         provider.readText('nextflow.config') >> MAIN_CONFIG
         provider.readText('conf/nested.config') >> NESTED_CONFIG

--- a/plugins/nf-console/src/main/nextflow/ui/console/Nextflow.groovy
+++ b/plugins/nf-console/src/main/nextflow/ui/console/Nextflow.groovy
@@ -30,7 +30,7 @@ import nextflow.Session
 import nextflow.cli.CliOptions
 import nextflow.cli.CmdInfo
 import nextflow.cli.CmdRun
-import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.script.ScriptBinding
 import nextflow.script.ScriptFile
 import nextflow.script.parser.v1.ScriptLoaderV1
@@ -80,7 +80,7 @@ class Nextflow extends Console {
         final base = script ? script.parent : Paths.get('.')
 
         // create the config object
-        return new ConfigBuilder()
+        return new ConfigCmdAdapter()
                     .setOptions( new CliOptions() )
                     .setBaseDir(base)
                     .setCmdRun( new CmdRun() )

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sDriverLauncher.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sDriverLauncher.groovy
@@ -30,6 +30,7 @@ import groovy.util.logging.Slf4j
 import nextflow.cli.CmdKubeRun
 import nextflow.cli.CmdRun
 import nextflow.config.ConfigBuilder
+import nextflow.config.ConfigCmdAdapter
 import nextflow.exception.AbortOperationException
 import nextflow.file.FileHelper
 import nextflow.k8s.client.K8sClient
@@ -265,17 +266,20 @@ class K8sDriverLauncher {
         // -- load local config if available
         final builder = new ConfigBuilder()
                 .setShowClosures(true)
-                .setOptions(cmd.launcher.options)
                 .setProfile(cmd.profile)
+
+        final adapter = new ConfigCmdAdapter(builder)
+                .setOptions(cmd.launcher.options)
                 .setCmdRun(cmd)
 
         if( !interactive && !pipelineName.startsWith('/') && !cmd.remoteProfile && !cmd.runRemoteConfig ) {
             // -- check and parse project remote config
             final pipelineConfig = new AssetManager(pipelineName, cmd.revision, cmd.mainScript, cmd).getConfigFile()
-            builder.setUserConfigFiles(pipelineConfig)
+            if( pipelineConfig )
+                adapter.setUserConfigFiles(pipelineConfig)
         }
 
-        return builder.buildConfigObject()
+        return adapter.buildConfigObject()
     }
 
     protected K8sConfig makeK8sConfig(Map config) {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/BaseCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/BaseCommandImpl.groovy
@@ -51,7 +51,6 @@ class BaseCommandImpl {
     }
 
     protected Map readConfig() {
-        // note: the Nextflow home config file is `$HOME/.nextflow/config` (not `nextflow.config`)
         final configFile = Const.APP_HOME_DIR.resolve('config')
         return new ConfigBuilder().build(configFile.exists() ? [ configFile ] : []).flatten()
     }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/BaseCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/BaseCommandImpl.groovy
@@ -51,8 +51,9 @@ class BaseCommandImpl {
     }
 
     protected Map readConfig() {
-        final builder = new ConfigBuilder().setHomeDir(Const.APP_HOME_DIR).setCurrentDir(Const.APP_HOME_DIR)
-        return builder.buildConfigObject().flatten()
+        // note: the Nextflow home config file is `$HOME/.nextflow/config` (not `nextflow.config`)
+        final configFile = Const.APP_HOME_DIR.resolve('config')
+        return new ConfigBuilder().build(configFile.exists() ? [ configFile ] : []).flatten()
     }
 
     protected List<Map> listUserWorkspaces(TowerClient client, String userId) {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/auth/AuthCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/auth/AuthCommandImpl.groovy
@@ -237,8 +237,8 @@ class AuthCommandImpl extends BaseCommandImpl implements CmdAuth.AuthCommand {
     private String normalizeApiUrl(String url) {
         if( !url ) {
             // Read config to get the actual resolved endpoint value
-            final builder = new ConfigBuilder().setHomeDir(Const.APP_HOME_DIR).setCurrentDir(Const.APP_HOME_DIR)
-            final configObject = builder.buildConfigObject()
+            final configFile = Const.APP_HOME_DIR.resolve('config')
+            final configObject = new ConfigBuilder().build(configFile.exists() ? [ configFile ] : [])
             final towerConfig = configObject.navigate('tower') as Map ?: [:]
             return PlatformHelper.getEndpoint(towerConfig, SysEnv.get())
         }
@@ -405,8 +405,8 @@ class AuthCommandImpl extends BaseCommandImpl implements CmdAuth.AuthCommand {
     @Override
     void config(Boolean showHeader = true) {
         // Read from both main config and seqera-auth.config file
-        final builder = new ConfigBuilder().setHomeDir(Const.APP_HOME_DIR).setCurrentDir(Const.APP_HOME_DIR)
-        final configObject = builder.buildConfigObject()
+        final configFile = Const.APP_HOME_DIR.resolve('config')
+        final configObject = new ConfigBuilder().build(configFile.exists() ? [ configFile ] : [])
         final config = configObject.flatten()
 
         // Navigate to tower config section (returns map without 'tower.' prefix)


### PR DESCRIPTION
Spun out from #5971 

Extract the CLI-specific configuration logic (option/command handling and config-file resolution: home, base dir, local, and user config files) from `ConfigBuilder` into a new `ConfigCmdAdapter` that wraps it. `ConfigBuilder` is left as a lean, `@CompileStatic` runtime builder that consumes an explicit list of config entries, and all call sites are migrated to `ConfigCmdAdapter` (CmdRun, CmdConfig, CmdClean, CmdNode, CmdFs, CmdLineage, CmdAuth, the module commands, PluginAbstractExec, K8sDriverLauncher, and the nf-console/nf-tower plugins). `DefaultRemoteModuleResolver` is updated for the new build() API.

This prepares the runtime config builder to be decoupled from the CLI, and keeps the forthcoming CLI/runtime module split a mechanical move.

Two intentional behavior changes come with the rewrite (both covered by new tests in ConfigBuilderTest):

- `session` is no longer created as a guaranteed top-level config scope. It is not a config scope, so code must not rely on it existing when unset.
- The v2 config parser no longer exposes environment variables to the config binding (they remain available to the v1 parser). The v2 parser does not support implicit environment variables.