### PR TITLE
Fix function call in process directive value with v2 parser

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/dsl/ProcessBuilder.groovy
@@ -19,6 +19,7 @@ package nextflow.script.dsl
 import java.util.regex.Pattern
 
 import groovy.transform.TypeChecked
+import nextflow.NF
 import nextflow.exception.IllegalConfigException
 import nextflow.exception.IllegalDirectiveException
 import nextflow.exception.ScriptRuntimeException
@@ -98,21 +99,35 @@ class ProcessBuilder {
         this.config = config
     }
 
+    // NOTE: replace with internal DSL after v1 parser is removed
     def methodMissing( String name, def args ) {
-        checkName(name)
+        if( DIRECTIVES.contains(name) || name == 'when' || name == 'stub' ) {
+            applyDirective(name, args)
+            return
+        }
 
+        // v1 parser: report error if method call is not a directive
+        if( !NF.isSyntaxParserV2() ) {
+            reportInvalidDirective(name)
+            return
+        }
+
+        // v2 parser: delegate method call to the script (which will report a
+        // missing method itself if the name is not a script-defined function)
+        if( ownerScript != null )
+            return ownerScript.invokeMethod(name, args)
+
+        throw new MissingMethodException(name, this.getClass(), args as Object[])
+    }
+
+    private void applyDirective(String name, def args) {
         if( args instanceof Object[] )
             config.put(name, args.size()==1 ? args[0] : args.toList())
         else
             config.put(name, args)
     }
 
-    private void checkName(String name) {
-        if( DIRECTIVES.contains(name) )
-            return
-        if( name == 'when' || name == 'stub' )
-            return
-
+    private void reportInvalidDirective(String name) {
         String message = "Unknown process directive: `$name`"
         def alternatives = DIRECTIVES.closest(name)
         if( alternatives.size()==1 ) {

--- a/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessBuilderTest.groovy
@@ -18,7 +18,9 @@ package nextflow.script.dsl
 
 import spock.lang.Specification
 
+import nextflow.SysEnv
 import nextflow.exception.IllegalDirectiveException
+import nextflow.script.BaseScript
 import nextflow.script.ProcessConfig
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
@@ -30,6 +32,10 @@ class ProcessBuilderTest extends Specification {
 
     def createBuilder() {
         new ProcessBuilder(new ProcessConfig([:]))
+    }
+
+    def createBuilder(BaseScript script) {
+        new ProcessBuilder(new ProcessConfig(script))
     }
 
     def 'should set directives' () {
@@ -98,6 +104,8 @@ class ProcessBuilderTest extends Specification {
     def 'should throw IllegalDirectiveException'() {
 
         given:
+        SysEnv.push([NXF_SYNTAX_PARSER: 'v1'])
+        and:
         def builder = createBuilder()
 
         when:
@@ -113,6 +121,9 @@ class ProcessBuilderTest extends Specification {
                         shell
                 '''
                 .stripIndent().trim()
+
+        cleanup:
+        SysEnv.pop()
     }
 
     def 'should set process secret'() {
@@ -353,5 +364,25 @@ class ProcessBuilderTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    def 'should delegate non-directive method calls to the owner script' () {
+        given:
+        def owner = Mock(BaseScript)
+        def builder = createBuilder(owner)
+
+        // `container localTag()`
+        when:
+        def result = builder.localTag()
+        then:
+        1 * owner.invokeMethod('localTag', _) >> 'ubuntu:22.04'
+        result == 'ubuntu:22.04'
+
+        // `container imageTag('foo')`
+        when:
+        result = builder.imageTag('foo')
+        then:
+        1 * owner.invokeMethod('imageTag', { (it as List) == ['foo'] }) >> 'image-for-foo'
+        result == 'image-for-foo'
     }
 }


### PR DESCRIPTION
Fix #7323 

Calling a script-defined function from within a process directive value (e.g. `container localTag()`) failed at runtime with `Unknown process directive: <fn>`.

For the v1 parser, this apparently never worked. You can wrap the function call in a GString (`container "${localTag()}"`) and the v1 parser will make it lazy.

For the v2 parser, this method should simply delegate to the owner script. Process directives and function calls are already validated at compile-time in v2 so we don't need to do any more checking here.

methodMissing now delegates unrecognized (non-directive) names to the owner script under the v2 parser, which resolves the function or reports a missing method itself. The v1 parser keeps reporting unknown directives at runtime as before.