### PR TITLE
Quote CSV values only when required

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/util/CsvWriter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/CsvWriter.groovy
@@ -40,15 +40,22 @@ class CsvWriter {
 
         final columns = columnHeaders(header, records)
         if( columns )
-            path << columns.collect(column -> "\"${column}\"").join(sep) << '\n'
+            path << columns.collect(column -> formatCsvValue(column)).join(sep) << '\n'
 
         if( records.isEmpty() )
             path << ''
 
         for( final record : records ) {
             final values = rowValues(record, columns)
-            path << values.collect(v -> "\"${toCsvString(v)}\"").join(sep) << '\n'
+            path << values.collect(v -> formatCsvValue(v)).join(sep) << '\n'
         }
+    }
+
+    private String formatCsvValue(value) {
+        final str = toCsvString(value)
+        final escaped = str.replace('"', '""')
+        final needsQuote = escaped != str || str.contains(sep) || str.contains('\r') || str.contains('\n')
+        return needsQuote ? "\"${escaped}\"" : str
     }
 
     private static Collection columnHeaders(Object header, List records) {

--- a/modules/nextflow/src/test/groovy/nextflow/util/CsvWriterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/util/CsvWriterTest.groovy
@@ -38,20 +38,48 @@ class CsvWriterTest extends Specification {
         new CsvWriter([:]).apply(records, file)
         then:
         file.text == '''\
-            "1","1_1.fastq","1_2.fastq"
-            "2","2_1.fastq","2_2.fastq"
-            "3","3_1.fastq",""
+            1,1_1.fastq,1_2.fastq
+            2,2_1.fastq,2_2.fastq
+            3,3_1.fastq,
             '''.stripIndent()
 
         when:
         new CsvWriter([header: true]).apply(records, file)
         then:
         file.text == '''\
-            "id","fastq_1","fastq_2"
-            "1","1_1.fastq","1_2.fastq"
-            "2","2_1.fastq","2_2.fastq"
-            "3","3_1.fastq",""
+            id,fastq_1,fastq_2
+            1,1_1.fastq,1_2.fastq
+            2,2_1.fastq,2_2.fastq
+            3,3_1.fastq,
             '''.stripIndent()
+    }
+
+    def 'should quote only values that require it'() {
+        given:
+        def file = TestHelper.createInMemTempFile()
+        and:
+        def records = [
+            ['plain', 'with,comma', 'with "quote"', 'with\nnewline', 'with\rcarriage', '', null]
+        ]
+
+        when:
+        new CsvWriter([:]).apply(records, file)
+        then:
+        file.text == 'plain,"with,comma","with ""quote""","with\nnewline","with\rcarriage",,\n'
+    }
+
+    def 'should quote headers and honor a custom separator'() {
+        given:
+        def file = TestHelper.createInMemTempFile()
+        and:
+        def records = [
+            ['sample': 'S1', 'read|group': 'case|control']
+        ]
+
+        when:
+        new CsvWriter([header: ['sample', 'read|group'], sep: '|']).apply(records, file)
+        then:
+        file.text == 'sample|"read|group"\nS1|"case|control"\n'
     }
 
     def 'should write empty csv file'() {


### PR DESCRIPTION
## Summary
- quote CSV headers and record values only when required for valid CSV
- escape embedded double quotes using the standard doubled-quote representation
- cover plain values, separators, quotes, CR/LF, empty and null values, and custom separators

## Tests
- `./gradlew :nextflow:test --tests nextflow.util.CsvWriterTest`

Closes #5546