### PR TITLE
Direct execution of named workflows

### DIFF
--- a/adr/20260501-type-system.md
+++ b/adr/20260501-type-system.md
@@ -3,7 +3,7 @@
 - Authors: Ben Sherman
 - Status: accepted
 - Deciders: Ben Sherman, Paolo Di Tommaso
-- Date: 2026-05-1
+- Date: 2026-05-01
 - Tags: lang, static-types
 
 ## Summary

--- a/adr/20260601-named-workflow-execution.md
+++ b/adr/20260601-named-workflow-execution.md
@@ -130,7 +130,7 @@ The following coercions apply:
 | `Map<K,V>`, `Record` | not supported | used as-is |
 | `Tuple` | not supported | not supported |
 | record types | not supported | map converted to record; fields are validated and converted to declared type |
-| `Channel<E>` | a samplesheet path, loaded as described below | a samplesheet path |
+| `Channel<E>` | a samplesheet path, loaded as described below; `E` must be a `Map`, `Record`, or record type | same as the command line |
 | `Value<V>` | parsed as `V`, then wrapped in a value channel | converted to `V`, then wrapped in a value channel |
 
 Composite types cannot be expressed as a single command-line string, so they must be supplied through the config. Nextflow does not attempt to split a command-line string into a collection, because there is no separator that is safe for every element type.
@@ -176,7 +176,7 @@ Where `loadData()` is a generic data-loading function that supports multiple fil
 
 *Future work:* the supported formats are currently a fixed set (CSV, JSON, YAML) implemented internally, and `loadData()` is not available to pipeline code. Exposing it as a function and allowing it to be extended via plugin to support additional formats (e.g. Parquet) is deferred.
 
-The channel input can use a generic type such as `Map` or `Record`, or a custom record type to enable further validation. In the above example, using the `Sample` type ensures that each samplesheet row is validated against the record fields and the `fastq_1` and `fastq_2` columns are treated as file paths.
+The channel input can use a generic type such as `Map` or `Record`, or a custom record type to enable further validation. It cannot use a scalar element type such as `Path` or `String`, because a samplesheet record is a set of named fields, not a single value. In the above example, using the `Sample` type ensures that each samplesheet row is validated against the record fields and the `fastq_1` and `fastq_2` columns are treated as file paths.
 
 ### Saving output channels to index files
 

--- a/adr/20260601-named-workflow-execution.md
+++ b/adr/20260601-named-workflow-execution.md
@@ -172,7 +172,9 @@ workflow {
 }
 ```
 
-Where `loadData()` is a generic data-loading function that supports multiple file formats (CSV, JSON, YAML, etc). The file contents must be compatible with the declared element type; an error is thrown if they are not. CSV files must include a header row and use a comma as the column separator. This function may be extended via plugin to support additional formats (e.g. Parquet).
+Where `loadData()` is a generic data-loading function that supports multiple file formats (CSV, JSON, YAML, etc). The file contents must be compatible with the declared element type; an error is thrown if they are not. CSV files must include a header row and use a comma as the column separator.
+
+*Future work:* the supported formats are currently a fixed set (CSV, JSON, YAML) implemented internally, and `loadData()` is not available to pipeline code. Exposing it as a function and allowing it to be extended via plugin to support additional formats (e.g. Parquet) is deferred.
 
 The channel input can use a generic type such as `Map` or `Record`, or a custom record type to enable further validation. In the above example, using the `Sample` type ensures that each samplesheet row is validated against the record fields and the `fastq_1` and `fastq_2` columns are treated as file paths.
 

--- a/adr/20260601-named-workflow-execution.md
+++ b/adr/20260601-named-workflow-execution.md
@@ -71,7 +71,7 @@ Named workflows typically consume and produce channels so that they can be compo
 Given a named workflow with dataflow inputs and outputs, provide a way to execute it directly via `nextflow module run`:
 
 - Load each input record channel from an index file (e.g. CSV, JSON, or YAML file)
-- Save each output record channel as an index file
+- Print each output channel to standard output
 - Refer to output files by work directory path instead of publishing them
 
 ### Inferring the entry workflow
@@ -111,23 +111,29 @@ Each `take:` input becomes a param, and each `emit:` output becomes a published 
 
 ### Mapping parameters to workflow inputs
 
-Each `take:` input becomes a pipeline parameter of the same name, and the declared type determines how the parameter value is interpreted. This is the same mapping that the `params` block already performs for an entry workflow, so direct execution should reuse that mechanism rather than define a second set of rules. A workflow that is executed directly and an entry workflow that wraps it must accept the same command line.
+Each `take:` input becomes a pipeline parameter of the same name, and the declared type determines how the parameter value is interpreted. This is similar to the mapping that the `params` block already performs for an entry workflow, so direct execution should reuse that mechanism rather than define a second set of rules. It is not identical, because a `take:` input is not a param declaration:
 
-A parameter value can come from the command line, a params file, or the config. Command-line values are always strings and must be parsed according to the declared type. Values from a params file or config are already structured -- numbers, lists, maps -- and only need to be converted where the declared type is more specific than the source syntax, such as `Path` or a record type.
+- A `take:` input cannot declare a default value (see below).
+- A `Boolean` param defaults to `false`, whereas a `Boolean` input is required unless it is nullable.
+- A `Channel<E>` or `Value<V>` input is mapped to a channel, which a `params` block does not do.
+
+A parameter value can come from the command line, a params file, or the config. Command-line and params-file values are treated the same way: they are parsed according to the declared type, since a command-line value is always a string and a params file is merged into the command-line params. Values from the config are already structured -- numbers, lists, maps -- and only need to be converted where the declared type is more specific than the source syntax, such as `Path` or a record type.
 
 The following coercions apply:
 
-| Declared type | Command line | Params file / config |
-| ------------- | ------------ | -------------------- |
+| Declared type | Command line / params file | Config |
+| ------------- | -------------------------- | ------ |
 | `Boolean`, `Integer`, `Float`, `String` | parsed from the string | used as-is |
 | `Duration`, `MemoryUnit`, `VersionNumber` | parsed from the string | parsed if given as a string |
-| `Path` | resolved to a path, which must exist | resolved to a path |
+| `Path` | resolved to a path, which must exist | resolved to a path, which must exist |
 | `List<E>`, `Set<E>`, `Bag<E>` | not supported | each element converted to `E` |
-| `Map<K,V>`, `Tuple`, `Record`, record types | not supported | each value converted to its declared type; record fields are validated |
+| `Map<K,V>`, `Record` | not supported | used as-is |
+| `Tuple` | not supported | not supported |
+| record types | not supported | map converted to record; fields are validated and converted to declared type |
 | `Channel<E>` | a samplesheet path, loaded as described below | a samplesheet path |
 | `Value<V>` | parsed as `V`, then wrapped in a value channel | converted to `V`, then wrapped in a value channel |
 
-Composite types cannot be expressed as a single command-line string, so they must be supplied through a params file or the config. Nextflow does not attempt to split a command-line string into a collection, because there is no separator that is safe for every element type.
+Composite types cannot be expressed as a single command-line string, so they must be supplied through the config. Nextflow does not attempt to split a command-line string into a collection, because there is no separator that is safe for every element type.
 
 An input is required unless it is declared as nullable (e.g. `samples: Channel<Sample>?`), in which case an unspecified parameter is passed as `null`. Unlike a param declaration, a `take:` input cannot specify a default value; a workflow that needs a default should declare the input as nullable and apply the default in its `main:` section, so that the default is applied whether the workflow is executed directly or called by another workflow.
 

--- a/adr/20260601-named-workflow-execution.md
+++ b/adr/20260601-named-workflow-execution.md
@@ -109,6 +109,30 @@ output {
 
 Each `take:` input becomes a param, and each `emit:` output becomes a published output with no `path` directive. Only typed workflows can be executed directly, since the input types are needed to map pipeline parameters to workflow inputs.
 
+### Mapping parameters to workflow inputs
+
+Each `take:` input becomes a pipeline parameter of the same name, and the declared type determines how the parameter value is interpreted. This is the same mapping that the `params` block already performs for an entry workflow, so direct execution should reuse that mechanism rather than define a second set of rules. A workflow that is executed directly and an entry workflow that wraps it must accept the same command line.
+
+A parameter value can come from the command line, a params file, or the config. Command-line values are always strings and must be parsed according to the declared type. Values from a params file or config are already structured -- numbers, lists, maps -- and only need to be converted where the declared type is more specific than the source syntax, such as `Path` or a record type.
+
+The following coercions apply:
+
+| Declared type | Command line | Params file / config |
+| ------------- | ------------ | -------------------- |
+| `Boolean`, `Integer`, `Float`, `String` | parsed from the string | used as-is |
+| `Duration`, `MemoryUnit`, `VersionNumber` | parsed from the string | parsed if given as a string |
+| `Path` | resolved to a path, which must exist | resolved to a path |
+| `List<E>`, `Set<E>`, `Bag<E>` | not supported | each element converted to `E` |
+| `Map<K,V>`, `Tuple`, `Record`, record types | not supported | each value converted to its declared type; record fields are validated |
+| `Channel<E>` | a samplesheet path, loaded as described below | a samplesheet path |
+| `Value<V>` | parsed as `V`, then wrapped in a value channel | converted to `V`, then wrapped in a value channel |
+
+Composite types cannot be expressed as a single command-line string, so they must be supplied through a params file or the config. Nextflow does not attempt to split a command-line string into a collection, because there is no separator that is safe for every element type.
+
+An input is required unless it is declared as nullable (e.g. `samples: Channel<Sample>?`), in which case an unspecified parameter is passed as `null`. Unlike a param declaration, a `take:` input cannot specify a default value; a workflow that needs a default should declare the input as nullable and apply the default in its `main:` section, so that the default is applied whether the workflow is executed directly or called by another workflow.
+
+After coercion, the value is checked for assignability against the declared type. An error that names the parameter, the declared type, and the offending value is preferable to passing an ill-typed value into the workflow.
+
 ### Loading input channels from samplesheets
 
 A channel param such as `samples: Channel<Sample>` is supplied on the command line as a samplesheet path, so Nextflow needs to load record channels directly from samplesheets. This can be done by loading the samplesheet data based on the file extension (CSV, JSON, YAML), casting each record to the given record type, and loading the collection as a channel.

--- a/adr/20260601-named-workflow-execution.md
+++ b/adr/20260601-named-workflow-execution.md
@@ -1,0 +1,155 @@
+# Direct execution for named workflows
+
+- Authors: Ben Sherman
+- Status: accepted
+- Date: 2026-06-01
+- Tags: lang, workflows
+
+## Summary
+
+Introduce the ability to execute named workflows directly with the `nextflow module run` command.
+
+## Problem Statement
+
+Consider the following entry workflow which simply wraps a named workflow:
+
+```groovy
+params {
+    input: Path
+    index: Path
+}
+
+workflow {
+    main:
+    samples = params.input.splitCsv(header: true) as List<Sample>
+    ch_samples = channel.fromList(samples)
+    rnaseq = RNASEQ(ch_samples, index)
+
+    publish:
+    aligned = rnaseq.aligned
+    multiqc_report = rnaseq.multiqc_report
+}
+
+output {
+    aligned: Channel<AlignedSample> {
+        path { s -> /* ... */ }
+        index { path 'aligned.json' }
+    }
+    multiqc_report: Path {
+        path '.'
+    }
+}
+```
+
+Where the `RNASEQ` workflow is defined as follows:
+
+```groovy
+workflow RNASEQ {
+    take:
+    samples: Channel<Sample>
+    index: Path
+
+    main:
+    ch_aligned = ALIGN(samples, index)
+    multiqc_report = MULTIQC(ch_aligned.collect())
+
+    emit:
+    aligned: Channel<AlignedSample> = ch_aligned
+    multiqc_report: Path = multiqc_report
+}
+
+record Sample { /* ... */ }
+record AlignedSample { /* ... */ }
+```
+
+This example demonstrates that most of the `params` / `workflow` / `output` trio can be equivalently expressed by a named workflow: the `params` block mirrors the `take:` section, and the `output` block and `publish:` section together mirror the `emit:` section.
+
+Named workflows typically consume and produce channels so that they can be composed into larger pipelines. But this prevents them from being directly executable -- the purpose of an entry workflow is to translate between dataflow logic and the external world. If this translation could be inferred automatically, it would allow a named workflow to be both executable and composable, eliminating the need to define explicit entry workflows.
+
+## Solution
+
+Given a named workflow with dataflow inputs and outputs, provide a way to execute it directly via `nextflow module run`:
+
+- Load each input record channel from an index file (e.g. CSV, JSON, or YAML file)
+- Save each output record channel as an index file
+- Refer to output files by work directory path instead of publishing them
+
+### Inferring the entry workflow
+
+The `params` and `output` blocks are inferred from the `take:` and `emit:` sections, so the `RNASEQ` workflow above can be invoked directly:
+
+```bash
+nextflow module run rnaseq.nf \
+    --samples samples.csv \
+    --index index.fasta
+```
+
+Nextflow executes it as if it were wrapped in the following entry workflow:
+
+```groovy
+params {
+    samples: Channel<Sample>
+    index: Path
+}
+
+workflow {
+    main:
+    rnaseq = RNASEQ(params.samples, params.index)
+
+    publish:
+    aligned = rnaseq.aligned
+    multiqc_report = rnaseq.multiqc_report
+}
+
+output {
+    aligned: Channel<AlignedSample> {}
+    multiqc_report: Path {}
+}
+```
+
+Each `take:` input becomes a param, and each `emit:` output becomes a published output with no `path` directive. Only typed workflows can be executed directly, since the input types are needed to map pipeline parameters to workflow inputs.
+
+### Loading input channels from samplesheets
+
+A channel param such as `samples: Channel<Sample>` is supplied on the command line as a samplesheet path, so Nextflow needs to load record channels directly from samplesheets. This can be done by loading the samplesheet data based on the file extension (CSV, JSON, YAML), casting each record to the given record type, and loading the collection as a channel.
+
+For example, given the following named workflow:
+
+```groovy
+workflow RNASEQ {
+    take:
+    samples: Channel<Sample>
+
+    // ...
+}
+
+record Sample {
+    id: String
+    fastq_1: Path
+    fastq_2: Path
+}
+```
+
+The `samples` param desugars to a path -- a CSV, JSON, or YAML file -- which is loaded as follows:
+
+```groovy
+params {
+    samples: Path
+}
+
+workflow {
+    RNASEQ(channel.fromList(loadData(params.samples) as List<Sample>))
+}
+```
+
+Where `loadData()` is a generic data-loading function that supports multiple file formats (CSV, JSON, YAML, etc). The file contents must be compatible with the declared element type; an error is thrown if they are not. CSV files must include a header row and use a comma as the column separator. This function may be extended via plugin to support additional formats (e.g. Parquet).
+
+The channel input can use a generic type such as `Map` or `Record`, or a custom record type to enable further validation. In the above example, using the `Sample` type ensures that each samplesheet row is validated against the record fields and the `fastq_1` and `fastq_2` columns are treated as file paths.
+
+### Saving output channels to index files
+
+The `emit:` section of a workflow can be treated like the `publish:` section of a entry workflow, defining which files are *terminal outputs* vs *intermediate outputs*. However, the output directory structure cannot be automatically inferred from the `emit:` section. It is normally specified by the output `path` directive, and does not necessarily correspond to the structure of the output channels.
+
+When executing a named workflow directly, output files are not published to an output directory. Instead, the workflow output printed by Nextflow simply refers to output files by their work directory path.
+
+This approach aligns with our goal to create a global content-addressable data store for files produced by Nextflow pipelines. A global data store with global search, caching, and automatic cleanup eliminates the need for per-run output directories. If needed, an output directory can be reconstructed from the structured workflow output.

--- a/docs/modules/using-modules.mdx
+++ b/docs/modules/using-modules.mdx
@@ -127,7 +127,7 @@ $ nextflow module run ./modules/local/fastqc/main.nf \
 ```
 
 :::note
-The local module should define a single process, or else the command will fail.
+The local module should define a single process or a single named workflow, or else the command will fail.
 :::
 
 See [module run][cli-module-run] for the full command reference.

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -989,9 +989,7 @@ class Session implements ISession {
 
     /**
      * Whether the entry script was launched directly as a module via
-     * `nextflow module run`. Used to decide whether the entry script's
-     * `resources/` bundle (and module bin paths) should be picked up
-     * even though the script is not being loaded via `include`.
+     * `nextflow module run`.
      */
     private volatile boolean moduleRun
 

--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -108,6 +108,13 @@ class PublishOp {
     protected void onNext(value) {
         log.trace "Received value for workflow output '${name}': ${value}"
 
+        // if output directory is disabled, report output files by
+        // their work directory path instead of publishing them
+        if( session.outputDir == null ) {
+            publishedValues << value
+            return
+        }
+
         // evaluate dynamic path
         final targetResolver = getTargetDir(value)
         if( targetResolver == null )
@@ -223,13 +230,13 @@ class PublishOp {
             : publishedValues
 
         // publish workflow output
-        final indexPath = indexOpts
+        final indexPath = session.outputDir && indexOpts
             ? session.outputDir.resolve(indexOpts.path)
             : null
         session.notifyWorkflowOutput(new WorkflowOutputEvent(name, outputValue, indexPath))
 
         // write value to index file
-        if( indexOpts ) {
+        if( indexPath ) {
             final ext = indexPath.getExtension()
             indexPath.parent.mkdirs()
             if( ext == 'csv' ) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -277,13 +277,18 @@ abstract class BaseScript extends Script implements ExecutionContext {
         }
 
         if( !entryFlow ) {
-            if( meta.getLocalWorkflowNames() )
-                throw new AbortOperationException("No entry workflow specified")
-            // Check if we have standalone processes that can be executed automatically
-            if( meta.hasExecutableProcesses() ) {
+            if( meta.hasExecutableWorkflows() ) {
+                // Create an entry workflow that calls the single named workflow automatically
+                final handler = new WorkflowEntryHandler(this, session, meta)
+                this.entryFlow = handler.createEntryWorkflow()
+            }
+            else if( meta.hasExecutableProcesses() ) {
                 // Create a workflow to execute the process (single process or first of multiple)
                 final handler = new ProcessEntryHandler(this, session, meta)
                 this.entryFlow = handler.createEntryWorkflow()
+            }
+            else if( meta.getLocalWorkflowNames() ) {
+                throw new AbortOperationException("No entry workflow specified")
             }
             else {
                 return result

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -262,6 +262,11 @@ abstract class BaseScript extends Script implements ExecutionContext {
             return result
         }
 
+        // a module defines a single process or named workflow, which is
+        // executed directly -- there is no entry workflow to select
+        if( binding.entryName && session.isModuleRun() )
+            throw new AbortOperationException("Option `-entry` is not supported when a script is executed as a module")
+
         // if an `entryName` was specified via the command line, override the `entryFlow` to be executed
         if( binding.entryName && !(entryFlow=meta.getWorkflow(binding.entryName) ) ) {
             def msg = "Unknown workflow entry name: ${binding.entryName}"

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -273,13 +273,18 @@ abstract class BaseScript extends Script implements ExecutionContext {
         }
 
         if( !entryFlow ) {
-            if( meta.getLocalWorkflowNames() )
-                throw new AbortOperationException("No entry workflow specified")
-            // Check if we have standalone processes that can be executed automatically
-            if( meta.hasExecutableProcesses() ) {
+            if( meta.hasExecutableWorkflows() ) {
+                // Create an entry workflow that calls the single named workflow automatically
+                final handler = new WorkflowEntryHandler(this, session, meta)
+                this.entryFlow = handler.createEntryWorkflow()
+            }
+            else if( meta.hasExecutableProcesses() ) {
                 // Create a workflow to execute the process (single process or first of multiple)
                 final handler = new ProcessEntryHandler(this, session, meta)
                 this.entryFlow = handler.createEntryWorkflow()
+            }
+            else if( meta.getLocalWorkflowNames() ) {
+                throw new AbortOperationException("No entry workflow specified")
             }
             else {
                 return result

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -273,12 +273,15 @@ abstract class BaseScript extends Script implements ExecutionContext {
         }
 
         if( !entryFlow ) {
-            if( meta.hasExecutableWorkflows() ) {
+            // a process or named workflow can be executed directly only
+            // when the script was launched via `nextflow module run`
+            final moduleRun = session.isModuleRun()
+            if( moduleRun && meta.hasExecutableWorkflows() ) {
                 // Execute a single named workflow directly
                 final handler = new WorkflowEntryHandler(this, session, meta)
                 this.entryFlow = handler.createEntryWorkflow()
             }
-            else if( meta.hasExecutableProcesses() ) {
+            else if( moduleRun && meta.hasExecutableProcesses() ) {
                 // Execute a single process directly
                 final handler = new ProcessEntryHandler(this, session, meta)
                 this.entryFlow = handler.createEntryWorkflow()

--- a/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/BaseScript.groovy
@@ -274,19 +274,20 @@ abstract class BaseScript extends Script implements ExecutionContext {
 
         if( !entryFlow ) {
             if( meta.hasExecutableWorkflows() ) {
-                // Create an entry workflow that calls the single named workflow automatically
+                // Execute a single named workflow directly
                 final handler = new WorkflowEntryHandler(this, session, meta)
                 this.entryFlow = handler.createEntryWorkflow()
             }
             else if( meta.hasExecutableProcesses() ) {
-                // Create a workflow to execute the process (single process or first of multiple)
+                // Execute a single process directly
                 final handler = new ProcessEntryHandler(this, session, meta)
                 this.entryFlow = handler.createEntryWorkflow()
             }
-            else if( meta.getLocalWorkflowNames() ) {
-                throw new AbortOperationException("No entry workflow specified")
+            else if( meta.getLocalProcessNames() || meta.getLocalWorkflowNames() ) {
+                throw new AbortOperationException("No entry workflow specified -- script must define an entry workflow, a single process or named workflow, or be a code snippet")
             }
             else {
+                // NOTE: remove after v1 parser is removed
                 return result
             }
         }

--- a/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy
@@ -110,12 +110,14 @@ class OutputDsl {
             session.printConsole(output.values().first().toString())
             return
         }
-        final outputDir = session.outputDir.toUriString()
+        final outputDir = session.outputDir?.toUriString()
         final sb = new StringBuilder()
         sb.append('\n')
         sb.append("Outputs:\n")
-        sb.append('\n')
-        sb.append("  ${outputDir}\n")
+        if( outputDir ) {
+            sb.append('\n')
+            sb.append("  ${outputDir}\n")
+        }
         for( final outputName : output.keySet() ) {
             final outputValue = output[outputName]
             sb.append('\n')
@@ -141,8 +143,10 @@ class OutputDsl {
     }
 
     private static String normalizeOutput(Object value, String outputDir) {
-        return DumpHelper.prettyPrintYaml(value, style: 'flow')
-            .replace(outputDir + '/', '')
+        final result = DumpHelper.prettyPrintYaml(value, style: 'flow')
+        return outputDir
+            ? result.replace(outputDir + '/', '')
+            : result
     }
 
     Map<String,Object> getOutput() {

--- a/modules/nextflow/src/main/groovy/nextflow/script/Param.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/Param.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script
+
+import java.lang.reflect.Type
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+/**
+ * Models a declared parameter -- either a param declaration in the
+ * `params` block or a `take:` input of a named workflow, which is
+ * mapped from a pipeline parameter when the workflow is executed
+ * directly.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@Canonical
+@CompileStatic
+class Param {
+
+    String name
+
+    /** The declared type, or null if the param is untyped. */
+    Type type
+
+    /** Whether the declared type is nullable. */
+    boolean optional
+
+    /** The declared default value, or null. Workflow takes cannot declare a default. */
+    Object defaultValue
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsDsl.groovy
@@ -60,11 +60,13 @@ class ParamsDsl {
         final params = new HashMap<String,?>()
         for( final name : declarations.keySet() ) {
             final decl = declarations[name]
-            if( cliParams.containsKey(name) ) {
-                params[name] = ParamsHelper.resolveFromCli(decl, cliParams[name])
+            final cliValue = cliParams[name]
+            final configValue = configParams[name]
+            if( cliValue != null ) {
+                params[name] = ParamsHelper.resolveFromCli(decl, cliValue)
             }
-            else if( configParams.containsKey(name) ) {
-                params[name] = ParamsHelper.resolveFromCode(decl, configParams[name])
+            else if( configValue != null ) {
+                params[name] = ParamsHelper.resolveFromCode(decl, configValue)
             }
             else if( decl.defaultValue != null ) {
                 params[name] = ParamsHelper.resolveFromCode(decl, decl.defaultValue)

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsDsl.groovy
@@ -60,28 +60,28 @@ class ParamsDsl {
         final params = new HashMap<String,?>()
         for( final name : declarations.keySet() ) {
             final decl = declarations[name]
-            final cliValue = cliParams[name]
-            final configValue = configParams[name]
-            if( cliValue != null ) {
-                params[name] = ParamsHelper.resolveFromCli(decl, cliValue)
+            if( cliParams.containsKey(name) ) {
+                params[name] = ParamsHelper.resolveFromCli(decl, cliParams[name])
             }
-            else if( configValue != null ) {
-                params[name] = ParamsHelper.resolveFromCode(decl, configValue)
+            else if( configParams.containsKey(name) ) {
+                params[name] = ParamsHelper.resolveFromCode(decl, configParams[name])
             }
             else if( decl.defaultValue != null ) {
                 params[name] = ParamsHelper.resolveFromCode(decl, decl.defaultValue)
             }
-            else if( decl.optional ) {
+            else {
                 params[name] = null
             }
-            else {
-                throw new ScriptRuntimeException("Parameter `$name` is required but was not specified on the command line, params file, or config")
+
+            if( params[name] == null && !decl.optional ) {
+                throw new ScriptRuntimeException("Parameter `$name` is required but no value was provided")
             }
 
             final expectedType = TypeHelper.getRawType(decl.type)
             final actualType = params[name]?.getClass()
-            if( actualType != null && !ParamsHelper.isAssignableFrom(expectedType, actualType) )
+            if( actualType != null && !ParamsHelper.isAssignableFrom(expectedType, actualType) ) {
                 throw new ScriptRuntimeException("Parameter `$name` with type ${Types.getName(decl.type)} cannot be assigned to ${params[name]} [${Types.getName(actualType)}]")
+            }
         }
 
         // propagate resolved params to all scripts for legacy compatibility

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsDsl.groovy
@@ -17,20 +17,13 @@
 package nextflow.script
 
 import java.lang.reflect.Type
-import java.nio.file.Path
 
-import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.exception.ScriptRuntimeException
 import nextflow.script.dsl.Types
-import nextflow.script.types.Record
-import nextflow.util.Duration
-import nextflow.util.MemoryUnit
-import nextflow.util.RecordMap
 import nextflow.util.TypeHelper
-import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 /**
  * Implements the DSL for defining workflow params
  *
@@ -68,13 +61,13 @@ class ParamsDsl {
         for( final name : declarations.keySet() ) {
             final decl = declarations[name]
             if( cliParams.containsKey(name) ) {
-                params[name] = resolveFromCli(decl, cliParams[name])
+                params[name] = ParamsHelper.resolveFromCli(decl, cliParams[name])
             }
             else if( configParams.containsKey(name) ) {
-                params[name] = resolveFromCode(decl, configParams[name])
+                params[name] = ParamsHelper.resolveFromCode(decl, configParams[name])
             }
             else if( decl.defaultValue != null ) {
-                params[name] = resolveFromCode(decl, decl.defaultValue)
+                params[name] = ParamsHelper.resolveFromCode(decl, decl.defaultValue)
             }
             else if( decl.optional ) {
                 params[name] = null
@@ -85,7 +78,7 @@ class ParamsDsl {
 
             final expectedType = TypeHelper.getRawType(decl.type)
             final actualType = params[name]?.getClass()
-            if( actualType != null && !isAssignableFrom(expectedType, actualType) )
+            if( actualType != null && !ParamsHelper.isAssignableFrom(expectedType, actualType) )
                 throw new ScriptRuntimeException("Parameter `$name` with type ${Types.getName(decl.type)} cannot be assigned to ${params[name]} [${Types.getName(actualType)}]")
         }
 
@@ -98,102 +91,6 @@ class ParamsDsl {
             final script = ScriptMeta.getScriptByPath(scriptPath)
             script.binding.setParams(params, true)
         }
-    }
-
-    private static Object resolveFromCli(Param decl, Object value) {
-        if( value == null )
-            return null
-
-        if( value instanceof Collection || value instanceof Map )
-            return asType(value, decl)
-
-        if( value !instanceof CharSequence )
-            return value
-
-        final str = value.toString()
-
-        if( decl.type == Boolean ) {
-            if( str.toLowerCase() == 'true' ) return Boolean.TRUE
-            if( str.toLowerCase() == 'false' ) return Boolean.FALSE
-        }
-
-        if( decl.type == Integer || decl.type == Float ) {
-            if( str.isInteger() ) return str.toInteger()
-            if( str.isLong() ) return str.toLong()
-            if( str.isBigInteger() ) return str.toBigInteger()
-        }
-
-        if( decl.type == Float ) {
-            if( str.isFloat() ) return str.toFloat()
-            if( str.isDouble() ) return str.toDouble()
-            if( str.isBigDecimal() ) return str.toBigDecimal()
-        }
-
-        if( decl.type == Duration ) {
-            return Duration.of(str)
-        }
-
-        if( decl.type == MemoryUnit ) {
-            return MemoryUnit.of(str)
-        }
-
-        if( decl.type == Path ) {
-            return TypeHelper.asPathType(str)
-        }
-
-        return value
-    }
-
-    private static Object resolveFromCode(Param decl, Object value) {
-        if( value == null )
-            return null
-
-        if( value instanceof Collection || value instanceof Map )
-            return asType(value, decl)
-
-        if( value !instanceof CharSequence )
-            return value
-
-        final str = value.toString()
-
-        if( decl.type == Path )
-            return TypeHelper.asPathType(str)
-
-        return value
-    }
-
-    private static Object asType(Object value, Param decl) {
-        try {
-            return TypeHelper.asType(value, decl.type)
-        }
-        catch( GroovyCastException | UnsupportedOperationException e ) {
-            final actualType = value.getClass()
-            throw new ScriptRuntimeException("Parameter `${decl.name}` with type ${Types.getName(decl.type)} cannot be assigned to ${value} [${Types.getName(actualType)}]")
-        }
-    }
-
-    private static boolean isAssignableFrom(Class target, Class source) {
-        // any numeric value can be assigned to Float
-        if( target == Float.class )
-            return Number.class.isAssignableFrom(source)
-
-        // any integer value can be assigned to Integer
-        if( target == Integer.class )
-            return source == BigInteger.class || source == Long.class || source == Integer.class
-
-        // any record can be assigned to a record type (validation is handled by asType())
-        if( Record.class.isAssignableFrom(target) )
-            return source == RecordMap.class
-
-        return target.isAssignableFrom(source)
-    }
-
-    @Canonical
-    private static class Param {
-        String name
-        Type type
-        boolean optional
-        Object defaultValue
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -31,9 +31,8 @@ import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 /**
  * Resolves a declared param against a given value.
  *
- * Used both by the `params` block of an entry workflow and by the
- * `take:` inputs of a named workflow that is executed directly, so
- * that both accept the same command line.
+ * Used by pipeline params, typed workflows, and typed processes, so
+ * that they all map a given value to a declared type the same way.
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script
+
+import java.nio.file.Path
+
+import groovy.transform.CompileStatic
+import nextflow.exception.ScriptRuntimeException
+import nextflow.script.dsl.Types
+import nextflow.script.types.Record
+import nextflow.util.Duration
+import nextflow.util.MemoryUnit
+import nextflow.util.RecordMap
+import nextflow.util.TypeHelper
+import nextflow.util.VersionNumber
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+/**
+ * Resolves a declared param against a given value.
+ *
+ * Used both by the `params` block of an entry workflow and by the
+ * `take:` inputs of a named workflow that is executed directly, so
+ * that both accept the same command line.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@CompileStatic
+class ParamsHelper {
+
+    /**
+     * Resolve a value given on the command line. Command-line values are
+     * always strings, so they are parsed according to the declared type.
+     *
+     * @param decl
+     * @param value
+     */
+    static Object resolveFromCli(Param decl, Object value) {
+        if( value == null )
+            return null
+
+        if( value instanceof Collection || value instanceof Map )
+            return asType(value, decl)
+
+        if( value !instanceof CharSequence )
+            return value
+
+        final str = value.toString()
+
+        if( decl.type == Boolean ) {
+            if( str.toLowerCase() == 'true' ) return Boolean.TRUE
+            if( str.toLowerCase() == 'false' ) return Boolean.FALSE
+        }
+
+        if( decl.type == Integer || decl.type == Float ) {
+            if( str.isInteger() ) return str.toInteger()
+            if( str.isLong() ) return str.toLong()
+            if( str.isBigInteger() ) return str.toBigInteger()
+        }
+
+        if( decl.type == Float ) {
+            if( str.isFloat() ) return str.toFloat()
+            if( str.isDouble() ) return str.toDouble()
+            if( str.isBigDecimal() ) return str.toBigDecimal()
+        }
+
+        return resolveFromString(decl, str, value)
+    }
+
+    /**
+     * Resolve a value given in a params file or the config. Such values are
+     * already structured, so they only need to be converted where the
+     * declared type is more specific than the source syntax.
+     *
+     * @param decl
+     * @param value
+     */
+    static Object resolveFromCode(Param decl, Object value) {
+        if( value == null )
+            return null
+
+        if( value instanceof Collection || value instanceof Map )
+            return asType(value, decl)
+
+        if( value !instanceof CharSequence )
+            return value
+
+        return resolveFromString(decl, value.toString(), value)
+    }
+
+    /**
+     * Convert a string to a declared type that is always expressed as a
+     * string, regardless of where the value came from. Returns the given
+     * fallback if the declared type is not one of these.
+     *
+     * @param decl
+     * @param str
+     * @param fallback
+     */
+    private static Object resolveFromString(Param decl, String str, Object fallback) {
+        if( decl.type == Path )
+            return TypeHelper.asPathType(str)
+
+        if( decl.type == Duration )
+            return Duration.of(str)
+
+        if( decl.type == MemoryUnit )
+            return MemoryUnit.of(str)
+
+        if( decl.type == VersionNumber )
+            return new VersionNumber(str)
+
+        return fallback
+    }
+
+    private static Object asType(Object value, Param decl) {
+        try {
+            return TypeHelper.asType(value, decl.type)
+        }
+        catch( GroovyCastException | UnsupportedOperationException e ) {
+            final actualType = value.getClass()
+            throw new ScriptRuntimeException("Parameter `${decl.name}` with type ${Types.getName(decl.type)} cannot be assigned to ${value} [${Types.getName(actualType)}]")
+        }
+    }
+
+    static boolean isAssignableFrom(Class target, Class source) {
+        // any numeric value can be assigned to Float
+        if( target == Float.class )
+            return Number.class.isAssignableFrom(source)
+
+        // any integer value can be assigned to Integer
+        if( target == Integer.class )
+            return source == BigInteger.class || source == Long.class || source == Integer.class
+
+        // any record can be assigned to a record type (validation is handled by asType())
+        if( Record.class.isAssignableFrom(target) )
+            return source == RecordMap.class
+
+        return target.isAssignableFrom(source)
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -108,9 +108,10 @@ class ParamsHelper {
      * lost for a value that is too large for the declared type.
      *
      * Returns null if the declared type is not numeric, or if the value
-     * cannot be represented by it -- an Integer rejects a fractional value
-     * rather than silently truncating it. The value is then reported by the
-     * caller as not assignable to the declared type.
+     * cannot be represented by it -- an Integer accepts an integral value in
+     * any notation (e.g. `3`, `3.0`, `3e2`) but rejects one with a fractional
+     * part, rather than silently truncating it. The value is then reported by
+     * the caller as not assignable to the declared type.
      *
      * @param decl
      * @param value
@@ -188,10 +189,10 @@ class ParamsHelper {
 
     /**
      * Convert a composite value (a collection, map, or record) to the
-     * declared type, reporting a conversion failure in terms of the param
-     * rather than the underlying element -- a NumberFormatException from an
+     * declared type, reporting a conversion failure in terms of the param as
+     * well as the underlying element -- a NumberFormatException from an
      * element of a `List<Integer>`, for example, names neither the param nor
-     * the declared type.
+     * the declared type on its own.
      *
      * @param value
      * @param decl
@@ -202,7 +203,8 @@ class ParamsHelper {
         }
         catch( GroovyCastException | UnsupportedOperationException | IllegalArgumentException e ) {
             final actualType = value.getClass()
-            throw new ScriptRuntimeException("Parameter `${decl.name}` with type ${Types.getName(decl.type)} cannot be assigned to ${value} [${Types.getName(actualType)}]")
+            final detail = e.message ? " -- ${e.message}" : ''
+            throw new ScriptRuntimeException("Parameter `${decl.name}` with type ${Types.getName(decl.type)} cannot be assigned to ${value} [${Types.getName(actualType)}]${detail}")
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -54,6 +54,10 @@ class ParamsHelper {
         if( value instanceof Collection || value instanceof Map )
             return asType(value, decl)
 
+        final number = asNumberType(decl, value)
+        if( number != null )
+            return number
+
         if( value !instanceof CharSequence )
             return value
 
@@ -62,18 +66,6 @@ class ParamsHelper {
         if( decl.type == Boolean ) {
             if( str.toLowerCase() == 'true' ) return Boolean.TRUE
             if( str.toLowerCase() == 'false' ) return Boolean.FALSE
-        }
-
-        if( decl.type == Integer ) {
-            if( str.isInteger() ) return str.toInteger()
-            if( str.isLong() ) return str.toLong()
-            if( str.isBigInteger() ) return str.toBigInteger()
-        }
-
-        if( decl.type == Float ) {
-            if( str.isFloat() ) return str.toFloat()
-            if( str.isDouble() ) return str.toDouble()
-            if( str.isBigDecimal() ) return str.toBigDecimal()
         }
 
         return resolveFromString(decl, str, value)
@@ -94,10 +86,48 @@ class ParamsHelper {
         if( value instanceof Collection || value instanceof Map )
             return asType(value, decl)
 
+        final number = asNumberType(decl, value)
+        if( number != null )
+            return number
+
         if( value !instanceof CharSequence )
             return value
 
         return resolveFromString(decl, value.toString(), value)
+    }
+
+    /**
+     * Convert a value to a declared numeric type. Integer and Float are the
+     * only numeric types in the Nextflow type system, but a value can be
+     * given as any number (e.g. a Double or BigDecimal in the config), and a
+     * command-line value is always a string, so the value is normalized to
+     * the declared type.
+     *
+     * Returns null if the declared type is not numeric, or if the value
+     * cannot be represented by it -- an Integer rejects a fractional value
+     * rather than silently truncating it. The value is then reported by the
+     * caller as not assignable to the declared type.
+     *
+     * @param decl
+     * @param value
+     */
+    private static Number asNumberType(Param decl, Object value) {
+        if( decl.type != Integer && decl.type != Float )
+            return null
+        try {
+            final number = new BigDecimal(value.toString().trim())
+            if( decl.type == Float )
+                return number.floatValue()
+            // widen an integral value that is too large for an Integer,
+            // and reject a fractional one
+            final integer = number.toBigIntegerExact()
+            return integer.bitLength() < Integer.SIZE
+                ? integer.intValue()
+                : ( integer.bitLength() < Long.SIZE ? integer.longValue() : integer )
+        }
+        catch( NumberFormatException | ArithmeticException e ) {
+            return null
+        }
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -64,7 +64,7 @@ class ParamsHelper {
             if( str.toLowerCase() == 'false' ) return Boolean.FALSE
         }
 
-        if( decl.type == Integer || decl.type == Float ) {
+        if( decl.type == Integer ) {
             if( str.isInteger() ) return str.toInteger()
             if( str.isLong() ) return str.toLong()
             if( str.isBigInteger() ) return str.toBigInteger()

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -186,11 +186,21 @@ class ParamsHelper {
         return fallback
     }
 
+    /**
+     * Convert a composite value (a collection, map, or record) to the
+     * declared type, reporting a conversion failure in terms of the param
+     * rather than the underlying element -- a NumberFormatException from an
+     * element of a `List<Integer>`, for example, names neither the param nor
+     * the declared type.
+     *
+     * @param value
+     * @param decl
+     */
     private static Object asType(Object value, Param decl) {
         try {
             return TypeHelper.asType(value, decl.type)
         }
-        catch( GroovyCastException | UnsupportedOperationException e ) {
+        catch( GroovyCastException | UnsupportedOperationException | IllegalArgumentException e ) {
             final actualType = value.getClass()
             throw new ScriptRuntimeException("Parameter `${decl.name}` with type ${Types.getName(decl.type)} cannot be assigned to ${value} [${Types.getName(actualType)}]")
         }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ParamsHelper.groovy
@@ -102,6 +102,11 @@ class ParamsHelper {
      * command-line value is always a string, so the value is normalized to
      * the declared type.
      *
+     * The value is converted to the narrowest representation that can hold
+     * it -- Integer, Long, or BigInteger for an integral value, Float,
+     * Double, or BigDecimal for a fractional one -- so that no precision is
+     * lost for a value that is too large for the declared type.
+     *
      * Returns null if the declared type is not numeric, or if the value
      * cannot be represented by it -- an Integer rejects a fractional value
      * rather than silently truncating it. The value is then reported by the
@@ -115,18 +120,45 @@ class ParamsHelper {
             return null
         try {
             final number = new BigDecimal(value.toString().trim())
-            if( decl.type == Float )
-                return number.floatValue()
-            // widen an integral value that is too large for an Integer,
-            // and reject a fractional one
-            final integer = number.toBigIntegerExact()
-            return integer.bitLength() < Integer.SIZE
-                ? integer.intValue()
-                : ( integer.bitLength() < Long.SIZE ? integer.longValue() : integer )
+            return decl.type == Float
+                ? asFloatType(number)
+                : asIntegerType(number)
         }
         catch( NumberFormatException | ArithmeticException e ) {
             return null
         }
+    }
+
+    /**
+     * Convert a number to a Float, widening it to a Double or BigDecimal
+     * if it is too large to be represented by a Float.
+     *
+     * @param number
+     */
+    private static Number asFloatType(BigDecimal number) {
+        final floatValue = number.floatValue()
+        if( !floatValue.isInfinite() )
+            return floatValue
+        final doubleValue = number.doubleValue()
+        return !doubleValue.isInfinite()
+            ? doubleValue
+            : number
+    }
+
+    /**
+     * Convert a number to an Integer, widening it to a Long or BigInteger if
+     * it is too large to be represented by an Integer. A fractional value is
+     * rejected rather than being truncated.
+     *
+     * @param number
+     */
+    private static Number asIntegerType(BigDecimal number) {
+        final integer = number.toBigIntegerExact()
+        if( integer.bitLength() < Integer.SIZE )
+            return integer.intValue()
+        return integer.bitLength() < Long.SIZE
+            ? integer.longValue()
+            : integer
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -24,6 +24,7 @@ import nextflow.Nextflow
 import nextflow.module.ModuleSpec
 import nextflow.module.ModuleSpecFactory
 import nextflow.module.ModuleStorage
+import nextflow.script.dsl.Types
 import nextflow.script.params.DefaultInParam
 import nextflow.script.params.EnvInParam
 import nextflow.script.params.FileInParam
@@ -32,11 +33,8 @@ import nextflow.script.params.StdInParam
 import nextflow.script.params.TupleInParam
 import nextflow.script.params.v2.ProcessInput
 import nextflow.script.params.v2.ProcessTupleInput
-import nextflow.script.dsl.Types
 import nextflow.script.types.Record
 import nextflow.util.RecordMap
-import nextflow.util.TypeHelper
-import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 
 /**
  * Helper class for process entry execution feature.
@@ -412,13 +410,15 @@ class ProcessEntryHandler {
     /**
      * Gets the appropriate value for a typed process input.
      *
+     * A typed input is resolved in the same way as a pipeline parameter,
+     * so that a process and a workflow accept the same command line.
+     *
      * @param param Input declaration
      * @param namedArgs Map of command-line arguments
      * @return Properly typed value for the input
      */
     private static Object getValueForInputV2(ProcessInput param, Map namedArgs) {
         final name = param.getName()
-        final type = param.getType()
         final value = namedArgs.get(name)
 
         if( value == null ) {
@@ -427,46 +427,16 @@ class ProcessEntryHandler {
             throw new IllegalArgumentException("Missing required parameter: --${name}")
         }
 
-        if( value instanceof Collection || value instanceof Map )
-            return asType(value, param)
+        final type = param.getType()
+        final result = ParamsHelper.resolveFromCli(new Param(name, type, param.isOptional(), null), value)
 
-        if( value !instanceof CharSequence )
-            return value
+        // report a value that could not be converted, instead of passing
+        // an ill-typed value to the task
+        final actualType = result?.getClass()
+        if( type != null && actualType != null && !ParamsHelper.isAssignableFrom(type, actualType) )
+            throw new IllegalArgumentException("Parameter `--${name}` with type ${Types.getName(type)} cannot be assigned to ${result} [${Types.getName(actualType)}]")
 
-        final str = value.toString()
-
-        if( type == Boolean ) {
-            if( str.toLowerCase() == 'true' ) return Boolean.TRUE
-            if( str.toLowerCase() == 'false' ) return Boolean.FALSE
-        }
-
-        if( type == Integer || type == Float ) {
-            if( str.isInteger() ) return str.toInteger()
-            if( str.isLong() ) return str.toLong()
-            if( str.isBigInteger() ) return str.toBigInteger()
-        }
-
-        if( type == Float ) {
-            if( str.isFloat() ) return str.toFloat()
-            if( str.isDouble() ) return str.toDouble()
-            if( str.isBigDecimal() ) return str.toBigDecimal()
-        }
-
-        if( type == Path ) {
-            return TypeHelper.asPathType(str)
-        }
-
-        return value
-    }
-
-    private static Object asType(Object value, ProcessInput param) {
-        try {
-            return TypeHelper.asType(value, param.type)
-        }
-        catch( GroovyCastException | UnsupportedOperationException e ) {
-            final actualType = value.getClass()
-            throw new IllegalArgumentException("Parameter `--${param.name}` with type ${Types.getName(param.type)} cannot be assigned to ${value} [${Types.getName(actualType)}]")
-        }
+        return result
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -119,6 +119,9 @@ class ProcessEntryHandler {
         final dsl = new OutputDsl()
         for( final name : outputNames )
             dsl.declare(name, { -> })
+        // disable the output directory -- report output files by
+        // their work directory path instead of publishing them
+        session.outputDir = null
         dsl.apply(session)
     }
 
@@ -153,7 +156,7 @@ class ProcessEntryHandler {
      * the command line and in the config to the declared process inputs.
      *
      * <p>Uses the same binding as the reusable static
-     * {@link #getProcessArguments(ProcessDef, Map, Path)}, passing the sibling
+     * {@link #getProcessArguments(ProcessDef, Map, ModuleSpec)}, passing the sibling
      * {@code meta.yml} resolved from the running script path so the existing
      * {@code module run} behavior (dot-params, type coercion from {@code meta.yml},
      * tuple assembly) is preserved exactly.
@@ -177,25 +180,10 @@ class ProcessEntryHandler {
      * per input channel (a tuple input becomes a {@code List} of its component values, e.g.
      * {@code [[id:'s1'], file(reads)]}). This is the reusable, instance-free form of the
      * {@code module run} param→channel binding: dot-notation params are folded into nested maps,
-     * legacy (V1) inputs are coerced using the input TYPES declared in the sibling module spec
-     * ({@code meta.yml}), and typed (V2) inputs are coerced from their declared
-     * {@link nextflow.script.params.v2.ProcessInput} type.
-     *
-     * @param processDef     the process whose inputs are bound
-     * @param params         the (possibly dotted) param map to bind by input name
-     * @param moduleSpecPath the sibling {@code meta.yml} path used to load input types for the
-     *                       legacy (V1) path; may be {@code null}/missing, in which case an empty
-     *                       type map is used (same as when the spec cannot be loaded)
-     * @return list of values to pass to {@link ProcessDef#run}, one per input channel
-     */
-    static List getProcessArguments(ProcessDef processDef, Map params, Path moduleSpecPath) {
-        return bindProcessArguments(processDef, getModuleSpecInputTypes(moduleSpecPath), params, params)
-    }
-
-    /**
-     * Variant of {@link #getProcessArguments(ProcessDef, Map, Path)} that takes an already-loaded
-     * {@link ModuleSpec} (no path round-trip), used by callers that already hold the spec (e.g.
-     * the agent tool bridge).
+     * legacy (V1) inputs are coerced using the input TYPES declared in the given module spec,
+     * and typed (V2) inputs are coerced from their declared
+     * {@link nextflow.script.params.v2.ProcessInput} type. Every value is treated as
+     * command-line text.
      *
      * @param processDef the process whose inputs are bound
      * @param params     the (possibly dotted) param map to bind by input name

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -39,12 +39,13 @@ import nextflow.util.RecordMap
 /**
  * Helper class for process entry execution feature.
  *
- * This feature enables direct execution of Nextflow processes without explicit workflows:
- * - Single process scripts run automatically: `nextflow run script.nf --param value`
- * - Multi-process scripts run the first process automatically: `nextflow run script.nf --param value`
- * - Command-line parameters are mapped directly to process inputs
- * - Process outputs are mapped to workflow outputs
- * - Supports the following process input qualifiers: val, path, tuple, each
+ * A script that defines a single process and no workflows can be executed
+ * directly, without an explicit entry workflow:
+ * {@code nextflow module run script.nf --param value}
+ *
+ * Command-line parameters are mapped to the process inputs, and the process
+ * outputs become the workflow outputs. Supports the following process input
+ * qualifiers: val, path, tuple, each
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
@@ -80,7 +81,7 @@ class ProcessEntryHandler {
             // Create the workflow execution logic
             final workflowExecutionClosure = { ->
                 // Map parameters to process inputs
-                final inputArgs = getProcessArguments(processDef, session.params)
+                final inputArgs = getProcessArguments(processDef)
                 // Execute the process
                 final output = processDef.run(inputArgs as Object[]) as ChannelOut
                 // Publish process outputs as workflow outputs
@@ -148,21 +149,27 @@ class ProcessEntryHandler {
     }
 
     /**
-     * Gets the input arguments for a process by mapping the session params to
-     * declared process inputs.
+     * Gets the input arguments for a process by mapping the params given on
+     * the command line and in the config to the declared process inputs.
      *
-     * <p>Delegates to the reusable static {@link #getProcessArguments(ProcessDef, Map, Path)}
-     * binding, passing the sibling {@code meta.yml} resolved from the running script path so
-     * the existing {@code module run} behavior (dot-params, type coercion from {@code meta.yml},
+     * <p>Uses the same binding as the reusable static
+     * {@link #getProcessArguments(ProcessDef, Map, Path)}, passing the sibling
+     * {@code meta.yml} resolved from the running script path so the existing
+     * {@code module run} behavior (dot-params, type coercion from {@code meta.yml},
      * tuple assembly) is preserved exactly.
+     *
+     * <p>A typed (V2) input is resolved from the command-line params, then the
+     * remaining params, in the same way as a pipeline param or a workflow
+     * input, since a command-line value is a string that must be parsed
+     * whereas a config or script value is already structured.
      *
      * @param processDef The ProcessDef object containing the process definition
      * @return List of parameter values to pass to the process
      */
-    protected List getProcessArguments(ProcessDef processDef, Map params) {
+    protected List getProcessArguments(ProcessDef processDef) {
         final scriptPath = script?.getBinding()?.getScriptPath()
         final moduleSpecPath = scriptPath?.resolveSibling(ModuleStorage.MODULE_MANIFEST_FILE)
-        return getProcessArguments(processDef, params, moduleSpecPath)
+        return bindProcessArguments(processDef, getModuleSpecInputTypes(moduleSpecPath), session.params ?: [:], session.cliParams ?: [:])
     }
 
     /**
@@ -182,7 +189,7 @@ class ProcessEntryHandler {
      * @return list of values to pass to {@link ProcessDef#run}, one per input channel
      */
     static List getProcessArguments(ProcessDef processDef, Map params, Path moduleSpecPath) {
-        return bindProcessArguments(processDef, params, getModuleSpecInputTypes(moduleSpecPath))
+        return bindProcessArguments(processDef, getModuleSpecInputTypes(moduleSpecPath), params, params)
     }
 
     /**
@@ -197,10 +204,18 @@ class ProcessEntryHandler {
      * @return list of values to pass to {@link ProcessDef#run}, one per input channel
      */
     static List getProcessArguments(ProcessDef processDef, Map params, ModuleSpec spec) {
-        return bindProcessArguments(processDef, params, spec != null ? moduleSpecInputTypes(spec) : Collections.<String,Class>emptyMap())
+        return bindProcessArguments(processDef, spec != null ? moduleSpecInputTypes(spec) : Collections.<String,Class>emptyMap(), params, params)
     }
 
-    private static List bindProcessArguments(ProcessDef processDef, Map params, Map<String,Class> paramTypes) {
+    /**
+     * @param processDef the process whose inputs are bound
+     * @param paramTypes the input types declared in the module spec, for the legacy (V1) path
+     * @param params     all param values, as structured by the config and the script
+     * @param cliParams  the param values given on the command line or in a params file,
+     *                   as raw strings; the same map as {@code params} when every value
+     *                   should be treated as such
+     */
+    private static List bindProcessArguments(ProcessDef processDef, Map<String,Class> paramTypes, Map params, Map cliParams) {
         try {
             log.debug "Getting input arguments for process: ${processDef.name}"
             log.debug "Session params: ${params}"
@@ -208,7 +223,7 @@ class ProcessEntryHandler {
             final config = processDef.getProcessConfig()
             final inputArgs = config instanceof ProcessConfigV1
                 ? getProcessArgumentsV1(config, params, paramTypes)
-                : getProcessArgumentsV2((ProcessConfigV2) config, params)
+                : getProcessArgumentsV2((ProcessConfigV2) config, params, cliParams)
 
             log.debug "Final input arguments: ${inputArgs}"
             return inputArgs
@@ -299,13 +314,13 @@ class ProcessEntryHandler {
     /**
      * Gets the appropriate value for a legacy process input.
      *
-     * @param param Input declaration
+     * @param decl Input declaration
      * @param namedArgs Map of command-line arguments
      * @param paramTypes Map of input types from module spec
      * @return Properly typed value for the input
      */
-    private static Object getValueForInputV1(InParam param, Map namedArgs, Map<String,Class> paramTypes) {
-        final name = param.getName()
+    private static Object getValueForInputV1(InParam decl, Map namedArgs, Map<String,Class> paramTypes) {
+        final name = decl.getName()
         final type = paramTypes.get(name)
         final value = namedArgs.get(name)
 
@@ -315,7 +330,7 @@ class ProcessEntryHandler {
         // tools, an optional path input is skipped by supplying nothing at all, not by
         // supplying the option with an empty value. An empty value therefore falls through to
         // `file('')`, which fails loudly.
-        if( param instanceof FileInParam ) {
+        if( decl instanceof FileInParam ) {
             if( value == null ) {
                 log.warn "Path input '--${name}' not provided, defaulting to empty list"
                 return []
@@ -328,7 +343,7 @@ class ProcessEntryHandler {
             throw new IllegalArgumentException("Missing required parameter: --${name}")
 
         // handle env, stdin inputs
-        switch( param ) {
+        switch( decl ) {
             case EnvInParam:
                 throw new IllegalArgumentException("Process `env` input qualifier is not supported by implicit process entry")
 
@@ -372,7 +387,7 @@ class ProcessEntryHandler {
         return str
     }
 
-    private static List getProcessArgumentsV2(ProcessConfigV2 config, Map params) {
+    private static List getProcessArgumentsV2(ProcessConfigV2 config, Map params, Map cliParams) {
         final declaredInputs = config.getInputs().getParams()
 
         if( declaredInputs.isEmpty() ) {
@@ -385,7 +400,7 @@ class ProcessEntryHandler {
             if( param instanceof ProcessTupleInput && param.getType() == Record.class ) {
                 final Map<String,Object> recordFields = [:]
                 for( final innerParam : param.getComponents() ) {
-                    final value = getValueForInputV2(innerParam, params)
+                    final value = getValueForInputV2(innerParam, params, cliParams)
                     recordFields.put(innerParam.getName(), value)
                 }
                 arguments.add(new RecordMap(recordFields))
@@ -393,13 +408,13 @@ class ProcessEntryHandler {
             else if( param instanceof ProcessTupleInput ) {
                 final List tupleElements = []
                 for( final innerParam : param.getComponents() ) {
-                    final value = getValueForInputV2(innerParam, params)
+                    final value = getValueForInputV2(innerParam, params, cliParams)
                     tupleElements.add(value)
                 }
                 arguments.add(tupleElements)
             }
             else {
-                final value = getValueForInputV2(param, params)
+                final value = getValueForInputV2(param, params, cliParams)
                 arguments.add(value)
             }
         }
@@ -413,25 +428,32 @@ class ProcessEntryHandler {
      * A typed input is resolved in the same way as a pipeline parameter,
      * so that a process and a workflow accept the same command line.
      *
-     * @param param Input declaration
-     * @param namedArgs Map of command-line arguments
+     * @param decl Input declaration
+     * @param params All param values, as structured by the config and the script
+     * @param cliParams The param values given on the command line or in a params file
      * @return Properly typed value for the input
      */
-    private static Object getValueForInputV2(ProcessInput param, Map namedArgs) {
-        final name = param.getName()
-        final value = namedArgs.get(name)
+    private static Object getValueForInputV2(ProcessInput decl, Map params, Map cliParams) {
+        final name = decl.getName()
+        final type = decl.getType()
+        final decl = new Param(name, type, decl.isOptional(), null)
 
-        if( value == null ) {
-            if( param.isOptional() )
+        final cliValue = cliParams.get(name)
+        final value = params.get(name)
+
+        if( cliValue == null && value == null ) {
+            if( decl.isOptional() )
                 return null
             throw new IllegalArgumentException("Missing required parameter: --${name}")
         }
 
-        final type = param.getType()
-        final result = ParamsHelper.resolveFromCli(new Param(name, type, param.isOptional(), null), value)
+        // a command-line value is a string that must be parsed, whereas a
+        // config or script value is already structured
+        final result = cliValue != null
+            ? ParamsHelper.resolveFromCli(decl, cliValue)
+            : ParamsHelper.resolveFromCode(decl, value)
 
-        // report a value that could not be converted, instead of passing
-        // an ill-typed value to the task
+        // report a value that could not be converted
         final actualType = result?.getClass()
         if( type != null && actualType != null && !ParamsHelper.isAssignableFrom(type, actualType) )
             throw new IllegalArgumentException("Parameter `--${name}` with type ${Types.getName(type)} cannot be assigned to ${result} [${Types.getName(actualType)}]")

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -428,15 +428,15 @@ class ProcessEntryHandler {
      * A typed input is resolved in the same way as a pipeline parameter,
      * so that a process and a workflow accept the same command line.
      *
-     * @param decl Input declaration
+     * @param input Input declaration
      * @param params All param values, as structured by the config and the script
      * @param cliParams The param values given on the command line or in a params file
      * @return Properly typed value for the input
      */
-    private static Object getValueForInputV2(ProcessInput decl, Map params, Map cliParams) {
-        final name = decl.getName()
-        final type = decl.getType()
-        final decl = new Param(name, type, decl.isOptional(), null)
+    private static Object getValueForInputV2(ProcessInput input, Map params, Map cliParams) {
+        final name = input.getName()
+        final type = input.getType()
+        final decl = new Param(name, type, input.isOptional(), null)
 
         final cliValue = cliParams.get(name)
         final value = params.get(name)

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -63,10 +63,9 @@ class ProcessEntryHandler {
         this.session = session
 
         final processNames = meta.getLocalProcessNames()
-        if( processNames.isEmpty() )
-            throw new IllegalStateException("No processes found for automatic execution")
+        if( processNames.size() != 1 )
+            throw new IllegalStateException("Direct execution of processes is only supported for scripts with exactly one process")
 
-        // Always pick the first process (whether single or multiple processes)
         final processName = processNames.first()
         this.processDef = meta.getProcess(processName)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -171,8 +171,7 @@ class ProcessEntryHandler {
      */
     protected List getProcessArguments(ProcessDef processDef) {
         final scriptPath = script?.getBinding()?.getScriptPath()
-        final moduleSpecPath = scriptPath?.resolveSibling(ModuleStorage.MODULE_MANIFEST_FILE)
-        return bindProcessArguments(processDef, getModuleSpecInputTypes(moduleSpecPath), session.params ?: [:], session.cliParams ?: [:])
+        return bindProcessArguments(processDef, getModuleSpecInputTypes(scriptPath), session.params ?: [:], session.cliParams ?: [:])
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -327,7 +327,7 @@ class ProcessEntryHandler {
 
         // non-file inputs: a missing value is a hard error (required)
         if( value == null )
-            throw new IllegalArgumentException("Missing required parameter: --${name}")
+            throw new IllegalArgumentException("Parameter `--${name}` is required but no value was provided")
 
         // handle env, stdin inputs
         switch( decl ) {
@@ -425,20 +425,18 @@ class ProcessEntryHandler {
         final type = input.getType()
         final decl = new Param(name, type, input.isOptional(), null)
 
-        final cliValue = cliParams.get(name)
-        final value = params.get(name)
-
-        if( cliValue == null && value == null ) {
-            if( decl.isOptional() )
-                return null
-            throw new IllegalArgumentException("Missing required parameter: --${name}")
-        }
-
         // a command-line value is a string that must be parsed, whereas a
         // config or script value is already structured
-        final result = cliValue != null
-            ? ParamsHelper.resolveFromCli(decl, cliValue)
-            : ParamsHelper.resolveFromCode(decl, value)
+        final result =
+            cliParams.containsKey(name) ? ParamsHelper.resolveFromCli(decl, cliParams.get(name)) :
+            params.containsKey(name) ? ParamsHelper.resolveFromCode(decl, params.get(name)) :
+            null
+
+        if( result == null ) {
+            if( decl.isOptional() )
+                return null
+            throw new IllegalArgumentException("Parameter `--${name}` is required but no value was provided")
+        }
 
         // report a value that could not be converted
         final actualType = result?.getClass()

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -304,6 +304,21 @@ class ScriptMeta {
     }
 
     /**
+     * Check if this script has a named workflow that can be executed
+     * automatically without an explicit entry workflow.
+     *
+     * @return true if the script has exactly one named workflow
+     */
+    boolean hasExecutableWorkflows() {
+        // Don't allow execution of true modules (those are meant for inclusion)
+        if( isModule() )
+            return false
+
+        // Must have exactly one workflow
+        return getLocalWorkflowNames().size() == 1
+    }
+
+    /**
      * Check if this script has standalone processes that can be executed
      * automatically without requiring workflows
      *

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -336,6 +336,21 @@ class ScriptMeta {
     }
 
     /**
+     * Check if this script has a named workflow that can be executed
+     * automatically without an explicit entry workflow.
+     *
+     * @return true if the script has exactly one named workflow
+     */
+    boolean hasExecutableWorkflows() {
+        // Don't allow execution of true modules (those are meant for inclusion)
+        if( isModule() )
+            return false
+
+        // Must have exactly one workflow
+        return getLocalWorkflowNames().size() == 1
+    }
+
+    /**
      * Check if this script has standalone processes that can be executed
      * automatically without requiring workflows
      *

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptMeta.groovy
@@ -346,28 +346,31 @@ class ScriptMeta {
         if( isModule() )
             return false
 
+        // Must not have any process definitions
+        if( !getLocalProcessNames().isEmpty() )
+            return false
+
         // Must have exactly one workflow
         return getLocalWorkflowNames().size() == 1
     }
 
     /**
-     * Check if this script has standalone processes that can be executed
+     * Check if this script has a standalone process that can be executed
      * automatically without requiring workflows
      *
-     * @return true if the script has one or more processes and no workflows
+     * @return true if the script has exactly one process and no workflows
      */
     boolean hasExecutableProcesses() {
         // Don't allow execution of true modules (those are meant for inclusion)
         if( isModule() )
             return false
 
-        // Must have at least one process
-        final processNames = getLocalProcessNames()
-        if( processNames.isEmpty() )
+        // Must not have any workflow definitions
+        if( !getLocalWorkflowNames().isEmpty() )
             return false
 
-        // Must not have any workflow definitions (including unnamed workflow)
-        return getLocalWorkflowNames().isEmpty()
+        // Must have exactly one process
+        return getLocalProcessNames().size() == 1
     }
 
     void addModule(BaseScript script, String name, String alias) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
@@ -40,6 +40,8 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
 
     private List<String> declaredInputs
 
+    private Map<String,Class> declaredInputTypes
+
     private List<String> declaredOutputs
 
     private Set<String> variableNames
@@ -64,6 +66,7 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
         this.body = copy.call()
         // now it can access the parameters
         this.declaredInputs = new ArrayList<>(resolver.getTakes())
+        this.declaredInputTypes = new HashMap<>(resolver.getTakeTypes())
         this.declaredOutputs = new ArrayList<>(resolver.getEmits())
         this.variableNames = getVarNames0()
     }
@@ -101,6 +104,8 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
     @PackageScope BodyDef getBody() { body }
 
     @PackageScope List<String> getDeclaredInputs() { declaredInputs }
+
+    @PackageScope Map<String,Class> getDeclaredInputTypes() { declaredInputTypes }
 
     @PackageScope List<String> getDeclaredOutputs() { declaredOutputs }
 
@@ -222,14 +227,20 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
 @CompileStatic
 class WorkflowParamsDsl {
 
-    private static final String TAKE = '_take_'
-    private static final String EMIT = '_emit_'
-
     List<String> takes = new ArrayList<>(10)
+    Map<String,Class> takeTypes = new HashMap<>()
     List<String> emits = new ArrayList<>(10)
 
-    void _take_(String name) {
+    /**
+     * Called by generated code for each workflow take parameter.
+     *
+     * @param name the parameter name
+     * @param type the parameter type (may be Object for untyped workflows)
+     */
+    void _take_(String name, Class type = null) {
         takes.add(name)
+        if( type != null && type != Object )
+            takeTypes.put(name, type)
     }
 
     void _emit_(String name) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.script
 
+import java.lang.reflect.Type
+
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
@@ -38,9 +40,7 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
 
     private BodyDef body
 
-    private List<String> declaredInputs
-
-    private Map<String,Class> declaredInputTypes
+    private List<Param> declaredInputs
 
     private List<String> declaredOutputs
 
@@ -66,7 +66,6 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
         this.body = copy.call()
         // now it can access the parameters
         this.declaredInputs = new ArrayList<>(resolver.getTakes())
-        this.declaredInputTypes = new HashMap<>(resolver.getTakeTypes())
         this.declaredOutputs = new ArrayList<>(resolver.getEmits())
         this.variableNames = getVarNames0()
     }
@@ -103,9 +102,7 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
 
     @PackageScope BodyDef getBody() { body }
 
-    @PackageScope List<String> getDeclaredInputs() { declaredInputs }
-
-    @PackageScope Map<String,Class> getDeclaredInputTypes() { declaredInputTypes }
+    @PackageScope List<Param> getDeclaredInputs() { declaredInputs }
 
     @PackageScope List<String> getDeclaredOutputs() { declaredOutputs }
 
@@ -119,7 +116,7 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
         def variableNames = body.getValNames()
         if( variableNames ) {
             Set<String> declaredNames = []
-            declaredNames.addAll( declaredInputs )
+            declaredNames.addAll( declaredInputs*.name )
             if( declaredNames )
                 variableNames = variableNames - declaredNames
         }
@@ -136,7 +133,7 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
 
         // attach declared inputs with the invocation arguments
         for( int i=0; i< declaredInputs.size(); i++ ) {
-            final name = declaredInputs[i]
+            final name = declaredInputs[i].name
             context.setProperty( name, params[i] )
         }
     }
@@ -227,20 +224,22 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
 @CompileStatic
 class WorkflowParamsDsl {
 
-    List<String> takes = new ArrayList<>(10)
-    Map<String,Class> takeTypes = new HashMap<>()
+    List<Param> takes = new ArrayList<>(10)
     List<String> emits = new ArrayList<>(10)
 
     /**
      * Called by generated code for each workflow take parameter.
      *
-     * @param name the parameter name
-     * @param type the parameter type (may be Object for untyped workflows)
+     * @param name     the parameter name
+     * @param clazz    the hidden class holding the declared take types,
+     *                 or null for an untyped workflow (see ScriptToGroovyVisitor)
+     * @param optional whether the parameter type is nullable
      */
-    void _take_(String name, Class type = null) {
-        takes.add(name)
-        if( type != null && type != Object )
-            takeTypes.put(name, type)
+    void _take_(String name, Class clazz = null, boolean optional = false) {
+        final type = clazz != null
+            ? clazz.getField(name).getGenericType()
+            : null
+        takes.add(new Param(name, type != Object ? type : null, optional, null))
     }
 
     void _emit_(String name) {

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script
+
+import java.nio.file.Path
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import groovy.yaml.YamlSlurper
+import nextflow.Session
+import nextflow.dataflow.ChannelNamespace
+import nextflow.exception.ScriptRuntimeException
+import nextflow.file.FileHelper
+import nextflow.script.types.Channel
+import nextflow.script.types.Value
+import nextflow.splitter.CsvSplitter
+import nextflow.util.TypeHelper
+
+/**
+ * Helper class for named workflow execution.
+ *
+ * This feature enables direct execution of a named workflow without
+ * an explicit entry workflow:
+ * - Scripts with a single named workflow run it automatically:
+ *   {@code nextflow run script.nf --param value}
+ * - Command-line parameters are mapped directly to workflow inputs ({@code take:})
+ * - Inputs of collection type are loaded from samplesheet files (CSV, JSON, YAML)
+ * - Non-collection inputs are passed through as values
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+class WorkflowEntryHandler {
+
+    private final BaseScript script
+    private final Session session
+    private final WorkflowDef workflowDef
+
+    WorkflowEntryHandler(BaseScript script, Session session, ScriptMeta meta) {
+        this.script = script
+        this.session = session
+
+        final workflowNames = meta.getLocalWorkflowNames()
+        if( workflowNames.size() != 1 )
+            throw new IllegalStateException("Direct execution of named workflows is only supported for scripts with exactly one named workflow")
+
+        if( !script.isTypingEnabled() )
+            throw new IllegalStateException("Direct execution of named workflows is only supported when static typing is enabled")
+
+        final workflowName = workflowNames.first()
+        this.workflowDef = meta.getWorkflow(workflowName)
+    }
+
+    /**
+     * Creates an entry workflow that calls the selected named workflow.
+     *
+     * Parameters are automatically mapped to workflow inputs, with
+     * collection-typed inputs loaded from samplesheet files.
+     *
+     * Workflow emits are published as pipeline outputs, without creating
+     * an output directory.
+     */
+    WorkflowDef createEntryWorkflow() {
+        final workflowName = workflowDef.name
+        final entryBody = { ->
+            final entryExecutionClosure = { ->
+                // Map parameters to workflow inputs
+                final inputs = getWorkflowArguments(workflowDef, session.params)
+                // Execute the named workflow
+                final output = workflowDef.run(inputs as Object[]) as ChannelOut
+                // Publish workflow emits as pipeline outputs
+                assignOutputs(output)
+                publishOutputs()
+                return output
+            }
+            final sourceCode = "    // Auto-generated workflow entry\n    ${workflowName}(...)"
+            return new BodyDef(entryExecutionClosure, sourceCode, 'workflow')
+        }
+        return new WorkflowDef(script, entryBody)
+    }
+
+    private void assignOutputs(ChannelOut output) {
+        final outputNames = workflowDef.getDeclaredOutputs()
+        final dsl = script.getBinding()
+        if( output.size() == 1 && outputNames.size() == 1 ) {
+            dsl._publish_(outputNames.first(), output[0])
+        }
+        else {
+            for( final name : outputNames )
+                dsl._publish_(name, output.getProperty(name))
+        }
+    }
+
+    // TODO: disable output directory so that workflow output is produced without
+    // actually copying files to output directory
+    private void publishOutputs() {
+        final outputNames = workflowDef.getDeclaredOutputs()
+        final dsl = new OutputDsl()
+        for( final name : outputNames )
+            dsl.declare(name, { -> })
+        dsl.apply(session)
+    }
+
+    /**
+     * Resolves the workflow input arguments from the current session params.
+     *
+     * For each declared input ({@code take:} parameter) of the named workflow:
+     * - If the input is typed as {@code Channel<T>}, the param value is resolved
+     *   as a samplesheet path or collection and loaded into a channel
+     * - If the param value is a collection, it is loaded into a channel via
+     *   {@code channel.fromList()}
+     * - If the param value is a string path to a samplesheet (CSV, JSON, YAML),
+     *   the file is loaded and its contents are emitted as a channel
+     * - Otherwise the value is passed directly as a workflow variable
+     *
+     * @param workflowDef
+     * @param params
+     */
+    private List getWorkflowArguments(WorkflowDef workflowDef, Map params) {
+        final inputs = workflowDef.getDeclaredInputs()
+        final inputTypes = workflowDef.getDeclaredInputTypes()
+
+        log.debug "Getting input arguments for workflow: ${workflowDef.name}"
+        log.debug "Session params: ${params}"
+
+        final arguments = []
+        for( final name : inputs ) {
+            final value = params.get(name)
+            if( value == null && !params.containsKey(name) )
+                throw new ScriptRuntimeException("Workflow `${workflowDef.name}` requires input `${name}` but no parameter `--${name}` was provided")
+
+            final type = inputTypes.get(name)
+            arguments.add(resolveInput(name, type, value))
+        }
+
+        log.debug "Final input arguments: ${arguments}"
+        return arguments
+    }
+
+    /**
+     * Resolves a single workflow input value.
+     *
+     * When the declared type is {@code Channel} (or a subtype), the value is
+     * always resolved to a channel — either by loading a samplesheet file or by
+     * wrapping an existing collection with {@code channel.fromList()}.
+     *
+     * For other (or unknown) types the value is passed through as-is, unless it
+     * happens to be a collection or a samplesheet path, in which case a channel
+     * is also created (heuristic fallback for untyped workflows).
+     *
+     * @param name  the input name (for error messages)
+     * @param type  the declared type of the input, or {@code null} if untyped
+     * @param value the raw param value
+     * @return a {@code ChannelImpl} if the value resolves to a channel, or the
+     *         raw value for scalar inputs
+     */
+    protected Object resolveInput(String name, Class type, Object value) {
+        if( value == null )
+            return value
+
+        // TODO: need to generate __Params class to preserve input types
+        if( type == Channel ) {
+            if( value instanceof Collection ) {
+                return ChannelNamespace.fromList((Collection)value)
+            }
+            if( value instanceof String ) {
+                final path = FileHelper.asPath(value)
+                return ChannelNamespace.fromList(loadFromFile(name, path))
+            }
+            throw new ScriptRuntimeException("Workflow input `${name}` expects a Channel but received: ${value} [${value.class.simpleName}]")
+        }
+
+        if( type == Value ) {
+            return ChannelNamespace.value(value)
+        }
+
+        if( value !instanceof String )
+            return TypeHelper.asType(value, type)
+
+        final str = (String) value
+
+        if( type == Boolean ) {
+            if( str.toLowerCase() == 'true' ) return Boolean.TRUE
+            if( str.toLowerCase() == 'false' ) return Boolean.FALSE
+        }
+
+        if( type == Integer || type == Float ) {
+            if( str.isInteger() ) return str.toInteger()
+            if( str.isLong() ) return str.toLong()
+        }
+
+        if( type == Float ) {
+            if( str.isFloat() ) return str.toFloat()
+            if( str.isDouble() ) return str.toDouble()
+        }
+
+        if( type == Path ) {
+            return TypeHelper.asPathType(str)
+        }
+
+        return value
+    }
+
+    /**
+     * Loads the contents of a samplesheet file as a list of records.
+     *
+     * Supported formats:
+     * - CSV: header row required, comma-separated
+     * - JSON: must be a top-level array
+     * - YAML / YML: must be a top-level sequence
+     *
+     * @param name the input name (for error messages)
+     * @param file the samplesheet file to load
+     * @return a list of raw records (maps)
+     */
+    protected List loadFromFile(String name, Path file) {
+        final ext = file.getExtension()
+        final value = switch( ext ) {
+            case 'csv'         -> new CsvSplitter().options(header: true, sep: ',').target(file).list()
+            case 'json'        -> new JsonSlurper().parse(file)
+            case 'yaml', 'yml' -> new YamlSlurper().parse(file)
+            default -> throw new ScriptRuntimeException("Unrecognized file format '${ext}' for input file '${file}' for workflow input `${name}` -- should be CSV, JSON, or YAML")
+        }
+        if( value !instanceof List )
+            throw new ScriptRuntimeException("Input file '${file}' for workflow input `${name}` must contain a list of records, but got: ${value.class.simpleName}")
+        return (List)value
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -154,16 +154,16 @@ class WorkflowEntryHandler {
         final arguments = []
         for( final decl : inputs ) {
             final name = decl.name
-            final cliValue = cliParams.get(name)
-            final configValue = configParams.get(name)
-            if( cliValue != null )
-                arguments.add(resolveInput(decl, cliValue, true))
-            else if( configValue != null )
-                arguments.add(resolveInput(decl, configValue, false))
-            else if( decl.optional )
-                arguments.add(null)
-            else
-                throw new ScriptRuntimeException("Workflow `${workflowDef.name}` requires input `${name}` but no parameter `--${name}` was provided")
+            final value =
+                cliParams.containsKey(name) ? resolveInput(decl, cliParams.get(name), true) :
+                configParams.containsKey(name) ? resolveInput(decl, configParams.get(name), false) :
+                null
+
+            if( value == null && !decl.optional ) {
+                throw new ScriptRuntimeException("Parameter `--${name}` is required but no value was provided")
+            }
+
+            arguments.add(value)
         }
         return arguments
     }
@@ -267,7 +267,7 @@ class WorkflowEntryHandler {
     protected List loadFromFile(String name, Path file) {
         final ext = file.getExtension()
         final value = switch( ext ) {
-            case 'csv'         -> new CsvSplitter().options(header: true, sep: ',').target(file).list()
+            case 'csv'         -> loadFromCsv(file)
             case 'json'        -> new JsonSlurper().parse(file)
             case 'yaml', 'yml' -> new YamlSlurper().parse(file)
             default -> throw new ScriptRuntimeException("Unrecognized file format '${ext}' for input file '${file}' for workflow input `${name}` -- should be CSV, JSON, or YAML")
@@ -275,6 +275,18 @@ class WorkflowEntryHandler {
         if( value !instanceof List )
             throw new ScriptRuntimeException("Input file '${file}' for workflow input `${name}` must contain a list of records, but got: ${value.class.simpleName}")
         return (List)value
+    }
+
+    /**
+     * Loads a CSV samplesheet as a list of records.
+     *
+     * @param file
+     */
+    private static List loadFromCsv(Path file) {
+        final rows = new CsvSplitter().options(header: true, sep: ',').target(file).list()
+        return rows.collect { row ->
+            ((Map)row).collectEntries { k, v -> [ k, v != '' ? v : null ] }
+        }
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -107,13 +107,14 @@ class WorkflowEntryHandler {
         }
     }
 
-    // TODO: disable output directory so that workflow output is produced without
-    // actually copying files to output directory
     private void publishOutputs() {
         final outputNames = workflowDef.getDeclaredOutputs()
         final dsl = new OutputDsl()
         for( final name : outputNames )
             dsl.declare(name, { -> })
+        // disable the output directory -- report output files by
+        // their work directory path instead of publishing them
+        session.outputDir = null
         dsl.apply(session)
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -27,7 +27,6 @@ import groovy.yaml.YamlSlurper
 import nextflow.Session
 import nextflow.dataflow.ChannelNamespace
 import nextflow.exception.ScriptRuntimeException
-import nextflow.file.FileHelper
 import nextflow.script.dsl.Types
 import nextflow.script.types.Channel
 import nextflow.script.types.Value
@@ -37,13 +36,16 @@ import nextflow.util.TypeHelper
 /**
  * Helper class for named workflow execution.
  *
- * This feature enables direct execution of a named workflow without
- * an explicit entry workflow:
- * - Scripts with a single named workflow run it automatically:
- *   {@code nextflow run script.nf --param value}
- * - Command-line parameters are mapped directly to workflow inputs ({@code take:})
- * - Inputs of collection type are loaded from samplesheet files (CSV, JSON, YAML)
- * - Non-collection inputs are passed through as values
+ * A script that defines a single named workflow and no processes can be
+ * executed directly, without an explicit entry workflow:
+ * {@code nextflow module run script.nf --param value}
+ *
+ * Each input ({@code take:}) becomes a pipeline parameter of the same name,
+ * and its declared type determines how the param value is interpreted -- a
+ * {@code Channel<E>} input is loaded from a samplesheet file (CSV, JSON,
+ * YAML), while any other input is converted to the declared type. The
+ * workflow emits are printed to standard output, without publishing them
+ * to an output directory.
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
@@ -63,11 +65,17 @@ class WorkflowEntryHandler {
         if( workflowNames.size() != 1 )
             throw new IllegalStateException("Direct execution of named workflows is only supported for scripts with exactly one named workflow")
 
-        if( !script.isTypingEnabled() )
-            throw new ScriptRuntimeException("Workflow `${workflowNames.first()}` cannot be executed directly because it is not typed -- static typing is required to map pipeline parameters to workflow inputs")
-
         final workflowName = workflowNames.first()
+        if( !script.isTypingEnabled() )
+            throw new ScriptRuntimeException("Workflow `${workflowName}` cannot be executed directly because it is not typed -- static typing is required to map pipeline parameters to workflow inputs")
+
         this.workflowDef = meta.getWorkflow(workflowName)
+
+        // every input must be typed, because the declared type determines
+        // how the corresponding param value is interpreted
+        final untyped = workflowDef.getDeclaredInputs().findAll { decl -> decl.type == null }*.name
+        if( untyped )
+            throw new ScriptRuntimeException("Workflow `${workflowName}` cannot be executed directly because the following inputs are not typed: ${untyped.join(', ')}")
     }
 
     /**
@@ -174,10 +182,6 @@ class WorkflowEntryHandler {
         if( value == null )
             return null
 
-        // an untyped input is passed through as-is
-        if( decl.type == null )
-            return value
-
         final rawType = TypeHelper.getRawType(decl.type)
 
         if( rawType == Channel )
@@ -215,7 +219,7 @@ class WorkflowEntryHandler {
 
         final path = value instanceof Path
             ? (Path)value
-            : FileHelper.asPath(value.toString())
+            : TypeHelper.asPathType(value.toString())
         final elementType = elementDecl(decl).type
         return loadFromFile(decl.name, path).collect { el -> TypeHelper.asType(el, elementType) }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -64,7 +64,7 @@ class WorkflowEntryHandler {
             throw new IllegalStateException("Direct execution of named workflows is only supported for scripts with exactly one named workflow")
 
         if( !script.isTypingEnabled() )
-            throw new IllegalStateException("Direct execution of named workflows is only supported when static typing is enabled")
+            throw new ScriptRuntimeException("Workflow `${workflowNames.first()}` cannot be executed directly because it is not typed -- static typing is required to map pipeline parameters to workflow inputs")
 
         final workflowName = workflowNames.first()
         this.workflowDef = meta.getWorkflow(workflowName)

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -29,6 +29,7 @@ import nextflow.dataflow.ChannelNamespace
 import nextflow.exception.ScriptRuntimeException
 import nextflow.script.dsl.Types
 import nextflow.script.types.Channel
+import nextflow.script.types.Record
 import nextflow.script.types.Value
 import nextflow.splitter.CsvSplitter
 import nextflow.util.TypeHelper
@@ -153,10 +154,12 @@ class WorkflowEntryHandler {
         final arguments = []
         for( final decl : inputs ) {
             final name = decl.name
-            if( cliParams.containsKey(name) )
-                arguments.add(resolveInput(decl, cliParams.get(name), true))
-            else if( configParams.containsKey(name) )
-                arguments.add(resolveInput(decl, configParams.get(name), false))
+            final cliValue = cliParams.get(name)
+            final configValue = configParams.get(name)
+            if( cliValue != null )
+                arguments.add(resolveInput(decl, cliValue, true))
+            else if( configValue != null )
+                arguments.add(resolveInput(decl, configValue, false))
             else if( decl.optional )
                 arguments.add(null)
             else
@@ -221,7 +224,19 @@ class WorkflowEntryHandler {
             ? (Path)value
             : TypeHelper.asPathType(value.toString())
         final elementType = elementDecl(decl).type
-        return loadFromFile(decl.name, path).collect { el -> TypeHelper.asType(el, elementType) }
+        final elementRawType = TypeHelper.getRawType(elementType)
+
+        if( !Map.isAssignableFrom(elementRawType) && !Record.isAssignableFrom(elementRawType) )
+            throw new ScriptRuntimeException("Workflow input `${decl.name}` with type ${Types.getName(decl.type)} cannot be loaded from a samplesheet -- the element type should be Map, Record, or a record type")
+
+        return loadFromFile(decl.name, path).collect { el ->
+            try {
+                TypeHelper.asType(el, elementType)
+            }
+            catch( Exception e ) {
+                throw new ScriptRuntimeException("Invalid record in samplesheet '${path}' for workflow input `${decl.name}` -- ${e.message}")
+            }
+        }
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowEntryHandler.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.script
 
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 import java.nio.file.Path
 
 import groovy.json.JsonSlurper
@@ -26,6 +28,7 @@ import nextflow.Session
 import nextflow.dataflow.ChannelNamespace
 import nextflow.exception.ScriptRuntimeException
 import nextflow.file.FileHelper
+import nextflow.script.dsl.Types
 import nextflow.script.types.Channel
 import nextflow.script.types.Value
 import nextflow.splitter.CsvSplitter
@@ -81,7 +84,7 @@ class WorkflowEntryHandler {
         final entryBody = { ->
             final entryExecutionClosure = { ->
                 // Map parameters to workflow inputs
-                final inputs = getWorkflowArguments(workflowDef, session.params)
+                final inputs = getWorkflowArguments(workflowDef)
                 // Execute the named workflow
                 final output = workflowDef.run(inputs as Object[]) as ChannelOut
                 // Publish workflow emits as pipeline outputs
@@ -121,101 +124,113 @@ class WorkflowEntryHandler {
     /**
      * Resolves the workflow input arguments from the current session params.
      *
-     * For each declared input ({@code take:} parameter) of the named workflow:
-     * - If the input is typed as {@code Channel<T>}, the param value is resolved
-     *   as a samplesheet path or collection and loaded into a channel
-     * - If the param value is a collection, it is loaded into a channel via
-     *   {@code channel.fromList()}
-     * - If the param value is a string path to a samplesheet (CSV, JSON, YAML),
-     *   the file is loaded and its contents are emitted as a channel
-     * - Otherwise the value is passed directly as a workflow variable
+     * Each declared input ({@code take:} parameter) of the named workflow becomes
+     * a pipeline parameter of the same name, and the declared type determines how
+     * the parameter value is interpreted. This is the same mapping performed by
+     * the {@code params} block for an entry workflow.
      *
      * @param workflowDef
-     * @param params
      */
-    private List getWorkflowArguments(WorkflowDef workflowDef, Map params) {
+    protected List getWorkflowArguments(WorkflowDef workflowDef) {
         final inputs = workflowDef.getDeclaredInputs()
-        final inputTypes = workflowDef.getDeclaredInputTypes()
+        final inputNames = inputs*.name
+        final cliParams = session.cliParams ?: [:]
+        final configParams = session.configParams ?: [:]
 
-        log.debug "Getting input arguments for workflow: ${workflowDef.name}"
-        log.debug "Session params: ${params}"
-
-        final arguments = []
-        for( final name : inputs ) {
-            final value = params.get(name)
-            if( value == null && !params.containsKey(name) )
-                throw new ScriptRuntimeException("Workflow `${workflowDef.name}` requires input `${name}` but no parameter `--${name}` was provided")
-
-            final type = inputTypes.get(name)
-            arguments.add(resolveInput(name, type, value))
+        for( final name : cliParams.keySet() ) {
+            if( name !in inputNames && !configParams.containsKey(name) )
+                throw new ScriptRuntimeException("Parameter `${name}` was specified on the command line but is not an input of workflow `${workflowDef.name}`")
         }
 
-        log.debug "Final input arguments: ${arguments}"
+        final arguments = []
+        for( final decl : inputs ) {
+            final name = decl.name
+            if( cliParams.containsKey(name) )
+                arguments.add(resolveInput(decl, cliParams.get(name), true))
+            else if( configParams.containsKey(name) )
+                arguments.add(resolveInput(decl, configParams.get(name), false))
+            else if( decl.optional )
+                arguments.add(null)
+            else
+                throw new ScriptRuntimeException("Workflow `${workflowDef.name}` requires input `${name}` but no parameter `--${name}` was provided")
+        }
         return arguments
     }
 
     /**
-     * Resolves a single workflow input value.
+     * Resolves a single workflow input value against its declared type.
      *
-     * When the declared type is {@code Channel} (or a subtype), the value is
-     * always resolved to a channel — either by loading a samplesheet file or by
-     * wrapping an existing collection with {@code channel.fromList()}.
+     * A {@code Channel<E>} input is loaded from a samplesheet file, with each
+     * record converted to the element type. A {@code Value<V>} input is
+     * converted to {@code V} and wrapped in a value channel. Any other input is
+     * converted directly to the declared type.
      *
-     * For other (or unknown) types the value is passed through as-is, unless it
-     * happens to be a collection or a samplesheet path, in which case a channel
-     * is also created (heuristic fallback for untyped workflows).
-     *
-     * @param name  the input name (for error messages)
-     * @param type  the declared type of the input, or {@code null} if untyped
-     * @param value the raw param value
-     * @return a {@code ChannelImpl} if the value resolves to a channel, or the
-     *         raw value for scalar inputs
+     * @param decl    the declared input
+     * @param value   the raw param value
+     * @param fromCli whether the value came from the command line (and is
+     *                therefore a string that may need to be parsed)
      */
-    protected Object resolveInput(String name, Class type, Object value) {
+    protected Object resolveInput(Param decl, Object value, boolean fromCli) {
         if( value == null )
+            return null
+
+        // an untyped input is passed through as-is
+        if( decl.type == null )
             return value
 
-        // TODO: need to generate __Params class to preserve input types
-        if( type == Channel ) {
-            if( value instanceof Collection ) {
-                return ChannelNamespace.fromList((Collection)value)
-            }
-            if( value instanceof String ) {
-                final path = FileHelper.asPath(value)
-                return ChannelNamespace.fromList(loadFromFile(name, path))
-            }
-            throw new ScriptRuntimeException("Workflow input `${name}` expects a Channel but received: ${value} [${value.class.simpleName}]")
-        }
+        final rawType = TypeHelper.getRawType(decl.type)
 
-        if( type == Value ) {
-            return ChannelNamespace.value(value)
-        }
+        if( rawType == Channel )
+            return ChannelNamespace.fromList(loadChannelInput(decl, value))
 
-        if( value !instanceof String )
-            return TypeHelper.asType(value, type)
+        if( rawType == Value )
+            return ChannelNamespace.value(resolveScalarInput(elementDecl(decl), value, fromCli))
 
-        final str = (String) value
+        return resolveScalarInput(decl, value, fromCli)
+    }
 
-        if( type == Boolean ) {
-            if( str.toLowerCase() == 'true' ) return Boolean.TRUE
-            if( str.toLowerCase() == 'false' ) return Boolean.FALSE
-        }
+    private Object resolveScalarInput(Param decl, Object value, boolean fromCli) {
+        final result = fromCli
+            ? ParamsHelper.resolveFromCli(decl, value)
+            : ParamsHelper.resolveFromCode(decl, value)
 
-        if( type == Integer || type == Float ) {
-            if( str.isInteger() ) return str.toInteger()
-            if( str.isLong() ) return str.toLong()
-        }
+        final expectedType = TypeHelper.getRawType(decl.type)
+        final actualType = result?.getClass()
+        if( actualType != null && !ParamsHelper.isAssignableFrom(expectedType, actualType) )
+            throw new ScriptRuntimeException("Workflow input `${decl.name}` with type ${Types.getName(decl.type)} cannot be assigned to ${result} [${Types.getName(actualType)}]")
 
-        if( type == Float ) {
-            if( str.isFloat() ) return str.toFloat()
-            if( str.isDouble() ) return str.toDouble()
-        }
+        return result
+    }
 
-        if( type == Path ) {
-            return TypeHelper.asPathType(str)
-        }
+    /**
+     * Loads a channel input from a samplesheet file, converting each record
+     * to the declared element type.
+     *
+     * @param decl
+     * @param value
+     */
+    private List loadChannelInput(Param decl, Object value) {
+        if( value !instanceof CharSequence && value !instanceof Path )
+            throw new ScriptRuntimeException("Workflow input `${decl.name}` with type ${Types.getName(decl.type)} should be a samplesheet file, but received: ${value} [${Types.getName(value.getClass())}]")
 
-        return value
+        final path = value instanceof Path
+            ? (Path)value
+            : FileHelper.asPath(value.toString())
+        final elementType = elementDecl(decl).type
+        return loadFromFile(decl.name, path).collect { el -> TypeHelper.asType(el, elementType) }
+    }
+
+    /**
+     * Returns the declared input for the element type of a parameterized
+     * input type, e.g. {@code Sample} for {@code Channel<Sample>}.
+     *
+     * @param decl
+     */
+    private static Param elementDecl(Param decl) {
+        final elementType = decl.type instanceof ParameterizedType
+            ? ((ParameterizedType)decl.type).getActualTypeArguments()[0]
+            : (Type)Object
+        return new Param(decl.name, elementType, decl.optional, null)
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/OutputDslTest.groovy
@@ -142,6 +142,65 @@ class OutputDslTest extends Specification {
         root?.deleteDir()
     }
 
+    def 'should not publish outputs when the output directory is disabled'() {
+        given:
+        def root = Files.createTempDirectory('test')
+        def outputDir = root.resolve('results')
+        def workDir = root.resolve('work')
+        def work1 = workDir.resolve('ab/1234'); Files.createDirectories(work1)
+        def file1 = work1.resolve('file1.txt'); file1.text = 'Hello'
+        and:
+        def config = [
+            outputDir: outputDir,
+            workDir: workDir
+        ]
+        and:
+        SysEnv.push(NXF_FILE_ROOT: root.toString())
+
+        when:
+        def session = Spy(createSession(config))
+        // the output directory is disabled when a named workflow is executed directly
+        session.outputDir = null
+
+        session.outputs.put('foo', Channel.of(file1))
+
+        def dsl = new OutputDsl()
+        dsl.declare('foo') {
+        }
+        dsl.apply(session)
+        session.fireDataflowNetwork()
+        def output = dsl.getOutput()
+
+        then:
+        // the output file is reported by its work directory path
+        output == [foo: [file1]]
+        and:
+        // no output directory is created and no file is published
+        !Files.exists(outputDir)
+        0 * session.notifyFilePublish(_)
+
+        cleanup:
+        SysEnv.pop()
+        root?.deleteDir()
+    }
+
+    def 'should print outputs when the output directory is disabled'() {
+        given:
+        def file1 = Path.of('/work/ab/1234/file1.txt')
+        def session = Mock(Session) {
+            getOutputDir() >> null
+        }
+
+        when:
+        OutputDsl.printOutput(session, [foo: [file1]])
+
+        then:
+        // the output file is listed, without a bogus 'null' output directory header
+        1 * session.printConsole({ String it ->
+            it.contains('/work/ab/1234/file1.txt') && !it.contains('null')
+        })
+    }
+
     def 'should preserve non-task output files in workflow output'() {
         given:
         def root = Files.createTempDirectory('test')

--- a/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
@@ -28,6 +28,10 @@ import nextflow.script.types.Record
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import nextflow.util.Duration
+import nextflow.util.MemoryUnit
+import nextflow.util.VersionNumber
+
 import static test.ScriptHelper.*
 /**
  *
@@ -61,6 +65,32 @@ class ParamsDslTest extends Specification {
 
         cleanup:
         inputFile?.delete()
+    }
+
+    def 'should parse duration, memory and version params'() {
+        given:
+        def cliParams = [time: '2h', memory: '4.GB', version: '1.2.3']
+
+        when:
+        def result = runScript(
+            '''\
+            params {
+                time: Duration
+                memory: MemoryUnit
+                version: VersionNumber
+            }
+
+            workflow { params }
+            ''',
+            config: [params: cliParams],
+            params: cliParams
+        )
+        then:
+        result == [
+            time: Duration.of('2h'),
+            memory: MemoryUnit.of('4.GB'),
+            version: new VersionNumber('1.2.3')
+        ]
     }
 
     def 'should allow optional param'() {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
@@ -299,4 +299,22 @@ class ParamsDslTest extends Specification {
         e.message == "Input record [id:1, name:sample1] is missing field 'value' required by record type 'Sample'"
     }
 
+    def 'should report a required param given a null value'() {
+        when:
+        runScript(
+            '''\
+            params {
+                limit: Integer
+            }
+
+            workflow { params.limit }
+            ''',
+            params: [limit: null]
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message == 'Parameter `limit` is required but was not specified on the command line, params file, or config'
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
@@ -28,10 +28,6 @@ import nextflow.script.types.Record
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import nextflow.util.Duration
-import nextflow.util.MemoryUnit
-import nextflow.util.VersionNumber
-
 import static test.ScriptHelper.*
 /**
  *
@@ -65,32 +61,6 @@ class ParamsDslTest extends Specification {
 
         cleanup:
         inputFile?.delete()
-    }
-
-    def 'should parse duration, memory and version params'() {
-        given:
-        def cliParams = [time: '2h', memory: '4.GB', version: '1.2.3']
-
-        when:
-        def result = runScript(
-            '''\
-            params {
-                time: Duration
-                memory: MemoryUnit
-                version: VersionNumber
-            }
-
-            workflow { params }
-            ''',
-            config: [params: cliParams],
-            params: cliParams
-        )
-        then:
-        result == [
-            time: Duration.of('2h'),
-            memory: MemoryUnit.of('4.GB'),
-            version: new VersionNumber('1.2.3')
-        ]
     }
 
     def 'should allow optional param'() {
@@ -194,12 +164,12 @@ class ParamsDslTest extends Specification {
     }
 
     @Unroll
-    def 'should validate float param with default value'() {
+    def 'should validate a numeric param default given in any numeric literal'() {
         when:
         runScript(
             """\
             params {
-                factor: Float = ${DEF_VALUE}
+                factor: ${TYPE} = ${DEF_VALUE}
             }
 
             workflow { params }
@@ -209,26 +179,13 @@ class ParamsDslTest extends Specification {
         noExceptionThrown()
 
         where:
-        DEF_VALUE << [ '0.1f', '0.1d', '0.1g' ]
-    }
-
-    @Unroll
-    def 'should validate integer param with default value'() {
-        when:
-        runScript(
-            """\
-            params {
-                factor: Integer = ${DEF_VALUE}
-            }
-
-            workflow { params }
-            """
-        )
-        then:
-        noExceptionThrown()
-
-        where:
-        DEF_VALUE << [ '100i', '100l', '100g' ]
+        TYPE      | DEF_VALUE
+        'Float'   | '0.1f'
+        'Float'   | '0.1d'
+        'Float'   | '0.1g'
+        'Integer' | '100i'
+        'Integer' | '100l'
+        'Integer' | '100g'
     }
 
     def 'should validate record collection param'() {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ParamsDslTest.groovy
@@ -79,10 +79,6 @@ class ParamsDslTest extends Specification {
     }
 
     def 'should report error for missing required param'() {
-        given:
-        def cliParams = [:]
-        def configParams = [outdir: 'results']
-
         when:
         runScript(
             '''\
@@ -93,12 +89,28 @@ class ParamsDslTest extends Specification {
 
             workflow { params }
             ''',
-            params: cliParams,
-            configParams: configParams
+            params: [:],
+            configParams: [outdir: 'results']
         )
         then:
         def e = thrown(ScriptRuntimeException)
-        e.message == 'Parameter `input` is required but was not specified on the command line, params file, or config'
+        e.message == 'Parameter `input` is required but no value was provided'
+
+        when:
+        runScript(
+            '''\
+            params {
+                limit: Integer = 10
+            }
+
+            workflow { params.limit }
+            ''',
+            configParams: [limit: null]
+        )
+
+        then:
+        e = thrown(ScriptRuntimeException)
+        e.message == 'Parameter `limit` is required but no value was provided'
     }
 
     def 'should report error for invalid param'() {
@@ -299,22 +311,21 @@ class ParamsDslTest extends Specification {
         e.message == "Input record [id:1, name:sample1] is missing field 'value' required by record type 'Sample'"
     }
 
-    def 'should report a required param given a null value'() {
+    def 'should apply a null param value over the declared default'() {
         when:
-        runScript(
+        def result = runScript(
             '''\
             params {
-                limit: Integer
+                limit: Integer? = 10
             }
 
             workflow { params.limit }
             ''',
-            params: [limit: null]
+            configParams: [limit: null]
         )
 
         then:
-        def e = thrown(ScriptRuntimeException)
-        e.message == 'Parameter `limit` is required but was not specified on the command line, params file, or config'
+        result == null
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ParamsHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ParamsHelperTest.groovy
@@ -97,6 +97,19 @@ class ParamsHelperTest extends Specification {
         '999999999999999999999999999'  | 999999999999999999999999999G
     }
 
+    def 'should widen a value that is too large for a Float'() {
+        expect:
+        final result = ParamsHelper.resolveFromCli(param(Float), VALUE)
+        result == EXPECTED
+        result.getClass() == EXPECTED.getClass()
+
+        where:
+        VALUE     | EXPECTED
+        '3.4e38'  | 3.4e38f
+        '1e39'    | 1e39d          // too large for a Float, but fits a Double
+        '1e400'   | 1e400G         // too large for a Double
+    }
+
     def 'should leave a value that the declared type cannot represent unconverted'() {
         when:
         // the value is reported by the caller as not assignable to the

--- a/modules/nextflow/src/test/groovy/nextflow/script/ParamsHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ParamsHelperTest.groovy
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import nextflow.util.Duration
+import nextflow.util.MemoryUnit
+import nextflow.util.RecordMap
+import nextflow.util.VersionNumber
+import spock.lang.Specification
+
+/**
+ * Tests for {@link ParamsHelper}.
+ *
+ * This is the shared mapping of a param value to a declared type, used by
+ * the `params` block, typed workflows, and typed processes. The exhaustive
+ * per-type coverage lives here -- each caller only needs to prove that it
+ * routes through this class.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+class ParamsHelperTest extends Specification {
+
+    private static Param param(java.lang.reflect.Type type) {
+        new Param('x', type, false, null)
+    }
+
+    def 'should resolve a value against the declared type'() {
+        expect:
+        final result = FROM_CLI
+            ? ParamsHelper.resolveFromCli(param(TYPE), VALUE)
+            : ParamsHelper.resolveFromCode(param(TYPE), VALUE)
+        result == EXPECTED
+        result?.getClass() == EXPECTED?.getClass()
+
+        where:
+        FROM_CLI | TYPE          | VALUE     | EXPECTED
+        // a command-line value is always a string, so it is parsed
+        true     | String        | 'hello'   | 'hello'
+        true     | Boolean       | 'true'    | true
+        true     | Boolean       | 'false'   | false
+        true     | Boolean       | 'TRUE'    | true
+        true     | Integer       | '42'      | 42
+        true     | Integer       | '0'       | 0
+        true     | Integer       | ' 42 '    | 42
+        true     | Float         | '5.5'     | 5.5f
+        true     | Float         | '5'       | 5.0f
+        true     | Duration      | '2h'      | Duration.of('2h')
+        true     | MemoryUnit    | '4.GB'    | MemoryUnit.of('4.GB')
+        true     | VersionNumber | '1.2.3'   | new VersionNumber('1.2.3')
+        // a config value is already structured, but a number is still
+        // normalized to the declared type
+        false    | String        | 'hello'   | 'hello'
+        false    | Integer       | 40        | 40
+        false    | Integer       | 40G       | 40
+        false    | Integer       | 40.0G     | 40
+        false    | Float         | 96.4G     | 96.4f
+        false    | Float         | 96.4d     | 96.4f
+        false    | Float         | 40        | 40.0f
+        false    | Duration      | '2h'      | Duration.of('2h')
+        false    | MemoryUnit    | '4.GB'    | MemoryUnit.of('4.GB')
+        false    | VersionNumber | '1.2.3'   | new VersionNumber('1.2.3')
+        // a null value is always passed through
+        true     | Integer       | null      | null
+        false    | Integer       | null      | null
+        // an untyped param is passed through unchanged
+        true     | null          | '42'      | '42'
+    }
+
+    def 'should widen an integral value that is too large for an Integer'() {
+        expect:
+        final result = ParamsHelper.resolveFromCli(param(Integer), VALUE)
+        result == EXPECTED
+        result.getClass() == EXPECTED.getClass()
+
+        where:
+        VALUE                          | EXPECTED
+        '2147483647'                   | 2147483647                       // Integer.MAX_VALUE
+        '99999999999'                  | 99999999999L
+        '-99999999999'                 | -99999999999L
+        '999999999999999999999999999'  | 999999999999999999999999999G
+    }
+
+    def 'should leave a value that the declared type cannot represent unconverted'() {
+        when:
+        // the value is reported by the caller as not assignable to the
+        // declared type, rather than being silently coerced
+        final result = ParamsHelper.resolveFromCli(param(TYPE), VALUE)
+
+        then:
+        result == VALUE
+        !ParamsHelper.isAssignableFrom(TYPE, result.getClass())
+
+        where:
+        TYPE    | VALUE
+        Integer | 'abc'
+        Integer | '3.7'      // a fractional value is not truncated
+        Float   | 'abc'
+    }
+
+    def 'should not convert a boolean string that came from the config'() {
+        expect:
+        // unlike a command-line value, a config value is expected to already
+        // be a boolean -- a string is left alone and reported as a mismatch
+        ParamsHelper.resolveFromCode(param(Boolean), 'false') == 'false'
+        ParamsHelper.resolveFromCode(param(Boolean), false) == false
+    }
+
+    def 'should resolve a Path and require it to exist'() {
+        given:
+        def file = Files.createTempFile('data', '.txt')
+
+        when:
+        def result = ParamsHelper.resolveFromCli(param(Path), file.toString())
+
+        then:
+        result == file
+
+        when:
+        ParamsHelper.resolveFromCli(param(Path), '/some/missing/file.txt')
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains('/some/missing/file.txt')
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'should determine whether a value type is assignable to a declared type'() {
+        expect:
+        ParamsHelper.isAssignableFrom(TARGET, SOURCE) == EXPECTED
+
+        where:
+        TARGET  | SOURCE     | EXPECTED
+        Integer | Integer    | true
+        Integer | Long       | true
+        Integer | BigInteger | true
+        Integer | Float      | false
+        Integer | String     | false
+        Float   | Float      | true
+        Float   | Integer    | true
+        Float   | BigDecimal | true
+        Float   | String     | false
+        String  | String     | true
+        String  | Integer    | false
+        SampleRec | RecordMap  | true
+        SampleRec | Map        | false
+    }
+
+    static class SampleRec implements nextflow.script.types.Record {
+        String id
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -235,7 +235,7 @@ class ProcessEntryHandlerTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == 'Missing required parameter: --id'
+        e.message == 'Parameter `--id` is required but no value was provided'
     }
 
     def 'should resolve a typed input like a pipeline parameter (v2)' () {
@@ -286,7 +286,7 @@ class ProcessEntryHandlerTest extends Specification {
         result == null
     }
 
-    def 'should throw error for missing required input (v2)' () {
+    def 'should report a required input with no value (v2)' () {
         given:
         def param = new ProcessInput('reads', Path, false)
 
@@ -295,6 +295,6 @@ class ProcessEntryHandlerTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == 'Missing required parameter: --reads'
+        e.message == 'Parameter `--reads` is required but no value was provided'
     }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -19,6 +19,7 @@ package nextflow.script
 import java.nio.file.Path
 
 import nextflow.Session
+import nextflow.module.ModuleSpec
 import nextflow.script.params.FileInParam
 import nextflow.script.params.ValueInParam
 import nextflow.script.params.v2.ProcessInput
@@ -101,7 +102,7 @@ class ProcessEntryHandlerTest extends Specification {
         }
 
         when:
-        def args = ProcessEntryHandler.getProcessArguments(processDef, ['id': 'abc', 'greeting': 'hello'], (Path)null)
+        def args = ProcessEntryHandler.getProcessArguments(processDef, ['id': 'abc', 'greeting': 'hello'], (ModuleSpec)null)
 
         then: 'a single RecordMap is returned'
         args.size() == 1
@@ -127,7 +128,7 @@ class ProcessEntryHandlerTest extends Specification {
         }
 
         when:
-        def args = ProcessEntryHandler.getProcessArguments(processDef, ['sample': ['id': 'a', 'text': 'hello']], (Path)null)
+        def args = ProcessEntryHandler.getProcessArguments(processDef, ['sample': ['id': 'a', 'text': 'hello']], (ModuleSpec)null)
 
         then: 'the nested map is converted into a record of the declared type'
         args.size() == 1

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -27,7 +27,10 @@ import nextflow.script.params.v2.ProcessInput
 import nextflow.script.params.v2.ProcessInputsDef
 import nextflow.script.params.v2.ProcessTupleInput
 import nextflow.script.types.Record
+import nextflow.util.Duration
+import nextflow.util.MemoryUnit
 import nextflow.util.RecordMap
+import nextflow.util.VersionNumber
 import spock.lang.Specification
 
 /**
@@ -382,6 +385,63 @@ class ProcessEntryHandlerTest extends Specification {
         then:
         def e = thrown(IllegalArgumentException)
         e.message == 'Missing required parameter: --id'
+    }
+
+    def 'should resolve a typed input like a pipeline parameter (v2)' () {
+        given:
+        def session = Mock(Session)
+        def script = Mock(BaseScript)
+        def meta = Mock(ScriptMeta) {
+            getLocalProcessNames() >> [ 'hello' ]
+        }
+        def handler = new ProcessEntryHandler(script, session, meta)
+
+        when:
+        def result = handler.getValueForInputV2(new ProcessInput('x', type, false), [x: value])
+
+        then:
+        result.getClass() == expected
+        result == parsed
+
+        where:
+        type        | value     | expected      | parsed
+        Boolean     | 'false'   | Boolean       | false
+        Integer     | '42'      | Integer       | 42
+        Float       | '5.5'     | Float         | 5.5f
+        Float       | '5'       | Float         | 5.0f
+        String      | 'hello'   | String        | 'hello'
+        Duration    | '2h'      | Duration      | Duration.of('2h')
+        MemoryUnit  | '4.GB'    | MemoryUnit    | MemoryUnit.of('4.GB')
+        VersionNumber | '1.2.3' | VersionNumber | new VersionNumber('1.2.3')
+        // a value can be given as any number, and is normalized to the declared type
+        Float       | 96.4G     | Float         | 96.4f
+        Float       | 96.4d     | Float         | 96.4f
+        Float       | 40        | Float         | 40.0f
+        Integer     | 40G       | Integer       | 40
+        Integer     | 40.0G     | Integer       | 40
+    }
+
+    def 'should reject a param value that cannot be converted to the declared input type (v2)' () {
+        given:
+        def session = Mock(Session)
+        def script = Mock(BaseScript)
+        def meta = Mock(ScriptMeta) {
+            getLocalProcessNames() >> [ 'hello' ]
+        }
+        def handler = new ProcessEntryHandler(script, session, meta)
+
+        when:
+        handler.getValueForInputV2(new ProcessInput('n50', type, false), [n50: value])
+
+        then: 'the mismatch is reported up front instead of reaching the task'
+        def e = thrown(IllegalArgumentException)
+        e.message == "Parameter `--n50` with type ${type.simpleName} cannot be assigned to ${value} [String]"
+
+        where:
+        type    | value
+        Integer | 'abc'
+        Integer | '3.7'      // a fractional value is not silently truncated
+        Float   | 'abc'
     }
 
     def 'should return null for missing optional input (v2)' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -101,7 +101,7 @@ class ProcessEntryHandlerTest extends Specification {
         }
 
         when:
-        def args = handler.getProcessArguments(processDef, ['id': 'abc', 'greeting': 'hello'])
+        def args = ProcessEntryHandler.getProcessArguments(processDef, ['id': 'abc', 'greeting': 'hello'], (Path)null)
 
         then: 'a single RecordMap is returned'
         args.size() == 1
@@ -127,7 +127,7 @@ class ProcessEntryHandlerTest extends Specification {
         }
 
         when:
-        def args = handler.getProcessArguments(processDef, ['sample': ['id': 'a', 'text': 'hello']])
+        def args = ProcessEntryHandler.getProcessArguments(processDef, ['sample': ['id': 'a', 'text': 'hello']], (Path)null)
 
         then: 'the nested map is converted into a record of the declared type'
         args.size() == 1
@@ -240,13 +240,13 @@ class ProcessEntryHandlerTest extends Specification {
     def 'should resolve a typed input like a pipeline parameter (v2)' () {
         expect:
         // the full type matrix is covered by ParamsHelperTest
-        handler.getValueForInputV2(new ProcessInput('x', Integer, false), [x: '42']) == 42
-        handler.getValueForInputV2(new ProcessInput('x', Duration, false), [x: '2h']) == Duration.of('2h')
+        handler.getValueForInputV2(new ProcessInput('x', Integer, false), [x: '42'], [x: '42']) == 42
+        handler.getValueForInputV2(new ProcessInput('x', Duration, false), [x: '2h'], [x: '2h']) == Duration.of('2h')
     }
 
     def 'should reject a param value that cannot be converted to the declared input type (v2)' () {
         when:
-        handler.getValueForInputV2(new ProcessInput('n50', type, false), [n50: value])
+        handler.getValueForInputV2(new ProcessInput('n50', type, false), [n50: value], [n50: value])
 
         then: 'the mismatch is reported up front instead of reaching the task'
         def e = thrown(IllegalArgumentException)
@@ -258,13 +258,28 @@ class ProcessEntryHandlerTest extends Specification {
         Float   | 'abc'
     }
 
+    def 'should resolve a config value as structured, not as command-line text (v2)' () {
+        given:
+        def decl = new ProcessInput('flag', Boolean, false)
+
+        expect: 'a command-line value is parsed'
+        handler.getValueForInputV2(decl, [flag: 'false'], [flag: 'false']) == false
+
+        when: 'the same value comes from the config, where a Boolean is expected to be a Boolean'
+        handler.getValueForInputV2(decl, [flag: 'false'], [:])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Parameter `--flag` with type Boolean cannot be assigned to false [String]'
+    }
+
     def 'should return null for missing optional input (v2)' () {
         // Regression test for https://github.com/nextflow-io/nextflow/issues/7161
         given:
         def param = new ProcessInput('gzi', Path, true)
 
         when: 'a v2 optional path input is not provided'
-        def result = handler.getValueForInputV2(param, [:])
+        def result = handler.getValueForInputV2(param, [:], [:])
 
         then: 'returns null instead of throwing'
         result == null
@@ -275,7 +290,7 @@ class ProcessEntryHandlerTest extends Specification {
         def param = new ProcessInput('reads', Path, false)
 
         when:
-        handler.getValueForInputV2(param, [:])
+        handler.getValueForInputV2(param, [:], [:])
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -16,39 +16,43 @@
 
 package nextflow.script
 
-import java.nio.file.Files
 import java.nio.file.Path
+
 import nextflow.Session
 import nextflow.script.params.FileInParam
-import nextflow.script.params.InputsList
-import nextflow.script.params.TupleInParam
 import nextflow.script.params.ValueInParam
 import nextflow.script.params.v2.ProcessInput
 import nextflow.script.params.v2.ProcessInputsDef
 import nextflow.script.params.v2.ProcessTupleInput
 import nextflow.script.types.Record
 import nextflow.util.Duration
-import nextflow.util.MemoryUnit
 import nextflow.util.RecordMap
-import nextflow.util.VersionNumber
 import spock.lang.Specification
 
 /**
- * Tests for ProcessEntryHandler parameter mapping functionality
+ * Tests for ProcessEntryHandler parameter mapping functionality.
+ *
+ * The per-type mapping of a param value to a declared input type is covered
+ * by {@link ParamsHelperTest} -- the v2 tests here only assert that a typed
+ * process input routes through it. The v1 tests cover the separate,
+ * meta.yml-driven resolution.
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class ProcessEntryHandlerTest extends Specification {
 
-    def 'should get value for val input type' () {
-        given:
+    ProcessEntryHandler handler
+
+    def setup() {
         def session = Mock(Session)
         def script = Mock(BaseScript)
         def meta = Mock(ScriptMeta) {
             getLocalProcessNames() >> [ 'hello' ]
         }
-        def handler = new ProcessEntryHandler(script, session, meta)
+        handler = new ProcessEntryHandler(script, session, meta)
+    }
 
+    def 'should get value for val input type' () {
         when:
         def complexParams = [
             'meta': [id: 'SAMPLE_001', name: 'TestSample'],
@@ -63,14 +67,6 @@ class ProcessEntryHandlerTest extends Specification {
     }
 
     def 'should get value for path input type' () {
-        given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-
         when:
         def complexParams = [
             'fasta': '/path/to/file.fa',
@@ -88,92 +84,8 @@ class ProcessEntryHandlerTest extends Specification {
         fileResult.toString().contains('data.txt')
     }
 
-    def 'should throw exception for missing required parameter' () {
-        given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-
-        when:
-        def complexParams = [
-            'meta': [id: 'SAMPLE_001']
-        ]
-        def missingInput = Mock(ValueInParam) { getName() >> 'missing' }
-        and:
-        handler.getValueForInputV1(missingInput, complexParams, [:])
-
-        then:
-        thrown(IllegalArgumentException)
-    }
-
-    def 'should map tuple input structure correctly' () {
-        given:
-        def session = Mock(Session) {
-            getParams() >> [
-                'meta': [
-                    'id': 'SAMPLE_001',
-                    'name': 'TestSample',
-                    'other': 'some-value',
-                ],
-                'fasta': '/path/to/file.fa'
-            ]
-        }
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def processDef = Mock(ProcessDef)
-        def handler = new ProcessEntryHandler(script, session, meta)
-
-        when:
-        // Mock input declaration for tuple val(meta), path(fasta)
-        def tupleParam = Mock(TupleInParam) {
-            getInner() >> [
-                Mock(ValueInParam) { getName() >> 'meta' },
-                Mock(FileInParam) { getName() >> 'fasta' }
-            ]
-        }
-
-        // Test the parameter mapping logic manually
-        def namedArgs = session.getParams()
-        def tupleElements = []
-
-        for( def innerParam : tupleParam.inner ) {
-            def value = handler.getValueForInputV1(innerParam, namedArgs, [:])
-            tupleElements.add(value)
-        }
-
-        then:
-        namedArgs.meta instanceof Map
-        namedArgs.meta.id == 'SAMPLE_001'
-        namedArgs.meta.name == 'TestSample'
-        namedArgs.meta.other == 'some-value'
-        namedArgs.fasta == '/path/to/file.fa'
-
-        tupleElements.size() == 2
-        tupleElements[0] instanceof Map  // meta as map
-        tupleElements[0].id == 'SAMPLE_001'
-        tupleElements[0].name == 'TestSample'
-        tupleElements[0].other == 'some-value'
-        // tupleElements[1] should be a Path object (mocked)
-        tupleElements[1].toString().contains('file.fa')
-    }
-
     def 'should support destructured record input in typed process' () {
-        given:
-        def session = Mock(Session) {
-            getParams() >> ['id': 'abc', 'greeting': 'hello']
-        }
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> ['RECORDS']
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-
-        and: 'a ProcessTupleInput representing a record(id: String, greeting: String)'
+        given: 'a ProcessTupleInput representing a record(id: String, greeting: String)'
         def idInput = new ProcessInput('id', String, false)
         def greetingInput = new ProcessInput('greeting', String, false)
         def recordParam = new ProcessTupleInput([idInput, greetingInput], Record)
@@ -205,11 +117,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should support record type input in typed process' () {
         given: 'a process with a record type input'
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> ['RECORDS']
-        }
         def inputsDef = new ProcessInputsDef()
         inputsDef.addParam('sample', Sample, false)
         def processConfig = Mock(ProcessConfigV2) {
@@ -218,7 +125,6 @@ class ProcessEntryHandlerTest extends Specification {
         def processDef = Mock(ProcessDef) {
             getProcessConfig() >> processConfig
         }
-        def handler = new ProcessEntryHandler(script, session, meta)
 
         when:
         def args = handler.getProcessArguments(processDef, ['sample': ['id': 'a', 'text': 'hello']])
@@ -232,12 +138,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should convert string parameter to type declared in module spec' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def param = Mock(ValueInParam) { getName() >> NAME }
 
         expect:
@@ -251,30 +151,12 @@ class ProcessEntryHandlerTest extends Specification {
         'count' | Integer | '42'    | 42
         'count' | Integer | '0'     | 0
         'ratio' | Number  | '3.14'  | 3.14f
-    }
-
-    def 'should return string parameter unchanged when no module spec type is declared' () {
-        given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-        def param = Mock(ValueInParam) { getName() >> 'name' }
-
-        expect:
-        handler.getValueForInputV1(param, [name: 'hello'], [:]) == 'hello'
+        // an undeclared type leaves the value unchanged
+        'name'  | null    | 'hello' | 'hello'
     }
 
     def 'should throw error when parameter value cannot be converted to declared type' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def param = Mock(ValueInParam) { getName() >> NAME }
 
         when:
@@ -296,12 +178,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should throw error when non-string parameter value has incompatible type' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def param = Mock(ValueInParam) { getName() >> 'count' }
 
         when:
@@ -313,14 +189,6 @@ class ProcessEntryHandlerTest extends Specification {
     }
 
     def 'should parse file input correctly' () {
-        given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-
         expect:
         handler.parseFileInput(INPUT) == EXPECTED_FILES
 
@@ -336,12 +204,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should return empty list for missing path input (v1)' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def pathParam = Mock(FileInParam) { getName() >> 'intervals' }
 
         when: 'the input is not present in params for a path input'
@@ -353,12 +215,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should reject an empty-string path input instead of treating it as not provided (v1)' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def pathParam = Mock(FileInParam) { getName() >> 'proteins' }
 
         when: 'an empty value is supplied for a path input'
@@ -371,12 +227,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should throw error for missing val input (v1)' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def valParam = Mock(ValueInParam) { getName() >> 'id' }
 
         when: 'a val input is absent'
@@ -388,48 +238,13 @@ class ProcessEntryHandlerTest extends Specification {
     }
 
     def 'should resolve a typed input like a pipeline parameter (v2)' () {
-        given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-
-        when:
-        def result = handler.getValueForInputV2(new ProcessInput('x', type, false), [x: value])
-
-        then:
-        result.getClass() == expected
-        result == parsed
-
-        where:
-        type        | value     | expected      | parsed
-        Boolean     | 'false'   | Boolean       | false
-        Integer     | '42'      | Integer       | 42
-        Float       | '5.5'     | Float         | 5.5f
-        Float       | '5'       | Float         | 5.0f
-        String      | 'hello'   | String        | 'hello'
-        Duration    | '2h'      | Duration      | Duration.of('2h')
-        MemoryUnit  | '4.GB'    | MemoryUnit    | MemoryUnit.of('4.GB')
-        VersionNumber | '1.2.3' | VersionNumber | new VersionNumber('1.2.3')
-        // a value can be given as any number, and is normalized to the declared type
-        Float       | 96.4G     | Float         | 96.4f
-        Float       | 96.4d     | Float         | 96.4f
-        Float       | 40        | Float         | 40.0f
-        Integer     | 40G       | Integer       | 40
-        Integer     | 40.0G     | Integer       | 40
+        expect:
+        // the full type matrix is covered by ParamsHelperTest
+        handler.getValueForInputV2(new ProcessInput('x', Integer, false), [x: '42']) == 42
+        handler.getValueForInputV2(new ProcessInput('x', Duration, false), [x: '2h']) == Duration.of('2h')
     }
 
     def 'should reject a param value that cannot be converted to the declared input type (v2)' () {
-        given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
-
         when:
         handler.getValueForInputV2(new ProcessInput('n50', type, false), [n50: value])
 
@@ -439,7 +254,6 @@ class ProcessEntryHandlerTest extends Specification {
 
         where:
         type    | value
-        Integer | 'abc'
         Integer | '3.7'      // a fractional value is not silently truncated
         Float   | 'abc'
     }
@@ -447,12 +261,6 @@ class ProcessEntryHandlerTest extends Specification {
     def 'should return null for missing optional input (v2)' () {
         // Regression test for https://github.com/nextflow-io/nextflow/issues/7161
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def param = new ProcessInput('gzi', Path, true)
 
         when: 'a v2 optional path input is not provided'
@@ -464,12 +272,6 @@ class ProcessEntryHandlerTest extends Specification {
 
     def 'should throw error for missing required input (v2)' () {
         given:
-        def session = Mock(Session)
-        def script = Mock(BaseScript)
-        def meta = Mock(ScriptMeta) {
-            getLocalProcessNames() >> [ 'hello' ]
-        }
-        def handler = new ProcessEntryHandler(script, session, meta)
         def param = new ProcessInput('reads', Path, false)
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptMetaTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptMetaTest.groovy
@@ -188,4 +188,32 @@ class ScriptMetaTest extends Dsl2Spec {
         bundle.getEntries() == ['foo.txt', 'bar.txt'] as Set
 
     }
+
+    def 'should determine which definitions are directly executable' () {
+        given:
+        def script = new FooScript(new ScriptBinding())
+        def meta = new ScriptMeta(script)
+        and:
+        if( processes )
+            meta.addDefinition(processes.collect { n -> createProcessDef(script, n) } as ComponentDef[])
+        if( workflows )
+            meta.addDefinition(workflows.collect { n -> new WorkflowDef(name: n) } as ComponentDef[])
+        if( module )
+            meta.setModule(true)
+
+        expect:
+        meta.hasExecutableWorkflows() == EXEC_WORKFLOW
+        meta.hasExecutableProcesses() == EXEC_PROCESS
+
+        where:
+        processes    | workflows    | module | EXEC_WORKFLOW | EXEC_PROCESS
+        []           | []           | false  | false         | false
+        ['p1']       | []           | false  | false         | true
+        ['p1', 'p2'] | []           | false  | false         | false
+        []           | ['w1']       | false  | true          | false
+        []           | ['w1', 'w2'] | false  | false         | false
+        ['p1']       | ['w1']       | false  | false         | false
+        ['p1']       | []           | true   | false         | false
+        []           | ['w1']       | true   | false         | false
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
@@ -46,7 +46,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
         '''
 
         when:
-        def result = runScript(SCRIPT)
+        def result = runScript(SCRIPT, moduleRun: true)
 
         then:
         // For single process execution, the result should contain the process output
@@ -70,7 +70,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
         """
 
         when:
-        def result = runScript(SCRIPT)
+        def result = runScript(SCRIPT, moduleRun: true)
 
         then:
         result != null
@@ -102,7 +102,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
         '''
 
         when:
-        runScript(SCRIPT)
+        runScript(SCRIPT, moduleRun: true)
 
         then:
         def e = thrown(AbortOperationException)
@@ -127,6 +127,27 @@ class ScriptProcessRunTest extends Dsl2Spec {
         '''
 
         when:
+        runScript(SCRIPT, moduleRun: true)
+
+        then:
+        def e = thrown(AbortOperationException)
+        e.message.contains('No entry workflow specified')
+    }
+
+    def 'should not execute a single process directly without module run' () {
+        given:
+        def SCRIPT = '''
+        params.sampleId = 'SAMPLE_001'
+
+        process testProcess {
+            input: val sampleId
+            output: val result
+            exec:
+                result = "Processed: $sampleId"
+        }
+        '''
+
+        when:
         runScript(SCRIPT)
 
         then:
@@ -146,7 +167,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
         '''
 
         when:
-        runScript(SCRIPT)
+        runScript(SCRIPT, moduleRun: true)
 
         then:
         def e = thrown(Exception)
@@ -176,7 +197,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
             '''
 
         when:
-        runScript(module, config: [params: [alignment_mode: 'false']])
+        runScript(module, moduleRun: true, config: [params: [alignment_mode: 'false']])
         then:
         Global.session.isSuccess()
 

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
@@ -139,7 +139,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
 
         then:
         def e = thrown(Exception)
-        e.message.contains('Missing required parameter: --requiredParam')
+        e.message.contains('Parameter `--requiredParam` is required but no value was provided')
     }
 
     def 'should cast boolean parameter to boolean' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
@@ -81,18 +81,16 @@ class ScriptProcessRunTest extends Dsl2Spec {
         Files.deleteIfExists(tempFile)
     }
 
-    def 'should fail when multiple processes and no entry workflow' () {
-        given:
-        def SCRIPT = '''
-        params.input = 'test'
-
+    static final String ONE_PROCESS = '''
         process firstProcess {
             input: val input
             output: val result
             exec:
                 result = "First: $input"
         }
+        '''
 
+    static final String TWO_PROCESSES = ONE_PROCESS + '''
         process secondProcess {
             input: val input
             output: val result
@@ -101,58 +99,28 @@ class ScriptProcessRunTest extends Dsl2Spec {
         }
         '''
 
-        when:
-        runScript(SCRIPT, moduleRun: true)
-
-        then:
-        def e = thrown(AbortOperationException)
-        e.message.contains('No entry workflow specified')
-    }
-
-    def 'should fail when a process and a named workflow are both defined' () {
-        given:
-        def SCRIPT = '''
-        process testProcess {
-            input: val input
-            output: val result
-            exec:
-                result = "Got: $input"
-        }
-
+    static final String PROCESS_AND_WORKFLOW = ONE_PROCESS + '''
         workflow testWorkflow {
             take: input
             main:
-                testProcess(input)
+                firstProcess(input)
         }
         '''
 
+    def 'should not execute a definition directly when it is not the only one, or without module run' () {
         when:
-        runScript(SCRIPT, moduleRun: true)
+        runScript(SCRIPT, moduleRun: MODULE_RUN, config: [params: [input: 'test']])
 
         then:
         def e = thrown(AbortOperationException)
         e.message.contains('No entry workflow specified')
-    }
 
-    def 'should not execute a single process directly without module run' () {
-        given:
-        def SCRIPT = '''
-        params.sampleId = 'SAMPLE_001'
-
-        process testProcess {
-            input: val sampleId
-            output: val result
-            exec:
-                result = "Processed: $sampleId"
-        }
-        '''
-
-        when:
-        runScript(SCRIPT)
-
-        then:
-        def e = thrown(AbortOperationException)
-        e.message.contains('No entry workflow specified')
+        where:
+        SCRIPT               | MODULE_RUN
+        TWO_PROCESSES        | true
+        PROCESS_AND_WORKFLOW | true
+        // a single process is executable, but only via `nextflow module run`
+        ONE_PROCESS          | false
     }
 
     def 'should fail when required parameter is missing' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptProcessRunTest.groovy
@@ -19,6 +19,7 @@ package nextflow.script
 import java.nio.file.Files
 
 import nextflow.Global
+import nextflow.exception.AbortOperationException
 import test.Dsl2Spec
 
 import static test.ScriptHelper.*
@@ -80,7 +81,7 @@ class ScriptProcessRunTest extends Dsl2Spec {
         Files.deleteIfExists(tempFile)
     }
 
-    def 'should handle multiple processes by running the first one' () {
+    def 'should fail when multiple processes and no entry workflow' () {
         given:
         def SCRIPT = '''
         params.input = 'test'
@@ -101,12 +102,36 @@ class ScriptProcessRunTest extends Dsl2Spec {
         '''
 
         when:
-        def result = runScript(SCRIPT)
+        runScript(SCRIPT)
 
         then:
-        result != null
-        println "Multi-process result: $result"
-        println "Multi-process result class: ${result?.getClass()}"
+        def e = thrown(AbortOperationException)
+        e.message.contains('No entry workflow specified')
+    }
+
+    def 'should fail when a process and a named workflow are both defined' () {
+        given:
+        def SCRIPT = '''
+        process testProcess {
+            input: val input
+            output: val result
+            exec:
+                result = "Got: $input"
+        }
+
+        workflow testWorkflow {
+            take: input
+            main:
+                testProcess(input)
+        }
+        '''
+
+        when:
+        runScript(SCRIPT)
+
+        then:
+        def e = thrown(AbortOperationException)
+        e.message.contains('No entry workflow specified')
     }
 
     def 'should fail when required parameter is missing' () {

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowDefTest.groovy
@@ -72,10 +72,10 @@ class WorkflowDefTest extends Dsl2Spec {
 
         then:
         meta.definitions.size() == 4
-        meta.getWorkflow('alpha') .declaredInputs == []
-        meta.getWorkflow('bravo') .declaredInputs == ['foo', 'bar']
-        meta.getWorkflow('delta') .declaredInputs == ['foo','bar']
-        meta.getWorkflow('empty') .declaredInputs == []
+        meta.getWorkflow('alpha') .declaredInputs*.name == []
+        meta.getWorkflow('bravo') .declaredInputs*.name == ['foo', 'bar']
+        meta.getWorkflow('delta') .declaredInputs*.name == ['foo','bar']
+        meta.getWorkflow('empty') .declaredInputs*.name == []
     }
 
     def 'should define entry workflow' () {
@@ -113,7 +113,7 @@ class WorkflowDefTest extends Dsl2Spec {
         def script = loadScript(SCRIPT, module: true)
         def workflow = ScriptMeta.get(script).getWorkflow('alpha')
         then:
-        workflow.declaredInputs == ['foo']
+        workflow.declaredInputs*.name == ['foo']
         workflow.declaredOutputs == ['bar', 'baz']
 
     }

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script
+
+import java.nio.file.Files
+
+import nextflow.Session
+import nextflow.exception.ScriptRuntimeException
+import spock.lang.Timeout
+import test.Dsl2Spec
+
+import static test.ScriptHelper.*
+
+/**
+ * Tests for {@link WorkflowEntryHandler}.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@Timeout(10)
+class WorkflowEntryHandlerTest extends Dsl2Spec {
+
+    // ── unit: loadFromFile ────────────────────────────────────────────────────
+
+    private WorkflowEntryHandler makeHandler(List<String> inputs = []) {
+        def workflowDef = Mock(WorkflowDef) {
+            getName() >> 'HELLO'
+            getDeclaredInputs() >> inputs
+            getDeclaredInputTypes() >> [:]
+        }
+        def session = Mock(Session) { getParams() >> [:] }
+        def script  = Mock(BaseScript) {
+            isTypingEnabled() >> true
+        }
+        def meta    = Mock(ScriptMeta) {
+            getLocalWorkflowNames() >> ['HELLO']
+            getWorkflow('HELLO') >> workflowDef
+        }
+        return new WorkflowEntryHandler(script, session, meta)
+    }
+
+    def 'should load records from a CSV file'() {
+        given:
+        def csvFile = Files.createTempFile('test', '.csv')
+        csvFile.text = '''\
+            id,name
+            1,sample1
+            2,sample2
+            '''.stripIndent()
+
+        when:
+        def result = makeHandler().loadFromFile('samples', csvFile.toAbsolutePath())
+
+        then:
+        result instanceof List
+        result.size() == 2
+        result[0].id == '1'
+        result[0].name == 'sample1'
+
+        cleanup:
+        csvFile?.delete()
+    }
+
+    def 'should load records from a JSON file'() {
+        given:
+        def jsonFile = Files.createTempFile('test', '.json')
+        jsonFile.text = '[{"id":1,"name":"s1"},{"id":2,"name":"s2"}]'
+
+        when:
+        def result = makeHandler().loadFromFile('samples', jsonFile.toAbsolutePath())
+
+        then:
+        result instanceof List
+        result.size() == 2
+        result[0].id == 1
+        result[1].name == 's2'
+
+        cleanup:
+        jsonFile?.delete()
+    }
+
+    def 'should load records from a YAML file'() {
+        given:
+        def yamlFile = Files.createTempFile('test', '.yml')
+        yamlFile.text = '''\
+            - id: 1
+              name: s1
+            - id: 2
+              name: s2
+            '''.stripIndent()
+
+        when:
+        def result = makeHandler().loadFromFile('samples', yamlFile.toAbsolutePath())
+
+        then:
+        result instanceof List
+        result.size() == 2
+        result[0].id == 1
+        result[1].name == 's2'
+
+        cleanup:
+        yamlFile?.delete()
+    }
+
+    def 'should throw for unrecognized samplesheet format'() {
+        given:
+        def txtFile = Files.createTempFile('test', '.txt')
+        txtFile.text = 'some text'
+
+        when:
+        makeHandler().loadFromFile('items', txtFile.toAbsolutePath())
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains("Unrecognized file format 'txt'")
+
+        cleanup:
+        txtFile?.delete()
+    }
+
+    def 'should throw for a JSON file whose top level is not a list'() {
+        given:
+        def jsonFile = Files.createTempFile('test', '.json')
+        jsonFile.text = '{"key":"value"}'   // object, not array
+
+        when:
+        makeHandler().loadFromFile('samples', jsonFile.toAbsolutePath())
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('must contain a list of records')
+
+        cleanup:
+        jsonFile?.delete()
+    }
+
+    // ── unit: getWorkflowArguments / error cases ──────────────────────────────
+
+    def 'should throw for a missing required workflow input'() {
+        given:
+        def workflowDef = Mock(WorkflowDef) {
+            getName() >> 'HELLO'
+            getDeclaredInputs() >> ['samples']
+            getDeclaredInputTypes() >> [:]
+        }
+        def session = Mock(Session)
+        def script  = Mock(BaseScript) {
+            isTypingEnabled() >> true
+        }
+        def meta    = Mock(ScriptMeta) {
+            getLocalWorkflowNames() >> ['HELLO']
+            getWorkflow('HELLO') >> workflowDef
+        }
+        def handler = new WorkflowEntryHandler(script, session, meta)
+
+        when:
+        handler.getWorkflowArguments(workflowDef, [:])
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('requires input `samples`')
+    }
+
+    def 'should throw error when multiple workflows are defined'() {
+        given:
+        def workflow1 = Mock(WorkflowDef) {
+            getName() >> 'FIRST'
+            getDeclaredInputs() >> []
+            getDeclaredInputTypes() >> [:]
+        }
+        def session = Mock(Session) { getParams() >> [:] }
+        def script  = Mock(BaseScript) {
+            isTypingEnabled() >> true
+        }
+        def meta    = Mock(ScriptMeta) {
+            getLocalWorkflowNames() >> ['FIRST', 'SECOND']
+            getWorkflow('FIRST') >> workflow1
+        }
+
+        when:
+        def handler = new WorkflowEntryHandler(script, session, meta)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains('exactly one named workflow')
+    }
+
+    // ── integration tests ─────────────────────────────────────────────────────
+
+    def 'should auto-run a named workflow with a scalar input'() {
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name: String
+
+                emit:
+                greeting = "Hello, ${name}!"
+            }
+            ''',
+            config: [params: [name: 'World']]
+        )
+
+        then:
+        result != null
+    }
+
+    def 'should auto-run a named workflow with a CSV samplesheet input'() {
+        given:
+        def csvFile = Files.createTempFile('samples', '.csv')
+        csvFile.text = '''\
+            id,value
+            1,alpha
+            2,beta
+            '''.stripIndent()
+
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow PROCESS_SAMPLES {
+                take:
+                samples: Channel<Record>
+
+                emit:
+                out = samples
+            }
+            ''',
+            config: [params: [samples: csvFile.toString()]]
+        )
+
+        then:
+        result != null
+
+        cleanup:
+        csvFile?.delete()
+    }
+
+    def 'should auto-run a named workflow with a JSON samplesheet input'() {
+        given:
+        def jsonFile = Files.createTempFile('samples', '.json')
+        jsonFile.text = '[{"id":1,"name":"s1"},{"id":2,"name":"s2"}]'
+
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow PROCESS_SAMPLES {
+                take:
+                samples: Channel<Record>
+
+                emit:
+                out = samples
+            }
+            ''',
+            config: [params: [samples: jsonFile.toString()]]
+        )
+
+        then:
+        result != null
+
+        cleanup:
+        jsonFile?.delete()
+    }
+
+    def 'should auto-run a named workflow with multiple inputs'() {
+        given:
+        def csvFile = Files.createTempFile('samples', '.csv')
+        csvFile.text = '''\
+            id,value
+            1,alpha
+            '''.stripIndent()
+
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow PIPELINE {
+                take:
+                samples: Channel<Record>
+                outdir: String
+
+                emit:
+                out = samples
+            }
+            ''',
+            config: [params: [samples: csvFile.toString(), outdir: 'results']]
+        )
+
+        then:
+        result != null
+
+        cleanup:
+        csvFile?.delete()
+    }
+
+    def 'should throw for a missing workflow input'() {
+        when:
+        runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name: String
+
+                emit:
+                greeting = "Hello!"
+            }
+            ''',
+            params: [:]
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('requires input `name`')
+    }
+
+    def 'should prefer explicit entry workflow over named workflow'() {
+        when:
+        // An explicit (unnamed) entry workflow takes priority over WorkflowEntryHandler
+        def result = runScript(
+            '''\
+            workflow {
+                "explicit entry"
+            }
+
+            workflow NAMED {
+                take:
+                x
+                emit:
+                out = x
+            }
+            ''',
+            params: [x: 'ignored']
+        )
+
+        then:
+        // The explicit entry workflow ran
+        result != null
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -29,6 +29,10 @@ import static test.ScriptHelper.*
 /**
  * Tests for {@link WorkflowEntryHandler}.
  *
+ * The per-type mapping of a param value to a declared input type is covered
+ * by {@link ParamsHelperTest} -- the tests here only assert that a workflow
+ * input routes through it.
+ *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
 @Timeout(10)
@@ -36,9 +40,9 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
     // ── unit: loadFromFile ────────────────────────────────────────────────────
 
-    private WorkflowEntryHandler makeHandler(List<String> inputs = []) {
+    private WorkflowEntryHandler makeHandler(List<String> inputs = [], List<String> workflowNames = ['HELLO']) {
         def workflowDef = Mock(WorkflowDef) {
-            getName() >> 'HELLO'
+            getName() >> workflowNames.first()
             getDeclaredInputs() >> inputs.collect { n -> new Param(n, null, false, null) }
         }
         def session = Mock(Session) { getParams() >> [:] }
@@ -46,73 +50,32 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
             isTypingEnabled() >> true
         }
         def meta    = Mock(ScriptMeta) {
-            getLocalWorkflowNames() >> ['HELLO']
-            getWorkflow('HELLO') >> workflowDef
+            getLocalWorkflowNames() >> workflowNames
+            getWorkflow(workflowNames.first()) >> workflowDef
         }
         return new WorkflowEntryHandler(script, session, meta)
     }
 
-    def 'should load records from a CSV file'() {
+    def 'should load records from a samplesheet'() {
         given:
-        def csvFile = Files.createTempFile('test', '.csv')
-        csvFile.text = '''\
-            id,name
-            1,sample1
-            2,sample2
-            '''.stripIndent()
+        def file = Files.createTempFile('test', ".${EXT}")
+        file.text = TEXT
 
         when:
-        def result = makeHandler().loadFromFile('samples', csvFile.toAbsolutePath())
+        def result = makeHandler().loadFromFile('samples', file.toAbsolutePath())
 
         then:
-        result instanceof List
-        result.size() == 2
-        result[0].id == '1'
-        result[0].name == 'sample1'
+        result == EXPECTED
 
         cleanup:
-        csvFile?.delete()
-    }
+        file?.delete()
 
-    def 'should load records from a JSON file'() {
-        given:
-        def jsonFile = Files.createTempFile('test', '.json')
-        jsonFile.text = '[{"id":1,"name":"s1"},{"id":2,"name":"s2"}]'
-
-        when:
-        def result = makeHandler().loadFromFile('samples', jsonFile.toAbsolutePath())
-
-        then:
-        result instanceof List
-        result.size() == 2
-        result[0].id == 1
-        result[1].name == 's2'
-
-        cleanup:
-        jsonFile?.delete()
-    }
-
-    def 'should load records from a YAML file'() {
-        given:
-        def yamlFile = Files.createTempFile('test', '.yml')
-        yamlFile.text = '''\
-            - id: 1
-              name: s1
-            - id: 2
-              name: s2
-            '''.stripIndent()
-
-        when:
-        def result = makeHandler().loadFromFile('samples', yamlFile.toAbsolutePath())
-
-        then:
-        result instanceof List
-        result.size() == 2
-        result[0].id == 1
-        result[1].name == 's2'
-
-        cleanup:
-        yamlFile?.delete()
+        where:
+        EXT    | TEXT                                             | EXPECTED
+        // CSV has no types, so every value is a string
+        'csv'  | 'id,name\n1,sample1\n2,sample2\n'                | [[id: '1', name: 'sample1'], [id: '2', name: 'sample2']]
+        'json' | '[{"id":1,"name":"s1"},{"id":2,"name":"s2"}]'    | [[id: 1, name: 's1'], [id: 2, name: 's2']]
+        'yml'  | '- id: 1\n  name: s1\n- id: 2\n  name: s2\n'     | [[id: 1, name: 's1'], [id: 2, name: 's2']]
     }
 
     def 'should throw for unrecognized samplesheet format'() {
@@ -147,49 +110,9 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         jsonFile?.delete()
     }
 
-    // ── unit: getWorkflowArguments / error cases ──────────────────────────────
-
-    def 'should throw for a missing required workflow input'() {
-        given:
-        def workflowDef = Mock(WorkflowDef) {
-            getName() >> 'HELLO'
-            getDeclaredInputs() >> [new Param('samples', String, false, null)]
-        }
-        def session = Mock(Session)
-        def script  = Mock(BaseScript) {
-            isTypingEnabled() >> true
-        }
-        def meta    = Mock(ScriptMeta) {
-            getLocalWorkflowNames() >> ['HELLO']
-            getWorkflow('HELLO') >> workflowDef
-        }
-        def handler = new WorkflowEntryHandler(script, session, meta)
-
-        when:
-        handler.getWorkflowArguments(workflowDef)
-
-        then:
-        def e = thrown(ScriptRuntimeException)
-        e.message.contains('requires input `samples`')
-    }
-
     def 'should throw error when multiple workflows are defined'() {
-        given:
-        def workflow1 = Mock(WorkflowDef) {
-            getName() >> 'FIRST'
-            getDeclaredInputs() >> []
-        }
-        def session = Mock(Session) { getParams() >> [:] }
-        def script  = Mock(BaseScript) {
-            isTypingEnabled() >> true
-        }
-        def meta    = Mock(ScriptMeta) {
-            getLocalWorkflowNames() >> ['FIRST', 'SECOND']
-            getWorkflow('FIRST') >> workflow1
-        }
-
         when:
-        def handler = new WorkflowEntryHandler(script, session, meta)
+        makeHandler([], ['FIRST', 'SECOND'])
 
         then:
         def e = thrown(IllegalStateException)
@@ -198,10 +121,20 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
     // ── integration tests ─────────────────────────────────────────────────────
 
+    /**
+     * Run a script as `nextflow module run`, with the given params supplied
+     * either on the command line (raw strings) or in the config (structured
+     * values) -- the two are resolved differently.
+     */
+    private static Object runWorkflow(String text, Map params, boolean fromConfig = false) {
+        return fromConfig
+            ? runScript(moduleRun: true, text, config: [params: params], configParams: params)
+            : runScript(moduleRun: true, text, config: [params: params], params: params)
+    }
+
     def 'should auto-run a named workflow with a scalar input'() {
         when:
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -213,8 +146,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 greeting = "Hello, ${name}!"
             }
             ''',
-            config: [params: [name: 'World']],
-            params: [name: 'World']
+            [name: 'World']
         )
 
         then:
@@ -231,8 +163,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
             '''.stripIndent()
 
         when:
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -244,8 +175,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = samples
             }
             ''',
-            config: [params: [samples: csvFile.toString()]],
-            params: [samples: csvFile.toString()]
+            [samples: csvFile.toString()]
         )
 
         then:
@@ -254,37 +184,6 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         cleanup:
         csvFile?.delete()
-    }
-
-    def 'should auto-run a named workflow with a JSON samplesheet input'() {
-        given:
-        def jsonFile = Files.createTempFile('samples', '.json')
-        jsonFile.text = '[{"id":1,"name":"s1"},{"id":2,"name":"s2"}]'
-
-        when:
-        def result = runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            workflow PROCESS_SAMPLES {
-                take:
-                samples: Channel<Record>
-
-                emit:
-                out = samples
-            }
-            ''',
-            config: [params: [samples: jsonFile.toString()]],
-            params: [samples: jsonFile.toString()]
-        )
-
-        then:
-        result.val == [id: 1, name: 's1']
-        result.val == [id: 2, name: 's2']
-
-        cleanup:
-        jsonFile?.delete()
     }
 
     def 'should auto-run a named workflow with multiple inputs'() {
@@ -296,8 +195,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
             '''.stripIndent()
 
         when:
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -310,8 +208,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = samples.map { s -> "${outdir}/${s.id}" }
             }
             ''',
-            config: [params: [samples: csvFile.toString(), outdir: 'results']],
-            params: [samples: csvFile.toString(), outdir: 'results']
+            [samples: csvFile.toString(), outdir: 'results']
         )
 
         then:
@@ -323,8 +220,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
     def 'should throw for a missing workflow input'() {
         when:
-        runScript(
-            moduleRun: true,
+        runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -336,7 +232,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 greeting = "Hello!"
             }
             ''',
-            params: [:]
+            [:]
         )
 
         then:
@@ -349,19 +245,20 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         def fastq = Files.createTempFile('reads', '.fastq')
         def csvFile = Files.createTempFile('samples', '.csv')
         csvFile.text = """\
-            id,fastq_1
-            s1,${fastq}
+            id,fastq_1,count,ratio
+            s1,${fastq},7,1.5
             """.stripIndent()
 
         when:
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             nextflow.enable.types = true
 
             record Sample {
                 id: String
                 fastq_1: Path
+                count: Integer
+                ratio: Float
             }
 
             workflow RNASEQ {
@@ -369,16 +266,15 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 samples: Channel<Sample>
 
                 emit:
-                out = samples.map { s -> [s.getClass().simpleName, s.fastq_1.getClass().simpleName] }
+                out = samples.map { s -> [s.getClass().simpleName, s.fastq_1.getClass().simpleName, s.count, s.ratio] }
             }
             ''',
-            config: [params: [samples: csvFile.toString()]],
-            params: [samples: csvFile.toString()]
+            [samples: csvFile.toString()]
         )
 
         then:
-        // each record is cast to the record type and `fastq_1` to a Path
-        result.val == ['RecordMap', 'UnixPath']
+        // each record is cast to the record type, and each field to its declared type
+        result.val == ['RecordMap', 'UnixPath', 7, 1.5f]
 
         cleanup:
         csvFile?.delete()
@@ -394,8 +290,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
             '''.stripIndent()
 
         when:
-        runScript(
-            moduleRun: true,
+        runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -412,8 +307,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = samples
             }
             ''',
-            config: [params: [samples: csvFile.toString()]],
-            params: [samples: csvFile.toString()]
+            [samples: csvFile.toString()]
         )
 
         then:
@@ -424,44 +318,58 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         csvFile?.delete()
     }
 
-    def 'should coerce scalar inputs to the declared type'() {
+    def 'should wrap a Value input in a channel'() {
         when:
-        def params = [dur: '2h', mem: '4.GB', ver: '1.2.3', num: '5.5', val: '42']
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             nextflow.enable.types = true
 
             workflow CHECK {
                 take:
-                dur: Duration
-                mem: MemoryUnit
-                ver: VersionNumber
-                num: Float
                 val: Value<Integer>
 
                 emit:
-                out = val.map { v -> [
-                    dur.getClass().simpleName,
-                    mem.getClass().simpleName,
-                    ver.getClass().simpleName,
-                    num.getClass().simpleName,
-                    v.getClass().simpleName
-                ] }
+                out = val.map { v -> [v.getClass().simpleName, v] }
             }
             ''',
-            config: [params: params],
-            params: params
+            [val: '42']
         )
 
         then:
-        result.val == ['Duration', 'MemoryUnit', 'VersionNumber', 'Float', 'Integer']
+        // the param is resolved to the element type, then wrapped in a channel
+        result.val == ['Integer', 42]
+    }
+
+    def 'should resolve a Path input and require it to exist'() {
+        given:
+        def file = Files.createTempFile('data', '.txt')
+
+        when:
+        def result = runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                data: Path
+
+                emit:
+                out = [data.getClass().simpleName, data.name]
+            }
+            ''',
+            [data: file.toString()]
+        )
+
+        then:
+        result.val == ['UnixPath', file.name]
+
+        cleanup:
+        file?.delete()
     }
 
     def 'should pass null for an omitted optional input'() {
         when:
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -474,8 +382,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = "${required}:${threads}"
             }
             ''',
-            config: [params: [required: 'hello']],
-            params: [required: 'hello']
+            [required: 'hello']
         )
 
         then:
@@ -484,8 +391,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
     def 'should reject a collection input given on the command line'() {
         when:
-        runScript(
-            moduleRun: true,
+        runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -497,8 +403,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = ids
             }
             ''',
-            config: [params: [ids: 'a,b,c']],
-            params: [ids: 'a,b,c']
+            [ids: 'a,b,c']
         )
 
         then:
@@ -508,31 +413,35 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
     def 'should convert collection elements for an input from config'() {
         when:
-        def result = runScript(
-            moduleRun: true,
-            '''\
+        def result = runWorkflow(
+            """\
             nextflow.enable.types = true
 
             workflow COLL {
                 take:
-                sizes: List<Integer>
+                values: ${DECL}
 
                 emit:
-                out = sizes
+                out = [values.getClass().simpleName, values.toList().sort()]
             }
-            ''',
-            config: [params: [sizes: ['1', '12']]],
-            configParams: [sizes: ['1', '12']]
+            """,
+            [values: PARAM],
+            true
         )
 
         then:
-        result.val == [1, 12]
+        result.val == [EXPECTED_CLASS, EXPECTED]
+
+        where:
+        DECL            | PARAM        | EXPECTED_CLASS  | EXPECTED
+        'List<Integer>' | ['1', '12']  | 'ArrayList'     | [1, 12]
+        'Set<Integer>'  | ['1', '2']   | 'LinkedHashSet' | [1, 2]
+        'Bag<String>'   | ['a', 'b']   | 'HashBag'       | ['a', 'b']
     }
 
     def 'should reject a parameter that is not a workflow input'() {
         when:
-        runScript(
-            moduleRun: true,
+        runWorkflow(
             '''\
             nextflow.enable.types = true
 
@@ -544,8 +453,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 greeting = "Hello, ${name}!"
             }
             ''',
-            config: [params: [name: 'World', bogus: '1']],
-            params: [name: 'World', bogus: '1']
+            [name: 'World', bogus: '1']
         )
 
         then:
@@ -556,8 +464,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     def 'should prefer explicit entry workflow over named workflow'() {
         when:
         // An explicit (unnamed) entry workflow takes priority over WorkflowEntryHandler
-        def result = runScript(
-            moduleRun: true,
+        def result = runWorkflow(
             '''\
             workflow {
                 "explicit entry"
@@ -570,183 +477,17 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = x
             }
             ''',
-            params: [x: 'ignored']
+            [x: 'ignored']
         )
 
         then:
-        // The explicit entry workflow ran
-        result != null
-    }
-
-    def 'should coerce an integral command line value to a Float input'() {
-        when:
-        def result = runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            workflow CHECK {
-                take:
-                num: Float
-
-                emit:
-                out = [num.getClass().simpleName, num]
-            }
-            ''',
-            config: [params: [num: '5']],
-            params: [num: '5']
-        )
-
-        then:
-        result.val == ['Float', 5.0f]
-    }
-
-    def 'should resolve a Path input and require it to exist'() {
-        given:
-        def file = Files.createTempFile('data', '.txt')
-
-        when:
-        def result = runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            workflow CHECK {
-                take:
-                data: Path
-
-                emit:
-                out = [data.getClass().simpleName, data.name]
-            }
-            ''',
-            config: [params: [data: file.toString()]],
-            params: [data: file.toString()]
-        )
-
-        then:
-        result.val == ['UnixPath', file.name]
-
-        cleanup:
-        file?.delete()
-    }
-
-    def 'should reject a Path input that does not exist'() {
-        when:
-        runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            workflow CHECK {
-                take:
-                data: Path
-
-                emit:
-                out = data
-            }
-            ''',
-            config: [params: [data: '/some/missing/file.txt']],
-            params: [data: '/some/missing/file.txt']
-        )
-
-        then:
-        def e = thrown(Exception)
-        e.message.contains('/some/missing/file.txt')
-    }
-
-    def 'should convert collection elements for Set and Bag inputs from config'() {
-        when:
-        def params = [ids: ['1', '2'], tags: ['a', 'b']]
-        def result = runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            workflow CHECK {
-                take:
-                ids: Set<Integer>
-                tags: Bag<String>
-
-                emit:
-                out = [ids.getClass().simpleName, ids.toList(), tags.getClass().simpleName, tags.size()]
-            }
-            ''',
-            config: [params: params],
-            configParams: params
-        )
-
-        then:
-        result.val == ['LinkedHashSet', [1, 2], 'HashBag', 2]
-    }
-
-    def 'should convert numeric record fields from a samplesheet'() {
-        given:
-        def csvFile = Files.createTempFile('samples', '.csv')
-        csvFile.text = '''\
-            id,count,ratio
-            s1,7,1.5
-            '''.stripIndent()
-
-        when:
-        def result = runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            record Sample {
-                id: String
-                count: Integer
-                ratio: Float
-            }
-
-            workflow RNASEQ {
-                take:
-                samples: Channel<Sample>
-
-                emit:
-                out = samples.map { s -> [s.count, s.ratio] }
-            }
-            ''',
-            config: [params: [samples: csvFile.toString()]],
-            params: [samples: csvFile.toString()]
-        )
-
-        then:
-        result.val == [7, 1.5f]
-
-        cleanup:
-        csvFile?.delete()
-    }
-
-    def 'should convert a number from config to the declared input type'() {
-        when:
-        def params = [ratio: 96.4G, count: 40]
-        def result = runScript(
-            moduleRun: true,
-            '''\
-            nextflow.enable.types = true
-
-            workflow CHECK {
-                take:
-                ratio: Float
-                count: Integer
-
-                emit:
-                out = [ratio.getClass().simpleName, ratio, count.getClass().simpleName]
-            }
-            ''',
-            config: [params: params],
-            configParams: params
-        )
-
-        then:
-        result.val == ['Float', 96.4f, 'Integer']
+        // the explicit entry workflow ran, and the named one was not invoked
+        result == 'explicit entry'
     }
 
     def 'should reject a named workflow in a script that does not enable typing'() {
         when:
-        runScript(
-            moduleRun: true,
+        runWorkflow(
             '''\
             workflow GREET {
                 take:
@@ -755,7 +496,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 greeting = "Hello, ${name}!"
             }
             ''',
-            params: [name: 'World']
+            [name: 'World']
         )
 
         then:

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -504,6 +504,51 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         e.message.contains('static typing is required')
     }
 
+    def 'should reject a workflow input that is not typed'() {
+        when:
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name
+
+                emit:
+                greeting = "Hello, ${name}!"
+            }
+            ''',
+            [name: 'World']
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('the following inputs are not typed: name')
+    }
+
+    def 'should report a samplesheet file that does not exist'() {
+        when:
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow RNASEQ {
+                take:
+                samples: Channel<Record>
+
+                emit:
+                out = samples
+            }
+            ''',
+            [samples: '/some/missing/samples.csv']
+        )
+
+        then:
+        // the file is reported by name, rather than as a raw NoSuchFileException
+        def e = thrown(Exception)
+        e.message.contains("Input file '/some/missing/samples.csv' does not exist")
+    }
+
     def 'should not execute a named workflow directly without module run'() {
         when:
         runScript(

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -237,7 +237,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         then:
         def e = thrown(ScriptRuntimeException)
-        e.message.contains('requires input `name`')
+        e.message.contains('Parameter `--name` is required but no value was provided')
     }
 
     def 'should convert samplesheet records to the declared element type'() {
@@ -572,7 +572,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         e.message.contains('No entry workflow specified')
     }
 
-    def 'should treat a null param value as not provided'() {
+    def 'should report a required input with no value'() {
         when:
         // e.g. a blank entry in a params file -- a required input must not be
         // silently satisfied by null
@@ -593,7 +593,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         then:
         def e = thrown(ScriptRuntimeException)
-        e.message.contains('Workflow `GREET` requires input `name` but no parameter `--name` was provided')
+        e.message.contains('Parameter `--name` is required but no value was provided')
     }
 
     def 'should pass a null param value to a nullable input'() {
@@ -703,6 +703,76 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         then: 'the param and declared type are named, rather than a bare NumberFormatException'
         def e = thrown(ScriptRuntimeException)
         e.message.contains('Parameter `ids` with type List<Integer> cannot be assigned to')
+    }
+
+    def 'should load a blank samplesheet cell as a missing value'() {
+        given:
+        def fastq = Files.createTempFile('reads', '.fq')
+        def file = Files.createTempFile('samples', '.csv')
+        file.text = "id,fastq_1,fastq_2\ns1,${fastq},\n"
+
+        when: 'an optional field is left blank rather than omitted'
+        def result = runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            record Sample {
+                id: String
+                fastq_1: Path
+                fastq_2: Path?
+            }
+
+            workflow GREET {
+                take:
+                samples: Channel<Sample>
+
+                emit:
+                out = samples.map { s -> "${s.id}:${s.fastq_2}" }
+            }
+            ''',
+            [samples: file.toString()]
+        )
+
+        then:
+        result.val == 's1:null'
+
+        cleanup:
+        file?.delete()
+        fastq?.delete()
+    }
+
+    def 'should report a required record field left blank in a samplesheet'() {
+        given:
+        def file = Files.createTempFile('samples', '.csv')
+        file.text = 'id,count\ns1,\n'
+
+        when:
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            record Sample {
+                id: String
+                count: Integer
+            }
+
+            workflow GREET {
+                take:
+                samples: Channel<Sample>
+
+                emit:
+                out = samples
+            }
+            ''',
+            [samples: file.toString()]
+        )
+
+        then: 'the missing field is named, rather than an empty-string conversion failure'
+        def e = thrown(Exception)
+        e.message.contains("missing field 'count'")
+
+        cleanup:
+        file?.delete()
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -19,6 +19,7 @@ package nextflow.script
 import java.nio.file.Files
 
 import nextflow.Session
+import nextflow.exception.AbortOperationException
 import nextflow.exception.ScriptRuntimeException
 import spock.lang.Timeout
 import test.Dsl2Spec
@@ -200,6 +201,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     def 'should auto-run a named workflow with a scalar input'() {
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -216,7 +218,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         )
 
         then:
-        result != null
+        result.val == 'Hello, World!'
     }
 
     def 'should auto-run a named workflow with a CSV samplesheet input'() {
@@ -230,6 +232,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -246,7 +249,8 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         )
 
         then:
-        result != null
+        result.val == [id: '1', value: 'alpha']
+        result.val == [id: '2', value: 'beta']
 
         cleanup:
         csvFile?.delete()
@@ -259,6 +263,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -275,7 +280,8 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         )
 
         then:
-        result != null
+        result.val == [id: 1, name: 's1']
+        result.val == [id: 2, name: 's2']
 
         cleanup:
         jsonFile?.delete()
@@ -291,6 +297,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -300,7 +307,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 outdir: String
 
                 emit:
-                out = samples
+                out = samples.map { s -> "${outdir}/${s.id}" }
             }
             ''',
             config: [params: [samples: csvFile.toString(), outdir: 'results']],
@@ -308,7 +315,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         )
 
         then:
-        result != null
+        result.val == 'results/1'
 
         cleanup:
         csvFile?.delete()
@@ -317,6 +324,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     def 'should throw for a missing workflow input'() {
         when:
         runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -347,6 +355,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -386,6 +395,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         when:
         runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -418,6 +428,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         when:
         def params = [dur: '2h', mem: '4.GB', ver: '1.2.3', num: '5.5', val: '42']
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -450,6 +461,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     def 'should pass null for an omitted optional input'() {
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -473,6 +485,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     def 'should reject a collection input given on the command line'() {
         when:
         runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -496,6 +509,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     def 'should convert collection elements for an input from config'() {
         when:
         def result = runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -504,20 +518,21 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 sizes: List<Integer>
 
                 emit:
-                out = sizes.collect { v -> v.getClass().simpleName }
+                out = sizes
             }
             ''',
-            config: [params: [sizes: ['1', '2']]],
-            configParams: [sizes: ['1', '2']]
+            config: [params: [sizes: ['1', '12']]],
+            configParams: [sizes: ['1', '12']]
         )
 
         then:
-        result.val == ['Integer', 'Integer']
+        result.val == [1, 12]
     }
 
     def 'should reject a parameter that is not a workflow input'() {
         when:
         runScript(
+            moduleRun: true,
             '''\
             nextflow.enable.types = true
 
@@ -542,6 +557,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         when:
         // An explicit (unnamed) entry workflow takes priority over WorkflowEntryHandler
         def result = runScript(
+            moduleRun: true,
             '''\
             workflow {
                 "explicit entry"
@@ -560,6 +576,189 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         then:
         // The explicit entry workflow ran
         result != null
+    }
+
+    def 'should coerce an integral command line value to a Float input'() {
+        when:
+        def result = runScript(
+            moduleRun: true,
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                num: Float
+
+                emit:
+                out = [num.getClass().simpleName, num]
+            }
+            ''',
+            config: [params: [num: '5']],
+            params: [num: '5']
+        )
+
+        then:
+        result.val == ['Float', 5.0f]
+    }
+
+    def 'should resolve a Path input and require it to exist'() {
+        given:
+        def file = Files.createTempFile('data', '.txt')
+
+        when:
+        def result = runScript(
+            moduleRun: true,
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                data: Path
+
+                emit:
+                out = [data.getClass().simpleName, data.name]
+            }
+            ''',
+            config: [params: [data: file.toString()]],
+            params: [data: file.toString()]
+        )
+
+        then:
+        result.val == ['UnixPath', file.name]
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'should reject a Path input that does not exist'() {
+        when:
+        runScript(
+            moduleRun: true,
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                data: Path
+
+                emit:
+                out = data
+            }
+            ''',
+            config: [params: [data: '/some/missing/file.txt']],
+            params: [data: '/some/missing/file.txt']
+        )
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains('/some/missing/file.txt')
+    }
+
+    def 'should convert collection elements for Set and Bag inputs from config'() {
+        when:
+        def params = [ids: ['1', '2'], tags: ['a', 'b']]
+        def result = runScript(
+            moduleRun: true,
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                ids: Set<Integer>
+                tags: Bag<String>
+
+                emit:
+                out = [ids.getClass().simpleName, ids.toList(), tags.getClass().simpleName, tags.size()]
+            }
+            ''',
+            config: [params: params],
+            configParams: params
+        )
+
+        then:
+        result.val == ['LinkedHashSet', [1, 2], 'HashBag', 2]
+    }
+
+    def 'should convert numeric record fields from a samplesheet'() {
+        given:
+        def csvFile = Files.createTempFile('samples', '.csv')
+        csvFile.text = '''\
+            id,count,ratio
+            s1,7,1.5
+            '''.stripIndent()
+
+        when:
+        def result = runScript(
+            moduleRun: true,
+            '''\
+            nextflow.enable.types = true
+
+            record Sample {
+                id: String
+                count: Integer
+                ratio: Float
+            }
+
+            workflow RNASEQ {
+                take:
+                samples: Channel<Sample>
+
+                emit:
+                out = samples.map { s -> [s.count, s.ratio] }
+            }
+            ''',
+            config: [params: [samples: csvFile.toString()]],
+            params: [samples: csvFile.toString()]
+        )
+
+        then:
+        result.val == [7, 1.5f]
+
+        cleanup:
+        csvFile?.delete()
+    }
+
+    def 'should reject a named workflow in a script that does not enable typing'() {
+        when:
+        runScript(
+            moduleRun: true,
+            '''\
+            workflow GREET {
+                take:
+                name
+                emit:
+                greeting = "Hello, ${name}!"
+            }
+            ''',
+            params: [name: 'World']
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('does not enable static typing')
+    }
+
+    def 'should not execute a named workflow directly without module run'() {
+        when:
+        runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name: String
+
+                emit:
+                greeting = "Hello, ${name}!"
+            }
+            ''',
+            config: [params: [name: 'World']],
+            params: [name: 'World']
+        )
+
+        then:
+        def e = thrown(AbortOperationException)
+        e.message.contains('No entry workflow specified')
     }
 
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -718,6 +718,31 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         csvFile?.delete()
     }
 
+    def 'should convert a number from config to the declared input type'() {
+        when:
+        def params = [ratio: 96.4G, count: 40]
+        def result = runScript(
+            moduleRun: true,
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                ratio: Float
+                count: Integer
+
+                emit:
+                out = [ratio.getClass().simpleName, ratio, count.getClass().simpleName]
+            }
+            ''',
+            config: [params: params],
+            configParams: params
+        )
+
+        then:
+        result.val == ['Float', 96.4f, 'Integer']
+    }
+
     def 'should reject a named workflow in a script that does not enable typing'() {
         when:
         runScript(

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -572,4 +572,137 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         e.message.contains('No entry workflow specified')
     }
 
+    def 'should treat a null param value as not provided'() {
+        when:
+        // e.g. a blank entry in a params file -- a required input must not be
+        // silently satisfied by null
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name: String
+
+                emit:
+                greeting = "Hello, ${name}!"
+            }
+            ''',
+            [name: null]
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('Workflow `GREET` requires input `name` but no parameter `--name` was provided')
+    }
+
+    def 'should pass a null param value to a nullable input'() {
+        when:
+        def result = runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name: String?
+
+                emit:
+                greeting = "Hello, ${name ?: 'World'}!"
+            }
+            ''',
+            [name: null]
+        )
+
+        then:
+        result.val == 'Hello, World!'
+    }
+
+    def 'should reject a channel element type that is not a record'() {
+        given:
+        def file = Files.createTempFile('samples', '.csv')
+        file.text = 'id\ns1\ns2\n'
+
+        when:
+        // a samplesheet record would otherwise be stringified, e.g. '[id:s1]'
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                samples: Channel<String>
+
+                emit:
+                out = samples
+            }
+            ''',
+            [samples: file.toString()]
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('cannot be loaded from a samplesheet')
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'should report an invalid samplesheet record with the param and file'() {
+        given:
+        def file = Files.createTempFile('samples', '.csv')
+        file.text = 'id,count\ns1,abc\n'
+
+        when:
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            record Sample {
+                id: String
+                count: Integer
+            }
+
+            workflow GREET {
+                take:
+                samples: Channel<Sample>
+
+                emit:
+                out = samples
+            }
+            ''',
+            [samples: file.toString()]
+        )
+
+        then: 'the param and file are named, rather than a bare NumberFormatException'
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('Invalid record in samplesheet')
+        e.message.contains('workflow input `samples`')
+
+        cleanup:
+        file?.delete()
+    }
+
+    def 'should report a collection element that cannot be converted'() {
+        when:
+        runWorkflow(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                ids: List<Integer>
+
+                emit:
+                out = ids
+            }
+            ''',
+            [ids: ['a', 'b']],
+            true
+        )
+
+        then: 'the param and declared type are named, rather than a bare NumberFormatException'
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('Parameter `ids` with type List<Integer> cannot be assigned to')
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -735,7 +735,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
 
         then:
         def e = thrown(ScriptRuntimeException)
-        e.message.contains('does not enable static typing')
+        e.message.contains('static typing is required')
     }
 
     def 'should not execute a named workflow directly without module run'() {

--- a/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/WorkflowEntryHandlerTest.groovy
@@ -38,8 +38,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
     private WorkflowEntryHandler makeHandler(List<String> inputs = []) {
         def workflowDef = Mock(WorkflowDef) {
             getName() >> 'HELLO'
-            getDeclaredInputs() >> inputs
-            getDeclaredInputTypes() >> [:]
+            getDeclaredInputs() >> inputs.collect { n -> new Param(n, null, false, null) }
         }
         def session = Mock(Session) { getParams() >> [:] }
         def script  = Mock(BaseScript) {
@@ -153,8 +152,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         given:
         def workflowDef = Mock(WorkflowDef) {
             getName() >> 'HELLO'
-            getDeclaredInputs() >> ['samples']
-            getDeclaredInputTypes() >> [:]
+            getDeclaredInputs() >> [new Param('samples', String, false, null)]
         }
         def session = Mock(Session)
         def script  = Mock(BaseScript) {
@@ -167,7 +165,7 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         def handler = new WorkflowEntryHandler(script, session, meta)
 
         when:
-        handler.getWorkflowArguments(workflowDef, [:])
+        handler.getWorkflowArguments(workflowDef)
 
         then:
         def e = thrown(ScriptRuntimeException)
@@ -179,7 +177,6 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         def workflow1 = Mock(WorkflowDef) {
             getName() >> 'FIRST'
             getDeclaredInputs() >> []
-            getDeclaredInputTypes() >> [:]
         }
         def session = Mock(Session) { getParams() >> [:] }
         def script  = Mock(BaseScript) {
@@ -214,7 +211,8 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 greeting = "Hello, ${name}!"
             }
             ''',
-            config: [params: [name: 'World']]
+            config: [params: [name: 'World']],
+            params: [name: 'World']
         )
 
         then:
@@ -243,7 +241,8 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = samples
             }
             ''',
-            config: [params: [samples: csvFile.toString()]]
+            config: [params: [samples: csvFile.toString()]],
+            params: [samples: csvFile.toString()]
         )
 
         then:
@@ -271,7 +270,8 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = samples
             }
             ''',
-            config: [params: [samples: jsonFile.toString()]]
+            config: [params: [samples: jsonFile.toString()]],
+            params: [samples: jsonFile.toString()]
         )
 
         then:
@@ -303,7 +303,8 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
                 out = samples
             }
             ''',
-            config: [params: [samples: csvFile.toString(), outdir: 'results']]
+            config: [params: [samples: csvFile.toString(), outdir: 'results']],
+            params: [samples: csvFile.toString(), outdir: 'results']
         )
 
         then:
@@ -333,6 +334,208 @@ class WorkflowEntryHandlerTest extends Dsl2Spec {
         then:
         def e = thrown(ScriptRuntimeException)
         e.message.contains('requires input `name`')
+    }
+
+    def 'should convert samplesheet records to the declared element type'() {
+        given:
+        def fastq = Files.createTempFile('reads', '.fastq')
+        def csvFile = Files.createTempFile('samples', '.csv')
+        csvFile.text = """\
+            id,fastq_1
+            s1,${fastq}
+            """.stripIndent()
+
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            record Sample {
+                id: String
+                fastq_1: Path
+            }
+
+            workflow RNASEQ {
+                take:
+                samples: Channel<Sample>
+
+                emit:
+                out = samples.map { s -> [s.getClass().simpleName, s.fastq_1.getClass().simpleName] }
+            }
+            ''',
+            config: [params: [samples: csvFile.toString()]],
+            params: [samples: csvFile.toString()]
+        )
+
+        then:
+        // each record is cast to the record type and `fastq_1` to a Path
+        result.val == ['RecordMap', 'UnixPath']
+
+        cleanup:
+        csvFile?.delete()
+        fastq?.delete()
+    }
+
+    def 'should reject a samplesheet that is missing a required record field'() {
+        given:
+        def csvFile = Files.createTempFile('samples', '.csv')
+        csvFile.text = '''\
+            id,wrong_column
+            s1,oops
+            '''.stripIndent()
+
+        when:
+        runScript(
+            '''\
+            nextflow.enable.types = true
+
+            record Sample {
+                id: String
+                fastq_1: Path
+            }
+
+            workflow RNASEQ {
+                take:
+                samples: Channel<Sample>
+
+                emit:
+                out = samples
+            }
+            ''',
+            config: [params: [samples: csvFile.toString()]],
+            params: [samples: csvFile.toString()]
+        )
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains("is missing field 'fastq_1' required by record type 'Sample'")
+
+        cleanup:
+        csvFile?.delete()
+    }
+
+    def 'should coerce scalar inputs to the declared type'() {
+        when:
+        def params = [dur: '2h', mem: '4.GB', ver: '1.2.3', num: '5.5', val: '42']
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow CHECK {
+                take:
+                dur: Duration
+                mem: MemoryUnit
+                ver: VersionNumber
+                num: Float
+                val: Value<Integer>
+
+                emit:
+                out = val.map { v -> [
+                    dur.getClass().simpleName,
+                    mem.getClass().simpleName,
+                    ver.getClass().simpleName,
+                    num.getClass().simpleName,
+                    v.getClass().simpleName
+                ] }
+            }
+            ''',
+            config: [params: params],
+            params: params
+        )
+
+        then:
+        result.val == ['Duration', 'MemoryUnit', 'VersionNumber', 'Float', 'Integer']
+    }
+
+    def 'should pass null for an omitted optional input'() {
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow OPT {
+                take:
+                required: String
+                threads: Integer?
+
+                emit:
+                out = "${required}:${threads}"
+            }
+            ''',
+            config: [params: [required: 'hello']],
+            params: [required: 'hello']
+        )
+
+        then:
+        result.val == 'hello:null'
+    }
+
+    def 'should reject a collection input given on the command line'() {
+        when:
+        runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow COLL {
+                take:
+                ids: List<String>
+
+                emit:
+                out = ids
+            }
+            ''',
+            config: [params: [ids: 'a,b,c']],
+            params: [ids: 'a,b,c']
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('cannot be assigned to a,b,c')
+    }
+
+    def 'should convert collection elements for an input from config'() {
+        when:
+        def result = runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow COLL {
+                take:
+                sizes: List<Integer>
+
+                emit:
+                out = sizes.collect { v -> v.getClass().simpleName }
+            }
+            ''',
+            config: [params: [sizes: ['1', '2']]],
+            configParams: [sizes: ['1', '2']]
+        )
+
+        then:
+        result.val == ['Integer', 'Integer']
+    }
+
+    def 'should reject a parameter that is not a workflow input'() {
+        when:
+        runScript(
+            '''\
+            nextflow.enable.types = true
+
+            workflow GREET {
+                take:
+                name: String
+
+                emit:
+                greeting = "Hello, ${name}!"
+            }
+            ''',
+            config: [params: [name: 'World', bogus: '1']],
+            params: [name: 'World', bogus: '1']
+        )
+
+        then:
+        def e = thrown(ScriptRuntimeException)
+        e.message.contains('Parameter `bogus` was specified on the command line but is not an input of workflow `GREET`')
     }
 
     def 'should prefer explicit entry workflow over named workflow'() {

--- a/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/parser/v2/ScriptLoaderV2Test.groovy
@@ -133,7 +133,7 @@ class ScriptLoaderV2Test extends Dsl2Spec {
 
         then:
         meta.definitions.size() == 2
-        meta.getWorkflow('hello').declaredInputs == ['foo', 'bar']
+        meta.getWorkflow('hello').declaredInputs*.name == ['foo', 'bar']
         meta.getWorkflow('hello').declaredOutputs == ['result']
     }
 

--- a/modules/nextflow/src/testFixtures/groovy/test/ScriptHelper.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/ScriptHelper.groovy
@@ -63,7 +63,9 @@ class ScriptHelper {
      * This function compiles and executes the script without
      * running the pipeline. The entry workflow is executed
      * (i.e. to construct the workflow DAG) unless opts.module
-     * is enabled.
+     * is enabled. Set opts.moduleRun to emulate `nextflow module
+     * run`, which allows a single process or named workflow to be
+     * executed directly.
      *
      * @param opts
      * @param text
@@ -73,6 +75,8 @@ class ScriptHelper {
         session.setBinding(new ScriptBinding())
 
         session.init(null, null, opts.params, opts.configParams)
+        if( opts.moduleRun )
+            session.setModuleRun(true)
         session.start()
 
         def loader = ScriptLoaderFactory.create(session)
@@ -163,6 +167,8 @@ class ScriptHelper {
         session.setBinding(new ScriptBinding())
 
         session.init(null, null, opts.params, opts.configParams)
+        if( opts.moduleRun )
+            session.setModuleRun(true)
         session.start()
 
         def loader = ScriptLoaderFactory.create(session)
@@ -197,6 +203,8 @@ class ScriptHelper {
         session.setBinding(new ScriptBinding())
 
         session.init( new ScriptFile(path), null, opts.params, null )
+        if( opts.moduleRun )
+            session.setModuleRun(true)
         session.start()
 
         def loader = ScriptLoaderFactory.create(session)

--- a/modules/nf-commons/src/main/nextflow/util/TypeHelper.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/TypeHelper.groovy
@@ -31,6 +31,7 @@ import nextflow.script.types.Bag
 import nextflow.script.types.Record
 import nextflow.util.HashBag
 import nextflow.util.RecordMap
+import org.codehaus.groovy.runtime.StringGroovyMethods
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 
@@ -113,7 +114,23 @@ class TypeHelper {
         if( type == Path )
             return TypeHelper.asPathType(value.toString())
 
-        return DefaultTypeTransformation.castToType(value, getRawType(type))
+        final rawType = getRawType(type)
+
+        // a string must be parsed, because the default coercion converts a
+        // single-character string to a char (e.g. '1' becomes 49) and treats
+        // any non-empty string as `true`
+        if( value instanceof CharSequence ) {
+            final str = value.toString()
+            if( Number.class.isAssignableFrom(rawType) )
+                return StringGroovyMethods.asType(str, rawType)
+            if( rawType == Boolean ) {
+                if( str.equalsIgnoreCase('true') ) return Boolean.TRUE
+                if( str.equalsIgnoreCase('false') ) return Boolean.FALSE
+                throw new AbortOperationException("Value '${str}' cannot be converted to a Boolean")
+            }
+        }
+
+        return DefaultTypeTransformation.castToType(value, rawType)
     }
 
     /**

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyHelper.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyHelper.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import nextflow.script.ast.ScriptNode;
 import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.Variable;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
@@ -43,6 +44,16 @@ public class ScriptToGroovyHelper {
 
     public ScriptToGroovyHelper(SourceUnit sourceUnit) {
         this.sourceUnit = sourceUnit;
+    }
+
+    /**
+     * Get the name used to qualify hidden classes generated for a script.
+     *
+     * @param moduleNode
+     */
+    public static String packageName(ScriptNode moduleNode) {
+        var scriptClass = moduleNode.getClasses().get(0);
+        return scriptClass.getNameWithoutPackage();
     }
 
     /**

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -236,7 +236,7 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
     private Statement workflowTakes(Parameter[] takes) {
         var statements = Arrays.stream(takes)
             .map((take) ->
-                stmt(callThisX("_take_", args(constX(take.getName()))))
+                stmt(callThisX("_take_", args(constX(take.getName()), classX(take.getType()))))
             )
             .toList();
         return block(null, statements);

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 
 import nextflow.script.ast.ASTNodeMarker;
 import nextflow.script.ast.AgentNode;
-import nextflow.script.ast.AssignmentExpression;
 import nextflow.script.ast.FeatureFlagNode;
 import nextflow.script.ast.FunctionNode;
 import nextflow.script.ast.IncludeNode;
@@ -45,14 +44,11 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
-import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.VariableScope;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
-import org.codehaus.groovy.ast.expr.VariableExpression;
-import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.ReturnStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
@@ -166,7 +162,7 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitParams(ParamBlockNode node) {
-        var paramsType = new RecordNode(packageName(moduleNode) + "." + "__Params");
+        var paramsType = new RecordNode(sgh.packageName(moduleNode) + "." + "__Params");
         for( var param : node.declarations ) {
             var fn = new FieldNode(
                 param.getName(),
@@ -194,11 +190,6 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
         moduleNode.addStatement(result);
     }
 
-    private static String packageName(ScriptNode moduleNode) {
-        var scriptClass = moduleNode.getClasses().get(0);
-        return scriptClass.getNameWithoutPackage();
-    }
-
     @Override
     public void visitParamV1(ParamNodeV1 node) {
         var result = stmt(assignX(node.target, node.value));
@@ -209,77 +200,8 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
     public void visitWorkflow(WorkflowNode node) {
         if( !node.isEntry() )
             checkReservedMethodName(node, "workflow");
-
-        var main = node.main instanceof BlockStatement block ? block : new BlockStatement();
-        visitWorkflowEmits(node.emits, main);
-        visitWorkflowPublishers(node.publishers, main);
-        visitWorkflowHandler(node.onComplete, "setOnComplete", main);
-        visitWorkflowHandler(node.onError, "setOnError", main);
-
-        var bodyDef = stmt(createX(
-            "nextflow.script.BodyDef",
-            args(
-                closureX(null, main),
-                constX(null),
-                constX("workflow")
-            )
-        ));
-        var closure = closureX(null, block(new VariableScope(), List.of(
-            workflowTakes(node.getParameters()),
-            node.emits,
-            bodyDef
-        )));
-        var arguments = node.isEntry()
-            ? args(closure)
-            : args(constX(node.getName()), closure);
-        var result = stmt(callThisX("workflow", arguments));
+        var result = new WorkflowToGroovyVisitor(sourceUnit).transform(node);
         moduleNode.addStatement(result);
-    }
-
-    private Statement workflowTakes(Parameter[] takes) {
-        var statements = Arrays.stream(takes)
-            .map((take) ->
-                stmt(callThisX("_take_", args(constX(take.getName()), classX(take.getType()))))
-            )
-            .toList();
-        return block(null, statements);
-    }
-
-    private void visitWorkflowEmits(Statement emits, BlockStatement main) {
-        for( var stmt : asBlockStatements(emits) ) {
-            var es = (ExpressionStatement)stmt;
-            var emit = es.getExpression();
-            if( emit instanceof VariableExpression ve ) {
-                es.setExpression(callThisX("_emit_", args(constX(ve.getName()))));
-            }
-            else if( emit instanceof AssignmentExpression ae ) {
-                var target = (VariableExpression)ae.getLeftExpression();
-                main.addStatement(assignS(target, emit));
-                es.setExpression(callThisX("_emit_", args(constX(target.getName()))));
-                main.addStatement(es);
-            }
-            else {
-                var target = varX("$out");
-                main.addStatement(assignS(target, emit));
-                es.setExpression(callThisX("_emit_", args(constX(target.getName()))));
-                main.addStatement(es);
-            }
-        }
-    }
-
-    private void visitWorkflowPublishers(Statement publishers, BlockStatement main) {
-        for( var stmt : asBlockStatements(publishers) ) {
-            var es = (ExpressionStatement)stmt;
-            var publish = (BinaryExpression)es.getExpression();
-            var target = asVarX(publish.getLeftExpression());
-            es.setExpression(callThisX("_publish_", args(constX(target.getName()), publish.getRightExpression())));
-            main.addStatement(es);
-        }
-    }
-
-    private void visitWorkflowHandler(Statement code, String name, BlockStatement main) {
-        if( code instanceof BlockStatement block )
-            main.addStatement(stmt(callX(varX("workflow"), name, args(closureX(null, block)))));
     }
 
     @Override

--- a/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/ScriptToGroovyVisitor.java
@@ -239,7 +239,7 @@ public class ScriptToGroovyVisitor extends ScriptVisitorSupport {
     private Statement workflowTakes(Parameter[] takes) {
         var statements = Arrays.stream(takes)
             .map((take) ->
-                stmt(callThisX("_take_", args(constX(take.getName()))))
+                stmt(callThisX("_take_", args(constX(take.getName()), classX(take.getType()))))
             )
             .toList();
         return block(null, statements);

--- a/modules/nf-lang/src/main/java/nextflow/script/control/WorkflowToGroovyVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/WorkflowToGroovyVisitor.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script.control;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+
+import nextflow.script.ast.ASTNodeMarker;
+import nextflow.script.ast.AssignmentExpression;
+import nextflow.script.ast.RecordNode;
+import nextflow.script.ast.ScriptNode;
+import nextflow.script.ast.WorkflowNode;
+import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.VariableScope;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.control.SourceUnit;
+
+import static nextflow.script.ast.ASTUtils.*;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
+
+/**
+ * Transform a workflow definition into a Groovy AST.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class WorkflowToGroovyVisitor {
+
+    private SourceUnit sourceUnit;
+
+    private ScriptNode moduleNode;
+
+    public WorkflowToGroovyVisitor(SourceUnit sourceUnit) {
+        this.sourceUnit = sourceUnit;
+        this.moduleNode = (ScriptNode) sourceUnit.getAST();
+    }
+
+    public Statement transform(WorkflowNode node) {
+        var main = node.main instanceof BlockStatement block ? block : new BlockStatement();
+        visitWorkflowEmits(node.emits, main);
+        visitWorkflowPublishers(node.publishers, main);
+        visitWorkflowHandler(node.onComplete, "setOnComplete", main);
+        visitWorkflowHandler(node.onError, "setOnError", main);
+
+        var bodyDef = stmt(createX(
+            "nextflow.script.BodyDef",
+            args(
+                closureX(null, main),
+                constX(null),
+                constX("workflow")
+            )
+        ));
+        var closure = closureX(null, block(new VariableScope(), List.of(
+            workflowTakes(node.getParameters(), node.isEntry() ? null : node.getName()),
+            node.emits,
+            bodyDef
+        )));
+        var arguments = node.isEntry()
+            ? args(closure)
+            : args(constX(node.getName()), closure);
+        return stmt(callThisX("workflow", arguments));
+    }
+
+    // The declared type of each workflow take is preserved from type
+    // erasure by storing it in a field of a hidden class, so that e.g.
+    // the element type of a `Channel<Sample>` input is available at
+    // runtime (see also StripTypesVisitor).
+    private Statement workflowTakes(Parameter[] takes, String workflowName) {
+        if( takes.length == 0 )
+            return block(null, List.of());
+
+        var takesType = new RecordNode(ScriptToGroovyHelper.packageName(moduleNode) + "." + "__Takes"
+            + (workflowName != null ? "_" + workflowName : ""));
+        for( var take : takes ) {
+            takesType.addField(new FieldNode(
+                take.getName(),
+                Modifier.PUBLIC,
+                take.getType(),
+                takesType,
+                null
+            ));
+        }
+        moduleNode.addClass(takesType);
+
+        var statements = Arrays.stream(takes)
+            .map((take) -> {
+                var optional = take.getType().getNodeMetaData(ASTNodeMarker.NULLABLE) != null;
+                return stmt(callThisX("_take_", args(constX(take.getName()), classX(takesType), constX(optional))));
+            })
+            .toList();
+        return block(null, statements);
+    }
+
+    private void visitWorkflowEmits(Statement emits, BlockStatement main) {
+        for( var stmt : asBlockStatements(emits) ) {
+            var es = (ExpressionStatement)stmt;
+            var emit = es.getExpression();
+            if( emit instanceof VariableExpression ve ) {
+                es.setExpression(callThisX("_emit_", args(constX(ve.getName()))));
+            }
+            else if( emit instanceof AssignmentExpression ae ) {
+                var target = (VariableExpression)ae.getLeftExpression();
+                main.addStatement(assignS(target, emit));
+                es.setExpression(callThisX("_emit_", args(constX(target.getName()))));
+                main.addStatement(es);
+            }
+            else {
+                var target = varX("$out");
+                main.addStatement(assignS(target, emit));
+                es.setExpression(callThisX("_emit_", args(constX(target.getName()))));
+                main.addStatement(es);
+            }
+        }
+    }
+
+    private void visitWorkflowPublishers(Statement publishers, BlockStatement main) {
+        for( var stmt : asBlockStatements(publishers) ) {
+            var es = (ExpressionStatement)stmt;
+            var publish = (BinaryExpression)es.getExpression();
+            var target = asVarX(publish.getLeftExpression());
+            es.setExpression(callThisX("_publish_", args(constX(target.getName()), publish.getRightExpression())));
+            main.addStatement(es);
+        }
+    }
+
+    private void visitWorkflowHandler(Statement code, String name, BlockStatement main) {
+        if( code instanceof BlockStatement block )
+            main.addStatement(stmt(callX(varX("workflow"), name, args(closureX(null, block)))));
+    }
+
+}

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -541,16 +541,17 @@ class LinObserver implements TraceObserverV2 {
      * @throws IllegalArgumentException
      */
     protected String getWorkflowRelative(Path path) throws IllegalArgumentException{
-        final outputDirAbs = session.outputDir.toAbsolutePath()
+        // the output directory is disabled when a named workflow is executed directly
+        final outputDirAbs = session.outputDir?.toAbsolutePath()
         if (path.isAbsolute()) {
-            if (path.startsWith(outputDirAbs)) {
+            if (outputDirAbs && path.startsWith(outputDirAbs)) {
                 return outputDirAbs.relativize(path).toString()
             }
             log.debug("Cannot get relative path for workflow output '${path.toUriString()}'")
             throw new OutputRelativePathException()
         }
         final pathAbs = path.toAbsolutePath()
-        if (pathAbs.startsWith(outputDirAbs)) {
+        if (outputDirAbs && pathAbs.startsWith(outputDirAbs)) {
             return outputDirAbs.relativize(pathAbs).toString()
         }
         if (path.normalize().getName(0).toString() == "..") {

--- a/tests/checks/.IGNORE-PARSER-V2
+++ b/tests/checks/.IGNORE-PARSER-V2
@@ -13,4 +13,5 @@ resume-typed-value-output.nf
 task-ext-block.nf
 topic-channel-typed.nf
 type-annotations.nf
+workflow-entry.nf
 workflow-oncomplete-v2.nf

--- a/tests/checks/process-entry.nf/.checks
+++ b/tests/checks/process-entry.nf/.checks
@@ -24,6 +24,12 @@ $NXF_RUN --sampleId "SAMPLE_001" --dataFile "../../data/sample_data.txt" --threa
 # Check that file processing worked (5 lines in sample_data.txt)
 [[ `grep -c '5 sample_data.txt' stdout` == 1 ]] || false
 
+# Output files are not published when a process is executed directly --
+# the output file is reported by its work directory path
+[[ ! -d results ]] || false
+[[ `grep -c 'analysis.txt' stdout` == 1 ]] || false
+[[ `grep -c '/results/analysis.txt' stdout` == 0 ]] || false
+
 #
 # Test with relative path
 #

--- a/tests/checks/process-entry.nf/.checks
+++ b/tests/checks/process-entry.nf/.checks
@@ -1,5 +1,8 @@
 set -e
 
+# a process can be executed directly only via `nextflow module run`
+NXF_RUN="$NXF_CMD -q module run $NXF_SCRIPT"
+
 #
 # Test single process auto-execution with parameter mapping
 #
@@ -8,7 +11,7 @@ echo '=== Testing single process auto-execution ==='
 $NXF_RUN --sampleId "SAMPLE_001" --dataFile "../../data/sample_data.txt" --threads "4" | tee stdout
 
 # Check that the process executed successfully
-[[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > analyzeData'` == 1 ]] || false
+[[ `grep 'INFO' .module.log | grep -c 'Submitted process > analyzeData'` == 1 ]] || false
 
 # Check that all parameters were properly mapped and used
 [[ `grep -c 'Single process execution test' stdout` == 1 ]] || false
@@ -26,9 +29,9 @@ $NXF_RUN --sampleId "SAMPLE_001" --dataFile "../../data/sample_data.txt" --threa
 #
 echo ''
 echo '=== Testing single process with relative path ==='
-rm -f .nextflow.log  # Clear log for clean test
+rm -f .module.log  # Clear log for clean test
 $NXF_RUN --sampleId "REL_TEST" --dataFile "../../data/sample_data.txt" --threads "2" | tee stdout2
 
-[[ `grep 'INFO' .nextflow.log | grep -c 'Submitted process > analyzeData'` == 1 ]] || false
+[[ `grep 'INFO' .module.log | grep -c 'Submitted process > analyzeData'` == 1 ]] || false
 [[ `grep -c 'Sample ID: REL_TEST' stdout2` == 1 ]] || false
 [[ `grep -c 'Threads: 2' stdout2` == 1 ]] || false

--- a/tests/checks/workflow-entry.nf/.checks
+++ b/tests/checks/workflow-entry.nf/.checks
@@ -1,0 +1,52 @@
+set -e
+
+# a named workflow can be executed directly only via `nextflow module run`
+NXF_RUN="$NXF_CMD -q module run $NXF_SCRIPT"
+
+DATA=$(cd ../../data && pwd)
+
+cat > samples.csv <<EOF
+id,data
+alpha,$DATA/sample_data.txt
+beta,$DATA/results_data.txt
+EOF
+
+#
+# Test direct execution of a named workflow
+#
+echo ''
+echo '=== Testing named workflow direct execution ==='
+$NXF_RUN --samples samples.csv --prefix Hello | tee stdout
+
+# each emit is reported as a workflow output
+[[ `grep -c 'greetings:' stdout` == 1 ]] || false
+[[ `grep -c 'info:' stdout` == 1 ]] || false
+
+# the samplesheet is loaded as a channel of records, with `data` as a path
+[[ `grep -c 'Hello, alpha (sample_data.txt)' stdout` == 1 ]] || false
+[[ `grep -c 'Hello, beta (results_data.txt)' stdout` == 1 ]] || false
+
+# the scalar input is mapped, and the omitted optional input is null
+[[ `grep -c 'prefix=Hello limit=null' stdout` == 1 ]] || false
+
+# no output directory is created
+[[ ! -d results ]] || false
+
+#
+# Test that an optional input can be given
+#
+echo ''
+echo '=== Testing optional workflow input ==='
+$NXF_RUN --samples samples.csv --prefix Hi --limit 5 | tee stdout2
+
+[[ `grep -c 'prefix=Hi limit=5' stdout2` == 1 ]] || false
+
+#
+# Test that a missing required input is reported
+#
+echo ''
+echo '=== Testing missing required input ==='
+$NXF_RUN --prefix Hello > stdout3 2>&1 || true
+
+[[ $(grep -c 'requires input' stdout3) == 1 ]] || false
+[[ $(grep -c 'samples' stdout3) -ge 1 ]] || false

--- a/tests/checks/workflow-entry.nf/.checks
+++ b/tests/checks/workflow-entry.nf/.checks
@@ -48,5 +48,5 @@ echo ''
 echo '=== Testing missing required input ==='
 $NXF_RUN --prefix Hello > stdout3 2>&1 || true
 
-[[ $(grep -c 'requires input' stdout3) == 1 ]] || false
+[[ $(grep -c 'Parameter `--samples` is required but no value was provided' stdout3) == 1 ]] || false
 [[ $(grep -c 'samples' stdout3) -ge 1 ]] || false

--- a/tests/process-entry.nf
+++ b/tests/process-entry.nf
@@ -23,7 +23,10 @@ process analyzeData {
     val sampleId
     path dataFile
     val threads
-    
+
+    output:
+    path 'analysis.txt'
+
     script:
     """
     echo "Single process execution test"
@@ -39,5 +42,6 @@ process analyzeData {
     fi
     
     echo "Analysis completed for sample ${sampleId}"
+    echo "${sampleId}" > analysis.txt
     """
 }

--- a/tests/workflow-entry.nf
+++ b/tests/workflow-entry.nf
@@ -1,0 +1,38 @@
+#!/usr/bin/env nextflow
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Test direct execution of a named workflow with parameter mapping
+nextflow.enable.types = true
+
+record Sample {
+    id: String
+    data: Path
+}
+
+workflow SAY_HELLO {
+    take:
+    samples: Channel<Sample>
+    prefix: String
+    limit: Integer?
+
+    main:
+    greetings = samples.map { s -> "${prefix}, ${s.id} (${s.data.name})" }
+
+    emit:
+    greetings: Channel<String> = greetings
+    info: Value<String> = "prefix=${prefix} limit=${limit}"
+}


### PR DESCRIPTION
> **Draft.** Ports PR #7208 ("Direct execution for named workflows"). Complements the workflow-modules PR (#7363) but is independent of it — this only touches the script/runtime layer, no module-system changes.

Enable running a single named, statically-typed workflow directly, without writing an explicit entry workflow. This is the execution primitive behind `nextflow module run scope/name` for workflow modules, and it also applies to a local `nextflow run script.nf` that defines exactly one named workflow.

## What it does

Given a script with a single named, typed workflow:

```groovy
nextflow.enable.types = true

workflow HELLO_SHEET {
    take:
    greetings: Channel<Map>   // samplesheet
    prefix: String            // scalar

    main:
    ...
    emit:
    result: Channel<String> = ...
}
```

```bash
nextflow run script.nf --greetings sheet.csv --prefix Hi
```

Nextflow synthesizes an entry workflow that maps `--<take>` params to the workflow inputs, invokes it, and publishes its `emit:` channels as outputs.

## Changes
- **nf-lang `ScriptToGroovyVisitor`** — lower each workflow take with its declared type (`_take_(name, type)`) so take types are available at runtime.
- **`WorkflowDef` / `WorkflowParamsDsl`** — record take types and expose `getDeclaredInputTypes()`; untyped takes (`Object`) are omitted.
- **`ScriptMeta.hasExecutableWorkflows()`** — a non-module script with exactly one named workflow.
- **`BaseScript.run0()`** — when no entry is selected, synthesize an entry via `WorkflowEntryHandler` for a single named workflow, else fall back to the process entry handler; a multi-workflow script still reports "No entry workflow specified".
- **`WorkflowEntryHandler`** (new) — maps `--<take>` params to inputs using the declared types:
  - `Channel<T>` → load a samplesheet file (CSV / JSON / YAML) or wrap a collection with `channel.fromList`;
  - `Value<T>` → value channel;
  - scalar (`String`/`Integer`/`Path`/…) → coerced value.
  Then invokes the workflow and publishes its emits. **Typed workflows only** (guarded by `isTypingEnabled()`).

## Not in this PR (follow-ups)
- **Outputs** reuse the existing `OutputDsl` publishing (as the process entry handler does); the ADR's no-output-directory / work-dir-path index-file behaviour is a follow-up.
- **Typed-record samplesheets** — rows currently load as `Map`s; casting each row to a custom `record` type (`Channel<Sample>`) is a follow-up (the `__Params`-class TODO from #7208).

## Testing
- **Unit**: `WorkflowEntryHandlerTest` (samplesheet loading for CSV/JSON/YAML, param→take resolution by type, guards). Full `nextflow.script.*` and `nf-lang` suites pass.
- **Manual e2e**: ran a typed workflow with a `Channel<Map>` samplesheet take + a scalar `String` take via `nextflow module run ./mod --greetings sheet.csv --prefix Hi` → outputs published; verified the scalar is passed as a value and the CSV becomes a channel.

Co-authored from PR #7208 by @bentshermann.
