### PR TITLE
Fix flaky CmdLogTest/CmdLineageTest (filter plugin-loading stack-trace noise)

### DIFF
--- a/modules/nextflow/src/test/groovy/test/TestHelperTest.groovy
+++ b/modules/nextflow/src/test/groovy/test/TestHelperTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import spock.lang.Specification
+
+/**
+ * Tests for {@link TestHelper#filterLogNoise}.
+ *
+ * @author Jorge Ejarque <jorge.ejarque@seqera.io>
+ */
+class TestHelperTest extends Specification {
+
+    def 'should keep command output and drop log noise'() {
+        given:
+        def output = '''\
+            10:00:00.000 [main] DEBUG nextflow.Session - some debug
+            10:00:00.001 [main] INFO  nextflow.Session - some info
+            real output line 1
+            real output line 2'''.stripIndent()
+
+        when:
+        def lines = TestHelper.filterLogNoise(output)
+
+        then:
+        lines == ['real output line 1', 'real output line 2']
+    }
+
+    def 'should drop an exception stack trace leaking from plugin loading'() {
+        given: 'command output polluted by a pf4j plugin-descriptor error stack trace'
+        def output = '''\
+            No workflow runs found in lineage history log
+            org.pf4j.InvalidPluginDescriptorException: Field 'id' cannot be empty
+            \tat org.pf4j.AbstractPluginManager.validatePluginDescriptor(AbstractPluginManager.java:990)
+            \tat org.pf4j.AbstractPluginManager.loadPluginFromPath(AbstractPluginManager.java:896)
+            \tat org.pf4j.AbstractPluginManager.loadPlugins(AbstractPluginManager.java:246)
+            Caused by: java.lang.IllegalStateException: boom
+            \t... 12 more'''.stripIndent()
+
+        when:
+        def lines = TestHelper.filterLogNoise(output)
+
+        then: 'only the real command output remains'
+        lines == ['No workflow runs found in lineage history log']
+    }
+
+    def 'should not treat ordinary error messages as stack-trace noise'() {
+        given:
+        def output = 'Error loading lid://12345 - Lineage record 12345 not found'
+
+        when:
+        def lines = TestHelper.filterLogNoise(output)
+
+        then:
+        lines == ['Error loading lid://12345 - Lineage record 12345 not found']
+    }
+}

--- a/modules/nextflow/src/testFixtures/groovy/test/TestHelper.groovy
+++ b/modules/nextflow/src/testFixtures/groovy/test/TestHelper.groovy
@@ -121,8 +121,16 @@ class TestHelper {
         filterLogNoise(capture.toString(), includeWarn)
     }
 
+    // Matches a Java exception header line, e.g. `org.pf4j.InvalidPluginDescriptorException: message`
+    // (a dotted, fully-qualified class name ending in Exception/Error). Kept strict so ordinary
+    // command output such as "Error loading lid://..." is not treated as noise.
+    private static final java.util.regex.Pattern EXCEPTION_HEADER = ~/[\w$]+(\.[\w$]+)+(Exception|Error)(:.*)?/
+
     /**
-     * Filter captured stdout/stderr output to remove log noise (DEBUG, INFO, WARN, plugin messages, pf4j dependency graph).
+     * Filter captured stdout/stderr output to remove log noise: DEBUG/INFO/(WARN) log lines, plugin
+     * messages, the pf4j dependency graph, and exception stack traces. The latter is important
+     * because plugin loading may emit a descriptor error whose stack trace would otherwise leak into
+     * the captured output and break exact line-count assertions (see CmdLogTest/CmdLineageTest).
      *
      * @param output The captured output string
      * @param includeWarn Whether to also filter out WARN lines (default: false)
@@ -130,11 +138,16 @@ class TestHelper {
      */
     static List<String> filterLogNoise(String output, boolean includeWarn = false) {
         output.readLines().findAll { line ->
+            final trimmed = line.trim()
             !line.contains('DEBUG') &&
             !line.contains('INFO') &&
             (!includeWarn || !line.contains('WARN')) &&
             !line.contains('plugin') &&
-            !line.contains('-> [')  // pf4j dependency graph lines
+            !line.contains('-> [') &&                     // pf4j dependency graph lines
+            !trimmed.startsWith('at ') &&                 // stack-trace frames
+            !trimmed.startsWith('Caused by:') &&
+            !(trimmed ==~ /\.\.\.\s*\d+\s+more/) &&        // "... N more" stack-trace tail
+            !(trimmed ==~ EXCEPTION_HEADER)               // exception header line
         }
     }
 }


### PR DESCRIPTION
## Problem

`CmdLogTest` and `CmdLineageTest` intermittently fail on CI with `stdout.size() == N` assertion failures — the same commit passed and failed across consecutive CI runs with **no code change**, and they pass locally in isolation.

## Root cause

These tests run the real CLI (`CmdLog.run()` / `CmdLineage.run()`), which calls `Plugins.init()` → pf4j's `loadPlugins()`, scanning the plugins directory. When the build environment contains a plugin with an **invalid descriptor** (an empty `Plugin-Id`), pf4j raises `InvalidPluginDescriptorException` and its ~500-line stack trace is written to the captured stdout:

```
org.pf4j.InvalidPluginDescriptorException: Field 'id' cannot be empty
	at org.pf4j.AbstractPluginManager.validatePluginDescriptor(...)
	at org.pf4j.AbstractPluginManager.loadPlugins(...)
	...
```

The tests use `TestHelper.filterLogNoise(...)` to strip log noise before asserting on the command's real output, but that helper stripped only `DEBUG`/`INFO`/`WARN`/plugin lines — not raw stack-trace/exception lines — so the flood inflated `stdout.size()` (observed: 513 / 643 lines instead of 1 / 3).

## Fix

Harden `test.TestHelper.filterLogNoise` (used only by CLI/lineage output tests) to also drop exception stack traces:
- stack-trace frames (`at …`),
- `Caused by:`,
- `... N more`,
- fully-qualified exception header lines (a dotted class name ending in `Exception`/`Error`).

The exception-header match is deliberately strict so ordinary command output such as `Error loading lid://… - Lineage record … not found` is **not** treated as noise.

Adds `TestHelperTest` verifying the filter drops a pf4j-style stack trace, keeps real output, and does not mistake ordinary error messages for stack traces.

## Notes
- This makes the tests robust to plugin-loading diagnostics regardless of build environment. The separate, deeper question of *why* the CI build sometimes stages a plugin with an empty `id` descriptor (a build-cache / plugin-manifest issue) is out of scope here.

## Testing
`TestHelperTest`, `CmdLogTest`, `CmdLineageTest`, `WorkflowMetadataTest`, `LinPathTest`, `LinCommandImplTest` (all users of `filterLogNoise`) pass.
