### PR TITLE
Add componentName to 'module view' command output

### DIFF
--- a/modules/nextflow/build.gradle
+++ b/modules/nextflow/build.gradle
@@ -71,8 +71,8 @@ dependencies {
     api 'io.seqera:lib-trace:0.1.0'
     api 'com.fasterxml.woodstox:woodstox-core:7.1.1'
     api 'org.apache.commons:commons-compress:1.27.1'  // For tar.gz extraction
-    api 'io.seqera:npr-api:0.22.0'
-    api 'io.seqera:npr-client:0.22.0'
+    api 'io.seqera:npr-api:0.25.0'
+    api 'io.seqera:npr-client:0.25.0'
     api 'com.networknt:json-schema-validator:1.5.6'
 
     testImplementation 'org.subethamail:subethasmtp:3.1.7'

--- a/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleView.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/module/CmdModuleView.groovy
@@ -145,6 +145,10 @@ class CmdModuleView extends CmdBase {
         println "URL:         ${moduleUrl}"
         println "Description: ${metadata.description ?: release.description ?: 'N/A'}"
 
+        if( metadata.componentName ) {
+            println "Component:   ${metadata.componentName}"
+        }
+
         if( metadata.authors ) {
             println "Authors:     ${metadata.authors.join(', ')}"
         }
@@ -290,6 +294,7 @@ class CmdModuleView extends CmdBase {
             version    : release.version,
             url        : moduleUrl,
             description: metadata.description ?: release.description,
+            componentName: metadata.componentName,
             authors    : metadata.authors,
             keywords   : metadata.keywords,
         ]

--- a/modules/nextflow/src/test/groovy/nextflow/cli/module/CmdModuleViewTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/cli/module/CmdModuleViewTest.groovy
@@ -96,6 +96,50 @@ class CmdModuleViewTest extends Specification {
         output.contains('Usage Template:')
     }
 
+    def 'should display component name in formatted and json output'() {
+        given:
+        def metadata = new ModuleMetadata(
+            description: 'FastQC quality control',
+            componentName: 'FASTQC'
+        )
+
+        and:
+        def release = new ModuleRelease(
+            version: '1.0.0',
+            metadata: metadata
+        )
+
+        and:
+        def cmd = new CmdModuleView()
+        cmd.args = ['nf-core/fastqc']
+        cmd.output = mode
+        cmd.launcher = Mock(Launcher) {
+            getOptions() >> null
+        }
+        cmd.root = tempDir
+
+        and:
+        def mockModule = Stub(Module) {
+            getLatest() >> release
+        }
+        def mockClient = Mock(RegistryClient) {
+            getModule(_) >> mockModule
+        }
+        cmd.client = mockClient
+
+        when:
+        cmd.run()
+        def output = capture.toString()
+
+        then:
+        output.contains(expected)
+
+        where:
+        mode   | expected
+        'text' | 'Component:   FASTQC'
+        'json' | '"componentName": "FASTQC"'
+    }
+
     def 'should display module info with specific version'() {
         given:
         def metadata = new ModuleMetadata(

--- a/modules/nf-commons/build.gradle
+++ b/modules/nf-commons/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api 'io.seqera:lib-retry:2.1.0'
     // patch gson dependency required by pf4j
     api 'com.google.code.gson:gson:2.13.1'
-    api 'io.seqera:npr-api:0.22.0'
+    api 'io.seqera:npr-api:0.25.0'
     // jackson 2.21.5 addresses high-severity PolymorphicTypeValidator bypasses
     // (GHSA-rmj7-2vxq-3g9f, GHSA-j3rv-43j4-c7qm) and related @JsonView/@JsonIgnore
     // deserialization advisories; pinned here so it propagates to all downstream modules


### PR DESCRIPTION
## What this does

Surfaces a module's callable component name — the Nextflow process name (e.g. `FASTQC`) — in the `nextflow module view` (alias `info`) command. This value is now exposed as the optional `componentName` attribute of the Module API metadata.

## Changes

- **`CmdModuleView`** — renders `componentName` when present:
  - text output: a `Component:` line
  - json output: a `componentName` field
- **Dependency bump** — `npr-api`/`npr-client` `0.22.0` → `0.25.0`, the version that adds `componentName` to `ModuleMetadata`.
- **Test** — `CmdModuleViewTest` covers both text and json rendering.

The field is optional; when the registry omits it (module `main.nf` has no parseable process declaration), no `Component:` line is printed and json carries `null`, consistent with the other optional metadata fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)