### PR TITLE
Fix dev-mode plugin discovery for 'make compile' flow

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -44,6 +44,9 @@ subprojects {
         into 'build/resources/main/META-INF'
         dependsOn jar
     }
+    // Run the copy on every jar build so `make compile` / exportClasspath (which
+    // build the plugin jars) populate the manifest for dev mode discovery too
+    jar.finalizedBy copyPluginManifest
     // Ensure manifest is available for test classpath (needed for dev mode plugin discovery)
     tasks.matching { it.name == 'test' }.configureEach {
         dependsOn copyPluginManifest


### PR DESCRIPTION
## Problem

[#7264](https://github.com/nextflow-io/nextflow/pull/7264) changed `DevPluginManager` to read the plugin manifest **only** from the dev classpath directories (`build/resources/main/META-INF/MANIFEST.MF`), deliberately ignoring the stray `build/tmp/jar/MANIFEST.MF` that pf4j's recursive search used to pick up non-deterministically.

The companion `copyPluginManifest` task (which copies the manifest into `build/resources/main/META-INF/`) was wired only to the `test` and `packagePlugin` tasks. The standard local dev flow — `make compile` (`./gradlew compile exportClasspath`) followed by `./launch.sh` — builds the plugin jars (via `exportClasspath`'s `dependsOn allprojects.jar`) but never runs `copyPluginManifest`.

As a result the manifest is missing from the resources dir and every plugin is reported as not built:

```
ERROR ~ Install is not supported on dev mode - Missing plugin nf-amazon <version>
```

## Fix

Run the copy on every jar build via `jar.finalizedBy copyPluginManifest`, so the `compile`/`exportClasspath` dev flow populates the manifest for dev-mode discovery as well. The existing `test`/`packagePlugin` hooks are kept (those tasks don't build the jar).

```groovy
jar.finalizedBy copyPluginManifest
```

## Verification

After deleting `build/resources/main/META-INF/MANIFEST.MF` from the plugins and running the exact `make compile` invocation (`./gradlew compile exportClasspath`), all plugin manifests are repopulated and dev-mode plugin discovery works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
