### PR TITLE
Add per-process array scheduling hints for Google Batch

### DIFF
--- a/docs/executor.mdx
+++ b/docs/executor.mdx
@@ -131,6 +131,22 @@ Resource requests and other job characteristics can be controlled via the follow
 - [resourcelabels][process-resourcelabels]
 - [time][process-time]
 
+The following [hints][process-hints] are supported:
+
+- `scheduling.policy`: Set the [task scheduling policy](https://cloud.google.com/batch/docs/create-run-job#execution) for a process that uses the `array` directive. The value is `in_order` (run the array's tasks sequentially by index on a single VM) or `as_soon_as_possible` (the default; tasks run in parallel as resources allow), case-insensitive. Only applies to array tasks. For example:
+
+  ```nextflow
+  hints 'scheduling.policy': 'in_order'
+  ```
+
+- `scheduling.parallelism`: Cap the number of an array process's tasks that run concurrently, so an array of N tasks runs at most this many at a time (fewer simultaneous VMs). The value is a positive integer, clamped to the array size; it is ignored when `scheduling.policy` is `in_order` (which pins concurrency to 1). Only applies to array tasks. For example:
+
+  ```nextflow
+  hints 'scheduling.parallelism': '8'
+  ```
+
+  These keys may be used as-is or with the `google-batch/` prefix to restrict them to this executor.
+
 See [Cloud Batch][google-batch]for further configuration details.
 
 ## HTCondor

--- a/docs/executor/google-batch.mdx
+++ b/docs/executor/google-batch.mdx
@@ -21,6 +21,22 @@ Use the following process directives to control resource requests and other job 
 - [resourcelabels][process-resourcelabels]
 - [time][process-time]
 
+The following [hints][process-hints] are supported:
+
+- `scheduling.policy`: Set the [task scheduling policy](https://cloud.google.com/batch/docs/create-run-job#execution) for a process that uses the `array` directive. The value is `in_order` (run the array's tasks sequentially by index on a single VM) or `as_soon_as_possible` (the default; tasks run in parallel as resources allow), case-insensitive. Only applies to array tasks. For example:
+
+  ```nextflow
+  hints 'scheduling.policy': 'in_order'
+  ```
+
+- `scheduling.parallelism`: Cap the number of an array process's tasks that run concurrently, so an array of N tasks runs at most this many at a time (fewer simultaneous VMs). The value is a positive integer, clamped to the array size; it is ignored when `scheduling.policy` is `in_order` (which pins concurrency to 1). Only applies to array tasks. For example:
+
+  ```nextflow
+  hints 'scheduling.parallelism': '8'
+  ```
+
+  These keys may be used as-is or with the `google-batch/` prefix to restrict them to this executor.
+
 See [Cloud Batch][google-batch] for further configuration details.
 
 [google-batch]: ../google#cloud-batch
@@ -29,6 +45,7 @@ See [Cloud Batch][google-batch] for further configuration details.
 [process-containeroptions]: ../reference/process/directives/container-options
 [process-cpus]: ../reference/process/directives/cpus
 [process-disk]: ../reference/process/directives/disk
+[process-hints]: ../reference/process/directives/hints
 [process-machinetype]: ../reference/process/directives/machine-type
 [process-memory]: ../reference/process/directives/memory
 [process-resourcelabels]: ../reference/process/directives/resource-labels

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -299,7 +299,10 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         if( task instanceof TaskArrayRun ) {
             final arraySize = task.getArraySize()
             taskGroup.setTaskCount(arraySize)
+            applyScheduling(taskGroup, task.config, arraySize)
         }
+        else if( hasSchedulingHint(task.config) )
+            log.warn1 "Google Batch hints '${SCHEDULING_POLICY_HINT}'/'${SCHEDULING_PARALLELISM_HINT}' apply only to array tasks and are ignored for process `${task.lazyName()}`"
 
         return taskGroup.build()
     }
@@ -356,6 +359,83 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     static class InstancePolicyResult {
         AllocationPolicy.InstancePolicyOrTemplate policy
         boolean requiresScratchVolume
+    }
+
+    private static final String HINT_PREFIX = 'google-batch/'
+    private static final String SCHEDULING_POLICY_HINT = 'scheduling.policy'
+    private static final String SCHEDULING_PARALLELISM_HINT = 'scheduling.parallelism'
+    private static final Set<String> KNOWN_HINTS = Set.of(SCHEDULING_POLICY_HINT, SCHEDULING_PARALLELISM_HINT)
+    private static final String SUPPORTED_HINTS_MSG =
+        KNOWN_HINTS.collect { HINT_PREFIX + it }.sort().join(', ')
+
+    /**
+     * Validate the google-batch prefixed hints, throwing if a prefixed key is not supported
+     *
+     * @param hints The hints map from the task config
+     */
+    protected void validateHints(Map<String,Object> hints) {
+        if( !hints )
+            return
+        final unknown = []
+        for( final key : hints.keySet() ) {
+            if( !key?.startsWith(HINT_PREFIX) )
+                continue
+            if( !KNOWN_HINTS.contains(key.substring(HINT_PREFIX.length())) )
+                unknown.add(key)
+        }
+        if( unknown )
+            throw new IllegalArgumentException("Unknown Google Batch hint(s): ${unknown.collect { "'$it'" }.join(', ')} -- supported keys are: ${SUPPORTED_HINTS_MSG}")
+    }
+
+    /**
+     * Check whether the config sets an array scheduling hint, in bare or prefixed form
+     *
+     * @param config The task config
+     * @return {@code true} if a scheduling hint is present
+     */
+    private boolean hasSchedulingHint(TaskConfig config) {
+        final hints = config?.getHints()
+        if( !hints )
+            return false
+        return [SCHEDULING_POLICY_HINT, SCHEDULING_PARALLELISM_HINT].any {
+            hints.containsKey(it) || hints.containsKey(HINT_PREFIX + it)
+        }
+    }
+
+    /**
+     * Apply the array task-group scheduling hints (scheduling.policy, scheduling.parallelism) for Google Batch
+     *
+     * @param taskGroup The task group builder to update
+     * @param config The task config carrying the hints
+     * @param arraySize The number of tasks in the array
+     */
+    protected void applyScheduling(TaskGroup.Builder taskGroup, TaskConfig config, int arraySize) {
+        final hints = config.getHints()
+        if( !hints )
+            return
+
+        final policyValue = hints.get(HINT_PREFIX + SCHEDULING_POLICY_HINT) ?: hints.get(SCHEDULING_POLICY_HINT)
+        final policy = policyValue != null ? policyValue.toString().trim().toLowerCase().replace('-', '_') : null
+
+        if( policy == 'in_order' ) {
+            // IN_ORDER requires parallelism=1 and runs tasks sequentially by index
+            taskGroup.setSchedulingPolicy(TaskGroup.SchedulingPolicy.IN_ORDER)
+            taskGroup.setParallelism(1)
+            return
+        }
+        if( policy != null && policy != 'as_soon_as_possible' )
+            throw new IllegalArgumentException("Invalid '${SCHEDULING_POLICY_HINT}' hint value: '${policyValue}' -- it must be one of: in_order, as_soon_as_possible")
+
+        // cap concurrent tasks, clamped to the array size
+        final parallelismValue = hints.get(HINT_PREFIX + SCHEDULING_PARALLELISM_HINT) ?: hints.get(SCHEDULING_PARALLELISM_HINT)
+        if( parallelismValue == null )
+            return
+        final Integer m = parallelismValue instanceof Number
+            ? (parallelismValue as Integer)
+            : (parallelismValue.toString().trim().isInteger() ? parallelismValue.toString().trim() as Integer : null)
+        if( m == null || m < 1 )
+            throw new IllegalArgumentException("Invalid '${SCHEDULING_PARALLELISM_HINT}' hint value: '${parallelismValue}' -- it must be a positive integer")
+        taskGroup.setParallelism(Math.min(m, arraySize))
     }
 
     /**
@@ -553,6 +633,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     protected Job newSubmitRequest(TaskRun task, GoogleBatchLauncherSpec launcher) {
+        // validate the task's hints once per submission
+        validateHints(task.config.getHints())
+
         // container validation
         if( !task.container )
             throw new ProcessUnrecoverableException("Process `${task.lazyName()}` failed because the container image was not specified")

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -29,6 +29,7 @@ import java.nio.file.Path
 
 import com.google.cloud.batch.v1.GCS
 import com.google.cloud.batch.v1.StatusEvent
+import com.google.cloud.batch.v1.TaskGroup
 import com.google.cloud.batch.v1.TaskStatus
 import com.google.cloud.batch.v1.Volume
 import com.google.protobuf.Timestamp
@@ -1375,6 +1376,91 @@ class GoogleBatchTaskHandlerTest extends Specification {
         // ? replacing the family discriminator digit is treated as a literal character (not a wildcard)
         'e?-standard-4'       | 'local-ssd'          // 'e?' does not match regex ^e2-.*$, so not classified as e2
         'h?-standard-88'      | 'local-ssd'          // 'h?' does not match regex ^h3-.*$, so not classified as h3
+    }
+
+    // array task-group scheduling hints: scheduling.policy / scheduling.parallelism
+
+    private GoogleBatchTaskHandler schedulingHandler() {
+        def task = Mock(TaskRun) { hashLog >> '1234567890'; getWorkDir() >> Path.of('/work/dir') }
+        def exec = Mock(GoogleBatchExecutor) { getClient() >> Mock(BatchClient); getBatchConfig() >> Mock(BatchConfig) }
+        return Spy(new GoogleBatchTaskHandler(task, exec))
+    }
+
+    def 'should apply array scheduling from hints' () {
+        given:
+        def handler = schedulingHandler()
+        def tg = TaskGroup.newBuilder()
+        def config = Mock(TaskConfig) { getHints() >> HINTS }
+
+        when:
+        handler.applyScheduling(tg, config, ARRAY_SIZE)
+
+        then:
+        tg.getSchedulingPolicy() == POLICY
+        tg.getParallelism() == PARALLELISM
+
+        where:
+        HINTS                                            | ARRAY_SIZE || POLICY                                                   | PARALLELISM
+        [:]                                              | 5          || TaskGroup.SchedulingPolicy.SCHEDULING_POLICY_UNSPECIFIED | 0
+        ['scheduling.policy': 'in_order']                | 5          || TaskGroup.SchedulingPolicy.IN_ORDER                      | 1
+        ['scheduling.policy': 'in-order']                | 5          || TaskGroup.SchedulingPolicy.IN_ORDER                      | 1
+        ['scheduling.policy': 'as_soon_as_possible']     | 5          || TaskGroup.SchedulingPolicy.SCHEDULING_POLICY_UNSPECIFIED | 0
+        ['scheduling.parallelism': '8']                  | 20         || TaskGroup.SchedulingPolicy.SCHEDULING_POLICY_UNSPECIFIED | 8
+        ['scheduling.parallelism': 8]                    | 20         || TaskGroup.SchedulingPolicy.SCHEDULING_POLICY_UNSPECIFIED | 8
+        ['scheduling.parallelism': '50']                 | 4          || TaskGroup.SchedulingPolicy.SCHEDULING_POLICY_UNSPECIFIED | 4
+        ['google-batch/scheduling.policy': 'in_order']   | 5          || TaskGroup.SchedulingPolicy.IN_ORDER                      | 1
+    }
+
+    def 'should throw on invalid array scheduling hint' () {
+        given:
+        def handler = schedulingHandler()
+        def tg = TaskGroup.newBuilder()
+        def config = Mock(TaskConfig) { getHints() >> HINTS }
+
+        when:
+        handler.applyScheduling(tg, config, 5)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        HINTS << [
+            ['scheduling.policy': 'bogus'],
+            ['scheduling.parallelism': 'lots'],
+            ['scheduling.parallelism': '0'],
+            ['scheduling.parallelism': -3],
+        ]
+    }
+
+    def 'should accept known and unprefixed google-batch hints' () {
+        given:
+        def handler = schedulingHandler()
+
+        when:
+        handler.validateHints(HINTS)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        HINTS << [
+            null,
+            [:],
+            ['google-batch/scheduling.policy': 'in_order'],
+            ['scheduling.policy': 'in_order'],   // bare (unprefixed) keys are not validated
+            ['other-executor/foo': 'bar'],       // foreign-executor keys are left untouched
+        ]
+    }
+
+    def 'should reject unknown prefixed google-batch hints' () {
+        given:
+        def handler = schedulingHandler()
+
+        when:
+        handler.validateHints(['google-batch/scheduling.unknown': 'x'])
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
 }


### PR DESCRIPTION
### Summary

closes #6825

Adds two per-process array task-group scheduling hints for the Google Batch executor, exposed through the `hints` process directive (#7034): `scheduling.policy` and `scheduling.parallelism`. They let a pipeline control how an `array` process's tasks are scheduled on Batch - run sequentially on a single VM, and/or with a concurrency cap - per process, which isn't possible today. The keys follow the `scheduling.*` namespace convention from the hints-process-directive ADR (`20260323-hints-process-directive.md`); the ADR catalogs `scheduling.provisioningModel` (#7343) and `scheduling.priority`, and these two array-scheduling keys extend that same namespace.

### What it adds

- A **`scheduling.policy`** hint (a `String`) on the Google Batch executor, mapping to the Batch `TaskGroup.SchedulingPolicy`:
  - `in_order` > `IN_ORDER`: the array's tasks run sequentially by index on a single VM. Batch requires `parallelism = 1` for `IN_ORDER`, so it is set automatically.
  - `as_soon_as_possible` > the default; the policy is left unset (today's behaviour).
  - values are case-insensitive and trimmed (`in-order` is accepted as `in_order`).
- A **`scheduling.parallelism`** hint (a positive integer) that caps how many of an array's tasks run concurrently, clamped to the array size. Ignored under `in_order` (which pins parallelism to 1).
- **Array-only.** Both hints apply only to array (`TaskArrayRun`) tasks. A non-array process that sets them gets a warning and no effect.
- **Strict value validation.** An unknown `scheduling.policy` value, or a non-integer / non-positive `scheduling.parallelism`, throws `IllegalArgumentException` - no silent fallback, so a typo fails fast.
- **Unknown-key validation.** An unrecognized `google-batch/`-prefixed hint key throws, per the ADR (unrecognized prefixed hints are errors); all unknown prefixed keys are reported together in one exception. Bare and foreign-executor keys are left untouched.
- **Resolution.** Each hint resolves both the bare key (`scheduling.policy`) and the executor-prefixed key (`google-batch/scheduling.policy`); the prefixed form is prioritized. This mirrors the AWS Batch executor's existing hint resolution (`get(prefix+key) ?: get(key)`).
- **Fallback.** When the hints are unset, task-group construction is unchanged from today.

```nextflow
process BIG_ARRAY {
  array 100
  hints 'scheduling.policy': 'in_order'
  // or
  hints 'scheduling.parallelism': '8'
}
```

### Tests

Unit tests added in nf-google (`GoogleBatchTaskHandlerTest`):

1. `should apply array scheduling from hints` - policy mapping (`in_order`, the `in-order` spelling, `as_soon_as_possible`), the `parallelism` cap, clamping to the array size, string and integer values, and the `google-batch/`-prefixed form.
2. `should throw on invalid array scheduling hint` - an unknown policy value and a non-integer / zero / negative `parallelism` all throw.
3. `should accept known and unprefixed google-batch hints` - `null`/empty maps, a known prefixed key, a bare key, and a foreign-executor key are all left untouched (no throw).
4. `should reject unknown prefixed google-batch hints` - an unrecognized `google-batch/`-prefixed key throws, per the ADR's prefixed-error rule.

### Validation

The unit tests above assert the resulting `TaskGroup` (`schedulingPolicy` and `parallelism`) for each case. I have **not** run this against a live Google Batch project yet.

## Related

- **Key names.** I followed the ADR's `scheduling.*` namespace (`scheduling.policy`, `scheduling.parallelism`)
- Closes #6825
- Built on the `hints` process directive (#7034 / ADR `20260323-hints-process-directive.md`)
- Related to#7343 (`scheduling.provisioningModel`) targets the same executor, the same handler, and the same `scheduling.*` namespace, and uses the same `get(prefix+key) ?: get(key)` resolution and unknown-`google-batch/*`-key validation. This PR carries the minimal shared plumbing itself so it stands alone; either can merge first.