### PR TITLE
Fix GitLab repository tree pagination

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/GitlabRepositoryProvider.groovy
@@ -223,14 +223,12 @@ class GitlabRepositoryProvider extends RepositoryProvider {
         if (depth > 1) {
             params.add("recursive=true")
         }
+        params.add("per_page=${MAX_PER_PAGE}")
 
-        if (params) {
-            url += "?" + params.join("&")
-        }
+        url += "?" + params.join("&")
 
-        // Make the API call and parse response
-        String response = invoke(url)
-        List<Map> treeEntries = response ? new JsonSlurper().parseText(response) as List<Map> : []
+        // Make the API call and parse response, fetching all pages
+        List<Map> treeEntries = this.<Map>invokeAndResponseWithPaging(url, { Map entry -> entry })
 
         if (!treeEntries) {
             return []

--- a/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/GitlabRepositoryProviderTest.groovy
@@ -260,6 +260,34 @@ class GitlabRepositoryProviderTest extends Specification {
         entries.every { it.path && it.sha }
     }
 
+    def 'should follow all GitLab pagination links when listing a directory' () {
+        given:
+        def provider = Spy(GitlabRepositoryProvider, constructorArgs: ['pditommaso/hello', new ProviderConfig('gitlab')])
+        provider.setRevision('main')
+        and:
+        def base = 'https://gitlab.com/api/v4/projects/pditommaso%2Fhello/repository/tree?ref=main&per_page=100'
+        int page = 0
+
+        when:
+        def entries = provider.listDirectory('/', 1)
+
+        then:
+        101 * provider.invokeResponse(_ as String) >> { String url ->
+            page++
+            assert url == (page == 1 ? base : "${base}&page=${page}")
+            final next = page < 101 ? "${base}&page=${page + 1}" : null
+            final link = next ? "<${next}>; rel=\"next\"" : null
+            response(
+                url,
+                """[{"id":"sha-${page}","name":"file-${page}.nf","type":"blob","path":"file-${page}.nf"}]""",
+                link
+            )
+        }
+        and:
+        entries.size() == 101
+        entries.every { it.type == RepositoryProvider.EntryType.FILE && it.path && it.sha }
+    }
+
     def 'should follow GitLab pagination links when listing branches' () {
         given:
         def provider = Spy(GitlabRepositoryProvider, constructorArgs: ['pditommaso/hello', new ProviderConfig('gitlab')])


### PR DESCRIPTION
## Summary

- request the maximum GitLab page size when listing repository trees
- follow GitLab-provided pagination links through the reusable pagination layer from the preceding PR
- verify directory traversal can fetch more than 100 pages without silently truncating results

## Test plan

- `./gradlew :nextflow:test --tests nextflow.scm.GitlabRepositoryProviderTest --rerun-tasks`

## Stack

- ADR: #7401
- Depends on: #7402
- This PR contains only the repository-tree integration and its focused test.