### PR TITLE
Revert "Mirror test containers to public.cr.seqera.io" (#7195)

### DIFF
--- a/tests-v1/nextflow.config
+++ b/tests-v1/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 } 
 
 process {
-  container = 'public.cr.seqera.io/mirror/tests'
+  container = 'quay.io/nextflow/tests'
 }
 
 

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 } 
 
 process {
-  container = 'public.cr.seqera.io/mirror/tests'
+  container = 'quay.io/nextflow/tests'
 }
 
 

--- a/validation/awsbatch-unstage-fail.config
+++ b/validation/awsbatch-unstage-fail.config
@@ -6,7 +6,7 @@
 workDir = 's3://nextflow-ci/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-ci'
-process.container = 'public.cr.seqera.io/mirror/test-aws-unstage-fail:1.0'
+process.container = 'quay.io/nextflow/test-aws-unstage-fail:1.0'
 aws.region = 'eu-west-1'
 aws.batch.maxTransferAttempts = 3 
 aws.batch.delayBetweenAttempts = '5 sec'

--- a/validation/awsbatch.config
+++ b/validation/awsbatch.config
@@ -6,7 +6,7 @@
 workDir = 's3://nextflow-ci/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-ci'
-process.container = 'public.cr.seqera.io/mirror/rnaseq-nf:latest'
+process.container = 'quay.io/nextflow/rnaseq-nf:latest'
 aws.region = 'eu-west-1'
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
 aws.batch.maxTransferAttempts = 3 

--- a/validation/awsfargate.config
+++ b/validation/awsfargate.config
@@ -6,7 +6,7 @@
 workDir = 's3://nextflow-ci/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-fg'
-process.container = 'public.cr.seqera.io/mirror/rnaseq-nf:latest'
+process.container = 'quay.io/nextflow/rnaseq-nf:latest'
 aws.region = 'eu-west-1'
 aws.batch.platformType = 'fargate'
 aws.batch.jobRole = 'arn:aws:iam::195996028523:role/nf-batchjobrole'

--- a/validation/azure.config
+++ b/validation/azure.config
@@ -5,7 +5,7 @@
 
 process {
   executor = 'azurebatch'
-  container = 'public.cr.seqera.io/mirror/rnaseq-nf:v1.1'
+  container = 'quay.io/nextflow/rnaseq-nf:v1.1'
   queue = 'nextflow-ci'
 }
 

--- a/validation/google.config
+++ b/validation/google.config
@@ -7,6 +7,6 @@ params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
 params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
 params.multiqc = 'gs://rnaseq-nf/multiqc'
 process.executor = 'google-batch'
-process.container = 'public.cr.seqera.io/mirror/rnaseq-nf:latest'
+process.container = 'quay.io/nextflow/rnaseq-nf:latest'
 process.machineType = "n1-standard-1"
 workDir = 'gs://rnaseq-nf/scratch'

--- a/validation/test-overwrite.nf
+++ b/validation/test-overwrite.nf
@@ -3,7 +3,7 @@ workflow {
 }
 
 process foo {
-  container 'public.cr.seqera.io/mirror/bash'
+  container 'quay.io/nextflow/bash'
   publishDir "gs://rnaseq-nf/scratch/tests", overwrite: true
   output:
   path 'hello.txt'


### PR DESCRIPTION
Reverts 539081bc.

Integration tests fail intermittently when pulling test images from `public.cr.seqera.io`. Restore the previous `quay.io/nextflow/*` container references until the mirror is reliable.