### PR TITLE
Fix `params` block breaking piped operators in the entry workflow

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -260,7 +260,6 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
     public void visitWorkflow(WorkflowNode node) {
         var classScope = workflowDsl(node.isEntry());
         if( node.isEntry() && paramsType != null ) {
-            classScope = new ClassNode(classScope.getTypeClass());
             var paramsMethod = classScope.getDeclaredMethods("getParams").get(0);
             paramsMethod.setReturnType(paramsType);
         }

--- a/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
@@ -534,4 +534,21 @@ class ScriptResolveTest extends Specification {
         deleteDir(root)
     }
 
+    def 'should resolve piped operators in the entry workflow with a params block' () {
+        when:
+        def errors = check(
+            '''\
+            params {
+                greeting: String = 'hello'
+            }
+
+            workflow {
+                channel.of(1, 2) | view
+            }
+            '''
+        )
+        then:
+        errors.size() == 0
+    }
+
 }


### PR DESCRIPTION
Fix #7399

This PR fixes a bug in the strict parser where a `params {}` block causes piped operators like `ch | view` to not be recognized in the entry workflow

This is because the `WorkflowDsl` class used by the entry workflow must be augmented both with the typed `params` variable (when `params` block is defined) and the piped operators (when static typing is not enabled)

Due to code entropy (and lack of a unit test) these two behaviors accidentally clobbered each other. This PR fixes the issue and adds a regression test keep it fixed