### PR TITLE
Use Platform user identity for the Seqera executor userName label

### DIFF
--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -1786,7 +1786,7 @@ The following settings are available:
 
 ###### `seqera.executor.autoLabels`
 
-When `true`, automatically adds workflow metadata labels to the session with the `nextflow.io/` prefix (default: `false`). The following labels are added: `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`. A `seqera.io/runId` label is also added, computed as a SipHash of the session ID and run name.
+When `true`, automatically adds workflow metadata labels to the session with the `nextflow.io/` prefix (default: `false`). The following labels are added: `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`. A `seqera.io/runId` label is also added, computed as a SipHash of the session ID and run name. The `userName` label reports the Seqera Platform user that submitted the run, falling back to the OS user running the Nextflow launcher when no Platform identity is available.
 
 ###### `seqera.executor.computeEnvId`
 

--- a/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
@@ -58,8 +58,10 @@ class Labels {
         if( !include ) return this
         if( include.contains('projectName') && workflow.projectName )
             entries.put('nextflow.io/projectName', workflow.projectName)
-        if( include.contains('userName') && workflow.userName )
-            entries.put('nextflow.io/userName', workflow.userName)
+        // the Platform user that submitted the run, falling back to the OS user running the launcher
+        final userName = workflow.platform?.user?.userName ?: workflow.userName
+        if( include.contains('userName') && userName )
+            entries.put('nextflow.io/userName', userName)
         if( include.contains('runName') && workflow.runName )
             entries.put('nextflow.io/runName', workflow.runName)
         if( include.contains('sessionId') && workflow.sessionId )

--- a/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
@@ -61,6 +61,28 @@ class LabelsTest extends Specification {
         labels.entries['nextflow.io/runtimeVersion'] == NextflowMeta.instance.version.toString()
     }
 
+    def 'should prefer the platform user name over the OS user name'() {
+        given:
+        def platform = new PlatformMetadata()
+        if( platformUser )
+            platform.user = new PlatformMetadata.User(id: '1', userName: platformUser)
+        def workflow = Mock(WorkflowMetadata) {
+            getUserName() >> 'ec2-user'
+            getPlatform() >> platform
+        }
+
+        when:
+        def labels = new Labels().withWorkflowMetadata(workflow, ['userName'] as Set)
+
+        then:
+        labels.entries['nextflow.io/userName'] == expected
+
+        where:
+        platformUser    | expected
+        'jane.doe'      | 'jane.doe'
+        null            | 'ec2-user'
+    }
+
     def 'should compute stable runId from sessionId and runName'() {
         given:
         def sid = 'e2315a82-49b0-4langc3-a58a-0d7d52f7e3a1'


### PR DESCRIPTION
The `nextflow.io/userName` auto label emitted by the Seqera executor was taken from `workflow.userName` — the OS user running the launcher — so the resource tags that end up on scheduler-provisioned cloud resources reported `ec2-user`/`root` (or whoever runs the launcher pod) instead of the Seqera Platform user that submitted the run. Cost reports grouped by that tag therefore attribute spend to the launcher environment, not to a person.

The label now reports `workflow.platform.user.userName`, which the Platform observer populates from the trace-create response (`onFlowCreate`) before the first task submission — so it is available when the executor builds the run labels. When there is no Platform identity (runs launched without a Platform token, plain CLI usage) it falls back to the OS user as before, so behaviour outside Platform is unchanged.

Only the value changes: the key stays `nextflow.io/userName`, so existing cost reports and dashboards built on it keep working and start showing the submitting Platform principal. Note that the identity is the owner of the token Nextflow was given — a user PAT resolves to that user, a workspace automation token resolves to that service account.

Docs: the `seqera.executor.autoLabels` reference now states which identity `userName` carries.

Related: seqeralabs/sched#883

🤖 Generated with [Claude Code](https://claude.com/claude-code)
