### PR TITLE
docs: cleanup and fix inconsistencies

### DIFF
--- a/.docusaurus_site/src/theme/prism-nextflow.js
+++ b/.docusaurus_site/src/theme/prism-nextflow.js
@@ -75,7 +75,7 @@ export default function(Prism) {
       alias: 'property'
     },
     'nextflow-keyword': {
-      pattern: /\b(?:process|workflow|params|input|output|stage|topic|publish|script|shell|exec|when|channel|emit|take|main|tuple|path|val|file|env|stdin|stdout|stderr|include|from)\b/,
+      pattern: /\b(?:process|workflow|params|input|output|stage|topic|publish|script|shell|exec|when|emit|take|main|include|from)\b/,
       alias: 'keyword'
     },
     // Standard types used by static typing, including generic types such as

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -263,20 +263,6 @@ See [drop][cli-drop] for more information.
 
 The `module` command allows you to discover, install, and run modules through a centralized module registry. See [Using modules][using-modules-page] and the [`module`][cli-module] command reference for more information.
 
-### Secret management
-
-The `secrets` command manages secure pipeline secrets.
-
-Use this to store credentials securely, reference them in pipelines without exposing values, and manage sensitive data centrally across your organization:
-
-```bash
-nextflow secrets list
-nextflow secrets set AWS_ACCESS_KEY_ID
-nextflow secrets delete AWS_ACCESS_KEY_ID
-```
-
-See [secrets][cli-secrets] for more information.
-
 ## Configuration and validation
 
 Configuration and validation options and commands help you control and verify pipeline settings. Configuration options supplement pipeline configuration at runtime, while validation commands inspect how Nextflow interprets your configuration files, process definitions, and scripts.
@@ -502,6 +488,20 @@ nextflow plugin my-plugin:hello --alpha --beta
 ```
 
 See individual plugin documentation for plugin specific commands.
+
+### Secrets
+
+The `secrets` command manages secure pipeline secrets.
+
+Use this to store credentials securely, reference them in pipelines without exposing values, and manage sensitive data centrally across your organization:
+
+```bash
+nextflow secrets list
+nextflow secrets set AWS_ACCESS_KEY_ID
+nextflow secrets delete AWS_ACCESS_KEY_ID
+```
+
+See [secrets][cli-secrets] for more information.
 
 ### Nextflow updates
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -593,5 +593,5 @@ http://nextflow.io
 [config-page]: ./config
 [config-params]: ./config#parameters
 [data-lineage-page]: ./tutorials/data-lineage
-[git-page]: ./cli
+[git-page]: ./git
 [using-modules-page]: ./modules/using-modules

--- a/docs/conda.mdx
+++ b/docs/conda.mdx
@@ -47,12 +47,12 @@ Conda package names can be specified using the `conda` directive. Multiple packa
 
 ```nextflow
 process hello {
-  conda 'bwa samtools multiqc'
-
-  script:
-  """
-  your_command --here
-  """
+    conda 'bwa samtools multiqc'
+    
+    script:
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -87,12 +87,12 @@ The path of an environment file can be specified using the `conda` directive:
 
 ```nextflow
 process hello {
-  conda '/some/path/my-env.yaml'
-
-  script:
-  """
-  your_command --here
-  """
+    conda '/some/path/my-env.yaml'
+    
+    script:
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -178,12 +178,12 @@ If you already have a local Conda environment, you can use it in your workflow s
 
 ```nextflow
 process hello {
-  conda '/path/to/an/existing/env/directory'
-
-  script:
-  """
-  your_command --here
-  """
+    conda '/path/to/an/existing/env/directory'
+    
+    script:
+    """
+    your_command --here
+    """
 }
 ```
 
@@ -202,14 +202,14 @@ Specifying the Conda environments in a separate configuration [profile][config-p
 
 ```groovy
 profiles {
-  conda {
-    process.conda = 'samtools'
-  }
+    conda {
+        process.conda = 'samtools'
+    }
 
-  docker {
-    process.container = 'biocontainers/samtools'
-    docker.enabled = true
-  }
+    docker {
+        process.container = 'biocontainers/samtools'
+        docker.enabled = true
+    }
 }
 ```
 

--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -145,10 +145,12 @@ When including a config file, the included config is evaluated with the paramete
 You should declare parameters in the config file only when other config options use them. When you use a parameter in the script, you should declare it there and override it in config profiles as needed:
 
 ```nextflow
+// main.nf
 params.input = null
 ```
 
 ```groovy
+// nextflow.config
 params {
     publish_mode = 'copy'
 }

--- a/docs/git.mdx
+++ b/docs/git.mdx
@@ -91,10 +91,6 @@ API tokens are supported for BitBucket authentication. When both `token` and `pa
 
 [Bitbucket Server](https://confluence.atlassian.com/bitbucketserver) is a self-hosted Git repository and management platform.
 
-:::note
-Bitbucket Servers use a different API from the [Bitbucket](https://bitbucket.org/) Cloud service. Make sure to use the right configuration whether you are using the cloud service or a self-hosted installation.
-:::
-
 To access your local Bitbucket Server, create an entry in the [SCM configuration file](#git-configuration) as shown below:
 
 ```groovy
@@ -108,6 +104,10 @@ providers {
     }
 }
 ```
+
+:::note
+Bitbucket Servers use a different API from the [Bitbucket](https://bitbucket.org/) Cloud service. Make sure to use the right configuration whether you are using the cloud service or a self-hosted installation.
+:::
 
 ### GitHub
 

--- a/docs/notifications.mdx
+++ b/docs/notifications.mdx
@@ -79,7 +79,7 @@ sendMail(
 )
 ```
 
-You can also specify mail options as a DSL:
+You can also specify mail options using a closure:
 
 ```nextflow
 sendMail {

--- a/docs/notifications.mdx
+++ b/docs/notifications.mdx
@@ -47,7 +47,7 @@ workflow.onError {
 ```
 
 :::note
-Both the `onError` and `onComplete` handlers are invoked when an error condition is encountered. The `onError` handler is called as soon as the error is raised, while `onComplete` is called just before the pipeline execution is about to terminate. When using the `finish` [errorStrategy][process-error-strategy], there may be a significant gap between the two, depending on the time required to complete any pending job.
+Both the `onError` and `onComplete` handlers are invoked when an error condition is encountered. The `onError` handler is called as soon as the error is raised, while `onComplete` is called just before the pipeline execution is about to terminate.
 :::
 
 <AddedInVersion version="25.10" />
@@ -66,11 +66,9 @@ workflow {
 
 ## Mail
 
-The built-in function `sendMail` allows you to send a mail message from a workflow script.
+Use the `sendMail` function to send a mail message from a workflow script.
 
-### Basic mail
-
-The mail attributes are specified as named parameters or an equivalent map. For example:
+For example:
 
 ```nextflow
 sendMail(
@@ -81,73 +79,7 @@ sendMail(
 )
 ```
 
-which is equivalent to:
-
-```nextflow
-mail = [
-    to: 'you@gmail.com',
-    subject: 'Catch up',
-    body: 'Hi, how are you!',
-    attach: '/some/path/attachment/file.txt'
-]
-
-sendMail(mail)
-```
-
-The following parameters can be specified:
-
-
-##### `to`
-
-*Multiple email addresses can be specified by separating them with a comma.*
-
-The mail target recipients.
-
-##### `cc`
-
-*Multiple email addresses can be specified by separating them with a comma.*
-
-The mail CC recipients.
-
-##### `bcc`
-
-*Multiple email addresses can be specified by separating them with a comma.*
-
-The mail BCC recipients.
-
-##### `from`
-
-*Multiple email addresses can be specified by separating them with a comma.*
-
-The mail sender address.
-
-##### `subject`
-
-The mail subject.
-
-##### `charset`
-
-The mail content charset (default: `UTF-8`).
-
-##### `text`
-
-The mail plain text content.
-
-##### `body`
-
-The mail body content. It can be either plain text or HTML content.
-
-##### `type`
-
-The mail body mime type. If not specified it's automatically detected.
-
-##### `attach`
-
-Single file or a list of files to be included as mail attachments.
-
-### Advanced mail
-
-Another version of `sendMail` allows a more idiomatic syntax:
+You can also specify mail options as a DSL:
 
 ```nextflow
 sendMail {
@@ -157,6 +89,7 @@ sendMail {
     attach '/other/path/image.png'
     subject 'Catch up'
 
+    // string expression is treated as the mail body
     '''
     Hi there,
     Look! Multi-lines
@@ -165,39 +98,7 @@ sendMail {
 }
 ```
 
-The same attributes listed in the table in the previous section are allowed.
-
-:::tip
-A string expression at the end is implicitly interpreted as the mail body content, therefore the `body` parameter can be omitted as shown above.
-:::
-
-:::tip
-To send an email that includes text and HTML content, use both the `text` and `body` attributes. The first is used for the plain text content, while the second is used for the rich HTML content.
-:::
-
-### Mail attachments
-
-When using the curly brackets syntax, the `attach` parameter can be repeated two or more times to include multiple attachments in the mail message.
-
-Moreover for each attachment it's possible to specify any of the following options:
-
-##### `contentId`
-
-Defines the `Content-ID` header field for the attachment.
-
-##### `disposition`
-
-Defines the `Content-Disposition` header field for the attachment.
-
-##### `fileName`
-
-Defines the `filename` parameter of the `Content-Disposition` header field.
-
-##### `description`
-
-Defines the `Content-Description` header field for the attachment.
-
-For example:
+Attach multiple files with custom headers:
 
 ```nextflow
 sendMail {
@@ -210,6 +111,8 @@ sendMail {
     '''
 }
 ```
+
+See [sendMail][stdlib-namespaces-sendmail] for the full reference.
 
 ### Mail configuration
 
@@ -316,3 +219,4 @@ See [Completion handler](#completion-handler) to learn more about the workflow n
 [config-mail]: ./reference/config#mail
 [config-notification]: ./reference/config#notification
 [process-error-strategy]: ./reference/process#errorstrategy
+[stdlib-namespaces-sendmail]: ./reference/stdlib-namespaces/global#sendmail-options-

--- a/docs/reference/stdlib-namespaces/global.mdx
+++ b/docs/reference/stdlib-namespaces/global.mdx
@@ -86,7 +86,6 @@ When `true`, interprets characters `*`, `?`, `[]` and `{}` as glob wildcards, ot
 
 When `true`, includes hidden files in the resulting paths (default: `false`).
 
-
 ###### `maxDepth: int`
 
 Maximum number of directory levels to visit (default: *no limit*).
@@ -124,6 +123,55 @@ Print a value to standard output with a newline.
 ##### `sendMail( [options] )`
 
 Send an email. See [Notifications][mail-page] for more information.
+
+Available options:
+
+###### `to`
+
+The mail target recipients. Multiple email addresses can be specified as a comma-separated list.
+
+###### `cc`
+
+The mail CC recipients. Multiple email addresses can be specified as a comma-separated list.
+
+###### `bcc`
+
+The mail BCC recipients. Multiple email addresses can be specified as a comma-separated list.
+
+###### `from`
+
+The mail sender address.
+
+###### `subject`
+
+The mail subject.
+
+###### `charset`
+
+The mail content charset (default: `UTF-8`).
+
+###### `text`
+
+The mail plain text content.
+
+###### `body`
+
+The mail body content. Can be either plain text or HTML content.
+
+To send an email that includes both plain text and HTML content, use both the `text` and `body` attributes: `text` is used for the plain text content, while `body` is used for the rich HTML content.
+
+###### `type`
+
+The mail body mime type (default: automatically detected).
+
+###### `attach`
+
+List of file attachments. Each attachment may specify the following params:
+
+- `contentId`: The `Content-ID` header field
+- `disposition`: The `Content-Disposition` header field
+- `fileName`: The `filename` parameter of the `Content-Disposition` header field
+- `description`: The `Content-Description` header field
 
 ##### `sleep( milliseconds: long )`
 

--- a/docs/reference/stdlib-namespaces/global.mdx
+++ b/docs/reference/stdlib-namespaces/global.mdx
@@ -128,15 +128,15 @@ Available options:
 
 ###### `to`
 
-The mail target recipients. Multiple email addresses can be specified as a comma-separated list.
+The mail target recipients. Specify multiple addresses as a comma-separated list.
 
 ###### `cc`
 
-The mail CC recipients. Multiple email addresses can be specified as a comma-separated list.
+The mail CC recipients. Specify multiple addresses as a comma-separated list.
 
 ###### `bcc`
 
-The mail BCC recipients. Multiple email addresses can be specified as a comma-separated list.
+The mail BCC recipients. Specify multiple addresses as a comma-separated list.
 
 ###### `from`
 
@@ -166,7 +166,7 @@ The mail body mime type (default: automatically detected).
 
 ###### `attach`
 
-List of file attachments. Each attachment may specify the following params:
+List of file attachments. Each attachment may specify the following options:
 
 - `contentId`: The `Content-ID` header field
 - `disposition`: The `Content-Disposition` header field

--- a/docs/script.mdx
+++ b/docs/script.mdx
@@ -149,7 +149,7 @@ Records and tuples are both immutable -- once created, they cannot be modified. 
 Operators are symbols that perform specific functions on one or more values. This section highlights some of the most commonly used operators. See [Operators][semantics-operators] for the full set.
 
 :::note
-Operators in this context are different from *channel operators*, which are the methods used to work with channels. See [Dataflow][dataflow-page] for more information.
+Operators in this context are different from *channel operators*, which are the methods used to work with channels. See [Dataflow][workflow-dataflow] for more information.
 :::
 
 The `==` and `!=` operators test whether two values are equal (or not equal):
@@ -355,7 +355,6 @@ workflow {
 See [Processes][process-page], [Workflows][workflow-page], and [Scripts][semantics-scripts] for more information about how to use these features in your Nextflow scripts.
 
 [cache-global-var-race-condition]: ./cache-and-resume#race-condition-on-a-global-variable
-[dataflow-page]: ./process
 [process-page]: ./process
 [semantics-booleans]: ./reference/semantics#booleans
 [semantics-closures]: ./reference/semantics#closures
@@ -373,3 +372,4 @@ See [Processes][process-page], [Workflows][workflow-page], and [Scripts][semanti
 [stdlib-types-map]: ./reference/stdlib-types/map
 [syntax-page]: ./reference/syntax
 [workflow-page]: ./workflow
+[workflow-dataflow]: ./workflow#dataflow

--- a/docs/spack.mdx
+++ b/docs/spack.mdx
@@ -49,12 +49,12 @@ Spack package names can be specified using the `spack` directive. Multiple packa
 
 ```nextflow
 process hello {
-  spack 'bwa samtools py-multiqc'
-
-  script:
-  '''
-  your_command --here
-  '''
+    spack 'bwa samtools py-multiqc'
+    
+    script:
+    '''
+    your_command --here
+    '''
 }
 ```
 
@@ -94,12 +94,12 @@ The path of an environment file can be specified using the `spack` directive:
 
 ```nextflow
 process hello {
-  spack '/some/path/my-env.yaml'
-
-  script:
-  '''
-  your_command --here
-  '''
+    spack '/some/path/my-env.yaml'
+    
+    script:
+    '''
+    your_command --here
+    '''
 }
 ```
 
@@ -113,12 +113,12 @@ If you already have a local Spack environment, you can use it in your workflow s
 
 ```nextflow
 process hello {
-  spack '/path/to/an/existing/env/directory'
-
-  script:
-  '''
-  your_command --here
-  '''
+    spack '/path/to/an/existing/env/directory'
+    
+    script:
+    '''
+    your_command --here
+    '''
 }
 ```
 
@@ -155,14 +155,14 @@ recommended to allow the execution via a command line option and to enhance the 
 
 ```groovy
 profiles {
-  spack {
-    process.spack = 'samtools'
-  }
+    spack {
+        process.spack = 'samtools'
+    }
 
-  docker {
-    process.container = 'biocontainers/samtools'
-    docker.enabled = true
-  }
+    docker {
+        process.container = 'biocontainers/samtools'
+        docker.enabled = true
+    }
 }
 ```
 

--- a/docs/vscode.mdx
+++ b/docs/vscode.mdx
@@ -92,8 +92,6 @@ The extension can automatically migrate scripts to static types. See [Migrating 
 
 To migrate a script, open the Command Palette, search for **Convert script to static types**, and select it.
 
-To migrate an entire pipeline, use the **Convert pipeline to static types** command.
-
 ## Troubleshooting
 
 In the event of a language server error, you can use the **Nextflow: Restart language server** command in the command palette to restart the language server.

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -665,7 +665,7 @@ These operators are not supported when [static typing][preparing-static-types] i
 The following operators have a special meaning when used with process and workflow calls in a workflow:
 
 - The `|` *pipe* operator can be used to chain processes, operators, and workflows.
-- The `&` *and* operator can be used to call multiple processes in parallel with the same channel(s).
+- The `&` *fork* operator can be used to call multiple processes in parallel with the same channel(s).
 
 For example:
 

--- a/docs/working-with-files.mdx
+++ b/docs/working-with-files.mdx
@@ -21,9 +21,7 @@ Use the `files()` function to obtain a list of files. When using the wildcard ch
 listOfFiles = files('some/path/*.fa')
 ```
 
-:::note
 The `file()` function can also be called with a glob pattern, as long as the pattern is intended to match exactly one file.
-:::
 
 A double asterisk (`**`) in a glob pattern works like `*` but also searches through subdirectories:
 


### PR DESCRIPTION
This PR fixes various issues that I found while doing a general review

Topline change: simplify the `sendMail` documentation and move reference content (sendMail options) to the stdlib reference