### PR TITLE
Rebuild the integration tests container

### DIFF
--- a/tests-v1/Dockerfile
+++ b/tests-v1/Dockerfile
@@ -1,42 +1,22 @@
-FROM pditommaso/dkrbase:1.2
+FROM debian:stable-slim
 
-MAINTAINER Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+# Tools required by the test suite: blastp (blast.nf, blast-parallel.nf),
+# t_coffee (blast-parallel.nf, watch.nf), AMPA.pl (ampa.nf).
+# Math::CDF is not packaged by Debian, so it is the only source build.
+# gnuplot is required: AMPA.pl exits 2 if absent, even with -noplot.
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends \
+      ncbi-blast+ \
+      t-coffee \
+      libmath-round-perl \
+      gnuplot-nox \
+      build-essential \
+      cpanminus && \
+    cpanm --notest Math::CDF && \
+    apt-get purge -qq -y build-essential cpanminus && \
+    apt-get autoremove -qq -y && \
+    rm -rf /var/lib/apt/lists/* /root/.cpanm
 
-RUN apt-get update -y && apt-get install -q -y gnuplot python && apt-get clean 
+COPY bin/AMPA.pl /usr/local/bin/
 
-#
-# Required PERL modules
-#
-RUN cpanm Math::CDF Math::Round && \
-  rm -rf /root/.cpanm/work/
-
-
-#
-# BLAST
-#
-RUN wget -q ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.2.29/ncbi-blast-2.2.29+-x64-linux.tar.gz && \
-    tar xf ncbi-blast-2.2.29+-x64-linux.tar.gz && \
-    mv ncbi-blast-2.2.29+ /opt/ && \
-    rm -rf ncbi-blast-2.2.29+-x64-linux.tar.gz && \
-    ln -s /opt/ncbi-blast-2.2.29+/ /opt/blast
-
-# 
-# install T-Coffee 
-#
-RUN wget -q http://tcoffee.org/Packages/Stable/Version_11.00.8cbe486/linux/T-COFFEE_installer_Version_11.00.8cbe486_linux_x64.tar.gz && \
-  tar xf T-COFFEE_installer_Version_11.00.8cbe486_linux_x64.tar.gz -C /opt && \
-  mv /opt/T-COFFEE_installer_Version_11.00.8cbe486_linux_x64 /opt/tcoffee && \
-  rm -rf /opt/tcoffee/plugins/linux/*  && \
-  rm T-COFFEE_installer_Version_11.00.8cbe486_linux_x64.tar.gz 
-
-#
-# Add AMPA script to bin folder 
-#
-ADD bin/AMPA.pl /usr/local/bin/
-
-
-#
-# Configure the env
-#
-ENV PATH="$PATH:/opt/ncbi-blast-2.2.29+/bin:/opt/tcoffee/bin"
-
+CMD ["/bin/bash"]

--- a/tests-v1/nextflow.config
+++ b/tests-v1/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 } 
 
 process {
-  container = 'public.cr.seqera.io/mirror/tests'
+  container = 'public.cr.seqera.io/mirror/tests:v2'
 }
 
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,42 +1,22 @@
-FROM pditommaso/dkrbase:1.2
+FROM debian:stable-slim
 
-MAINTAINER Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+# Tools required by the test suite: blastp (blast.nf, blast-parallel.nf),
+# t_coffee (blast-parallel.nf, watch.nf), AMPA.pl (ampa.nf).
+# Math::CDF is not packaged by Debian, so it is the only source build.
+# gnuplot is required: AMPA.pl exits 2 if absent, even with -noplot.
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends \
+      ncbi-blast+ \
+      t-coffee \
+      libmath-round-perl \
+      gnuplot-nox \
+      build-essential \
+      cpanminus && \
+    cpanm --notest Math::CDF && \
+    apt-get purge -qq -y build-essential cpanminus && \
+    apt-get autoremove -qq -y && \
+    rm -rf /var/lib/apt/lists/* /root/.cpanm
 
-RUN apt-get update -y && apt-get install -q -y gnuplot python && apt-get clean 
+COPY bin/AMPA.pl /usr/local/bin/
 
-#
-# Required PERL modules
-#
-RUN cpanm Math::CDF Math::Round && \
-  rm -rf /root/.cpanm/work/
-
-
-#
-# BLAST
-#
-RUN wget -q ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.2.29/ncbi-blast-2.2.29+-x64-linux.tar.gz && \
-    tar xf ncbi-blast-2.2.29+-x64-linux.tar.gz && \
-    mv ncbi-blast-2.2.29+ /opt/ && \
-    rm -rf ncbi-blast-2.2.29+-x64-linux.tar.gz && \
-    ln -s /opt/ncbi-blast-2.2.29+/ /opt/blast
-
-# 
-# install T-Coffee 
-#
-RUN wget -q http://tcoffee.org/Packages/Stable/Version_11.00.8cbe486/linux/T-COFFEE_installer_Version_11.00.8cbe486_linux_x64.tar.gz && \
-  tar xf T-COFFEE_installer_Version_11.00.8cbe486_linux_x64.tar.gz -C /opt && \
-  mv /opt/T-COFFEE_installer_Version_11.00.8cbe486_linux_x64 /opt/tcoffee && \
-  rm -rf /opt/tcoffee/plugins/linux/*  && \
-  rm T-COFFEE_installer_Version_11.00.8cbe486_linux_x64.tar.gz 
-
-#
-# Add AMPA script to bin folder 
-#
-ADD bin/AMPA.pl /usr/local/bin/
-
-
-#
-# Configure the env
-#
-ENV PATH="$PATH:/opt/ncbi-blast-2.2.29+/bin:/opt/tcoffee/bin"
-
+CMD ["/bin/bash"]

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 } 
 
 process {
-  container = 'public.cr.seqera.io/mirror/tests'
+  container = 'public.cr.seqera.io/mirror/tests:v2'
 }
 
 


### PR DESCRIPTION
## Problem

The integration test suites run everything in `public.cr.seqera.io/mirror/tests`. That image was built on **2015-09-22 with Docker 1.6.2**, on an Ubuntu base layer from 2014. It could no longer be rebuilt from its `Dockerfile`: all three of its fetches are dead — the `pditommaso/dkrbase:1.2` base, the NCBI FTP path for BLAST 2.2.29, and the `tcoffee.org` package URL — and the apt repos inside that base are long EOL.

It was also amd64-only, so it runs under emulation on Apple Silicon and arm64 CI.

## Change

Rebuilt on `debian:stable-slim` using distro packages. Only `Math::CDF` is still built from source, because Debian doesn't package it.

Auditing what the suites actually invoke, the image needs four things — `blastp` (`blast.nf`, `blast-parallel.nf`), `t_coffee` (`blast-parallel.nf`, `watch.nf`), `AMPA.pl` (`ampa.nf`), and `gnuplot`. `gnuplot` is kept only because `AMPA.pl` probes for it and `exit 2`s before argument parsing, so the `-noplot` every caller passes never takes effect. `python`, `bc`, `procps`, `unzip`, `make`, and the compilers from the old base are unused and dropped.

|  | before | after |
|---|---|---|
| size (uncompressed) | 1.39 GB | 456 MB |
| layers | 17 | 3 |
| platforms | linux/amd64 | linux/amd64, linux/arm64 |
| external downloads | 3 (all dead) | 0 |
| BLAST | 2.2.29 (2014) | 2.16.0 |
| T-Coffee | 11.00 | 13.41.0 |

Published as `public.cr.seqera.io/mirror/tests:v2`; `:latest` is left untouched so this is a revert-by-config-change if anything goes wrong.

## Verification

Run inside the published `:v2` image, pulled fresh from the registry, on **both** architectures:

- `blastp -db tiny -query sample.fa -outfmt 6` against the existing `blast-db/tiny` returns the same 36-row hit table — the BLAST 2.2.x database format is still read by 2.16.0, so the committed fixtures did not need regenerating.
- `t_coffee -in p1.fa` exits 0 and produces `p1.aln` / `p1.dnd`.
- The literal `ampa.nf` command line, `AMPA.pl -in=p1.fa -noplot -rf=result -df=data`, exits 0 and reports `0 bactericidal stretches` / `mean antimicrobial value of 0.258`.

Full CI on this branch is what exercises the rest of the suite.

## Note for review

`tests/Dockerfile` and `tests-v1/Dockerfile` were byte-identical before this change and still are — both build the single published image, and `tests-v1/bin/AMPA.pl` is identical to `tests/bin/AMPA.pl`. I kept both in sync rather than deleting one, but the duplication looks removable if you'd prefer that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)