### PR TITLE
chore: Quick fix docs sidebar

### DIFF
--- a/.docusaurus_site/src/custom.css
+++ b/.docusaurus_site/src/custom.css
@@ -31,21 +31,24 @@ h5, h6 {
 }
 
 /* Sidebar scrolling.
-   The theme sticks the sidebar viewport at `--ifm-navbar-height - 2rem` but
-   leaves its `max-height` at `100vh` (stock Docusaurus sticks it at `top: 0`),
-   so the scroll container hangs 2rem below the window. Since it is sticky, that
-   2rem never comes into view: the last menu entry and the end of the scrollbar
-   track are unreachable no matter how far the page is scrolled. Subtract the
-   offset from the height so the container ends at the window edge. `overflow-y`
-   is stated explicitly rather than relying on Infima's `.menu { overflow-x:
-   hidden }` computing the other axis to `auto`, and the extra bottom padding
-   keeps the last entry off the window edge once it can be scrolled to. */
+   @seqera/docusaurus-theme-seqera (1.0.39) sticks the sidebar viewport at
+   `--ifm-navbar-height - 2rem` but leaves its `max-height` at `100vh`, where
+   stock Docusaurus sticks it at `top: 0`. The scroll container therefore hangs
+   2rem below the window, and because it is sticky that 2rem never comes into
+   view: the last menu entry and the end of the scrollbar track are unreachable
+   at any page scroll position. Set both halves here so they cannot drift — the
+   offset stays 2rem, matching the theme's current geometry, and the height is
+   derived from it rather than from the theme's expression. `overflow-y` is
+   stated explicitly rather than relying on Infima's `.menu { overflow-x:
+   hidden }` computing the other axis to `auto`, and the bottom padding keeps
+   the last entry off the window edge once it can be scrolled to. */
 @media (min-width: 997px) {
   .theme-doc-sidebar-container > div {
-    max-height: calc(100vh - (var(--ifm-navbar-height) - 2rem));
+    top: 2rem;
+    max-height: calc(100vh - 2rem);
   }
 
-  .theme-doc-sidebar-container nav.menu {
+  .theme-doc-sidebar-container .menu {
     overflow-y: auto;
     padding-bottom: 1.5rem;
   }

--- a/.docusaurus_site/src/custom.css
+++ b/.docusaurus_site/src/custom.css
@@ -30,6 +30,27 @@ h5, h6 {
   margin-left: 1rem;
 }
 
+/* Sidebar scrolling.
+   The theme sticks the sidebar viewport at `--ifm-navbar-height - 2rem` but
+   leaves its `max-height` at `100vh` (stock Docusaurus sticks it at `top: 0`),
+   so the scroll container hangs 2rem below the window. Since it is sticky, that
+   2rem never comes into view: the last menu entry and the end of the scrollbar
+   track are unreachable no matter how far the page is scrolled. Subtract the
+   offset from the height so the container ends at the window edge. `overflow-y`
+   is stated explicitly rather than relying on Infima's `.menu { overflow-x:
+   hidden }` computing the other axis to `auto`, and the extra bottom padding
+   keeps the last entry off the window edge once it can be scrolled to. */
+@media (min-width: 997px) {
+  .theme-doc-sidebar-container > div {
+    max-height: calc(100vh - (var(--ifm-navbar-height) - 2rem));
+  }
+
+  .theme-doc-sidebar-container nav.menu {
+    overflow-y: auto;
+    padding-bottom: 1.5rem;
+  }
+}
+
 /* Make wide tables horizontally scrollable instead of overflowing the page */
 .markdown table {
   display: block;


### PR DESCRIPTION
- Add custom css to stop the sidebar from getting stuck when scrolling, and add some buffer to the bottom section is not cut off by the browser. Will make a fix in the base docusaurus package soon. 