### PR TITLE
Pre-pull the integration tests container

### DIFF
--- a/tests-v1/nextflow.config
+++ b/tests-v1/nextflow.config
@@ -21,6 +21,9 @@ manifest {
 } 
 
 process {
+  // NOTE: do not pin this by @sha256 digest -- checks/fusion-symlink.nf enables
+  // Wave and Fusion, and Wave rejects a digest-pinned image when the request
+  // carries a containerConfig attribute (HTTP 400).
   container = 'public.cr.seqera.io/mirror/tests'
 }
 

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -21,6 +21,9 @@ manifest {
 } 
 
 process {
+  // NOTE: do not pin this by @sha256 digest -- checks/fusion-symlink.nf enables
+  // Wave and Fusion, and Wave rejects a digest-pinned image when the request
+  // carries a containerConfig attribute (HTTP 400).
   container = 'public.cr.seqera.io/mirror/tests'
 }
 

--- a/validation/test.sh
+++ b/validation/test.sh
@@ -11,8 +11,31 @@ export NXF_CMD=${NXF_CMD:-$(get_abs_filename ../launch.sh)}
 export NXF_ANSI_LOG=false
 export NXF_DISABLE_CHECK_LATEST=true
 
+# Pull the test container up-front. Nextflow does not serialize image pulls, so
+# the first wave of tasks each trigger their own pull of the same image, and a
+# connection reset there fails the task with exit status 125.
+#
+# $1 is the test suite directory, relative to this script (../tests, ../tests-v1).
+# The image is read from that suite's nextflow.config so the reference stays
+# defined in one place only.
+prepull_container() {
+    local image attempt
+    image=$(grep -oE "public\.cr\.seqera\.io/[^'\"[:space:]]+" "$1/nextflow.config")
+    [[ $image ]] || { echo "ERROR: no container found in $1/nextflow.config"; exit 1; }
+    echo "Pre-pulling $image"
+    for attempt in 1 2 3; do
+      docker pull -q "$image" && return 0
+      echo "Pull attempt $attempt failed, retrying in $((attempt*5))s"
+      sleep $((attempt*5))
+    done
+    echo "ERROR: unable to pull $image after 3 attempts"
+    exit 1
+}
+
 test_integration() {
     (
+      # must run before the cd below, while $1 is still relative to this script
+      prepull_container "$1"
       cd "$1"
       sudo bash cleanup.sh
       cd checks


### PR DESCRIPTION
## Problem

Integration tests intermittently fail with exit status 125:

```
Unable to find image 'public.cr.seqera.io/mirror/tests:latest' locally
docker: Error response from daemon: Head "https://public.cr.seqera.io/v2/mirror/tests/manifests/latest":
        read tcp ...: read: connection reset by peer
```

Exit 125 means the Docker CLI failed before the task command ever ran. Nextflow doesn't serialize image pulls, so when the image isn't yet in the local cache the first wave of tasks each start their own pull of the same image. Any one of those connections being reset fails its task outright.

The registry itself is not the bottleneck — 30 concurrent authenticated manifest requests to `public.cr.seqera.io` all return `200` in ~250 ms. The resets happen below the registry, on the network path, so the fix is to stop making the pull part of the critical path of every task.

## Change

- **Pre-pull once** in `test_integration()`, before the suite starts, so tasks always find the image locally. This covers `tests/` and `tests-v1/` and both `test_integration` and `test_parser_v2` modes, since they all route through that one function.
- **Retry the pull** three times with a linear backoff, so a single reset during the pre-pull isn't fatal either.

The image reference is read out of each suite's `nextflow.config`, so it stays defined in exactly one place rather than being duplicated into the script.

## Why the image is not pinned by digest

Pinning `process.container` by `@sha256:` looks like the obvious companion change, and it does not work here. `checks/fusion-symlink.nf` enables Wave and Fusion, and Wave rejects a container request that carries a `containerConfig` attribute when the image is given as a digest:

```
error [io.seqera.wave.plugin.exception.BadResponseException]: Wave invalid response:
POST https://wave.seqera.io/v1alpha2/container [400]
{"message":"Container requests made using a SHA256 as tag does not support the 'containerConfig' attribute"}
```

An earlier revision of this PR pinned the digest and failed `test_integration` and `test_parser_v2` on both JDKs for exactly that reason. Both suites now carry a comment recording it, since both have a `fusion-symlink` check.

## Verification

- Pre-pull succeeded in CI on the previous revision — `Pre-pulling public.cr.seqera.io/mirror/tests@…` logged once, no retries, no error. That part of the change was already exercised end to end on a runner; only the digest pin was at fault.
- Locally, `ampa.nf` runs green with 5 concurrent tasks: `completed=5 failed=0` — the same shape that was throwing 125.
- Pre-pull timing: 10.8 s cold, 0.67 s on the second call, so the `tests-v1` invocation is effectively free.
- Retry failure path, against a nonexistent image: three attempts with 5/10/15 s backoff, then a clear error and exit 1. Confirmed it doesn't trip `set -e` early.

## Note

This supersedes #7430, which rebuilt the image on a current Debian base and broke many tests. This change keeps the existing image exactly as-is and only addresses the pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
