### PR TITLE
Use `command -v` instead of `which` in the launcher Java lookup

### DIFF
--- a/nextflow
+++ b/nextflow
@@ -295,7 +295,7 @@ NXF_CLASSPATH=${NXF_CLASSPATH:-''}
 
 # Determine the path to this file
 if [[ $NXF_PACK = dist ]]; then
-    NXF_BIN=$(which "$0" 2>/dev/null)
+    NXF_BIN=$(command -v "$0")
     [ $? -gt 0 -a -f "$0" ] && NXF_BIN="./$0"
 fi
 

--- a/nextflow
+++ b/nextflow
@@ -316,7 +316,7 @@ if [ ! -x "$JAVA_CMD" ] ; then
     elif [ -x /usr/libexec/java_home ]; then
         JAVA_CMD="$(/usr/libexec/java_home -v 17+ 2>/dev/null)/bin/java" || JAVA_CMD=java
     else
-        JAVA_CMD="$(which java)" || JAVA_CMD=java
+        JAVA_CMD="$(command -v java)" || JAVA_CMD=java
     fi
 fi
 


### PR DESCRIPTION
Fixes #7423

On Debian 12+ based images (`condaforge/miniforge3`, etc.) `which` is a shell function that pipes aliases and functions into `/usr/bin/which` with GNU-which flags:

```bash
which () { ( alias; declare -f ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot $@ }
```

Debian 12 replaced GNU which with the debianutils implementation, which accepts only `[-as]` and rejects those flags, so it prints `Illegal option --` on stderr. Bash exports shell functions through the environment, so the launcher inherits it. `$(...)` captures only stdout, so the error leaks to the terminal on every invocation:

```
$ nextflow -v
Illegal option --
nextflow version 26.04.6.12646
```

Harmless for the run itself, but it breaks anything parsing the output — e.g. a script taking the first line of `nextflow -v` as the version.

`command -v` is POSIX, is a shell builtin, cannot be shadowed by a distro function, and matches the seven other lookups already in this file (lines 72, 102, 104, 128, 130, 147, 149). Exit-status semantics are unchanged, so the `|| JAVA_CMD=java` fallback still fires when no `java` is on `PATH`.

The other `which` call, at line 298, already redirects stderr and is unaffected.

Credit to @rec3141 for the report and the diagnosis.
