### PR TITLE
docs: Apply style guide to config scopes

### DIFF
--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -7,12 +7,28 @@ description: Overview of the config scopes that are available in the Nextflow co
 
 The [Nextflow configuration][config-page] is organized into config scopes. The following pages describe the available settings in each scope.
 
+Each setting is listed by its fully qualified name, which includes the enclosing scopes. You can write a setting using either dot syntax or block syntax:
+
+```groovy
+// dot syntax
+docker.enabled = true
+docker.runOptions = '-u $(id -u):$(id -g)'
+
+// block syntax
+docker {
+    enabled = true
+    runOptions = '-u $(id -u):$(id -g)'
+}
+```
+
+See [Blocks][config-blocks] for more information about the two forms.
+
 ## Config scopes
 
 | Page | Description |
 | ---- | ----------- |
 | [Unscoped options][config-unscoped] | Settings that are not part of a config scope. |
-| [`appleContainer`][config-apple-container] | Controls how [Apple container](https://github.com/apple/container) is used by Nextflow. |
+| [<code style={{whiteSpace: 'nowrap'}}>appleContainer</code>][config-apple-container] | Controls how [Apple container](https://github.com/apple/container) is used by Nextflow. |
 | [`apptainer`][config-apptainer] | Controls how [Apptainer](https://apptainer.org) containers are executed by Nextflow. |
 | [`aws`][config-aws] | Controls the interactions with AWS, including AWS Batch and S3. |
 | [`azure`][config-azure] | Controls the interactions with Azure, including Azure Batch and Azure Blob Storage. |
@@ -49,6 +65,7 @@ The [Nextflow configuration][config-page] is organized into config scopes. The f
 [config-apptainer]: ./config/apptainer
 [config-aws]: ./config/aws
 [config-azure]: ./config/azure
+[config-blocks]: ../config#blocks
 [config-charliecloud]: ./config/charliecloud
 [config-conda]: ./config/conda
 [config-dag]: ./config/dag

--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -5,7 +5,7 @@ description: Overview of the config scopes that are available in the Nextflow co
 
 # Configuration options
 
-The [Nextflow configuration][config-page] is organized into config scopes, each of which controls a particular aspect of a pipeline run. The following pages describe all of the available settings in each config scope.
+The [Nextflow configuration][config-page] is organized into config scopes. The following pages describe the available settings in each scope.
 
 ## Config scopes
 
@@ -37,7 +37,7 @@ The [Nextflow configuration][config-page] is organized into config scopes, each 
 | [`shifter`][config-shifter] | Controls how [Shifter](https://docs.nersc.gov/programming/shifter/overview/) containers are executed by Nextflow. |
 | [`singularity`][config-singularity] | Controls how [Singularity](https://sylabs.io/singularity/) containers are executed by Nextflow. |
 | [`smolvm`][config-smolvm] | Controls how [smolvm](https://github.com/smol-machines/smolvm) microVMs are used by Nextflow. |
-| [`spack`][config-spack] | Controls the creation of a Spack environment by the Spack package manager. |
+| [`spack`][config-spack] | Controls the creation of Spack environments by the Spack package manager. |
 | [`timeline`][config-timeline] | Controls the generation of the [execution timeline][timeline-report]. |
 | [`tower`][config-tower] | Controls the settings for [Seqera Platform](https://seqera.io) (formerly Tower Cloud). |
 | [`trace`][config-trace] | Controls the generation of the [trace file][trace-report]. |

--- a/docs/reference/config/aws.mdx
+++ b/docs/reference/config/aws.mdx
@@ -187,7 +187,7 @@ The name of the signature algorithm to use for signing requests made by the clie
 This option is no longer supported.
 </DeprecatedInVersion>
 
-The Size hint (in bytes) for the low level TCP send buffer (default: `0`).
+The size hint (in bytes) for the low level TCP send buffer (default: `0`).
 
 ##### `aws.client.socketRecvBufferSizeHint`
 
@@ -195,7 +195,7 @@ The Size hint (in bytes) for the low level TCP send buffer (default: `0`).
 This option is no longer supported.
 </DeprecatedInVersion>
 
-The Size hint (in bytes) for the low level TCP receive buffer (default: `0`).
+The size hint (in bytes) for the low level TCP receive buffer (default: `0`).
 
 ##### `aws.client.socketTimeout`
 
@@ -207,11 +207,11 @@ The amount of time to wait (in milliseconds) for data to be transferred over an 
 
 ##### `aws.client.storageClass`
 
-The S3 storage class applied to stored objects, one of \[`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`\] (default: `STANDARD`).
+The S3 storage class applied to stored objects. Can be `STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, or `INTELLIGENT_TIERING` (default: `STANDARD`).
 
 ##### `aws.client.storageEncryption`
 
-The S3 server side encryption to be used when saving objects on S3. Can be `AES256` or `aws:kms` (defaultnone).
+The S3 server side encryption to be used when saving objects on S3. Can be `AES256` or `aws:kms` (default: none).
 
 ##### `aws.client.storageKmsKeyId`
 

--- a/docs/reference/config/azure.mdx
+++ b/docs/reference/config/azure.mdx
@@ -5,7 +5,7 @@ description: Reference for the azure config scope, which controls the interactio
 
 # `azure`
 
-The `azure` scope allows you to configure the interactions with Azure, including Azure Batch and Azure Blob Storage.
+The `azure` scope controls the interactions with Azure, including Azure Batch and Azure Blob Storage.
 
 ##### `azure.activeDirectory.servicePrincipalId`
 
@@ -107,7 +107,7 @@ Enable autoscaling feature for the pool identified with `<name>`.
 
 ##### `azure.batch.pools.<name>.fileShareRootPath`
 
-The internal root mount point when mounting File Shares. Must be `/mnt/resource/batch/tasks/fsmounts` for CentOS nodes or `/mnt/batch/tasks/fsmounts` for Ubuntu nodes (defaultCentOS).
+The internal root mount point when mounting File Shares. Must be `/mnt/resource/batch/tasks/fsmounts` for CentOS nodes or `/mnt/batch/tasks/fsmounts` for Ubuntu nodes (default: CentOS).
 
 ##### `azure.batch.pools.<name>.lowPriority`
 

--- a/docs/reference/config/dag.mdx
+++ b/docs/reference/config/dag.mdx
@@ -13,7 +13,7 @@ The `dag` scope controls the generation of the [workflow diagram][workflow-diagr
 
 *Supported by the HTML and Mermaid renderers.*
 
-Controls the maximum depth at which to render sub-workflows (defaultno limit).
+Controls the maximum depth at which to render sub-workflows (default: no limit).
 
 ##### `dag.direction`
 

--- a/docs/reference/config/env.mdx
+++ b/docs/reference/config/env.mdx
@@ -1,13 +1,13 @@
 ---
 title: env
-description: Reference for the env config scope, which defines environment variables that are exported into the task environment.
+description: Reference for the env config scope, which defines environment variables that are exported into the environment where tasks are executed.
 ---
 
 # `env`
 
-The `env` scope allows the definition of one or more variables that will be exported into the environment where workflow tasks are executed.
+The `env` scope defines environment variables that are exported into the environment where tasks are executed.
 
-Simply prefix your variable names with the `env` scope or surround them by curly brackets, as shown below:
+Prefix each variable name with the `env` scope or surround them by curly brackets, as shown below:
 
 ```groovy
 env.ALPHA = 'some value'

--- a/docs/reference/config/executor.mdx
+++ b/docs/reference/config/executor.mdx
@@ -109,7 +109,7 @@ Determines how often to fetch the queue status from the scheduler (default: `1 m
 
 ##### `executor.submitRateLimit`
 
-Determines the max rate of job submission per time unit, for example `'10sec'` (10 jobs per second) or `'50/2min'` (50 jobs every 2 minutes) (defaultunlimited).
+Determines the max rate of job submission per time unit, for example `'10sec'` (10 jobs per second) or `'50/2min'` (50 jobs every 2 minutes) (default: unlimited).
 
 ##### `executor.retry.delay`
 

--- a/docs/reference/config/google.mdx
+++ b/docs/reference/config/google.mdx
@@ -5,7 +5,7 @@ description: Reference for the google config scope, which controls the interacti
 
 # `google`
 
-The `google` scope allows you to configure the interactions with Google Cloud, including Google Cloud Batch and Google Cloud Storage.
+The `google` scope controls the interactions with Google Cloud, including Google Cloud Batch and Google Cloud Storage.
 
 ##### `google.enableRequesterPaysBuckets`
 
@@ -33,7 +33,7 @@ The Google Cloud project ID to use for pipeline execution.
 
 ##### `google.batch.allowedLocations`
 
-The set of [allowed locations](https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#locationpolicy) for VMs to be provisioned (defaultno restriction).
+The set of [allowed locations](https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#locationpolicy) for VMs to be provisioned (default: no restriction).
 
 ##### `google.batch.autoRetryExitCodes`
 
@@ -46,16 +46,16 @@ See [Google Batch documentation](https://cloud.google.com/batch/docs/troubleshoo
 
 <AddedInVersion version="24.10" />
 
-The image URI of the virtual machine boot disk, e.g `batch-debian` (defaultnone).
+The image URI of the virtual machine boot disk, e.g `batch-debian` (default: none).
 See [Google documentation](https://cloud.google.com/batch/docs/vm-os-environment-overview#vm-os-image-options) for details.
 
 ##### `google.batch.bootDiskSize`
 
-The size of the virtual machine boot disk, e.g `50.GB` (defaultnone).
+The size of the virtual machine boot disk, e.g `50.GB` (default: none).
 
 ##### `google.batch.cpuPlatform`
 
-The [minimum CPU Platform](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications), e.g. `'Intel Skylake'` (defaultnone).
+The [minimum CPU Platform](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform#specifications), e.g. `'Intel Skylake'` (default: none).
 
 ##### `google.batch.gcsfuseOptions`
 

--- a/docs/reference/config/k8s.mdx
+++ b/docs/reference/config/k8s.mdx
@@ -65,7 +65,7 @@ Include the hostname of each task in the execution trace (default: `false`).
 
 <AddedInVersion version="24.04" />
 
-The FUSE device plugin to be used when enabling Fusion in unprivileged mode (default: `['nextflow.io/fuse'1]`).
+The FUSE device plugin to be used when enabling Fusion in unprivileged mode (default: `['nextflow.io/fuse': 1]`).
 
 ##### `k8s.httpConnectTimeout`
 

--- a/docs/reference/config/manifest.mdx
+++ b/docs/reference/config/manifest.mdx
@@ -5,7 +5,7 @@ description: Reference for the manifest config scope, which defines pipeline met
 
 # `manifest`
 
-The `manifest` scope allows you to define some metadata that is useful when publishing or running your pipeline.
+The `manifest` scope defines pipeline metadata that is useful when publishing or running your pipeline.
 
 ##### `manifest.author`
 

--- a/docs/reference/config/report.mdx
+++ b/docs/reference/config/report.mdx
@@ -5,7 +5,7 @@ description: Reference for the report config scope, which controls the generatio
 
 # `report`
 
-The `report` scope controls the generation of the [Execution report][execution-report].
+The `report` scope controls the generation of the [execution report][execution-report].
 
 ##### `report.enabled`
 

--- a/docs/reference/config/seqera.mdx
+++ b/docs/reference/config/seqera.mdx
@@ -11,7 +11,7 @@ description: Reference for the seqera config scope, which controls the interacti
 Preview feature: may change in a future release.
 :::
 
-The `seqera` scope allows you to configure the interactions with Seqera services, including [Seqera executor][seqera-executor].
+The `seqera` scope controls the interactions with Seqera services, including the [Seqera executor][seqera-executor].
 
 ##### `seqera.executor.autoLabels`
 

--- a/docs/reference/config/singularity.mdx
+++ b/docs/reference/config/singularity.mdx
@@ -45,7 +45,7 @@ Pull the Singularity image with http protocol (default: `false`).
 
 *Requires Singularity 3.11 or later*
 
-When enabled, OCI (and Docker) container images are pull and converted to a SIF image file format implicitly by the Singularity run command, instead of Nextflow (default: `false`).
+When enabled, OCI (and Docker) container images are pulled and converted to the SIF format by the Singularity run command, instead of Nextflow (default: `false`).
 
 :::note
 Leave `ociAutoPull` disabled if willing to build a Singularity native image with Wave (see [Build Singularity native images][wave-singularity]).

--- a/docs/reference/config/spack.mdx
+++ b/docs/reference/config/spack.mdx
@@ -5,7 +5,7 @@ description: Reference for the spack config scope, which controls the creation o
 
 # `spack`
 
-The `spack` scope controls the creation of a Spack environment by the Spack package manager.
+The `spack` scope controls the creation of Spack environments by the Spack package manager.
 
 ##### `spack.cacheDir`
 
@@ -27,4 +27,4 @@ Execute tasks with Spack environments (default: `false`).
 
 ##### `spack.parallelBuilds`
 
-The maximum number of parallel package builds (defaultthe number of available CPUs).
+The maximum number of parallel package builds (default: the number of available CPUs).

--- a/docs/reference/config/timeline.mdx
+++ b/docs/reference/config/timeline.mdx
@@ -5,7 +5,7 @@ description: Reference for the timeline config scope, which controls the generat
 
 # `timeline`
 
-The `timeline` scope controls the generation of the [Execution timeline][timeline-report].
+The `timeline` scope controls the generation of the [execution timeline][timeline-report].
 
 ##### `timeline.enabled`
 

--- a/docs/reference/config/tower.mdx
+++ b/docs/reference/config/tower.mdx
@@ -39,6 +39,6 @@ The HTTP read timeout for Seqera Platform API requests (default: `'60s'`).
 
 ##### `tower.workspaceId`
 
-The workspace ID in Seqera Platform in which to save the run (defaultthe launching user's personal workspace).
+The workspace ID in Seqera Platform in which to save the run (default: the launching user's personal workspace).
 
 The workspace ID can also be specified using the environment variable `TOWER_WORKSPACE_ID` (config file has priority over the environment variable).

--- a/docs/reference/config/trace.mdx
+++ b/docs/reference/config/trace.mdx
@@ -5,7 +5,7 @@ description: Reference for the trace config scope, which controls the generation
 
 # `trace`
 
-The `trace` scope controls the generation of the [Trace file][trace-report].
+The `trace` scope controls the generation of the [trace file][trace-report].
 
 ##### `trace.enabled`
 

--- a/docs/reference/config/unscoped.mdx
+++ b/docs/reference/config/unscoped.mdx
@@ -5,7 +5,7 @@ description: Reference for the Nextflow configuration settings that are not part
 
 # Unscoped options
 
-Settings that are not part of a config scope.
+The following settings are not part of a config scope.
 
 ##### `bucketDir`
 

--- a/docs/reference/config/wave.mdx
+++ b/docs/reference/config/wave.mdx
@@ -55,7 +55,7 @@ The corresponding credentials must be provided in your Seqera Platform account.
 
 <AddedInVersion version="25.10" />
 
-The compression algorithm that should be used when building the container. Allowed values are`gzip`, `estargz` and `zstd` (default: `gzip`).
+The compression algorithm that should be used when building the container. Can be `gzip`, `estargz`, or `zstd` (default: `gzip`).
 
 ##### `wave.build.compression.level`
 

--- a/docs/reference/config/workflow.mdx
+++ b/docs/reference/config/workflow.mdx
@@ -79,7 +79,7 @@ Create an absolute symbolic link in the output directory for each output file.
 
 ##### `workflow.output.overwrite`
 
-When `true` any existing file in the specified folder will be overwritten (default: `'standard'`).
+Determines when to overwrite an existing file in the output directory (default: `'standard'`).
 
 Available options:
 
@@ -118,7 +118,7 @@ Specify arbitrary tags for published files.
 For example:
 
 ```groovy
-workflow.output.tags = [FOO'hello', BAR'world']
+workflow.output.tags = [FOO: 'hello', BAR: 'world']
 ```
 
 [process-error-strategy]: ../process#errorstrategy

--- a/modules/nextflow/src/main/groovy/nextflow/config/WorkflowConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/WorkflowConfig.groovy
@@ -104,7 +104,7 @@ class WorkflowOutputConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        When `true` any existing file in the specified folder will be overwritten (default: `'standard'`).
+        Determines when to overwrite an existing file in the output directory (default: `'standard'`).
     """)
     final Object overwrite
 


### PR DESCRIPTION
## Voice and consistency normalization

The split created three copies of each scope's summary (overview table row, frontmatter description, page intro) and they disagreed. Normalized to the table's direct-verb voice, which also matches the merged cli/*.mdx house style:

- azure, google, seqera — "allows you to configure" → "controls"
- manifest — "allows you to define some metadata" → "defines pipeline metadata"
- env — "allows the definition of one or more variables that will be exported" → "defines environment variables that are exported"; dropped "Simply" from the next sentence; aligned the frontmatter description
- unscoped — intro was a sentence fragment restating the title
- report, timeline, trace — lowercased mid-sentence link text to match the table
- spack — singular/plural "Spack environment(s)" disagreed across all three copies
- config.mdx intro — two sentences carrying one idea, tightened to one

## Mechanical typo fixes

All pre-existing text carried through the split, not introduced by it:

- 10 malformed (defaultnone) / (defaultCentOS) / (defaultunlimited) → (default: …) across aws, azure, dag, executor, google, spack, tower. The upstream cleanup in 2f403c8f8 caught the backticked cases and missed these.
- k8s.fuseDevicePlugin default was ['nextflow.io/fuse'1]; corrected to ['nextflow.io/fuse': 1] to match plugins/nf-k8s/src/main/nextflow/k8s/K8sConfig.groovy:111.
- singularity.ociAutoPull — "images are pull and converted to a SIF image file format implicitly by" → matches the correct sibling wording in apptainer.mdx.
- aws.client.socketSendBufferSizeHint / socketRecvBufferSizeHint — "The Size hint" mid-sentence.
- aws.client.storageClass — escaped \[…\] MDX artifact → the "Can be X, Y, or Z" form already used by uploadStorageClass two entries below.
- wave.build.compression.mode — missing space in "Allowed values are`gzip`"; switched to the house "Can be" form.

## Verification

I checked every reference-style link target in the 53 branch-modified docs resolves, and confirmed the six deep anchors in migrations/26-04.mdx land on the pages they now name.

## Other fix

workflow.output.overwrite (docs/reference/config/workflow.mdx:82) reads "Whin the specified folder will be overwritten (default: 'standard')" — a boolean-shaped sentence with a string default.