### PR TITLE
Fix description for process config options with method overloads

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/config/spec/SpecNode.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/spec/SpecNode.java
@@ -80,9 +80,9 @@ public sealed interface SpecNode {
      * process directives.
      *
      * Directives with multiple method overloads are treated as
-     * options with multiple supported types. Method overloads with
-     * multiple parameters are ignored because they are not supported
-     * in the configuration.
+     * options with multiple supported types. Only one overload needs
+     * to provide a description. Method overloads with multiple parameters
+     * are ignored because they are not supported in the configuration.
      */
     private static SpecNode processScope() {
         var description = """
@@ -94,13 +94,14 @@ public sealed interface SpecNode {
         for( var method : ProcessDsl.DirectiveDsl.class.getDeclaredMethods() ) {
             if( method.getParameters().length != 1 )
                 continue;
-            if( !children.containsKey(method.getName()) ) {
-                var desc = annotatedDescription(method, "");
-                children.put(method.getName(), new Option(desc, new ArrayList<>()));
-            }
-            var option = (Option) children.get(method.getName());
-            var paramType = method.getParameterTypes()[0];
-            option.types.add(paramType);
+            var name = method.getName();
+            var desc = annotatedDescription(method, "");
+            var option = (Option) children.get(name);
+            if( option == null )
+                children.put(name, option = new Option(desc, new ArrayList<>()));
+            else if( option.description().isEmpty() && !desc.isEmpty() )
+                children.put(name, option = new Option(desc, option.types()));
+            option.types.add(method.getParameterTypes()[0]);
         }
         return new Scope(description, children);
     }

--- a/modules/nf-lang/src/main/java/nextflow/config/spec/SpecNode.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/spec/SpecNode.java
@@ -92,9 +92,9 @@ public sealed interface SpecNode {
      * set of process directives.
      *
      * Directives with multiple method overloads are treated as
-     * options with multiple supported types. Method overloads with
-     * multiple parameters are ignored because they are not supported
-     * in the configuration.
+     * options with multiple supported types. Only one overload needs
+     * to provide a description. Method overloads with multiple parameters
+     * are ignored because they are not supported in the configuration.
      *
      * @param description
      */
@@ -103,13 +103,14 @@ public sealed interface SpecNode {
         for( var method : ProcessDsl.DirectiveDsl.class.getDeclaredMethods() ) {
             if( method.getParameters().length != 1 )
                 continue;
-            if( !children.containsKey(method.getName()) ) {
-                var desc = annotatedDescription(method, "");
-                children.put(method.getName(), new Option(desc, new ArrayList<>()));
-            }
-            var option = (Option) children.get(method.getName());
-            var paramType = method.getParameterTypes()[0];
-            option.types.add(paramType);
+            var name = method.getName();
+            var desc = annotatedDescription(method, "");
+            var option = (Option) children.get(name);
+            if( option == null )
+                children.put(name, option = new Option(desc, new ArrayList<>()));
+            else if( option.description().isEmpty() && !desc.isEmpty() )
+                children.put(name, option = new Option(desc, option.types()));
+            option.types.add(method.getParameterTypes()[0]);
         }
         return new Scope(description, children);
     }

--- a/modules/nf-lang/src/main/java/nextflow/config/spec/SpecNode.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/spec/SpecNode.java
@@ -106,11 +106,16 @@ public sealed interface SpecNode {
             var name = method.getName();
             var desc = annotatedDescription(method, "");
             var option = (Option) children.get(name);
-            if( option == null )
-                children.put(name, option = new Option(desc, new ArrayList<>()));
-            else if( option.description().isEmpty() && !desc.isEmpty() )
-                children.put(name, option = new Option(desc, option.types()));
-            option.types.add(method.getParameterTypes()[0]);
+            if( option == null ) {
+                option = new Option(desc, new ArrayList<>());
+                children.put(name, option);
+            }
+            else if( option.description().isEmpty() && !desc.isEmpty() ) {
+                option = new Option(desc, option.types());
+                children.put(name, option);
+            }
+            var paramType = method.getParameterTypes()[0];
+            option.types.add(paramType);
         }
         return new Scope(description, children);
     }

--- a/modules/nf-lang/src/test/groovy/nextflow/config/spec/SpecNodeTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/spec/SpecNodeTest.groovy
@@ -31,6 +31,14 @@ class SpecNodeTest extends Specification {
         def scope = SpecNode.ROOT.children.get('process')
 
         expect:
+        // every directive should have a description, even if it is overloaded
+        scope.children.get('arch').description
+        scope.children.get('cache').description
+        scope.children.get('clusterOptions').description
+        scope.children.get('cpus').description
+        scope.children.get('disk').description
+        scope.children.get('publishDir').description
+        and:
         scope.children.get('clusterOptions').types as Set == [ String, List, String[] ] as Set
         scope.children.get('cpus').types == [ Integer ]
         scope.children.get('errorStrategy').types == [ String ]


### PR DESCRIPTION
Fix https://github.com/nextflow-io/language-server/issues/173

This PR updates SpecNode to handle method overloads when loading process config from ProcessDsl

A process directive can have multiple overloads, but only one overload is expected to specify a description. So SpecNode needs to extract the description from whichever method defines it.