### PR TITLE
docs: Apply style guide to container runtimes

### DIFF
--- a/.docusaurus_site/sidebars.js
+++ b/.docusaurus_site/sidebars.js
@@ -67,7 +67,23 @@ module.exports = {
             collapsed: true,
             items: [
                 "git",
-                "container",
+                {
+                    type: "category",
+                    label: "Containers",
+                    collapsed: true,
+                    link: { type: "doc", id: "container" },
+                    items: [
+                        "container/apple-container",
+                        "container/apptainer",
+                        "container/charliecloud",
+                        "container/docker",
+                        "container/podman",
+                        "container/sarus",
+                        "container/shifter",
+                        "container/singularity",
+                        "container/smolvm"
+                    ]
+                },
                 "conda",
                 "spack",
                 "wave"

--- a/docs/container.mdx
+++ b/docs/container.mdx
@@ -5,9 +5,9 @@ description: Use Docker, Singularity, Apptainer, and other container runtimes wi
 
 # Containers
 
-Containerization allows you to write self-contained and reproducible computational pipelines, by packaging the binary dependencies of a script into a *container image* that can be executed on any platform that supports a *container runtime*.
+A *container image* packages the binary dependencies of a script so that the script runs on any platform with a *container runtime*. Containerizing a pipeline makes it self-contained and reproducible.
 
-A Nextflow pipeline can be executed with any of the supported container runtimes, as long as it is available in the target compute environment.
+Nextflow runs a pipeline with any of the supported container runtimes, provided the runtime is available in the target compute environment.
 
 ## Container configuration
 
@@ -35,7 +35,7 @@ process bye {
 }
 ```
 
-The same container settings can be defined in the configuration file:
+You can also define the same container settings in the configuration file:
 
 ```groovy
 process {
@@ -48,28 +48,32 @@ process {
 }
 ```
 
-See [Process configuration][config-process] and the [container][process-container] directive for more information.
+See [Process configuration][config-process] and the [`container`][process-container] directive for more information.
 
 :::tip
-Use the `nextflow inspect` command to preview the containers that will be used for each process in a pipeline.
+Use the `nextflow inspect` command to preview the container that each process in a pipeline uses.
 :::
 
 ## Caveats
 
-The following caveats apply when running Nextflow pipelines with containers:
+The following caveats apply when you run Nextflow pipelines with containers.
 
-- **Container image requirements**. Every container image must have Bash (>=3.0), `ps`, and other tools required for collecting metrics (see [Tasks][execution-report-tasks] for more information). Bash must be available on the path `/bin/bash` and it must be the container entrypoint.
+### Container image requirements
 
-- **Symbolic link inputs**. Nextflow automatically manages the file system mounts for a container in order to provide task inputs. However, when a task input is a *symbolic link*, the linked file must reside in the same directory as the symlink, or a sub-directory thereof. Otherwise, the task will fail because the container won't be able to access the linked file.
+Every container image must include Bash (>=3.0), `ps`, and the other tools required to collect metrics. See [Tasks][execution-report-tasks] for more information. Bash must be available at `/bin/bash` and must be the container entrypoint.
+
+### Symbolic link inputs
+
+Nextflow manages the file system mounts for a container to provide task inputs. When a task input is a *symbolic link*, the linked file must reside in the same directory as the symlink, or in a subdirectory of it. Otherwise, the task fails because the container cannot access the linked file.
 
 ## Container runtimes
 
 | Page | Description |
 | ---- | ----------- |
 | [<span style={{whiteSpace: 'nowrap'}}>Apple container</span>][container-apple-container] | A lightweight runtime that runs each container in its own virtual machine on macOS. |
-| [Apptainer][container-apptainer] | An open source fork of Singularity, suited to HPC workloads. |
+| [Apptainer][container-apptainer] | An open source fork of Singularity, suited to high-performance computing (HPC) workloads. |
 | [Charliecloud][container-charliecloud] | An unprivileged runtime for HPC environments, based on Linux user namespaces. |
-| [Docker][container-docker] | The industry standard container runtime. |
+| [Docker][container-docker] | The most widely used container runtime. |
 | [Podman][container-podman] | A drop-in replacement for Docker that can run with or without root privileges. |
 | [Sarus][container-sarus] | An HPC runtime, developed at CSCS, that converts Docker images to Squashfs layers. |
 | [Shifter][container-shifter] | An HPC runtime, developed at NERSC, that converts Docker images to Squashfs layers. |

--- a/docs/container.mdx
+++ b/docs/container.mdx
@@ -5,72 +5,37 @@ description: Use Docker, Singularity, Apptainer, and other container runtimes wi
 
 # Containers
 
-Nextflow supports a variety of container runtimes. Containerization allows you to write self-contained and truly reproducible computational pipelines, by packaging the binary dependencies of a script into a standard and portable format that can be executed on any platform that supports a container runtime. Furthermore, the same pipeline can be transparently executed with any of the supported container runtimes, depending on which runtimes are available in the target compute environment.
+Containerization allows you to write self-contained and reproducible computational pipelines, by packaging the binary dependencies of a script into a *container image* that can be executed on any platform that supports a *container runtime*.
 
-:::note
-When creating a container image to use with Nextflow, make sure that Bash (3.x or later) and `ps` are installed in the image, along with other tools required for collecting metrics (see [Tasks][execution-report-tasks] for more information). Bash should be available on the path `/bin/bash` and it should be the container entrypoint.
-:::
+A Nextflow pipeline can be executed with any of the supported container runtimes, as long as it is available in the target compute environment.
 
-## Apple container
+## Container configuration
 
-<AddedInVersion version="26.04" />
+Each process in a pipeline can specify its own container image.
 
-[Apple container](https://github.com/apple/container) is a lightweight container runtime that uses the [Virtualization framework](https://developer.apple.com/documentation/virtualization) to run each container inside its own virtual machine on macOS.
-
-### Prerequisites
-
-[Apple container](https://github.com/apple/container) requires Apple silicon (M1 or newer) and a recent macOS release.
-
-Start the system service before running your pipeline:
-
-```bash
-container system start
-```
-
-### How it works
-
-You don't need to modify your Nextflow script to run it with Apple container. Enable it in the Nextflow configuration file:
-
-```groovy
-process.container = 'nextflow/examples:latest'
-appleContainer.enabled = true
-```
-
-Each time your script launches a process, Nextflow wraps it and runs it inside a container created from the specified image using the `container run` command.
-
-:::note
-Each container runs in its own lightweight VM, so tasks benefit from strong isolation without the overhead of a full VM per task. Images are standard OCI images and can be pulled from any registry.
-:::
-
-:::note
-Apple container only supports Linux images. To run an `amd64` image on Apple silicon, pass `--rosetta` via `appleContainer.runOptions` and set the platform explicitly, for example, `process.arch = 'linux/amd64'`.
-:::
-
-### Multiple containers
-
-You can specify a different image for each process in your pipeline. For example, the following script defines two processes, `hello` and `bye`, each using a different image:
+For example:
 
 ```nextflow
 process hello {
-  container 'image_name_1'
-
-  script:
-  """
-  do this
-  """
+    container 'image_name_1'
+    
+    script:
+    """
+    do this
+    """
 }
 
 process bye {
-  container 'image_name_2'
-
-  script:
-  """
-  do that
-  """
+    container 'image_name_2'
+    
+    script:
+    """
+    do that
+    """
 }
 ```
 
-You can also define the same container assignments in the configuration file:
+The same container settings can be defined in the configuration file:
 
 ```groovy
 process {
@@ -81,702 +46,45 @@ process {
         container = 'image_name_2'
     }
 }
-
-appleContainer {
-    enabled = true
-}
 ```
 
-See [Process configuration][config-process] for more information about process configuration.
-
-### Advanced settings
-
-See [`appleContainer`][config-apple-container] on the Nextflow configuration page for advanced Apple container settings.
-
-## Apptainer
-
-[Apptainer](https://apptainer.org) is an alternative container runtime to Docker and an open source fork of Singularity. The main advantages of Apptainer are that it can be used without root privileges and it doesn't require a separate daemon process. These, along with other features such as support for autofs mounts, makes Apptainer better suited to the requirements of HPC workloads. Apptainer is able to use existing Docker images and can pull from Docker registries.
-
-### Prerequisites
-
-You will need Apptainer installed on your execution environment e.g. your computer or a distributed cluster, depending on where you want to run your pipeline.
-
-### Images
-
-Apptainer makes use of a container image file, which physically contains the container. Refer to the [Apptainer documentation](https://apptainer.org/docs) to learn how to create Apptainer images.
-
-Apptainer allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. However this feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
-
-:::note
-Nextflow expects that data paths are defined system wide, and your Apptainer images need to be created having the mount paths defined in the container file system.
-:::
-
-If your Apptainer installation support the "user bind control" feature, enable the Nextflow support for that by defining the `apptainer.autoMounts = true` setting in the Nextflow configuration file.
-
-### How it works
-
-The integration for Apptainer follows the same execution model implemented for Docker. You won't need to modify your Nextflow script in order to run it with Apptainer. Simply specify the Apptainer image file from where the containers are started by using the `-with-apptainer` command line option. For example:
-
-```bash
-nextflow run main.nf -with-apptainer [apptainer image file]
-```
-
-Every time your script launches a process execution, Nextflow will run it into an Apptainer container created by using the specified image. In practice Nextflow will automatically wrap your processes and launch them by running the `apptainer exec` command with the image you have provided.
-
-:::note
-An Apptainer image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
-:::
-
-If you want to avoid entering the Apptainer image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
-
-```groovy
-process.container = '/path/to/apptainer.img'
-apptainer.enabled = true
-```
-
-In the above example replace `/path/to/apptainer.img` with any Apptainer image of your choice.
-
-See [Configuration][config-page] to learn more about the configuration file and how to use it to configure your pipeline execution.
-
-:::note
-Unlike Docker, Nextflow does not automatically mount host paths in the container when using Apptainer. It expects that the paths are configured and mounted system wide by the Apptainer runtime. If your Apptainer installation allows user defined bind points. See [Apptainer][config-apptainer] to learn how to enable Nextflow auto mounts.
-:::
-
-:::warning
-When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Apptainer installation. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
-:::
-
-<ChangedInVersion version="23.10">
-Nextflow no longer mounts the home directory when launching an Apptainer container. To re-enable the old behavior, set the environment variable `NXF_APPTAINER_HOME_MOUNT` to `true`.
-</ChangedInVersion>
-
-### Multiple containers
-
-It is possible to specify a different Apptainer image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Apptainer images in the configuration file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-apptainer {
-    enabled = true
-}
-```
-
-See [Process configuration][config-process] to learn more about processes configuration.
-
-### Apptainer & Docker Hub
-
-Nextflow is able to transparently pull remote container images stored in any Docker compatible registry.
-
-By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it's used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
-
-If you want Nextflow to check only for local file images, prefix the container name with the `file://` pseudo-protocol. For example:
-
-```groovy
-process.container = 'file:///path/to/apptainer.img'
-apptainer.enabled = true
-```
-
-:::warning
-Use three `/` slashes to specify an **absolute** file path, otherwise the path will be interpreted as relative to the workflow launch directory.
-:::
-
-To pull images from Apptainer Hub or a third party Docker registry, prefix the image name with the `shub://`, `docker://` or `docker-daemon://` pseudo-protocol as required by Apptainer. For example:
-
-```groovy
-process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
-apptainer.enabled = true
-```
-
-You do not need to specify `docker://` to pull from a Docker repository. Nextflow will automatically prepend it to your image name when Apptainer is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
-
-:::note
-This feature requires the `apptainer` tool to be installed where the workflow execution is launched (as opposed to the compute nodes).
-:::
-
-Nextflow caches Apptainer images in the `apptainer` directory, in the pipeline work directory, by default. However, it is recommended to provide a centralized cache directory using the `NXF_APPTAINER_CACHEDIR` environment variable or the `apptainer.cacheDir` setting in the Nextflow config file.
-
-Nextflow uses the library directory to determine the location of Apptainer containers. The library directory can be defined using the `apptainer.libraryDir` configuration setting or the `NXF_APPTAINER_LIBRARYDIR` environment variable. The configuration file option overrides the environment variable if both are set.
-
-Nextflow first checks the library directory when searching for the image. If the image is not found it then checks the cache directory. The main difference between the library directory and the cache directory is that the first is assumed to be a read-only container repository, while the latter is expected to be writable path where container images can be added for caching purposes.
-
-:::warning
-When using a compute cluster, the Apptainer cache directory must reside in a shared filesystem accessible to all compute nodes.
-:::
-
-:::danger
-When pulling Docker images, Apptainer may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See Apptainer documentation for details.
-:::
-
-### Advanced settings
-
-Apptainer advanced configuration settings are described in[Apptainer][config-apptainer] section in the Nextflow configuration page.
-
-## Charliecloud
-
-:::note{title="Requires Charliecloud 0.28 or later."}
-:::
-
-:::warning{title="Experimental: not recommended for production environments."}
-:::
-
-[Charliecloud](https://hpc.github.io/charliecloud) is an alternative container runtime to Docker, that is better suited for use in HPC environments. Its main advantage is that it can be used without root privileges, making use of user namespaces in the Linux kernel. Charliecloud is able to pull from Docker registries.
-
-### Prerequisites
-
-You will need Charliecloud installed in your execution environment e.g. on your computer or a distributed cluster, depending on where you want to run your pipeline.
-
-### How it works
-
-You won't need to modify your Nextflow script in order to run it with Charliecloud. Simply specify the docker image from where the containers are started by using the `-with-charliecloud` command line option. For example:
-
-```bash
-nextflow run main.nf -with-charliecloud [container]
-```
-
-Every time your script launches a process execution, Nextflow will run it into a charliecloud container created by using the specified container image. In practice Nextflow will automatically wrap your processes and run them by executing the `ch-run` command with the container you have provided.
-
-:::note
-A container image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
-:::
-
-If you want to avoid entering the Container image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
-
-```groovy
-process.container = '/path/to/container'
-charliecloud.enabled = true
-```
-
-:::warning
-If an absolute path is provided, the container needs to be in the Charliecloud flat directory format. See below on compatibility with Docker registries.
-:::
-
-See [Configuration][config-page] to learn more about the configuration file and how to use it to configure your pipeline execution.
-
-:::warning
-Nextflow automatically manages the file system mounts whenever a container is launched depending on the process input files. However, when a process input is a *symbolic link*, the linked file **must** be stored in the same folder where the symlink is located, or a sub-folder of it. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
-:::
-
-### Charliecloud & Docker Hub
-
-Nextflow is able to transparently pull remote container images stored in any Docker compatible registry and converts them to the Charliecloud compatible format.
-
-By default when a container name is specified, Nextflow checks if a container with that name exists in the local file system. If it exists, it's used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the Docker Hub.
-
-To pull images from a third party Docker registry simply provide the URL to the image. If no URL is provided, Docker Hub is assumed. For example this can be used to pull an image from quay.io and convert it automatically to the Charliecloud container format:
-
-```groovy
-process.container = 'https://quay.io/biocontainers/multiqc:1.3--py35_2'
-charliecloud.enabled = true
-```
-
-Whereas this would pull from Docker Hub:
-
-```groovy
-process.container = 'nextflow/examples:latest'
-charliecloud.enabled = true
-```
-
-### Multiple containers
-
-It is possible to specify a different Docker image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Docker images for them in the config file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-
-charliecloud {
-    enabled = true
-}
-```
-
-See [Process configuration][config-process] to learn more about processes configuration.
-
-After running your pipeline, you can easily query the container image that each process used with the following command:
-
-```bash
-nextflow log last -f name,container
-```
-
-### Advanced settings
-
-Charliecloud advanced configuration settings are described in the [Charliecloud][config-charliecloud] section in the Nextflow configuration page.
-
-## Docker
-
-[Docker](http://www.docker.io) is the industry standard container runtime.
-
-### Prerequisites
-
-You will need Docker installed on your execution environment e.g. your computer or a distributed cluster, depending on where you want to run your pipeline.
-
-If you are running Docker on Mac OSX make sure you are mounting your local `/Users` directory into the Docker VM as explained in this excellent tutorial: [How to use Docker on OSX](http://viget.com/extend/how-to-use-docker-on-os-x-the-missing-guide).
-
-### How it works
-
-You won't need to modify your Nextflow script in order to run it with Docker. Simply specify the Docker image from where the containers are started by using the `-with-docker` command line option. For example:
-
-```bash
-nextflow run main.nf -with-docker [docker image]
-```
-
-Every time your script launches a process execution, Nextflow will run it into a Docker container created by using the specified image. In practice Nextflow will automatically wrap your processes and run them by executing the `docker run` command with the image you have provided.
-
-:::note
-A Docker image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
-:::
-
-If you want to avoid entering the Docker image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
-
-```groovy
-process.container = 'nextflow/examples:latest'
-docker.enabled = true
-```
-
-In the above example replace `nextflow/examples:latest` with any Docker image of your choice.
-
-See [Configuration][config-page] to learn more about the configuration file and how to use it to configure your pipeline execution.
-
-:::warning
-Nextflow automatically manages the file system mounts whenever a container is launched depending on the process input files. However, when a process input is a *symbolic link*, the linked file **must** be stored in the same folder where the symlink is located, or a sub-folder of it. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
-:::
-
-### Multiple containers
-
-It is possible to specify a different Docker image for each process definition in your pipeline script. Suppose you have two processes named `hello` and `bye`. You can specify two different Docker images for them in the Nextflow script as shown below:
-
-```nextflow
-process hello {
-  container 'image_name_1'
-
-  script:
-  """
-  do this
-  """
-}
-
-process bye {
-  container 'image_name_2'
-
-  script:
-  """
-  do that
-  """
-}
-```
-
-Alternatively, the same containers definitions can be provided by using the configuration file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-
-docker {
-    enabled = true
-}
-```
-
-See [Process configuration][config-process] to learn more.
-
-### Advanced settings
-
-Docker advanced configuration settings are described in the [docker][config-docker] section in the Nextflow configuration page.
-
-## Podman
-
-[Podman](http://www.podman.io) is a drop-in replacement for Docker that can run containers with or without root privileges.
-
-### Prerequisites
-
-You will need Podman installed on your execution environment e.g. your computer or a distributed cluster, depending on where you want to run your pipeline. Running in rootless mode requires appropriate OS configuration. Due to current Podman limits using cpuset for cpus and memory such is only possible using sudo.
-
-### How it works
-
-You won't need to modify your Nextflow script in order to run it with Podman. Simply specify the Podman image from where the containers are started by using the `-with-podman` command line option. For example:
-
-```bash
-nextflow run main.nf -with-podman [OCI container image]
-```
-
-Every time your script launches a process execution, Nextflow will run it into a Podman container created by using the specified image. In practice Nextflow will automatically wrap your processes and run them by executing the `podman run` command with the image you have provided.
-
-:::note
-An OCI container image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
-:::
-
-If you want to avoid entering the Podman image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
-
-```groovy
-process.container = 'nextflow/examples:latest'
-podman.enabled = true
-```
-
-In the above example replace `nextflow/examples:latest` with any Podman image of your choice.
-
-See [Configuration][config-page] to learn more about the configuration file and how to use it to configure your pipeline execution.
-
-:::warning
-Nextflow automatically manages the file system mounts whenever a container is launched depending on the process input files. However, when a process input is a *symbolic link*, the linked file **must** be stored in the same folder where the symlink is located, or a sub-folder of it. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
-:::
-
-### Multiple containers
-
-It is possible to specify a different container image for each process definition in your pipeline script. Let's suppose you have two processes named `hello` and `bye`. You can specify two different container images for them in the Nextflow script as shown below:
-
-```nextflow
-process hello {
-  container 'image_name_1'
-
-  script:
-  """
-  do this
-  """
-}
-
-process bye {
-  container 'image_name_2'
-
-  script:
-  """
-  do that
-  """
-}
-```
-
-Alternatively, the same containers definitions can be provided by using the configuration file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-
-podman {
-    enabled = true
-}
-```
-
-See[Process configuration][config-process] to learn more about processes configuration.
-
-### Advanced settings
-
-Podman advanced configuration settings are described in the [podman][config-podman] section in the Nextflow configuration page.
-
-## Sarus
-
-[Sarus](https://sarus.readthedocs.io) is an alternative container runtime to Docker. Sarus works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Sarus enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
-
-### Prerequisites
-
-You need Sarus installed in your execution environment, i.e. your personal computer or a distributed cluster, depending on where you want to run your pipeline.
-
-### Images
-
-Sarus converts a docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Sarus images see the [official documentation](https://sarus.readthedocs.io/en/stable/user/user_guide.html#develop-the-docker-image).
-
-### How it works
-
-The integration for Sarus, at this time, requires you to set up the following parameters in your config file:
-
-```groovy
-process.container = "dockerhub_user/image_name:image_tag"
-sarus.enabled = true
-```
-
-and it will always try to search the Docker Hub registry for the images.
-
-:::note
-if you do not specify an image tag, the `latest` tag will be fetched by default.
-:::
-
-### Multiple containers
-
-It is possible to specify a different Sarus image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Sarus images specifying them in the configuration file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-
-sarus {
-    enabled = true
-}
-```
-
-See [Process configuration][config-process] to learn more about processes configuration.
-
-## Shifter
-
-[Shifter](https://docs.nersc.gov/programming/shifter/overview/) is an alternative container runtime to Docker. Shifter works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Shifter enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
-
-### Prerequisites
-
-You need Shifter and Shifter image gateway installed in your execution environment, i.e: your personal computer or the entry node of a distributed cluster. In the case of a distributed cluster, you should have Shifter installed on all of the compute nodes and the `shifterimg` command should also be available and Shifter properly setup to access the Image gateway, for more information see the [official documentation](https://github.com/NERSC/shifter/tree/master/doc).
-
-### Images
-
-Shifter converts a Docker image to squashfs layers which are distributed and launched in the cluster. For more information on how to build Shifter images see the [official documentation](https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images).
-
-### How it works
-
-The integration for Shifter requires you to set up the following parameters in your config file:
-
-```groovy
-process.container = "dockerhub_user/image_name:image_tag"
-shifter.enabled = true
-```
-
-Shifter will search the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
-
-### Multiple containers
-
-It is possible to specify a different Shifter image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Shifter images specifying them in the configuration file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-
-shifter {
-    enabled = true
-}
-```
-
-See [Process configuration][config-process] to learn more about processes configuration.
-
-## Singularity
-
-[Singularity](http://singularity.lbl.gov/) is an alternative container runtime to Docker. The main advantages of Singularity are that it can be used without root privileges and it doesn't require a separate daemon process. These, along with other features such as support for autofs mounts, makes Singularity better suited to the requirements of HPC workloads. Singularity is able to use existing Docker images and can pull from Docker registries.
-
-### Prerequisites
-
-You will need Singularity installed on your execution environment e.g. your computer or a distributed cluster, depending on where you want to run your pipeline.
-
-### Images
-
-Singularity makes use of a container image file, which physically contains the container. Refer to the [Singularity documentation](https://www.sylabs.io/docs/) to learn how create Singularity images.
-
-Singularity allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. However this feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
-
-:::note
-Nextflow expects that data paths are defined system wide, and your Singularity images need to be created having the mount paths defined in the container file system.
-:::
-
-If your Singularity installation support the "user bind control" feature, enable the Nextflow support for that by defining the `singularity.autoMounts = true` setting in the Nextflow configuration file.
-
-### How it works
-
-The integration for Singularity follows the same execution model implemented for Docker. You won't need to modify your Nextflow script in order to run it with Singularity. Simply specify the Singularity image file from where the containers are started by using the `-with-singularity` command line option. For example:
-
-```bash
-nextflow run main.nf -with-singularity [singularity image file]
-```
-
-Every time your script launches a process execution, Nextflow will run it into a Singularity container created by using the specified image. In practice Nextflow will automatically wrap your processes and launch them by running the `singularity exec` command with the image you have provided.
-
-:::note
-A Singularity image can contain any tool or piece of software you may need to carry out a process execution. Moreover, the container is run in such a way that the process result files are created in the host file system, thus it behaves in a completely transparent manner without requiring extra steps or affecting the flow in your pipeline.
-:::
-
-If you want to avoid entering the Singularity image as a command line parameter, you can define it in the Nextflow configuration file. For example you can add the following lines in the configuration file:
-
-```groovy
-process.container = '/path/to/singularity.img'
-singularity.enabled = true
-```
-
-In the above example replace `/path/to/singularity.img` with any Singularity image of your choice.
-
-See [Configuration][config-page] to learn more about the configuration file and how to use it to configure your pipeline execution.
-
-:::note
-Unlike Docker, Nextflow does not automatically mount host paths in the container when using Singularity. It expects that the paths are configured and mounted system wide by the Singularity runtime. If your Singularity installation allows user defined bind points, see [Singularity][config-singularity] to learn how to enable Nextflow auto mounts.
-:::
-
-:::warning
-When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Singularity installation. Otherwise the process execution will fail because the launched container won't be able to access the linked file.
-:::
-
-<ChangedInVersion version="23.10">
-Nextflow no longer mounts the home directory when launching a Singularity container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_HOME_MOUNT` to `true`.
-</ChangedInVersion>
-
-<ChangedInVersion version="23.10">
-Nextflow automatically mounts the required host paths in the container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false` or set `singularity.autoMounts=false` in the Nextflow configuration file.
-</ChangedInVersion>
-
-<ChangedInVersion version="23.10">
-The execution command for Singularity/Apptainer containers can be set to `run` by means of the environment variable `NXF_SINGULARITY_RUN_COMMAND` (default command is `exec`).
-</ChangedInVersion>
-
-### Multiple containers
-
-It is possible to specify a different Singularity image for each process definition in your pipeline script. For example, suppose you have two processes named `hello` and `bye`. You can specify two different Singularity images specifying them in the configuration file as shown below:
-
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
-
-singularity {
-    enabled = true
-}
-```
-
-See [Process configuration][config-process] to learn more about processes configuration.
-
-### Singularity & Docker Hub
-
-*Requires Singularity 2.3 or later*
-
-Nextflow is able to transparently pull remote container images stored in the [Singularity-Hub](https://singularity-hub.org/), [Singularity Library](https://cloud.sylabs.io/library/), or any Docker compatible registry.
-
-By default when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it's used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the Docker Hub.
-
-If you want Nextflow to check only for local file images, prefix the container name with the `file://` pseudo-protocol. For example:
-
-```groovy
-process.container = 'file:///path/to/singularity.img'
-singularity.enabled = true
-```
-
-:::warning
-Use three `/` slashes to specify an **absolute** file path, otherwise the path will be interpreted as relative to the workflow launch directory.
-:::
-
-To pull images from the Singularity Hub or a third party Docker registry simply prefix the image name with the `shub://`, `docker://` or `docker-daemon://` pseudo-protocol as required by the Singularity tool. For example:
-
-```groovy
-process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
-singularity.enabled = true
-```
-
-You do not need to specify `docker://` to pull from a Docker repository. Nextflow will automatically prepend it to your image name when Singularity is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
-
-Nextflow supports the [Singularity Library](https://cloud.sylabs.io/library/) repository:
-
-```groovy
-process.container = 'library://library/default/alpine:3.8'
-```
-
-The `library://` pseudo-protocol allows you to import Singularity images from a local Docker installation instead of downloading them from a Docker registry. This feature requires the `singularity` tool to be installed where the workflow execution is launched (as opposed to the compute nodes).
-
-Nextflow caches Singularity images in the `singularity` directory, in the pipeline work directory, by default. However, it is recommended to provide a centralized cache directory using the `NXF_SINGULARITY_CACHEDIR` environment variable or the `singularity.cacheDir` setting in the Nextflow config file.
-
-Nextflow uses the library directory to determine the location of Singularity images. The library directory can be defined using the `singularity.libraryDir` configuration setting or the `NXF_SINGULARITY_LIBRARYDIR` environment variable. The configuration file option overrides the environment variable if both are set.
-
-Nextflow first checks the library directory when searching for the image. If the image is not found it then checks the cache directory. The main difference between the library directory and the cache directory is that the first is assumed to be a read-only container repository, while the latter is expected to be writable path where container images can be added for caching purposes.
-
-:::warning
-When using a compute cluster, the Singularity cache directory must reside in a shared filesystem accessible to all compute nodes.
-:::
-
-:::danger
-When pulling Docker images, Singularity may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See Singularity documentation for details.
-:::
-
-### Advanced settings
-
-Singularity advanced configuration settings are described in the [singularity][config-singularity] section in the Nextflow configuration page.
-
-## smolvm
-
-[smolvm](https://github.com/smol-machines/smolvm) is a lightweight container runtime that runs each task inside its own microVM.
-
-### Prerequisites
-
-Install the `smolvm` CLI and make sure it is available on the `PATH` where the workflow is launched.
-
-### How it works
-
-You don't need to modify your Nextflow script to run it with smolvm. Enable it in the Nextflow configuration file:
-
-```groovy
-process.container = 'nextflow/examples:latest'
-smolvm.enabled = true
-```
-
-Each time your script launches a process, Nextflow wraps it and runs it inside a microVM created from the specified image using the `smolvm machine run` command. Images are standard OCI images and can be pulled from any registry.
+See [Process configuration][config-process] and the [container][process-container] directive for more information.
 
 :::tip
-On Apple silicon, running a `linux/amd64` image requires Rosetta 2 translation. Enable it by passing `--rosetta` via `smolvm.runOptions`:
-
-```groovy
-smolvm.runOptions = '--rosetta'
-```
-
-Without it the microVM fails to start the container (`the container ... is not running`). This is not needed for native `arm64` images.
+Use the `nextflow inspect` command to preview the containers that will be used for each process in a pipeline.
 :::
 
-### Multiple containers
+## Caveats
 
-You can specify a different image for each process in your pipeline, either with the `container` directive or in the configuration file:
+The following caveats apply when running Nextflow pipelines with containers:
 
-```groovy
-process {
-    withName:hello {
-        container = 'image_name_1'
-    }
-    withName:bye {
-        container = 'image_name_2'
-    }
-}
+- **Container image requirements**. Every container image must have Bash (>=3.0), `ps`, and other tools required for collecting metrics (see [Tasks][execution-report-tasks] for more information). Bash must be available on the path `/bin/bash` and it must be the container entrypoint.
 
-smolvm {
-    enabled = true
-}
-```
+- **Symbolic link inputs**. Nextflow automatically manages the file system mounts for a container in order to provide task inputs. However, when a task input is a *symbolic link*, the linked file must reside in the same directory as the symlink, or a sub-directory thereof. Otherwise, the task will fail because the container won't be able to access the linked file.
 
-See [Process configuration][config-process] for more information about process configuration.
+## Container runtimes
 
-### Advanced settings
+| Page | Description |
+| ---- | ----------- |
+| [<span style={{whiteSpace: 'nowrap'}}>Apple container</span>][container-apple-container] | A lightweight runtime that runs each container in its own virtual machine on macOS. |
+| [Apptainer][container-apptainer] | An open source fork of Singularity, suited to HPC workloads. |
+| [Charliecloud][container-charliecloud] | An unprivileged runtime for HPC environments, based on Linux user namespaces. |
+| [Docker][container-docker] | The industry standard container runtime. |
+| [Podman][container-podman] | A drop-in replacement for Docker that can run with or without root privileges. |
+| [Sarus][container-sarus] | An HPC runtime, developed at CSCS, that converts Docker images to Squashfs layers. |
+| [Shifter][container-shifter] | An HPC runtime, developed at NERSC, that converts Docker images to Squashfs layers. |
+| [Singularity][container-singularity] | A runtime that requires no root privileges or daemon process, suited to HPC workloads. |
+| [smolvm][container-smolvm] | A lightweight runtime that runs each task inside its own microVM. |
 
-See [`smolvm`][config-smolvm] on the Nextflow configuration page for advanced smolvm settings.
-
-[execution-report-tasks]: ./reports#tasks
-[config-page]: ./config
-[config-apple-container]: ./reference/config/apple-container
-[config-apptainer]: ./reference/config/apptainer
 [config-process]: ./config#process-configuration
-[config-charliecloud]: ./reference/config/charliecloud
-[config-docker]: ./reference/config/docker
-[config-podman]: ./reference/config/podman
-[config-singularity]: ./reference/config/singularity
-[config-smolvm]: ./reference/config/smolvm
+[container-apple-container]: ./container/apple-container
+[container-apptainer]: ./container/apptainer
+[container-charliecloud]: ./container/charliecloud
+[container-docker]: ./container/docker
+[container-podman]: ./container/podman
+[container-sarus]: ./container/sarus
+[container-shifter]: ./container/shifter
+[container-singularity]: ./container/singularity
+[container-smolvm]: ./container/smolvm
+[execution-report-tasks]: ./reports#tasks
+[process-container]: ./reference/process#container

--- a/docs/container/apple-container.mdx
+++ b/docs/container/apple-container.mdx
@@ -1,6 +1,6 @@
 ---
 title: Apple container
-description: Use Apple container with Nextflow.
+description: Run Nextflow pipeline tasks in Apple container virtual machines on macOS.
 ---
 
 # Apple container
@@ -30,7 +30,7 @@ process.container = 'nextflow/examples:latest'
 
 Whenever your pipeline launches a task, Nextflow runs it inside a container created from the specified image using the `container run` command.
 
-Each container runs in its own lightweight VM, so tasks benefit from strong isolation without the overhead of a full VM per task. Images are standard OCI images and can be pulled from any registry.
+Each container runs in its own lightweight virtual machine. This isolates tasks without the overhead of running a full virtual machine for each one. Images are standard OCI images that you can pull from any registry.
 
 :::note
 Apple container only supports Linux images. To run an `amd64` image on Apple silicon, pass `--rosetta` via `appleContainer.runOptions` and set the platform explicitly, for example, `process.arch = 'linux/amd64'`.

--- a/docs/container/apple-container.mdx
+++ b/docs/container/apple-container.mdx
@@ -1,0 +1,43 @@
+---
+title: Apple container
+description: Use Apple container with Nextflow.
+---
+
+# Apple container
+
+<AddedInVersion version="26.04" />
+
+[Apple container](https://github.com/apple/container) is a lightweight container runtime that uses the [Virtualization framework](https://developer.apple.com/documentation/virtualization) to run each container inside its own virtual machine on macOS.
+
+## Prerequisites
+
+Apple container requires Apple silicon (M1 or newer) and a recent macOS release.
+
+Start the system service before running your pipeline:
+
+```bash
+container system start
+```
+
+## How it works
+
+Enable Apple container in the Nextflow configuration file:
+
+```groovy
+appleContainer.enabled = true
+process.container = 'nextflow/examples:latest'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside a container created from the specified image using the `container run` command.
+
+Each container runs in its own lightweight VM, so tasks benefit from strong isolation without the overhead of a full VM per task. Images are standard OCI images and can be pulled from any registry.
+
+:::note
+Apple container only supports Linux images. To run an `amd64` image on Apple silicon, pass `--rosetta` via `appleContainer.runOptions` and set the platform explicitly, for example, `process.arch = 'linux/amd64'`.
+:::
+
+## Advanced settings
+
+See the [`appleContainer`][config-apple-container] configuration scope for advanced Apple container settings.
+
+[config-apple-container]: ../reference/config/apple-container

--- a/docs/container/apptainer.mdx
+++ b/docs/container/apptainer.mdx
@@ -1,11 +1,11 @@
 ---
 title: Apptainer
-description: Use Apptainer with Nextflow.
+description: Run Nextflow pipeline tasks in Apptainer containers, including image caching and Docker registry support.
 ---
 
 # Apptainer
 
-[Apptainer](https://apptainer.org) is an alternative container runtime to Docker and an open source fork of Singularity. Apptainer can be used without root privileges and it doesn't require a separate daemon process, making it well-suited to HPC environments. Apptainer can use existing Docker images and pull from Docker registries.
+[Apptainer](https://apptainer.org) is a container runtime and an open source fork of Singularity. Apptainer runs without root privileges and without a separate daemon process, which suits high-performance computing (HPC) environments. Apptainer can use existing Docker images and pull from Docker registries.
 
 ## Prerequisites
 
@@ -13,9 +13,9 @@ Apptainer must be installed in your execution environment.
 
 ## Images
 
-Refer to the [Apptainer documentation](https://apptainer.org/docs) to learn how to create Apptainer images.
+To create Apptainer images, see the [Apptainer documentation](https://apptainer.org/docs).
 
-Apptainer allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. This feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
+Apptainer can create and mount paths that do not exist in the container when you specify them on the command line. This feature requires a host that supports the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is disabled by default.
 
 ## How it works
 
@@ -35,22 +35,22 @@ nextflow run main.nf -with-apptainer
 ```
 
 :::note
-Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature to be enabled in your Apptainer installation. To disable it, set `apptainer.autoMounts` to `false`.
+Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature in your Apptainer installation. To disable automatic mounts, set `apptainer.autoMounts` to `false`.
 :::
 
 :::warning
-When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Apptainer installation. Otherwise the task will fail because the container won't be able to access the linked file.
+When a process input is a *symbolic link*, store the linked file in a host directory that is accessible from a bind path defined in your Apptainer installation. Otherwise, the task fails because the container cannot access the linked file.
 :::
 
 <ChangedInVersion version="23.10">
 Nextflow no longer mounts the home directory when launching an Apptainer container. To re-enable the old behavior, set the environment variable `NXF_APPTAINER_HOME_MOUNT` to `true`.
 </ChangedInVersion>
 
-## Apptainer & Docker Hub
+## Apptainer and Docker Hub
 
-Nextflow can pull remote container images from any Docker-compatible registry. This requires Apptainer to be installed in the launch environment (as opposed to the compute nodes).
+Nextflow can pull remote container images from any Docker-compatible registry. This requires Apptainer in the launch environment, not on the compute nodes.
 
-By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
+When you specify a container name, Nextflow first checks whether an image file with that name exists in the local file system. If it does, Nextflow uses that file to execute the container. If it does not, Nextflow pulls an image with that name from the container registry.
 
 To use only local file images, prefix the container name with `file://`. For example:
 
@@ -60,7 +60,7 @@ process.container = 'file:///path/to/apptainer.img'
 ```
 
 :::warning
-Use three `/` slashes to specify an *absolute* file path, otherwise the path will be interpreted as relative to the workflow launch directory.
+Use three `/` slashes to specify an *absolute* file path. Otherwise, Nextflow interprets the path as relative to the workflow launch directory.
 :::
 
 To pull an image from a specific registry, prefix the image name with `shub://`, `docker://`, or `docker-daemon://` as required by Apptainer. For example:
@@ -70,7 +70,7 @@ apptainer.enabled = true
 process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
 ```
 
-You do not need to specify `docker://` to pull from a Docker registry. Nextflow will automatically prepend it to your image name when Apptainer is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
+You do not need to specify `docker://` to pull from a Docker registry. When Apptainer is enabled, Nextflow prepends it to your image name. The Docker engine does not work with containers specified as `docker://`.
 
 By default, Nextflow caches Apptainer images in the `apptainer` directory, in the pipeline work directory. Use the `NXF_APPTAINER_CACHEDIR` environment variable or the `apptainer.cacheDir` config setting to define a centralized cache directory.
 
@@ -79,11 +79,11 @@ Nextflow uses the library directory to determine the location of local Apptainer
 When resolving a container image, Nextflow first checks the library directory, then the cache directory. Use the library directory as a read-only container repository, and the cache directory as a writable location where container images can be cached.
 
 :::note
-When using a compute cluster, the Apptainer cache directory must reside in a shared filesystem accessible to all compute nodes.
+On a compute cluster, the Apptainer cache directory must reside on a shared file system that all compute nodes can access.
 :::
 
 :::warning
-When pulling Docker images, Apptainer may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See the Apptainer documentation for details.
+When pulling Docker images, Apptainer cannot determine the container size if the image uses an old Docker format. The pipeline execution then fails with an error. See the Apptainer documentation for details.
 :::
 
 ## Advanced settings

--- a/docs/container/apptainer.mdx
+++ b/docs/container/apptainer.mdx
@@ -1,0 +1,93 @@
+---
+title: Apptainer
+description: Use Apptainer with Nextflow.
+---
+
+# Apptainer
+
+[Apptainer](https://apptainer.org) is an alternative container runtime to Docker and an open source fork of Singularity. Apptainer can be used without root privileges and it doesn't require a separate daemon process, making it well-suited to HPC environments. Apptainer can use existing Docker images and pull from Docker registries.
+
+## Prerequisites
+
+Apptainer must be installed in your execution environment.
+
+## Images
+
+Refer to the [Apptainer documentation](https://apptainer.org/docs) to learn how to create Apptainer images.
+
+Apptainer allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. This feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
+
+## How it works
+
+Enable Apptainer in the Nextflow configuration file:
+
+```groovy
+apptainer.enabled = true
+process.container = '/path/to/apptainer.img'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside an Apptainer container created from the specified image using the `apptainer exec` command.
+
+You can also enable Apptainer on the command line:
+
+```bash
+nextflow run main.nf -with-apptainer
+```
+
+:::note
+Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature to be enabled in your Apptainer installation. To disable it, set `apptainer.autoMounts` to `false`.
+:::
+
+:::warning
+When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Apptainer installation. Otherwise the task will fail because the container won't be able to access the linked file.
+:::
+
+<ChangedInVersion version="23.10">
+Nextflow no longer mounts the home directory when launching an Apptainer container. To re-enable the old behavior, set the environment variable `NXF_APPTAINER_HOME_MOUNT` to `true`.
+</ChangedInVersion>
+
+## Apptainer & Docker Hub
+
+Nextflow can pull remote container images from any Docker-compatible registry. This requires Apptainer to be installed in the launch environment (as opposed to the compute nodes).
+
+By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
+
+To use only local file images, prefix the container name with `file://`. For example:
+
+```groovy
+apptainer.enabled = true
+process.container = 'file:///path/to/apptainer.img'
+```
+
+:::warning
+Use three `/` slashes to specify an *absolute* file path, otherwise the path will be interpreted as relative to the workflow launch directory.
+:::
+
+To pull an image from a specific registry, prefix the image name with `shub://`, `docker://`, or `docker-daemon://` as required by Apptainer. For example:
+
+```groovy
+apptainer.enabled = true
+process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
+```
+
+You do not need to specify `docker://` to pull from a Docker registry. Nextflow will automatically prepend it to your image name when Apptainer is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
+
+By default, Nextflow caches Apptainer images in the `apptainer` directory, in the pipeline work directory. Use the `NXF_APPTAINER_CACHEDIR` environment variable or the `apptainer.cacheDir` config setting to define a centralized cache directory.
+
+Nextflow uses the library directory to determine the location of local Apptainer container images. Use the `NXF_APPTAINER_LIBRARYDIR` environment variable or the `apptainer.libraryDir` config setting to define it. The configuration file option overrides the environment variable if both are set.
+
+When resolving a container image, Nextflow first checks the library directory, then the cache directory. Use the library directory as a read-only container repository, and the cache directory as a writable location where container images can be cached.
+
+:::note
+When using a compute cluster, the Apptainer cache directory must reside in a shared filesystem accessible to all compute nodes.
+:::
+
+:::warning
+When pulling Docker images, Apptainer may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See the Apptainer documentation for details.
+:::
+
+## Advanced settings
+
+See the [`apptainer`][config-apptainer] configuration scope for advanced Apptainer settings.
+
+[config-apptainer]: ../reference/config/apptainer

--- a/docs/container/charliecloud.mdx
+++ b/docs/container/charliecloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: Charliecloud
-description: Use Charliecloud with Nextflow.
+description: Run Nextflow pipeline tasks in Charliecloud containers without root privileges.
 ---
 
 # Charliecloud
@@ -11,7 +11,7 @@ description: Use Charliecloud with Nextflow.
 :::warning{title="Experimental: not recommended for production environments."}
 :::
 
-[Charliecloud](https://hpc.github.io/charliecloud) is an alternative container runtime to Docker that is better suited for HPC environments. It can be used without root privileges, making use of user namespaces in the Linux kernel, and it can pull from Docker registries.
+[Charliecloud](https://hpc.github.io/charliecloud) is a container runtime for high-performance computing (HPC) environments. Charliecloud runs without root privileges by using user namespaces in the Linux kernel, and it can pull from Docker registries.
 
 ## Prerequisites
 
@@ -35,23 +35,23 @@ nextflow run main.nf -with-charliecloud
 ```
 
 :::warning
-If an absolute path is provided, the container needs to be in the Charliecloud flat directory format. See [Charliecloud & Docker Hub](#charliecloud--docker-hub) for compatibility with Docker registries.
+If you provide an absolute path, the container must be in the Charliecloud flat directory format. See [Charliecloud and Docker Hub](#charliecloud-and-docker-hub) for compatibility with Docker registries.
 :::
 
-## Charliecloud & Docker Hub
+## Charliecloud and Docker Hub
 
 Nextflow can pull remote container images from any Docker-compatible registry and convert them to the Charliecloud format.
 
-By default, when a container name is specified, Nextflow checks if a container with that name exists in the local file system. If it exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the registry.
+When you specify a container name, Nextflow first checks whether a container with that name exists in the local file system. If it does, Nextflow uses that container. If it does not, Nextflow pulls an image with that name from the registry.
 
-To pull an image from a specific registry, provide the URL to the image. If no URL is provided, Docker Hub is assumed. For example, the following config pulls an image from quay.io and converts it to the Charliecloud format:
+To pull an image from a specific registry, give the URL to the image. Without a URL, Nextflow uses Docker Hub. For example, this configuration pulls an image from quay.io and converts it to the Charliecloud format:
 
 ```groovy
 charliecloud.enabled = true
 process.container = 'https://quay.io/biocontainers/multiqc:1.3--py35_2'
 ```
 
-Whereas the following config pulls from Docker Hub:
+This configuration pulls from Docker Hub:
 
 ```groovy
 charliecloud.enabled = true

--- a/docs/container/charliecloud.mdx
+++ b/docs/container/charliecloud.mdx
@@ -1,0 +1,65 @@
+---
+title: Charliecloud
+description: Use Charliecloud with Nextflow.
+---
+
+# Charliecloud
+
+:::note{title="Requires Charliecloud 0.28 or later."}
+:::
+
+:::warning{title="Experimental: not recommended for production environments."}
+:::
+
+[Charliecloud](https://hpc.github.io/charliecloud) is an alternative container runtime to Docker that is better suited for HPC environments. It can be used without root privileges, making use of user namespaces in the Linux kernel, and it can pull from Docker registries.
+
+## Prerequisites
+
+Charliecloud must be installed in your execution environment.
+
+## How it works
+
+Enable Charliecloud in the Nextflow configuration file:
+
+```groovy
+charliecloud.enabled = true
+process.container = '/path/to/container'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside a Charliecloud container created from the specified image using the `ch-run` command.
+
+You can also enable Charliecloud on the command line:
+
+```bash
+nextflow run main.nf -with-charliecloud
+```
+
+:::warning
+If an absolute path is provided, the container needs to be in the Charliecloud flat directory format. See [Charliecloud & Docker Hub](#charliecloud--docker-hub) for compatibility with Docker registries.
+:::
+
+## Charliecloud & Docker Hub
+
+Nextflow can pull remote container images from any Docker-compatible registry and convert them to the Charliecloud format.
+
+By default, when a container name is specified, Nextflow checks if a container with that name exists in the local file system. If it exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the registry.
+
+To pull an image from a specific registry, provide the URL to the image. If no URL is provided, Docker Hub is assumed. For example, the following config pulls an image from quay.io and converts it to the Charliecloud format:
+
+```groovy
+charliecloud.enabled = true
+process.container = 'https://quay.io/biocontainers/multiqc:1.3--py35_2'
+```
+
+Whereas the following config pulls from Docker Hub:
+
+```groovy
+charliecloud.enabled = true
+process.container = 'nextflow/examples:latest'
+```
+
+## Advanced settings
+
+See the [`charliecloud`][config-charliecloud] configuration scope for advanced Charliecloud settings.
+
+[config-charliecloud]: ../reference/config/charliecloud

--- a/docs/container/docker.mdx
+++ b/docs/container/docker.mdx
@@ -1,17 +1,17 @@
 ---
 title: Docker
-description: Use Docker with Nextflow.
+description: Run Nextflow pipeline tasks in Docker containers.
 ---
 
 # Docker
 
-[Docker](https://www.docker.com) is the industry standard container runtime.
+[Docker](https://www.docker.com) is the most widely used container runtime.
 
 ## Prerequisites
 
 Docker must be installed in your execution environment.
 
-If you are running Docker on Mac OSX make sure you are mounting your local `/Users` directory into the Docker VM as explained in this excellent tutorial: [How to use Docker on OSX](http://viget.com/extend/how-to-use-docker-on-os-x-the-missing-guide).
+On macOS, mount your local `/Users` directory into the Docker virtual machine.
 
 ## How it works
 

--- a/docs/container/docker.mdx
+++ b/docs/container/docker.mdx
@@ -1,0 +1,37 @@
+---
+title: Docker
+description: Use Docker with Nextflow.
+---
+
+# Docker
+
+[Docker](https://www.docker.com) is the industry standard container runtime.
+
+## Prerequisites
+
+Docker must be installed in your execution environment.
+
+If you are running Docker on Mac OSX make sure you are mounting your local `/Users` directory into the Docker VM as explained in this excellent tutorial: [How to use Docker on OSX](http://viget.com/extend/how-to-use-docker-on-os-x-the-missing-guide).
+
+## How it works
+
+Enable Docker in the Nextflow configuration file:
+
+```groovy
+docker.enabled = true
+process.container = 'nextflow/examples:latest'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside a Docker container created from the specified image using the `docker run` command.
+
+You can also enable Docker on the command line:
+
+```bash
+nextflow run main.nf -with-docker
+```
+
+## Advanced settings
+
+See the [`docker`][config-docker] configuration scope for advanced Docker settings.
+
+[config-docker]: ../reference/config/docker

--- a/docs/container/podman.mdx
+++ b/docs/container/podman.mdx
@@ -1,6 +1,6 @@
 ---
 title: Podman
-description: Use Podman with Nextflow.
+description: Run Nextflow pipeline tasks in Podman containers, with or without root privileges.
 ---
 
 # Podman
@@ -11,7 +11,7 @@ description: Use Podman with Nextflow.
 
 Podman must be installed in your execution environment.
 
-Running in rootless mode requires appropriate OS configuration. Due to Podman limitations, using cpuset for cpus and memory is only possible with root permissions.
+Rootless mode requires additional operating system configuration. Because of a Podman limitation, cpuset for CPUs and memory only works with root permissions.
 
 ## How it works
 

--- a/docs/container/podman.mdx
+++ b/docs/container/podman.mdx
@@ -1,0 +1,37 @@
+---
+title: Podman
+description: Use Podman with Nextflow.
+---
+
+# Podman
+
+[Podman](https://podman.io) is a drop-in replacement for Docker that can run containers with or without root privileges.
+
+## Prerequisites
+
+Podman must be installed in your execution environment.
+
+Running in rootless mode requires appropriate OS configuration. Due to Podman limitations, using cpuset for cpus and memory is only possible with root permissions.
+
+## How it works
+
+Enable Podman in the Nextflow configuration file:
+
+```groovy
+podman.enabled = true
+process.container = 'nextflow/examples:latest'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside a Podman container created from the specified image using the `podman run` command.
+
+You can also enable Podman on the command line:
+
+```bash
+nextflow run main.nf -with-podman
+```
+
+## Advanced settings
+
+See the [`podman`][config-podman] configuration scope for advanced Podman settings.
+
+[config-podman]: ../reference/config/podman

--- a/docs/container/sarus.mdx
+++ b/docs/container/sarus.mdx
@@ -1,11 +1,11 @@
 ---
 title: Sarus
-description: Use Sarus with Nextflow.
+description: Run Nextflow pipeline tasks in Sarus containers converted from Docker images.
 ---
 
 # Sarus
 
-[Sarus](https://sarus.readthedocs.io) is an alternative container runtime to Docker. Sarus works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Sarus enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
+[Sarus](https://sarus.readthedocs.io) is a container runtime that converts Docker images to a common format for distribution and launch on high-performance computing (HPC) systems. With Sarus, you select an image from [Docker Hub](https://hub.docker.com/) and submit jobs that run entirely within the container.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ Sarus must be installed in your execution environment.
 
 ## Images
 
-Sarus converts a Docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Sarus images, see the [official documentation](https://sarus.readthedocs.io/en/stable/user/user_guide.html#develop-the-docker-image).
+Sarus converts a Docker image to Squashfs layers that are distributed and launched in the cluster. To build Sarus images, see the [Sarus documentation](https://sarus.readthedocs.io/en/stable/user/user_guide.html#develop-the-docker-image).
 
 ## How it works
 
@@ -24,7 +24,7 @@ sarus.enabled = true
 process.container = 'dockerhub_user/image_name:image_tag'
 ```
 
-Sarus always searches the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
+Sarus always searches the Docker Hub registry for images. If you do not specify an image tag, Sarus fetches the `latest` tag.
 
 ## Advanced settings
 

--- a/docs/container/sarus.mdx
+++ b/docs/container/sarus.mdx
@@ -1,0 +1,33 @@
+---
+title: Sarus
+description: Use Sarus with Nextflow.
+---
+
+# Sarus
+
+[Sarus](https://sarus.readthedocs.io) is an alternative container runtime to Docker. Sarus works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Sarus enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
+
+## Prerequisites
+
+Sarus must be installed in your execution environment.
+
+## Images
+
+Sarus converts a Docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Sarus images, see the [official documentation](https://sarus.readthedocs.io/en/stable/user/user_guide.html#develop-the-docker-image).
+
+## How it works
+
+Enable Sarus in the Nextflow configuration file:
+
+```groovy
+sarus.enabled = true
+process.container = 'dockerhub_user/image_name:image_tag'
+```
+
+Sarus always searches the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
+
+## Advanced settings
+
+See the [`sarus`][config-sarus] configuration scope for advanced Sarus settings.
+
+[config-sarus]: ../reference/config/sarus

--- a/docs/container/shifter.mdx
+++ b/docs/container/shifter.mdx
@@ -1,0 +1,35 @@
+---
+title: Shifter
+description: Use Shifter with Nextflow.
+---
+
+# Shifter
+
+[Shifter](https://docs.nersc.gov/programming/shifter/overview/) is an alternative container runtime to Docker. Shifter works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Shifter enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
+
+## Prerequisites
+
+Shifter must be installed in your execution environment.
+
+In the case of a distributed cluster, Shifter must be installed on all of the compute nodes, the `shifterimg` command must be available, and Shifter should be configured to access the Image gateway. For more information, see the [official documentation](https://github.com/NERSC/shifter/tree/master/doc).
+
+## Images
+
+Shifter converts a Docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Shifter images see the [official documentation](https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images).
+
+## How it works
+
+Enable Shifter in the Nextflow configuration file:
+
+```groovy
+shifter.enabled = true
+process.container = 'dockerhub_user/image_name:image_tag'
+```
+
+Shifter always searches the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
+
+## Advanced settings
+
+See the [`shifter`][config-shifter] configuration scope for advanced Shifter settings.
+
+[config-shifter]: ../reference/config/shifter

--- a/docs/container/shifter.mdx
+++ b/docs/container/shifter.mdx
@@ -1,21 +1,21 @@
 ---
 title: Shifter
-description: Use Shifter with Nextflow.
+description: Run Nextflow pipeline tasks in Shifter containers converted from Docker images.
 ---
 
 # Shifter
 
-[Shifter](https://docs.nersc.gov/programming/shifter/overview/) is an alternative container runtime to Docker. Shifter works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Shifter enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
+[Shifter](https://docs.nersc.gov/programming/shifter/overview/) is a container runtime that converts Docker images to a common format for distribution and launch on high-performance computing (HPC) systems. With Shifter, you select an image from [Docker Hub](https://hub.docker.com/) and submit jobs that run entirely within the container.
 
 ## Prerequisites
 
 Shifter must be installed in your execution environment.
 
-In the case of a distributed cluster, Shifter must be installed on all of the compute nodes, the `shifterimg` command must be available, and Shifter should be configured to access the Image gateway. For more information, see the [official documentation](https://github.com/NERSC/shifter/tree/master/doc).
+On a distributed cluster, install Shifter on all compute nodes, make the `shifterimg` command available, and configure Shifter to access the Image gateway. For more information, see the [Shifter documentation](https://github.com/NERSC/shifter/tree/master/doc).
 
 ## Images
 
-Shifter converts a Docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Shifter images see the [official documentation](https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images).
+Shifter converts a Docker image to Squashfs layers that are distributed and launched in the cluster. To build Shifter images, see the [Shifter documentation](https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images).
 
 ## How it works
 
@@ -26,7 +26,7 @@ shifter.enabled = true
 process.container = 'dockerhub_user/image_name:image_tag'
 ```
 
-Shifter always searches the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
+Shifter always searches the Docker Hub registry for images. If you do not specify an image tag, Shifter fetches the `latest` tag.
 
 ## Advanced settings
 

--- a/docs/container/singularity.mdx
+++ b/docs/container/singularity.mdx
@@ -1,0 +1,101 @@
+---
+title: Singularity
+description: Use Singularity with Nextflow.
+---
+
+# Singularity
+
+[Singularity](https://sylabs.io/singularity/) is an alternative container runtime to Docker. Singularity can be used without root privileges and it doesn't require a separate daemon process, making it well-suited to HPC environments. Singularity can use existing Docker images and pull from Docker registries.
+
+## Prerequisites
+
+Singularity must be installed in your execution environment.
+
+## Images
+
+Refer to the [Singularity documentation](https://www.sylabs.io/docs/) to learn how to create Singularity images.
+
+Singularity allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. This feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
+
+## How it works
+
+Enable Singularity in the Nextflow configuration file:
+
+```groovy
+singularity.enabled = true
+process.container = '/path/to/singularity.img'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside a Singularity container created from the specified image using the `singularity exec` command.
+
+You can also enable Singularity on the command line:
+
+```bash
+nextflow run main.nf -with-singularity
+```
+
+:::note
+Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature to be enabled in your Singularity installation. To disable it, set `singularity.autoMounts` to `false`.
+:::
+
+:::warning
+When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Singularity installation. Otherwise the task will fail because the container won't be able to access the linked file.
+:::
+
+<ChangedInVersion version="23.10">
+Nextflow no longer mounts the home directory when launching a Singularity container. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_HOME_MOUNT` to `true`.
+</ChangedInVersion>
+
+<ChangedInVersion version="23.10">
+Host paths are mounted in the container automatically. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false`.
+</ChangedInVersion>
+
+<ChangedInVersion version="23.10">
+The execution command for Singularity/Apptainer containers can be set to `run` by means of the environment variable `NXF_SINGULARITY_RUN_COMMAND` (default command is `exec`).
+</ChangedInVersion>
+
+## Singularity & Docker Hub
+
+Nextflow can pull remote container images from [Singularity Hub](https://singularity-hub.org/), the [Singularity Library](https://cloud.sylabs.io/library/), or any Docker-compatible registry. This feature requires Singularity to be installed in the launch environment (as opposed to the compute nodes).
+
+By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
+
+To use only local file images, prefix the container name with `file://`. For example:
+
+```groovy
+singularity.enabled = true
+process.container = 'file:///path/to/singularity.img'
+```
+
+:::warning
+Use three `/` slashes to specify an *absolute* file path, otherwise the path will be interpreted as relative to the workflow launch directory.
+:::
+
+To pull an image from a specific registry, prefix the image name with `shub://`, `docker://`, `docker-daemon://`, or `library://` as required by Singularity. For example:
+
+```groovy
+singularity.enabled = true
+process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
+```
+
+You do not need to specify `docker://` to pull from a Docker registry. Nextflow will automatically prepend it to your image name when Singularity is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
+
+By default, Nextflow caches Singularity images in the `singularity` directory, in the pipeline work directory. Use the `NXF_SINGULARITY_CACHEDIR` environment variable or the `singularity.cacheDir` config setting to define a centralized cache directory.
+
+Nextflow uses the library directory to determine the location of local Singularity container images. Use the `NXF_SINGULARITY_LIBRARYDIR` environment variable or the `singularity.libraryDir` config setting to define it. The configuration file option overrides the environment variable if both are set.
+
+When resolving a container image, Nextflow first checks the library directory, then the cache directory. Use the library directory as a read-only container repository, and the cache directory as a writable location where container images can be cached.
+
+:::note
+When using a compute cluster, the Singularity cache directory must reside in a shared filesystem accessible to all compute nodes.
+:::
+
+:::warning
+When pulling Docker images, Singularity may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See the Singularity documentation for details.
+:::
+
+## Advanced settings
+
+See the [`singularity`][config-singularity] configuration scope for advanced Singularity settings.
+
+[config-singularity]: ../reference/config/singularity

--- a/docs/container/singularity.mdx
+++ b/docs/container/singularity.mdx
@@ -1,11 +1,11 @@
 ---
 title: Singularity
-description: Use Singularity with Nextflow.
+description: Run Nextflow pipeline tasks in Singularity containers, including image caching and Docker registry support.
 ---
 
 # Singularity
 
-[Singularity](https://sylabs.io/singularity/) is an alternative container runtime to Docker. Singularity can be used without root privileges and it doesn't require a separate daemon process, making it well-suited to HPC environments. Singularity can use existing Docker images and pull from Docker registries.
+[Singularity](https://sylabs.io/singularity/) is a container runtime. Singularity runs without root privileges and without a separate daemon process, which suits high-performance computing (HPC) environments. Singularity can use existing Docker images and pull from Docker registries.
 
 ## Prerequisites
 
@@ -13,9 +13,9 @@ Singularity must be installed in your execution environment.
 
 ## Images
 
-Refer to the [Singularity documentation](https://www.sylabs.io/docs/) to learn how to create Singularity images.
+To create Singularity images, see the [Singularity documentation](https://www.sylabs.io/docs/).
 
-Singularity allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. This feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
+Singularity can create and mount paths that do not exist in the container when you specify them on the command line. This feature requires a host that supports the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is disabled by default.
 
 ## How it works
 
@@ -35,11 +35,11 @@ nextflow run main.nf -with-singularity
 ```
 
 :::note
-Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature to be enabled in your Singularity installation. To disable it, set `singularity.autoMounts` to `false`.
+Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature in your Singularity installation. To disable automatic mounts, set `singularity.autoMounts` to `false`.
 :::
 
 :::warning
-When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Singularity installation. Otherwise the task will fail because the container won't be able to access the linked file.
+When a process input is a *symbolic link*, store the linked file in a host directory that is accessible from a bind path defined in your Singularity installation. Otherwise, the task fails because the container cannot access the linked file.
 :::
 
 <ChangedInVersion version="23.10">
@@ -47,18 +47,18 @@ Nextflow no longer mounts the home directory when launching a Singularity contai
 </ChangedInVersion>
 
 <ChangedInVersion version="23.10">
-Host paths are mounted in the container automatically. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false`.
+Nextflow mounts host paths in the container automatically. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false`.
 </ChangedInVersion>
 
 <ChangedInVersion version="23.10">
-The execution command for Singularity/Apptainer containers can be set to `run` by means of the environment variable `NXF_SINGULARITY_RUN_COMMAND` (default command is `exec`).
+To set the execution command for Singularity and Apptainer containers to `run`, set the environment variable `NXF_SINGULARITY_RUN_COMMAND`. The default command is `exec`.
 </ChangedInVersion>
 
-## Singularity & Docker Hub
+## Singularity and Docker Hub
 
-Nextflow can pull remote container images from [Singularity Hub](https://singularity-hub.org/), the [Singularity Library](https://cloud.sylabs.io/library/), or any Docker-compatible registry. This feature requires Singularity to be installed in the launch environment (as opposed to the compute nodes).
+Nextflow can pull remote container images from the [Singularity Library](https://cloud.sylabs.io/library/) or any Docker-compatible registry. This requires Singularity in the launch environment, not on the compute nodes.
 
-By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
+When you specify a container name, Nextflow first checks whether an image file with that name exists in the local file system. If it does, Nextflow uses that file to execute the container. If it does not, Nextflow pulls an image with that name from the container registry.
 
 To use only local file images, prefix the container name with `file://`. For example:
 
@@ -68,7 +68,7 @@ process.container = 'file:///path/to/singularity.img'
 ```
 
 :::warning
-Use three `/` slashes to specify an *absolute* file path, otherwise the path will be interpreted as relative to the workflow launch directory.
+Use three `/` slashes to specify an *absolute* file path. Otherwise, Nextflow interprets the path as relative to the workflow launch directory.
 :::
 
 To pull an image from a specific registry, prefix the image name with `shub://`, `docker://`, `docker-daemon://`, or `library://` as required by Singularity. For example:
@@ -78,7 +78,7 @@ singularity.enabled = true
 process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
 ```
 
-You do not need to specify `docker://` to pull from a Docker registry. Nextflow will automatically prepend it to your image name when Singularity is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
+You do not need to specify `docker://` to pull from a Docker registry. When Singularity is enabled, Nextflow prepends it to your image name. The Docker engine does not work with containers specified as `docker://`.
 
 By default, Nextflow caches Singularity images in the `singularity` directory, in the pipeline work directory. Use the `NXF_SINGULARITY_CACHEDIR` environment variable or the `singularity.cacheDir` config setting to define a centralized cache directory.
 
@@ -87,11 +87,11 @@ Nextflow uses the library directory to determine the location of local Singulari
 When resolving a container image, Nextflow first checks the library directory, then the cache directory. Use the library directory as a read-only container repository, and the cache directory as a writable location where container images can be cached.
 
 :::note
-When using a compute cluster, the Singularity cache directory must reside in a shared filesystem accessible to all compute nodes.
+On a compute cluster, the Singularity cache directory must reside on a shared file system that all compute nodes can access.
 :::
 
 :::warning
-When pulling Docker images, Singularity may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See the Singularity documentation for details.
+When pulling Docker images, Singularity cannot determine the container size if the image uses an old Docker format. The pipeline execution then fails with an error. See the Singularity documentation for details.
 :::
 
 ## Advanced settings

--- a/docs/container/smolvm.mdx
+++ b/docs/container/smolvm.mdx
@@ -1,6 +1,6 @@
 ---
 title: smolvm
-description: Use smolvm with Nextflow.
+description: Run Nextflow pipeline tasks in smolvm microVMs.
 ---
 
 # smolvm
@@ -9,7 +9,7 @@ description: Use smolvm with Nextflow.
 
 ## Prerequisites
 
-The `smolvm` CLI must be installed and available on the `PATH` where the workflow is launched.
+The `smolvm` CLI must be installed and available on the `PATH` in the launch environment.
 
 ## How it works
 
@@ -20,7 +20,7 @@ smolvm.enabled = true
 process.container = 'nextflow/examples:latest'
 ```
 
-Whenever your pipeline launches a task, Nextflow runs it inside a microVM created from the specified image using the `smolvm machine run` command. Images are standard OCI images and can be pulled from any registry.
+Whenever your pipeline launches a task, Nextflow runs it inside a microVM created from the specified image using the `smolvm machine run` command. Images are standard OCI images that you can pull from any registry.
 
 :::tip
 On Apple silicon, running a `linux/amd64` image requires Rosetta 2 translation. Enable it by passing `--rosetta` via `smolvm.runOptions`:
@@ -29,7 +29,7 @@ On Apple silicon, running a `linux/amd64` image requires Rosetta 2 translation. 
 smolvm.runOptions = '--rosetta'
 ```
 
-Without it the microVM fails to start the container (`the container ... is not running`). This is not needed for native `arm64` images.
+Without `--rosetta`, the microVM fails to start the container and reports `the container ... is not running`. Native `arm64` images do not need this option.
 :::
 
 ## Advanced settings

--- a/docs/container/smolvm.mdx
+++ b/docs/container/smolvm.mdx
@@ -1,0 +1,39 @@
+---
+title: smolvm
+description: Use smolvm with Nextflow.
+---
+
+# smolvm
+
+[smolvm](https://github.com/smol-machines/smolvm) is a lightweight container runtime that runs each task inside its own microVM.
+
+## Prerequisites
+
+The `smolvm` CLI must be installed and available on the `PATH` where the workflow is launched.
+
+## How it works
+
+Enable smolvm in the Nextflow configuration file:
+
+```groovy
+smolvm.enabled = true
+process.container = 'nextflow/examples:latest'
+```
+
+Whenever your pipeline launches a task, Nextflow runs it inside a microVM created from the specified image using the `smolvm machine run` command. Images are standard OCI images and can be pulled from any registry.
+
+:::tip
+On Apple silicon, running a `linux/amd64` image requires Rosetta 2 translation. Enable it by passing `--rosetta` via `smolvm.runOptions`:
+
+```groovy
+smolvm.runOptions = '--rosetta'
+```
+
+Without it the microVM fails to start the container (`the container ... is not running`). This is not needed for native `arm64` images.
+:::
+
+## Advanced settings
+
+See the [`smolvm`][config-smolvm] configuration scope for advanced smolvm settings.
+
+[config-smolvm]: ../reference/config/smolvm

--- a/docs/executor.mdx
+++ b/docs/executor.mdx
@@ -587,8 +587,8 @@ process {
 [azure-batch]: ./azure#azure-batch
 [config-executor]: ./reference/config/executor
 [config-seqera]: ./reference/config/seqera
-[container-docker]: ./container#docker
-[container-podman]: ./container#podman
+[container-docker]: ./container/docker
+[container-podman]: ./container/podman
 [google-batch]: ./google#cloud-batch
 [k8s-page]: ./kubernetes
 [process-accelerator]: ./reference/process#accelerator

--- a/docs/migrations/26-04.mdx
+++ b/docs/migrations/26-04.mdx
@@ -421,7 +421,7 @@ A Platform access token with appropriate permissions is required to download non
 - New standard library function: [`listDirectory()`][stdlib-listDirectory]
 - Support [Java 26][install-requirements]
 
-[apple-container]: ../container#apple-container
+[apple-container]: ../container/apple-container
 [cli-lint]: ../reference/cli/lint
 [cli-module]: ../reference/cli/module
 [cli-run]: ../reference/cli/run


### PR DESCRIPTION
### Changes

- Cut slop and fixed voice throughout.
- Converted ~15 future-tense constructions to present and passive to active.
- Rewrote all 9 frontmatter `description:` values — they were a `Use X with Nextflow.` template, thinner than the repo norm.
- Renamed the three `X & Docker Hub` headings to `X and Docker Hub` and updated the one in-page anchor link to match. No inbound anchors existed for any renamed heading.
- Split `container.mdx`'s two bold-first bullets into `###` subheadings; expanded HPC on first use per page.
- Dropped two stale links: Singularity Hub (shut down 2021) and an ~2014 `http://` viget.com Docker tutorial.

### Note

- `shub://` is still documented on `singularity.mdx` and `apptainer.mdx`. With Singularity Hub gone it may be dead too, but it's a runtime prefix rather than a doc link, so I left it.