### PR TITLE
docs: Apply style guide

### DIFF
--- a/docs/container.mdx
+++ b/docs/container.mdx
@@ -5,9 +5,9 @@ description: Use Docker, Singularity, Apptainer, and other container runtimes wi
 
 # Containers
 
-Containerization allows you to write self-contained and reproducible computational pipelines, by packaging the binary dependencies of a script into a *container image* that can be executed on any platform that supports a *container runtime*.
+A *container image* packages the binary dependencies of a script so that the script runs on any platform with a *container runtime*. Containerizing a pipeline makes it self-contained and reproducible.
 
-A Nextflow pipeline can be executed with any of the supported container runtimes, as long as it is available in the target compute environment.
+Nextflow runs a pipeline with any of the supported container runtimes, provided the runtime is available in the target compute environment.
 
 ## Container configuration
 
@@ -35,7 +35,7 @@ process bye {
 }
 ```
 
-The same container settings can be defined in the configuration file:
+You can also define the same container settings in the configuration file:
 
 ```groovy
 process {
@@ -48,28 +48,32 @@ process {
 }
 ```
 
-See [Process configuration][config-process] and the [container][process-container] directive for more information.
+See [Process configuration][config-process] and the [`container`][process-container] directive for more information.
 
 :::tip
-Use the `nextflow inspect` command to preview the containers that will be used for each process in a pipeline.
+Use the `nextflow inspect` command to preview the container that each process in a pipeline uses.
 :::
 
 ## Caveats
 
-The following caveats apply when running Nextflow pipelines with containers:
+The following caveats apply when you run Nextflow pipelines with containers.
 
-- **Container image requirements**. Every container image must have Bash (>=3.0), `ps`, and other tools required for collecting metrics (see [Tasks][execution-report-tasks] for more information). Bash must be available on the path `/bin/bash` and it must be the container entrypoint.
+### Container image requirements
 
-- **Symbolic link inputs**. Nextflow automatically manages the file system mounts for a container in order to provide task inputs. However, when a task input is a *symbolic link*, the linked file must reside in the same directory as the symlink, or a sub-directory thereof. Otherwise, the task will fail because the container won't be able to access the linked file.
+Every container image must include Bash (>=3.0), `ps`, and the other tools required to collect metrics. See [Tasks][execution-report-tasks] for more information. Bash must be available at `/bin/bash` and must be the container entrypoint.
+
+### Symbolic link inputs
+
+Nextflow manages the file system mounts for a container to provide task inputs. When a task input is a *symbolic link*, the linked file must reside in the same directory as the symlink, or in a subdirectory of it. Otherwise, the task fails because the container cannot access the linked file.
 
 ## Container runtimes
 
 | Page | Description |
 | ---- | ----------- |
 | [<span style={{whiteSpace: 'nowrap'}}>Apple container</span>][container-apple-container] | A lightweight runtime that runs each container in its own virtual machine on macOS. |
-| [Apptainer][container-apptainer] | An open source fork of Singularity, suited to HPC workloads. |
+| [Apptainer][container-apptainer] | An open source fork of Singularity, suited to high-performance computing (HPC) workloads. |
 | [Charliecloud][container-charliecloud] | An unprivileged runtime for HPC environments, based on Linux user namespaces. |
-| [Docker][container-docker] | The industry standard container runtime. |
+| [Docker][container-docker] | The most widely used container runtime. |
 | [Podman][container-podman] | A drop-in replacement for Docker that can run with or without root privileges. |
 | [Sarus][container-sarus] | An HPC runtime, developed at CSCS, that converts Docker images to Squashfs layers. |
 | [Shifter][container-shifter] | An HPC runtime, developed at NERSC, that converts Docker images to Squashfs layers. |

--- a/docs/container/apple-container.mdx
+++ b/docs/container/apple-container.mdx
@@ -1,6 +1,6 @@
 ---
 title: Apple container
-description: Use Apple container with Nextflow.
+description: Run Nextflow pipeline tasks in Apple container virtual machines on macOS.
 ---
 
 # Apple container
@@ -30,7 +30,7 @@ process.container = 'nextflow/examples:latest'
 
 Whenever your pipeline launches a task, Nextflow runs it inside a container created from the specified image using the `container run` command.
 
-Each container runs in its own lightweight VM, so tasks benefit from strong isolation without the overhead of a full VM per task. Images are standard OCI images and can be pulled from any registry.
+Each container runs in its own lightweight virtual machine. This isolates tasks without the overhead of running a full virtual machine for each one. Images are standard OCI images that you can pull from any registry.
 
 :::note
 Apple container only supports Linux images. To run an `amd64` image on Apple silicon, pass `--rosetta` via `appleContainer.runOptions` and set the platform explicitly, for example, `process.arch = 'linux/amd64'`.

--- a/docs/container/apptainer.mdx
+++ b/docs/container/apptainer.mdx
@@ -1,11 +1,11 @@
 ---
 title: Apptainer
-description: Use Apptainer with Nextflow.
+description: Run Nextflow pipeline tasks in Apptainer containers, including image caching and Docker registry support.
 ---
 
 # Apptainer
 
-[Apptainer](https://apptainer.org) is an alternative container runtime to Docker and an open source fork of Singularity. Apptainer can be used without root privileges and it doesn't require a separate daemon process, making it well-suited to HPC environments. Apptainer can use existing Docker images and pull from Docker registries.
+[Apptainer](https://apptainer.org) is a container runtime and an open source fork of Singularity. Apptainer runs without root privileges and without a separate daemon process, which suits high-performance computing (HPC) environments. Apptainer can use existing Docker images and pull from Docker registries.
 
 ## Prerequisites
 
@@ -13,9 +13,9 @@ Apptainer must be installed in your execution environment.
 
 ## Images
 
-Refer to the [Apptainer documentation](https://apptainer.org/docs) to learn how to create Apptainer images.
+To create Apptainer images, see the [Apptainer documentation](https://apptainer.org/docs).
 
-Apptainer allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. This feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
+Apptainer can create and mount paths that do not exist in the container when you specify them on the command line. This feature requires a host that supports the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is disabled by default.
 
 ## How it works
 
@@ -34,21 +34,21 @@ You can also enable Apptainer on the command line:
 nextflow run main.nf -with-apptainer
 ```
 
-Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature to be enabled in your Apptainer installation. To disable it, set `apptainer.autoMounts` to `false`.
+Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature in your Apptainer installation. To disable automatic mounts, set `apptainer.autoMounts` to `false`.
 
 :::warning
-When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Apptainer installation. Otherwise the task will fail because the container won't be able to access the linked file.
+When a process input is a *symbolic link*, store the linked file in a host directory that is accessible from a bind path defined in your Apptainer installation. Otherwise, the task fails because the container cannot access the linked file.
 :::
 
 <ChangedInVersion version="23.10">
 Nextflow no longer mounts the home directory when launching an Apptainer container. To re-enable the old behavior, set the environment variable `NXF_APPTAINER_HOME_MOUNT` to `true`.
 </ChangedInVersion>
 
-## Apptainer & Docker Hub
+## Apptainer and Docker Hub
 
-Nextflow can pull remote container images from any Docker-compatible registry. This requires Apptainer to be installed in the launch environment (as opposed to the compute nodes).
+Nextflow can pull remote container images from any Docker-compatible registry. This requires Apptainer in the launch environment, not on the compute nodes.
 
-By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
+When you specify a container name, Nextflow first checks whether an image file with that name exists in the local file system. If it does, Nextflow uses that file to execute the container. If it does not, Nextflow pulls an image with that name from the container registry.
 
 To use only local file images, prefix the container name with `file://`. For example:
 
@@ -58,7 +58,7 @@ process.container = 'file:///path/to/apptainer.img'
 ```
 
 :::warning
-Use three `/` slashes to specify an *absolute* file path, otherwise the path will be interpreted as relative to the workflow launch directory.
+Use three `/` slashes to specify an *absolute* file path. Otherwise, Nextflow interprets the path as relative to the workflow launch directory.
 :::
 
 To pull an image from a specific registry, prefix the image name with `shub://`, `docker://`, or `docker-daemon://` as required by Apptainer. For example:
@@ -68,7 +68,7 @@ apptainer.enabled = true
 process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
 ```
 
-You do not need to specify `docker://` to pull from a Docker registry. Nextflow will automatically prepend it to your image name when Apptainer is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
+You do not need to specify `docker://` to pull from a Docker registry. When Apptainer is enabled, Nextflow prepends it to your image name. The Docker engine does not work with containers specified as `docker://`.
 
 By default, Nextflow caches Apptainer images in the `apptainer` directory, in the pipeline work directory. Use the `NXF_APPTAINER_CACHEDIR` environment variable or the `apptainer.cacheDir` config setting to define a centralized cache directory.
 
@@ -77,11 +77,11 @@ Nextflow uses the library directory to determine the location of local Apptainer
 When resolving a container image, Nextflow first checks the library directory, then the cache directory. Use the library directory as a read-only container repository, and the cache directory as a writable location where container images can be cached.
 
 :::note
-When using a compute cluster, the Apptainer cache directory must reside in a shared filesystem accessible to all compute nodes.
+On a compute cluster, the Apptainer cache directory must reside on a shared file system that all compute nodes can access.
 :::
 
 :::warning
-When pulling Docker images, Apptainer may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See the Apptainer documentation for details.
+When pulling Docker images, Apptainer cannot determine the container size if the image uses an old Docker format. The pipeline execution then fails with an error. See the Apptainer documentation for details.
 :::
 
 ## Advanced settings

--- a/docs/container/charliecloud.mdx
+++ b/docs/container/charliecloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: Charliecloud
-description: Use Charliecloud with Nextflow.
+description: Run Nextflow pipeline tasks in Charliecloud containers without root privileges.
 ---
 
 # Charliecloud
@@ -11,7 +11,7 @@ description: Use Charliecloud with Nextflow.
 :::warning{title="Experimental: not recommended for production environments."}
 :::
 
-[Charliecloud](https://hpc.github.io/charliecloud) is an alternative container runtime to Docker that is better suited for HPC environments. It can be used without root privileges, making use of user namespaces in the Linux kernel, and it can pull from Docker registries.
+[Charliecloud](https://hpc.github.io/charliecloud) is a container runtime for high-performance computing (HPC) environments. Charliecloud runs without root privileges by using user namespaces in the Linux kernel, and it can pull from Docker registries.
 
 ## Prerequisites
 
@@ -35,23 +35,23 @@ nextflow run main.nf -with-charliecloud
 ```
 
 :::warning
-If an absolute path is provided, the container needs to be in the Charliecloud flat directory format. See [Charliecloud & Docker Hub](#charliecloud--docker-hub) for compatibility with Docker registries.
+If you provide an absolute path, the container must be in the Charliecloud flat directory format. See [Charliecloud and Docker Hub](#charliecloud-and-docker-hub) for compatibility with Docker registries.
 :::
 
-## Charliecloud & Docker Hub
+## Charliecloud and Docker Hub
 
 Nextflow can pull remote container images from any Docker-compatible registry and convert them to the Charliecloud format.
 
-By default, when a container name is specified, Nextflow checks if a container with that name exists in the local file system. If it exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the registry.
+When you specify a container name, Nextflow first checks whether a container with that name exists in the local file system. If it does, Nextflow uses that container. If it does not, Nextflow pulls an image with that name from the registry.
 
-To pull an image from a specific registry, provide the URL to the image. If no URL is provided, Docker Hub is assumed. For example, the following config pulls an image from quay.io and converts it to the Charliecloud format:
+To pull an image from a specific registry, give the URL to the image. Without a URL, Nextflow uses Docker Hub. For example, this configuration pulls an image from quay.io and converts it to the Charliecloud format:
 
 ```groovy
 charliecloud.enabled = true
 process.container = 'https://quay.io/biocontainers/multiqc:1.3--py35_2'
 ```
 
-Whereas the following config pulls from Docker Hub:
+This configuration pulls from Docker Hub:
 
 ```groovy
 charliecloud.enabled = true

--- a/docs/container/docker.mdx
+++ b/docs/container/docker.mdx
@@ -1,17 +1,17 @@
 ---
 title: Docker
-description: Use Docker with Nextflow.
+description: Run Nextflow pipeline tasks in Docker containers.
 ---
 
 # Docker
 
-[Docker](https://www.docker.com) is the industry standard container runtime.
+[Docker](https://www.docker.com) is the most widely used container runtime.
 
 ## Prerequisites
 
 Docker must be installed in your execution environment.
 
-If you are running Docker on Mac OSX make sure you are mounting your local `/Users` directory into the Docker VM as explained in this excellent tutorial: [How to use Docker on OSX](http://viget.com/extend/how-to-use-docker-on-os-x-the-missing-guide).
+On macOS, mount your local `/Users` directory into the Docker virtual machine.
 
 ## How it works
 

--- a/docs/container/podman.mdx
+++ b/docs/container/podman.mdx
@@ -1,6 +1,6 @@
 ---
 title: Podman
-description: Use Podman with Nextflow.
+description: Run Nextflow pipeline tasks in Podman containers, with or without root privileges.
 ---
 
 # Podman
@@ -11,7 +11,7 @@ description: Use Podman with Nextflow.
 
 Podman must be installed in your execution environment.
 
-Running in rootless mode requires appropriate OS configuration. Due to Podman limitations, using cpuset for cpus and memory is only possible with root permissions.
+Rootless mode requires additional operating system configuration. Because of a Podman limitation, cpuset for CPUs and memory only works with root permissions.
 
 ## How it works
 

--- a/docs/container/sarus.mdx
+++ b/docs/container/sarus.mdx
@@ -1,11 +1,11 @@
 ---
 title: Sarus
-description: Use Sarus with Nextflow.
+description: Run Nextflow pipeline tasks in Sarus containers converted from Docker images.
 ---
 
 # Sarus
 
-[Sarus](https://sarus.readthedocs.io) is an alternative container runtime to Docker. Sarus works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Sarus enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
+[Sarus](https://sarus.readthedocs.io) is a container runtime that converts Docker images to a common format for distribution and launch on high-performance computing (HPC) systems. With Sarus, you select an image from [Docker Hub](https://hub.docker.com/) and submit jobs that run entirely within the container.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ Sarus must be installed in your execution environment.
 
 ## Images
 
-Sarus converts a Docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Sarus images, see the [official documentation](https://sarus.readthedocs.io/en/stable/user/user_guide.html#develop-the-docker-image).
+Sarus converts a Docker image to Squashfs layers that are distributed and launched in the cluster. To build Sarus images, see the [Sarus documentation](https://sarus.readthedocs.io/en/stable/user/user_guide.html#develop-the-docker-image).
 
 ## How it works
 
@@ -24,7 +24,7 @@ sarus.enabled = true
 process.container = 'dockerhub_user/image_name:image_tag'
 ```
 
-Sarus always searches the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
+Sarus always searches the Docker Hub registry for images. If you do not specify an image tag, Sarus fetches the `latest` tag.
 
 ## Advanced settings
 

--- a/docs/container/shifter.mdx
+++ b/docs/container/shifter.mdx
@@ -1,21 +1,21 @@
 ---
 title: Shifter
-description: Use Shifter with Nextflow.
+description: Run Nextflow pipeline tasks in Shifter containers converted from Docker images.
 ---
 
 # Shifter
 
-[Shifter](https://docs.nersc.gov/programming/shifter/overview/) is an alternative container runtime to Docker. Shifter works by converting Docker images to a common format that can then be distributed and launched on HPC systems. The user interface to Shifter enables a user to select an image from [Docker Hub](https://hub.docker.com/) and then submit jobs which run entirely within the container.
+[Shifter](https://docs.nersc.gov/programming/shifter/overview/) is a container runtime that converts Docker images to a common format for distribution and launch on high-performance computing (HPC) systems. With Shifter, you select an image from [Docker Hub](https://hub.docker.com/) and submit jobs that run entirely within the container.
 
 ## Prerequisites
 
 Shifter must be installed in your execution environment.
 
-In the case of a distributed cluster, Shifter must be installed on all of the compute nodes, the `shifterimg` command must be available, and Shifter should be configured to access the Image gateway. For more information, see the [official documentation](https://github.com/NERSC/shifter/tree/master/doc).
+On a distributed cluster, install Shifter on all compute nodes, make the `shifterimg` command available, and configure Shifter to access the Image gateway. For more information, see the [Shifter documentation](https://github.com/NERSC/shifter/tree/master/doc).
 
 ## Images
 
-Shifter converts a Docker image to Squashfs layers which are distributed and launched in the cluster. For more information on how to build Shifter images see the [official documentation](https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images).
+Shifter converts a Docker image to Squashfs layers that are distributed and launched in the cluster. To build Shifter images, see the [Shifter documentation](https://docs.nersc.gov/programming/shifter/how-to-use/#building-shifter-images).
 
 ## How it works
 
@@ -26,7 +26,7 @@ shifter.enabled = true
 process.container = 'dockerhub_user/image_name:image_tag'
 ```
 
-Shifter always searches the Docker Hub registry for the images. If you do not specify an image tag, the `latest` tag will be fetched by default.
+Shifter always searches the Docker Hub registry for images. If you do not specify an image tag, Shifter fetches the `latest` tag.
 
 ## Advanced settings
 

--- a/docs/container/singularity.mdx
+++ b/docs/container/singularity.mdx
@@ -1,11 +1,11 @@
 ---
 title: Singularity
-description: Use Singularity with Nextflow.
+description: Run Nextflow pipeline tasks in Singularity containers, including image caching and Docker registry support.
 ---
 
 # Singularity
 
-[Singularity](https://sylabs.io/singularity/) is an alternative container runtime to Docker. Singularity can be used without root privileges and it doesn't require a separate daemon process, making it well-suited to HPC environments. Singularity can use existing Docker images and pull from Docker registries.
+[Singularity](https://sylabs.io/singularity/) is a container runtime. Singularity runs without root privileges and without a separate daemon process, which suits high-performance computing (HPC) environments. Singularity can use existing Docker images and pull from Docker registries.
 
 ## Prerequisites
 
@@ -13,9 +13,9 @@ Singularity must be installed in your execution environment.
 
 ## Images
 
-Refer to the [Singularity documentation](https://www.sylabs.io/docs/) to learn how to create Singularity images.
+To create Singularity images, see the [Singularity documentation](https://www.sylabs.io/docs/).
 
-Singularity allows paths that do not currently exist within the container to be created and mounted dynamically by specifying them on the command line. This feature is only supported on hosts that support the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is not enabled by default.
+Singularity can create and mount paths that do not exist in the container when you specify them on the command line. This feature requires a host that supports the [Overlay file system](https://en.wikipedia.org/wiki/OverlayFS) and is disabled by default.
 
 ## How it works
 
@@ -34,10 +34,10 @@ You can also enable Singularity on the command line:
 nextflow run main.nf -with-singularity
 ```
 
-Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature to be enabled in your Singularity installation. To disable it, set `singularity.autoMounts` to `false`.
+Nextflow automatically mounts the required host paths in the container. This requires the `user bind control` feature in your Singularity installation. To disable automatic mounts, set `singularity.autoMounts` to `false`.
 
 :::warning
-When a process input is a *symbolic link* file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Singularity installation. Otherwise the task will fail because the container won't be able to access the linked file.
+When a process input is a *symbolic link*, store the linked file in a host directory that is accessible from a bind path defined in your Singularity installation. Otherwise, the task fails because the container cannot access the linked file.
 :::
 
 <ChangedInVersion version="23.10">
@@ -45,18 +45,18 @@ Nextflow no longer mounts the home directory when launching a Singularity contai
 </ChangedInVersion>
 
 <ChangedInVersion version="23.10">
-Host paths are mounted in the container automatically. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false`.
+Nextflow mounts host paths in the container automatically. To re-enable the old behavior, set the environment variable `NXF_SINGULARITY_AUTO_MOUNTS` to `false`.
 </ChangedInVersion>
 
 <ChangedInVersion version="23.10">
-The execution command for Singularity/Apptainer containers can be set to `run` by means of the environment variable `NXF_SINGULARITY_RUN_COMMAND` (default command is `exec`).
+To set the execution command for Singularity and Apptainer containers to `run`, set the environment variable `NXF_SINGULARITY_RUN_COMMAND`. The default command is `exec`.
 </ChangedInVersion>
 
-## Singularity & Docker Hub
+## Singularity and Docker Hub
 
-Nextflow can pull remote container images from [Singularity Hub](https://singularity-hub.org/), the [Singularity Library](https://cloud.sylabs.io/library/), or any Docker-compatible registry. This feature requires Singularity to be installed in the launch environment (as opposed to the compute nodes).
+Nextflow can pull remote container images from the [Singularity Library](https://cloud.sylabs.io/library/) or any Docker-compatible registry. This requires Singularity in the launch environment, not on the compute nodes.
 
-By default, when a container name is specified, Nextflow checks if an image file with that name exists in the local file system. If that image file exists, it is used to execute the container. If a matching file does not exist, Nextflow automatically tries to pull an image with the specified name from the container registry.
+When you specify a container name, Nextflow first checks whether an image file with that name exists in the local file system. If it does, Nextflow uses that file to execute the container. If it does not, Nextflow pulls an image with that name from the container registry.
 
 To use only local file images, prefix the container name with `file://`. For example:
 
@@ -66,7 +66,7 @@ process.container = 'file:///path/to/singularity.img'
 ```
 
 :::warning
-Use three `/` slashes to specify an *absolute* file path, otherwise the path will be interpreted as relative to the workflow launch directory.
+Use three `/` slashes to specify an *absolute* file path. Otherwise, Nextflow interprets the path as relative to the workflow launch directory.
 :::
 
 To pull an image from a specific registry, prefix the image name with `shub://`, `docker://`, `docker-daemon://`, or `library://` as required by Singularity. For example:
@@ -76,7 +76,7 @@ singularity.enabled = true
 process.container = 'docker://quay.io/biocontainers/multiqc:1.3--py35_2'
 ```
 
-You do not need to specify `docker://` to pull from a Docker registry. Nextflow will automatically prepend it to your image name when Singularity is enabled. Additionally, the Docker engine will not work with containers specified as `docker://`.
+You do not need to specify `docker://` to pull from a Docker registry. When Singularity is enabled, Nextflow prepends it to your image name. The Docker engine does not work with containers specified as `docker://`.
 
 By default, Nextflow caches Singularity images in the `singularity` directory, in the pipeline work directory. Use the `NXF_SINGULARITY_CACHEDIR` environment variable or the `singularity.cacheDir` config setting to define a centralized cache directory.
 
@@ -85,11 +85,11 @@ Nextflow uses the library directory to determine the location of local Singulari
 When resolving a container image, Nextflow first checks the library directory, then the cache directory. Use the library directory as a read-only container repository, and the cache directory as a writable location where container images can be cached.
 
 :::note
-When using a compute cluster, the Singularity cache directory must reside in a shared filesystem accessible to all compute nodes.
+On a compute cluster, the Singularity cache directory must reside on a shared file system that all compute nodes can access.
 :::
 
 :::warning
-When pulling Docker images, Singularity may be unable to determine the container size if the image was stored using an old Docker format, resulting in a pipeline execution error. See the Singularity documentation for details.
+When pulling Docker images, Singularity cannot determine the container size if the image uses an old Docker format. The pipeline execution then fails with an error. See the Singularity documentation for details.
 :::
 
 ## Advanced settings

--- a/docs/container/smolvm.mdx
+++ b/docs/container/smolvm.mdx
@@ -1,6 +1,6 @@
 ---
 title: smolvm
-description: Use smolvm with Nextflow.
+description: Run Nextflow pipeline tasks in smolvm microVMs.
 ---
 
 # smolvm
@@ -9,7 +9,7 @@ description: Use smolvm with Nextflow.
 
 ## Prerequisites
 
-The `smolvm` CLI must be installed and available on the `PATH` where the workflow is launched.
+The `smolvm` CLI must be installed and available on the `PATH` in the launch environment.
 
 ## How it works
 
@@ -20,7 +20,7 @@ smolvm.enabled = true
 process.container = 'nextflow/examples:latest'
 ```
 
-Whenever your pipeline launches a task, Nextflow runs it inside a microVM created from the specified image using the `smolvm machine run` command. Images are standard OCI images and can be pulled from any registry.
+Whenever your pipeline launches a task, Nextflow runs it inside a microVM created from the specified image using the `smolvm machine run` command. Images are standard OCI images that you can pull from any registry.
 
 :::tip
 On Apple silicon, running a `linux/amd64` image requires Rosetta 2 translation. Enable it by passing `--rosetta` via `smolvm.runOptions`:
@@ -29,7 +29,7 @@ On Apple silicon, running a `linux/amd64` image requires Rosetta 2 translation. 
 smolvm.runOptions = '--rosetta'
 ```
 
-Without it the microVM fails to start the container (`the container ... is not running`). This is not needed for native `arm64` images.
+Without `--rosetta`, the microVM fails to start the container and reports `the container ... is not running`. Native `arm64` images do not need this option.
 :::
 
 ## Advanced settings


### PR DESCRIPTION
**What changed**

- Cut slop and fixed voice throughout.
- Converted ~15 future-tense constructions to present and passive to active.
- Rewrote all 9 frontmatter `description:` values — they were a `Use X with Nextflow.` template, thinner than the repo norm.
- Renamed the three `X & Docker Hub` headings to `X and Docker Hub` and updated the one in-page anchor link to match. No inbound anchors existed for any renamed heading.
- Split `container.mdx`'s two bold-first bullets into `###` subheadings; expanded HPC on first use per page.
- Dropped two stale links: Singularity Hub (shut down 2021) and an ~2014 `http://` viget.com Docker tutorial.