### PR TITLE
Fix tests failing on macOS and on hosts with NXF_REGISTRY_TOKEN

### DIFF
--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -256,7 +256,7 @@ class ConfigBuilderTest extends Specification {
         new ConfigBuilder().build([file])
         then:
         def e = thrown(ConfigParseException)
-        e.message == "Unknown config attribute `bar` -- check config file: ${file.toRealPath()}".toString()
+        e.message == "Unknown config attribute `bar` -- check config file: ${file}".toString()
 
         cleanup:
         SysEnv.pop()
@@ -340,7 +340,7 @@ class ConfigBuilderTest extends Specification {
         new ConfigBuilder().build([file])
         then:
         def e = thrown(ConfigParseException)
-        e.message == "Unknown config attribute `foo.bar` -- check config file: ${file.toRealPath()}".toString()
+        e.message == "Unknown config attribute `foo.bar` -- check config file: ${file}".toString()
 
         cleanup:
         SysEnv.pop()

--- a/modules/nextflow/src/test/groovy/nextflow/module/RegistryClientFactoryTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/module/RegistryClientFactoryTest.groovy
@@ -19,6 +19,7 @@ package nextflow.module
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import groovy.json.JsonOutput
+import nextflow.SysEnv
 import nextflow.config.RegistryConfig
 import io.seqera.npr.client.RegistryException
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
@@ -47,6 +48,9 @@ class RegistryClientFactoryTest extends Specification {
     String url
     static final String MODULES_API_PATH = "/api/v1/modules"
     def setup() {
+        // isolate from the host environment, otherwise `NXF_REGISTRY_TOKEN`
+        // leaks into the client via `RegistryConfig.getApiKey()`
+        SysEnv.push([:])
         wireMock = new WireMockServer(wireMockConfig().dynamicPort())
         wireMock.start()
         WireMock.configureFor("localhost", wireMock.port())
@@ -55,6 +59,7 @@ class RegistryClientFactoryTest extends Specification {
 
     def cleanup() {
         wireMock?.stop()
+        SysEnv.pop()
     }
 
     def 'should fetch module metadata from registry'() {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskInputResolverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskInputResolverTest.groovy
@@ -203,12 +203,14 @@ class TaskInputResolverTest extends Specification {
         // see issue #378: a `path` input in an `exec:` block must resolve to the
         // absolute, symlink-resolved real path so that e.g. `.exists()` works,
         // not the relative stage name (which is never materialized for native tasks)
+        // note: the holders are built as the resolver does it in production, ie. via
+        // the `FileHolder` constructor which resolves the store path to the real path
         given:
         def file1 = Files.createTempFile('test1', '.txt')
         def file2 = Files.createTempFile('test2', '.txt')
 
         when:
-        def list = [ FileHolder.get(file1, 'staged_1.txt') ]
+        def list = [ new FileHolder(file1).withName('staged_1.txt') ]
         def result = TaskInputResolver.singleItemOrList(list, true, ScriptType.GROOVY)
         then:
         result == file1.toRealPath()
@@ -216,7 +218,7 @@ class TaskInputResolverTest extends Specification {
         result.exists()
 
         when:
-        list = [ FileHolder.get(file1, 'staged_1.txt'), FileHolder.get(file2, 'staged_2.txt') ]
+        list = [ new FileHolder(file1).withName('staged_1.txt'), new FileHolder(file2).withName('staged_2.txt') ]
         result = TaskInputResolver.singleItemOrList(list, false, ScriptType.GROOVY)
         then:
         result*.toString() == [ file1.toRealPath().toString(), file2.toRealPath().toString() ]


### PR DESCRIPTION
Three unit tests pass on the Linux CI but fail when the suite is run locally on macOS. None of them indicate a defect in the runtime — each test makes an assumption that only holds on the CI environment.

### `RegistryClientFactoryTest` — leaks the host environment

`RegistryConfig.getApiKey()` falls back to `SysEnv.get('NXF_REGISTRY_TOKEN')`, and the test constructs `new RegistryConfig([url: url])` without a key. On a machine where that variable is exported, the client is built *with* a token, so it never reaches its "Authentication required" precondition and issues a real POST instead — which WireMock answers with a 404, since no stub matches. The CI has no such variable, so the client fails fast as expected.

Fixed by pushing an empty environment for the duration of the test, the same pattern already used in `CondaCacheTest`, `SecretsLoaderTest` and `RepositoryProviderTest`.

### `ConfigBuilderTest` and `TaskInputResolverTest` — `/var` is a symlink on macOS

Both assert against `toRealPath()`. On Linux `/tmp` is a real directory so that call is a no-op and the assertions hold by accident; on macOS `Files.createTempFile` lands under `/var/folders/...` and `/var` is a symlink to `/private/var`, so expected and actual differ by exactly that prefix. The two cases have different causes, though:

- **`ConfigBuilderTest`** — the assertion was simply wrong. `ConfigBuilder.build()` passes the config entries through to `checkUnresolvedConfig()` untouched, so the `Unknown config attribute` message reports the file exactly as the caller supplied it, with no normalisation at any hop. The test now compares against the file itself.

- **`TaskInputResolverTest`** — the stated contract is correct and is preserved. `FileHolder`'s public constructors run `real(path)`, which resolves symlinks, and the runtime builds holders exclusively that way (`TaskInputResolver` lines 149, 200, 210). The test instead used the `FileHolder.get()` helper, which goes through the protected three-arg constructor and stores the path verbatim — it is only ever called from tests. So the holder under test never had a resolved store path to begin with. The test now builds its holders the way the resolver does, via `new FileHolder(file).withName(stageName)`, and the `toRealPath()` assertion from #7272 is left intact.

### Verification

`ConfigBuilderTest`, `RegistryClientFactoryTest` and `TaskInputResolverTest` — 76 tests, 0 failures — now pass on macOS with `NXF_REGISTRY_TOKEN` still exported. Test-only change; no runtime code touched.
