### PR TITLE
Resolve Azure virtual directories via the file system provider

### DIFF
--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzPath.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/nio/AzPath.groovy
@@ -45,6 +45,19 @@ class AzPath implements Path {
 
     private AzFileAttributes attributes
 
+    /**
+     * Records the trailing slash used to build this path, *not* whether the object
+     * store holds a directory at this location — blob storage has no directories,
+     * only virtual prefixes inferred from the blobs below them.
+     *
+     * NOTE: do not expose this as a public {@code isDirectory()} getter. It would
+     * shadow the {@code FilesEx.isDirectory(Path)} extension method, so
+     * {@code path.isDirectory()} would answer from the path string instead of
+     * storage, and {@code az://container/output} would be reported as a file (#6427).
+     * Use {@link java.nio.file.Files#isDirectory} instead, which resolves virtual
+     * directories through {@link AzFileSystem#readAttributes}. The field is also read
+     * by the generated {@code equals}/{@code hashCode}, which must stay I/O-free.
+     */
     @PackageScope
     boolean directory
 
@@ -91,22 +104,6 @@ class AzPath implements Path {
     AzPath setAttributes(AzFileAttributes attrs) {
         this.attributes = attrs
         return this
-    }
-
-    /**
-     * Determines whether this path is a directory. Groovy property access via
-     * {@code path.directory} invokes this method and may perform a remote
-     * attribute lookup for an absolute path without a trailing slash.
-     */
-    boolean isDirectory() {
-        if( directory )
-            return true
-        if( attributes )
-            return attributes.isDirectory()
-        if( !isAbsolute() )
-            return false
-        attributes = fs.readAttributes(this)
-        return attributes?.isDirectory() ?: false
     }
 
     String checkContainerName() {

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/nio/AzNioTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/nio/AzNioTest.groovy
@@ -959,8 +959,8 @@ class AzNioTest extends Specification implements AzBaseSpec {
         def file = Path.of(new URI("az://$bucketName/output/file.txt"))
 
         then: 'it is recognised as a directory (via both entry points) while the blob is a file'
-        (azPath as AzPath).isDirectory()
-        Files.isDirectory(nioPath)
+        azPath.isDirectory()        // the Groovy call nf-schema makes, via the FilesEx extension
+        Files.isDirectory(nioPath)  // the plain NIO call
         !Files.isDirectory(file)
 
         cleanup:

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/nio/AzPathTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/nio/AzPathTest.groovy
@@ -74,17 +74,18 @@ class AzPathTest extends Specification {
         then:
         path.containerName == CONTAINER
 //        path.objectName == BLOB
+        path.@directory == IS_DIRECTORY
         path.isContainer() == IS_CONTAINER
         and:
         path.getContainerName() == path.checkContainerName()
 //        path.getObjectName() == path.blobName()
 
         where:
-        PATH                    | CONTAINER     | BLOB          | IS_CONTAINER
-        '/alpha/beta/delta'     | 'alpha'       | 'beta/delta'  | false
-        '/alpha/beta/delta/'    | 'alpha'       | 'beta/delta/' | false
-        '/alpha/'               | 'alpha'       | null          | true
-        '/alpha'                | 'alpha'       | null          | true
+        PATH                    | CONTAINER     | BLOB          | IS_DIRECTORY  | IS_CONTAINER
+        '/alpha/beta/delta'     | 'alpha'       | 'beta/delta'  | false         | false
+        '/alpha/beta/delta/'    | 'alpha'       | 'beta/delta/' | true          | false
+        '/alpha/'               | 'alpha'       | null          | true          | true
+        '/alpha'                | 'alpha'       | null          | true          | true
 
     }
 
@@ -334,56 +335,44 @@ class AzPathTest extends Specification {
 
     }
 
-    def 'isDirectory should reuse cached attributes for a path without a trailing slash'() {
-        given: 'a slashless path whose resolved attributes report a directory'
-        def path = azpath('/pipeline/output')
-        def attrs = new AzFileAttributes(size: 0, objectId: '/pipeline/output', directory: true)
-        path.setAttributes(attrs)
-
+    def 'should not declare an isDirectory getter'() {
+        // A public isDirectory() would shadow the FilesEx.isDirectory(Path) extension
+        // method, so `path.isDirectory()` would answer from the trailing slash instead
+        // of storage and report `az://container/output` as a file -- see #6427. It would
+        // also be picked up by the generated equals(), making it perform remote I/O.
         expect:
-        !path.@directory        // the trailing-slash field alone says "not a directory"
-        path.isDirectory()      // ...but the resolved attributes identify it as a directory
-        path.attributesCache().is(attrs) // retain the one-shot cache for a later readAttributes call
+        AzPath.declaredMethods.every { it.name !in ['isDirectory','getDirectory'] }
     }
 
-    def 'isDirectory should reuse attributes resolved from storage'() {
+    def 'equals should not trigger a remote attribute lookup'() {
         given:
         def fs = Mock(AzFileSystem)
         fs.getContainerName() >> 'pipeline'
-        def path = new AzPath(fs, '/pipeline/output')
+        def left = new AzPath(fs, '/pipeline/output')
+        def right = new AzPath(fs, '/pipeline/output')
 
         when:
-        def first = path.isDirectory()
-        def second = path.isDirectory()
+        left.equals(right)
 
         then:
-        first
-        second
-        1 * fs.readAttributes(path) >> new AzFileAttributes(directory: true)
-        0 * _
+        0 * fs.readAttributes(_)
     }
 
-    def 'isDirectory should return false for a relative path'() {
-        given:
-        def path = azpath('some/file.txt')
-
-        expect:
-        !path.isDirectory()
-    }
-
-    def 'isDirectory should propagate attribute lookup failures'() {
-        given:
+    def 'equals should not depend on the resolved attributes'() {
+        given: 'two equal paths, only one of which carries listing-sourced attributes'
         def fs = Mock(AzFileSystem)
         fs.getContainerName() >> 'pipeline'
-        def path = new AzPath(fs, '/pipeline/output')
+        def withAttrs = new AzPath(fs, '/pipeline/output')
+        withAttrs.setAttributes(new AzFileAttributes(directory: true))
+        def bare = new AzPath(fs, '/pipeline/output')
 
-        when:
-        path.isDirectory()
+        expect: 'equality is symmetric and consistent with hashCode'
+        withAttrs == bare
+        bare == withAttrs
+        withAttrs.hashCode() == bare.hashCode()
 
-        then:
-        def error = thrown(IllegalStateException)
-        error.message == 'Unable to read attributes'
-        1 * fs.readAttributes(path) >> { throw new IllegalStateException('Unable to read attributes') }
+        and: 'so a map lookup finds the entry'
+        [(bare): 'value'].get(withAttrs) == 'value'
     }
 
     def 'should only recognise zero-size hdi_isfolder markers'() {


### PR DESCRIPTION
Stacked on top of #6428 — review that one first; this PR's diff is only the delta.

## Problem

#6428 fixes a real bug: `Nextflow.file('az://container/output').isDirectory()` returns `false` for a virtual directory referenced without a trailing slash, so nf-schema rejects a valid `--outdir`.

It fixes it by making `AzPath.isDirectory()` consult storage. That reintroduces the answer in the right place, but `isDirectory()` is also the Groovy getter for the `directory` property, and:

```groovy
@EqualsAndHashCode(includes = 'fs,path,directory', includeFields = true)
```

compiles `equals()` to `this.@directory == other.isDirectory()` — the field on the left, **the getter on the right**. `javap -c` on the class built from #6428:

```
120: getfield      #169   // Field directory:Z       <- this:  raw field
127: invokevirtual #427   // Method isDirectory:()Z  <- other: getter, now hits the network
```

`hashCode()` reads the raw field on both sides. So with a remote lookup behind the getter, `equals()`:

1. performs an Azure REST round-trip and can throw `BlobStorageException`/`NoSuchFileException`,
2. becomes asymmetric — `a.equals(b) != b.equals(a)`,
3. disagrees with `hashCode()`, so a `HashMap` lookup with an equal key can miss.

Point 3 bites on the task path, where `AzPath` is routinely a hash key:

- `TaskProcessor.groovy:1827` `Map<Path,FileHolder> holders` → `TaskInputResolver.groovy:132` `holders.containsKey(value)`
- `PublishDir.groovy:70` `Map<Path,Boolean> makeCache` → `PublishDir.groovy:559` `makeCache.containsKey(dir)`
- `TaskRun.outputFiles` / `TaskProcessor.getPublishFiles` — `Set<Path>`

## Fix

`AzFileSystemProvider.readAttributes` → `readBlobAttrs0` → `guessPath` **already** resolves slashless virtual directories correctly, on master, with no changes. Probing master directly, for a container holding only `output/file.txt` and referenced as `az://container/output`:

```
Files.isDirectory = true    AzPath.isDirectory = false
```

The entire bug is that `AzPath` declares a public `isDirectory()` which shadows the `FilesEx.isDirectory(Path)` extension method and answers from the path string — and that shadowed method is exactly what nf-schema's `Nextflow.file(value).isDirectory()` resolves to under Groovy dynamic dispatch.

So this PR **removes** `AzPath.isDirectory()` rather than teaching it to do I/O. `path.isDirectory()` then falls through to `FilesEx.isDirectory` → `Files.isDirectory` → the provider, which is both correct and the answer users already get from plain NIO. `equals()`/`hashCode()` go back to reading the field on both sides:

```
--- public int hashCode();
    61: getfield  #169   // Field directory:Z
    76: getfield  #169   // Field directory:Z
--- public boolean equals(java.lang.Object);
   120: getfield  #169   // Field directory:Z
   127: getfield  #169   // Field directory:Z
```

`directory` is still part of equality, so equality semantics are unchanged from master. A doc comment on the field records why the getter must not come back.

`AzPath` is plugin-local (no references outside `plugins/nf-azure`) and nothing called `isDirectory()` under `@CompileStatic`, so removing it is safe. The `AzFileAttributes` and listing-metadata changes from #6428 are untouched — they're independently correct and stay.

## Tests

- `AzPathTest` — added a guard that `AzPath` declares no `isDirectory`/`getDirectory` method, plus two regression tests pinning `equals()` as I/O-free, symmetric, and hashCode-consistent. Restored the `IS_DIRECTORY` column that #6428 had to drop (now asserted via `path.@directory`).
- `AzNioTest` — `should detect a virtual directory without a trailing slash` now asserts `azPath.isDirectory()` (the Groovy call nf-schema makes, via the extension method) alongside `Files.isDirectory(...)`.

## Validation

`./gradlew :plugins:nf-azure:test` against a real Azure storage account: **322 tests, 1 skipped, 1 failure**.

The one failure is `AzNioTest > should list root directory` — a 30s `SpockTimeoutError`. It reproduces identically on master and on #6428; it's an artifact of a test account holding many containers while that test walks the whole tree under a fixed timeout. Unrelated to either PR.

`should detect a virtual directory without a trailing slash` passes live in 0.33s, and fails on master — so the #6427 fix is verified end-to-end through both entry points.

The three `equals()` regression tests fail on #6428 and pass here and on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
