### PR TITLE
Add per-process Spot to on-demand fallback hint for Google Batch

### DIFF
--- a/docs/executor/google-batch.mdx
+++ b/docs/executor/google-batch.mdx
@@ -21,15 +21,36 @@ Use the following process directives to control resource requests and other job 
 - [resourcelabels][process-resourcelabels]
 - [time][process-time]
 
+The following [hints][process-hints] are supported:
+
+- `scheduling.spotAttempts`: Run a process on Spot for its first N attempts, then automatically fall back to on-demand (`STANDARD`) for later attempts. The value is a positive integer N: attempts `1` to `N` request a Spot VM, attempts after `N` request on-demand. The attempt count is the greater of the task's execution attempt and its submit attempt, so the fallback is triggered both by a mid-run Spot reclaim and by a failure to obtain a Spot VM (the latter in combination with the [`maxSubmitAwait`][process-maxsubmitawait] directive). Requires `errorStrategy 'retry'` with `maxRetries` set high enough to reach the on-demand attempts. For example:
+
+  ```nextflow
+  process EXAMPLE {
+      errorStrategy 'retry'
+      maxRetries 3
+      hints 'scheduling.spotAttempts': '2'   // Spot for attempts 1 and 2, on-demand from attempt 3
+  }
+  ```
+
+  This key may be used as-is or with the `google-batch/` prefix to restrict it to this executor.
+
+  :::note
+  `scheduling.spotAttempts` is distinct from the [`google.batch.maxSpotAttempts`][config-maxspotattempts] config option, despite the similar name. `google.batch.maxSpotAttempts` sets the number of times Cloud Batch retries a job *internally* after a Spot reclaim, and each retry requests a Spot VM again; it applies to every process in the run. `scheduling.spotAttempts` instead changes the provisioning model across Nextflow-level attempts, and is set per process. The two can be combined.
+  :::
+
 See [Cloud Batch][google-batch] for further configuration details.
 
+[config-maxspotattempts]: ../reference/config/google#googlebatchmaxspotattempts
 [google-batch]: ../google#cloud-batch
 [process-accelerator]: ../reference/process/directives/accelerator
 [process-container]: ../reference/process/directives/container
 [process-containeroptions]: ../reference/process/directives/container-options
 [process-cpus]: ../reference/process/directives/cpus
 [process-disk]: ../reference/process/directives/disk
+[process-hints]: ../reference/process/directives/hints
 [process-machinetype]: ../reference/process/directives/machine-type
+[process-maxsubmitawait]: ../reference/process/directives/max-submit-await
 [process-memory]: ../reference/process/directives/memory
 [process-resourcelabels]: ../reference/process/directives/resource-labels
 [process-time]: ../reference/process/directives/time

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -358,6 +358,77 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         boolean requiresScratchVolume
     }
 
+    private static final String HINT_PREFIX = 'google-batch/'
+    private static final String SPOT_ATTEMPTS_HINT = 'scheduling.spotAttempts'
+    private static final Set<String> KNOWN_HINTS = Set.of(SPOT_ATTEMPTS_HINT)
+    private static final String SUPPORTED_HINTS_MSG =
+        KNOWN_HINTS.collect { HINT_PREFIX + it }.sort().join(', ')
+
+    /**
+     * Validate the google-batch prefixed hints, throwing if a prefixed key is not supported
+     *
+     * @param hints The hints map from the task config
+     */
+    protected void validateHints(Map<String,Object> hints) {
+        if( !hints )
+            return
+        final unknown = []
+        for( final key : hints.keySet() ) {
+            if( !key?.startsWith(HINT_PREFIX) )
+                continue
+            if( !KNOWN_HINTS.contains(key.substring(HINT_PREFIX.length())) )
+                unknown.add(key)
+        }
+        if( unknown )
+            throw new IllegalArgumentException("Unknown Google Batch hint(s): ${unknown.collect { "'$it'" }.join(', ')} -- supported keys are: ${SUPPORTED_HINTS_MSG}")
+    }
+
+    /**
+     * Resolve the effective provisioning model for a task, honouring the scheduling.spotAttempts hint
+     *
+     * @param config The task config
+     * @return The effective provisioning model
+     */
+    protected AllocationPolicy.ProvisioningModel resolveProvisioningModel(TaskConfig config) {
+        final spotAttempts = resolveSpotAttempts(config)
+        if( spotAttempts != null ) {
+            // run on spot for the first N attempts, then fall back to on-demand (STANDARD).
+            // `attempt` covers a mid-run reclaim; `submitAttempt` covers a failure to obtain a VM
+            // (via `maxSubmitAwait`), so the larger of the two drives the escalation
+            final attempt = Math.max(config.getAttempt(), config.getSubmitAttempt())
+            return attempt <= spotAttempts
+                ? AllocationPolicy.ProvisioningModel.SPOT
+                : AllocationPolicy.ProvisioningModel.STANDARD
+        }
+        // otherwise use the global config: spot wins over preemptible, else on-demand
+        if( batchConfig.spot )
+            return AllocationPolicy.ProvisioningModel.SPOT
+        if( batchConfig.preemptible )
+            return AllocationPolicy.ProvisioningModel.PREEMPTIBLE
+        return AllocationPolicy.ProvisioningModel.STANDARD
+    }
+
+    /**
+     * The scheduling.spotAttempts hint value, or null when unset; throws on a non-positive integer
+     *
+     * @param config The task config
+     * @return The number of leading attempts to run on spot, or null
+     */
+    protected Integer resolveSpotAttempts(TaskConfig config) {
+        final hints = config?.getHints()
+        if( !hints )
+            return null
+        final value = hints.get(HINT_PREFIX + SPOT_ATTEMPTS_HINT) ?: hints.get(SPOT_ATTEMPTS_HINT)
+        if( value == null )
+            return null
+        final n = value instanceof Number
+            ? (value as Integer)
+            : (value.toString().trim().isInteger() ? value.toString().trim() as Integer : null)
+        if( n == null || n < 1 )
+            throw new IllegalArgumentException("Invalid '${SPOT_ATTEMPTS_HINT}' hint value: '${value}' -- it must be a positive integer")
+        return n
+    }
+
     /**
      * Build the instance policy or template for job allocation.
      * Note: This method sets machineInfo field as a side effect.
@@ -392,6 +463,10 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
             if( batchConfig.spot )
                 log.warn1 'Config option `google.batch.spot` ignored because an instance template was specified'
+
+            final hints = task.config.getHints()
+            if( hints?.containsKey(SPOT_ATTEMPTS_HINT) || hints?.containsKey(HINT_PREFIX + SPOT_ATTEMPTS_HINT) )
+                log.warn1 "Google Batch hint '${SPOT_ATTEMPTS_HINT}' ignored because an instance template was specified"
 
             instancePolicyOrTemplate
                 .setInstallGpuDrivers(batchConfig.getInstallGpuDrivers())
@@ -479,11 +554,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             if( batchConfig.cpuPlatform )
                 instancePolicy.setMinCpuPlatform(batchConfig.cpuPlatform)
 
-            if( batchConfig.preemptible )
-                instancePolicy.setProvisioningModel(AllocationPolicy.ProvisioningModel.PREEMPTIBLE)
-
-            if( batchConfig.spot )
-                instancePolicy.setProvisioningModel(AllocationPolicy.ProvisioningModel.SPOT)
+            final provisioningModel = resolveProvisioningModel(task.config)
+            if( provisioningModel != AllocationPolicy.ProvisioningModel.STANDARD )
+                instancePolicy.setProvisioningModel(provisioningModel)
 
             instancePolicyOrTemplate.setPolicy(instancePolicy)
         }
@@ -553,6 +626,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
     }
 
     protected Job newSubmitRequest(TaskRun task, GoogleBatchLauncherSpec launcher) {
+        // validate the task's hints once per submission
+        validateHints(task.config.getHints())
+
         // container validation
         if( !task.container )
             throw new ProcessUnrecoverableException("Process `${task.lazyName()}` failed because the container image was not specified")
@@ -922,7 +998,10 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         final location = client.location
         final cpus = config.getCpus()
         final memory = config.getMemory() ? config.getMemory().toMega().toInteger() : 1024
-        final spot = batchConfig.spot ?: batchConfig.preemptible
+        // price as spot when the effective provisioning model is SPOT or PREEMPTIBLE
+        final provisioningModel = resolveProvisioningModel(config)
+        final spot = provisioningModel == AllocationPolicy.ProvisioningModel.SPOT \
+                  || provisioningModel == AllocationPolicy.ProvisioningModel.PREEMPTIBLE
         final machineType = config.getMachineType()
         final families = machineType ? machineType.tokenize(',') : List.<String>of()
         final priceModel = spot ? PriceModel.spot : PriceModel.standard

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -27,6 +27,7 @@ import nextflow.exception.ProcessException
 
 import java.nio.file.Path
 
+import com.google.cloud.batch.v1.AllocationPolicy
 import com.google.cloud.batch.v1.GCS
 import com.google.cloud.batch.v1.StatusEvent
 import com.google.cloud.batch.v1.TaskStatus
@@ -1375,6 +1376,91 @@ class GoogleBatchTaskHandlerTest extends Specification {
         // ? replacing the family discriminator digit is treated as a literal character (not a wildcard)
         'e?-standard-4'       | 'local-ssd'          // 'e?' does not match regex ^e2-.*$, so not classified as e2
         'h?-standard-88'      | 'local-ssd'          // 'h?' does not match regex ^h3-.*$, so not classified as h3
+    }
+
+    // provisioning model resolution: scheduling.spotAttempts spot -> on-demand fallback
+
+    private GoogleBatchTaskHandler provisioningHandler(boolean useSpot = false, boolean usePreemptible = false) {
+        def task = Mock(TaskRun) { hashLog >> '1234567890'; getWorkDir() >> Path.of('/work/dir') }
+        def cfg = Mock(BatchConfig) {
+            getSpot() >> useSpot; isSpot() >> useSpot
+            getPreemptible() >> usePreemptible; isPreemptible() >> usePreemptible
+        }
+        def exec = Mock(GoogleBatchExecutor) { getClient() >> Mock(BatchClient); getBatchConfig() >> cfg }
+        return Spy(new GoogleBatchTaskHandler(task, exec))
+    }
+
+    def 'should resolve provisioning model from spotAttempts hint' () {
+        given:
+        def handler = provisioningHandler(GLOBAL_SPOT, GLOBAL_PREEMPT)
+        def config = Mock(TaskConfig) { getHints() >> HINTS; getAttempt() >> ATTEMPT; getSubmitAttempt() >> SUBMIT }
+
+        expect:
+        handler.resolveProvisioningModel(config) == AllocationPolicy.ProvisioningModel.valueOf(EXPECTED)
+
+        where:
+        HINTS                                         | ATTEMPT | SUBMIT | GLOBAL_SPOT | GLOBAL_PREEMPT || EXPECTED
+        ['scheduling.spotAttempts': '2']              | 1       | 1      | false       | false          || 'SPOT'
+        ['scheduling.spotAttempts': '2']              | 2       | 1      | false       | false          || 'SPOT'
+        ['scheduling.spotAttempts': '2']              | 3       | 1      | false       | false          || 'STANDARD'
+        ['scheduling.spotAttempts': '2']              | 1       | 3      | false       | false          || 'STANDARD'   // submitAttempt (stockout) drives the fallback
+        ['scheduling.spotAttempts': '2']              | 1       | 2      | false       | false          || 'SPOT'
+        ['scheduling.spotAttempts': 2]                | 1       | 1      | false       | false          || 'SPOT'
+        ['google-batch/scheduling.spotAttempts': '1'] | 2       | 1      | false       | false          || 'STANDARD'
+        [:]                                           | 1       | 1      | true        | false          || 'SPOT'        // global fallback, unchanged
+        [:]                                           | 1       | 1      | false       | true           || 'PREEMPTIBLE'
+        [:]                                           | 1       | 1      | false       | false          || 'STANDARD'
+        [:]                                           | 1       | 1      | true        | true           || 'SPOT'        // spot wins over preemptible
+    }
+
+    def 'should throw on invalid spotAttempts hint' () {
+        given:
+        def handler = provisioningHandler()
+        def config = Mock(TaskConfig) { getHints() >> HINTS }
+
+        when:
+        handler.resolveSpotAttempts(config)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        HINTS << [
+            ['scheduling.spotAttempts': 'lots'],
+            ['scheduling.spotAttempts': '0'],
+            ['scheduling.spotAttempts': -1],
+        ]
+    }
+
+    def 'should accept known and unprefixed google-batch hints' () {
+        given:
+        def handler = provisioningHandler()
+
+        when:
+        handler.validateHints(HINTS)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        HINTS << [
+            null,
+            [:],
+            ['google-batch/scheduling.spotAttempts': '2'],
+            ['scheduling.spotAttempts': '2'],    // bare (unprefixed) keys are not validated
+            ['other-executor/foo': 'bar'],       // foreign-executor keys are left untouched
+        ]
+    }
+
+    def 'should reject unknown prefixed google-batch hints' () {
+        given:
+        def handler = provisioningHandler()
+
+        when:
+        handler.validateHints(['google-batch/scheduling.unknown': 'x'])
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
 }


### PR DESCRIPTION
Closes the gap that leaves Google Batch unable to express something both other
provisioning-aware executors already support: running a process on Spot and
automatically falling back to on-demand when Spot cannot be obtained or is reclaimed.

### Motivation

Attempt-based Spot to on-demand fallback is expressible on AWS Batch today, and on the
Seqera executor as of #7412. On Google Batch it cannot be expressed at all:

| Executor | Per-process Spot to on-demand? | Mechanism |
| --- | --- | --- |
| AWS Batch | Yes, today | dynamic `queue` closure over `task.attempt`, routing to a Spot vs on-demand compute environment |
| Seqera | Yes | `machineRequirement.provisioning` (`spotFirst`)plus `maxSpotAttempts`, per process via hints; resolved server-side by the Platform scheduler |
| **Google Batch** | **No** | `google.batch.spot`, a single global boolean |

`google.batch.spot` is a config option rather than a process directive, so it cannot be a
closure, cannot vary per process, and cannot vary per attempt. There is no workaround: Cloud
Batch has no queue abstraction to route through, and `google.batch.maxSpotAttempts` only
retries *on Spot* (see below).

This matters most for the case that motivates the feature: `ZONE_RESOURCE_POOL_EXHAUSTED`
while well under quota. A task that cannot obtain a Spot VM currently retries onto Spot
forever, or the run fails; there is no way to say "try Spot twice, then just pay for it."

The docs already recommend exactly this strategy without offering a mechanism. From
`docs/guides/updating-spot-retries.mdx`, Best Practices: *"Consider partial usage of Spot:
some workflows may mix on-demand instances for critical or long tasks and Spot Instances for
shorter, less critical tasks."*

### What this adds

A `scheduling.spotAttempts` hint on the Google Batch executor, taking a positive integer N:
attempts `1..N` request a Spot VM, attempts after `N` request on-demand (`STANDARD`).

```nextflow
process EXAMPLE {
    errorStrategy 'retry'
    maxRetries 3
    hints 'scheduling.spotAttempts': '2'   // Spot for attempts 1 and 2, on-demand from attempt 3
}
```

The attempt count is `max(task.attempt, task.submitAttempt)`, so the fallback is driven by
both failure modes:

* `task.attempt` covers a mid-run Spot **reclaim**
* `task.submitAttempt` covers a failure to **obtain** a Spot VM, in combination with `maxSubmitAwait`

The second is the important one, and the reason a plain attempt counter is not enough: a
stockout is a submission-side failure, not an execution-side one.

### Relationship to `google.batch.maxSpotAttempts`

Similar name, different mechanism. This is called out explicitly in the docs:

* `google.batch.maxSpotAttempts` sets Cloud Batch's *internal* retry count after a Spot
  reclaim. Every retry requests Spot again. It is global to the run.
* `scheduling.spotAttempts` changes the *provisioning model* across Nextflow-level attempts,
  per process.

They compose: Batch-internal Spot retries first, then Nextflow-level escalation to on-demand.

### Relationship to #7343

This composes with #7343 (@reece-maticebio) rather than duplicating it. That PR sets
provisioning **statically** per process and explicitly scoped `spotFirst`-style fallback out;
this adds the **attempt-aware** dimension. If #7343 lands first, this can be rebased to read
its resolved provisioning model as the starting rung instead of `google.batch.spot`.

Note that the Seqera executor resolves this in the Platform scheduler rather than in Nextflow, so there is no existing in-tree implementation of attempt-based provisioning escalation to build on.

One longer-term unification worth discussing: the shared Nextflow idiom here is a closure over
`task.attempt`, which is how AWS Batch users already do this via `queue`. Making #7343's
`scheduling.provisioningModel` accept a dynamic value would subsume both, with an attempt
count as ergonomic shorthand. Out of scope here, happy to follow up.

### Implementation notes

* Provisioning is resolved once in `resolveProvisioningModel()` and reused by both the
  instance policy and machine-type pricing, so `PriceModel` stays consistent with what is
  actually requested.
* When the hint is unset, `google.batch.spot` and `preemptible` behaviour is unchanged.
* Non-positive and non-integer values are rejected with a clear message.
* Under an instance template the hint has no effect and warns, matching how the existing
  `spot` and `preemptible` options behave there.
* Unknown `google-batch/`-prefixed hints are rejected, per the hints ADR.
* Both the bare and `google-batch/`-prefixed forms are accepted; prefixed wins.

### Tests

`GoogleBatchTaskHandlerTest`, 128 tests pass. New coverage: the attempt/submitAttempt
escalation matrix, both hint forms, numeric and string values, invalid values, the unchanged
global-config fallback path, and prefixed-hint validation.

### Note for reviewers

The `google-batch/` hint validation scaffolding (`HINT_PREFIX`, `KNOWN_HINTS`,
`validateHints()`) also appears in #7395. The
overlap is about 30 lines and mechanical.

Closes #7396
