### PR TITLE
Use the wiremock self-contained distribution in nf-tower

### DIFF
--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -70,8 +70,10 @@ dependencies {
     testImplementation "org.apache.groovy:groovy:4.0.33"
     testImplementation "org.apache.groovy:groovy-nio:4.0.33"
     testImplementation "org.apache.groovy:groovy-json:4.0.33"
-    // wiremock required by TowerFusionEnvTest
-    testImplementation "org.wiremock:wiremock:3.13.2"
+    // wiremock required by TowerFusionEnvTest; the self-contained distribution shades its
+    // own dependencies and therefore keeps jetty, handlebars and httpcomponents off the
+    // test classpath (same approach already used by nextflow, nf-commons and nf-httpfs)
+    testImplementation ('org.wiremock:wiremock-standalone:3.13.2') { exclude module: 'groovy-all' }
     // Address security vulnerabilities CVE-2022-45688 and CVE-2023-5072
     testImplementation 'org.json:json:20240303'
 }


### PR DESCRIPTION
nf-tower was the last module still depending on the plain `org.wiremock:wiremock`
artifact, which leaks its own dependency tree onto the test classpath: jetty
11.0.26, handlebars 4.3.1 and an old httpclient5/httpcore5 pair. Switching to
`wiremock-standalone`, already used by nextflow, nf-commons and nf-httpfs, shades
those away. WireMock's own classes keep the same package names, so the test code
is unchanged.

Addresses the following advisories:

- jetty-security: GHSA-2fvj-hgj9-j2gr
- jetty-server: GHSA-7p3p-8qv8-m2vh
- jetty-http: GHSA-wjpw-4j6x-6rwh, GHSA-qh8g-58pp-2wxh
- handlebars: GHSA-r4gv-qr8j-p3pg

Signed-off-by: Paolo Di Tommaso <paolo.ditommaso@gmail.com>
Assisted-by: Claude Opus 5 (1M context)
Signed-off-by: Paolo Di Tommaso <paolo.ditommaso@gmail.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>