### PR TITLE
Stop fabricating a memory request for the Seqera executor

### DIFF
--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -245,11 +245,21 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
      * whole run of unspecified tasks looked deliberately sized. Omitting the field instead lets the
      * scheduler resolve and surface its default (seqeralabs/sched#1086).
      * <p>
-     * A non-positive figure gets the same treatment for the same reason — it carries no usable
-     * intent — but it is worth telling the user about, because unlike an absent directive it is
-     * almost always a config accident: a {@code memory} closure that evaluated to zero, or a
-     * {@code params.max_memory} that was never set. Warned once per process rather than once per
-     * task, since the mistake belongs to the process definition.
+     * A zero-valued directive is omitted for the same reason, and warned about once per process,
+     * since unlike an absent directive it is a config accident rather than a choice. Exactly zero
+     * is the only invalid figure reachable here: {@code MemoryUnit(long)} asserts a non-negative
+     * value, and {@code TaskConfig.getMemory0} maps a falsy directive to null via
+     * {@code MemoryUnit.asBoolean}, so what survives is the string form — {@code memory '0 GB'} —
+     * whose string is truthy.
+     * <p>
+     * The conversion below can still yield zero for a <em>positive</em> sub-MiB directive: the
+     * size-derived idiom nf-core uses for index builds, {@code memory { 6.B * fasta.size() }} in
+     * {@code nf-core/bwa/index}, falls under 1 MiB for any reference below ~170 KB — which is what
+     * a test or CI profile supplies, and is why {@code BWAMEM1_INDEX} submits a zero today. That
+     * zero is forwarded deliberately rather than caught here. The scheduler already resolves any
+     * non-positive request to its default and reports having done so; restating that rule
+     * client-side would split one normalisation across two codebases that then have to be kept in
+     * agreement, which is the failure this whole change is undoing.
      *
      * @return the requested memory in MiB, or null to leave the axis unspecified
      */
@@ -258,7 +268,7 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
         if( memory == null )
             return null
         if( memory.toBytes() <= 0 ) {
-            log.warn1("Process `${task.processor?.name ?: task.lazyName()}` declares a non-positive `memory` directive (${memory}) -- ignoring it; the scheduler will apply its own default", firstOnly: true)
+            log.warn1("Process `${task.processor.name}` declares a zero `memory` directive -- ignoring it; the scheduler will apply its own default", firstOnly: true)
             return null
         }
         return (int) (memory.toBytes() / (1024 * 1024))

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -101,11 +101,12 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
     @Override
     void submit() {
         executor.ensureRunCreated()
-        int cpuShares = (task.config.getCpus() ?: 1) * 1024
-        int memoryMiB = task.config.getMemory() ? (int) (task.config.getMemory().toBytes() / (1024 * 1024)) : 1024
+        // cpus needs no unspecified handling: TaskConfig.getCpus() already guarantees at least 1
+        // and throws on a negative, so there is never an absent or non-positive value to forward.
+        // memory has no such guarantee — see memoryMiB().
         final resourceReq = new ResourceRequirement()
-            .cpuShares(cpuShares)
-            .memoryMiB(memoryMiB)
+            .cpuShares(task.config.getCpus() * 1024)
+            .memoryMiB(memoryMiB())
         // add accelerator settings if defined
         final accelerator = task.config.getAccelerator()
         if( accelerator ) {
@@ -232,6 +233,35 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
         log.debug "[SEQERA] Batch submission failed for task ${task.lazyName()}: ${cause.message}"
         task.error = cause
         this.status = TaskStatus.COMPLETED
+    }
+
+    /**
+     * The memory to request, in MiB, or {@code null} when the process declares none.
+     * <p>
+     * The {@code memory} directive is optional, and leaving it out is a legitimate way of saying
+     * "I have no opinion". Substituting a figure here fabricated an opinion the user never
+     * expressed: the scheduler received a concrete request indistinguishable from a declared one,
+     * so it could neither apply its own default nor report that nothing had been asked for, and a
+     * whole run of unspecified tasks looked deliberately sized. Omitting the field instead lets the
+     * scheduler resolve and surface its default (seqeralabs/sched#1086).
+     * <p>
+     * A non-positive figure gets the same treatment for the same reason — it carries no usable
+     * intent — but it is worth telling the user about, because unlike an absent directive it is
+     * almost always a config accident: a {@code memory} closure that evaluated to zero, or a
+     * {@code params.max_memory} that was never set. Warned once per process rather than once per
+     * task, since the mistake belongs to the process definition.
+     *
+     * @return the requested memory in MiB, or null to leave the axis unspecified
+     */
+    protected Integer memoryMiB() {
+        final memory = task.config.getMemory()
+        if( memory == null )
+            return null
+        if( memory.toBytes() <= 0 ) {
+            log.warn1("Process `${task.processor?.name ?: task.lazyName()}` declares a non-positive `memory` directive (${memory}) -- ignoring it; the scheduler will apply its own default", firstOnly: true)
+            return null
+        }
+        return (int) (memory.toBytes() / (1024 * 1024))
     }
 
     /**

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -873,6 +873,27 @@ class SeqeraTaskHandlerTest extends Specification {
         handler.getGrantedTime() == Duration.of('6h').toMillis()
     }
 
+    def 'should request memory only when the directive declares a usable figure: #scenario'() {
+        given:
+        def taskConfig = Mock(TaskConfig) { getMemory() >> memory }
+        def taskRun = Mock(TaskRun) {
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getConfig() >> taskConfig
+            lazyName() >> 'test_task'
+        }
+        def executor = Mock(SeqeraExecutor) { getClient() >> Mock(SchedClient); getRunResourceLabels() >> [:] }
+        def handler = new SeqeraTaskHandler(taskRun, executor)
+
+        expect: 'an unusable figure leaves the axis unset so the scheduler applies and reports its own default'
+        handler.memoryMiB() == expected
+
+        where:
+        scenario   | memory                | expected
+        'declared' | MemoryUnit.of('2 GB') | 2048
+        'absent'   | null                  | null
+        'zero'     | MemoryUnit.of(0)      | null
+    }
+
     def 'should build resource limit from task config'() {
         given:
         def taskConfig = Mock(TaskConfig) {

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -879,19 +879,71 @@ class SeqeraTaskHandlerTest extends Specification {
         def taskRun = Mock(TaskRun) {
             getWorkDir() >> Paths.get('/work/ab/cd1234')
             getConfig() >> taskConfig
-            lazyName() >> 'test_task'
+            getProcessor() >> Mock(TaskProcessor) { getName() >> 'test_process' }
         }
         def executor = Mock(SeqeraExecutor) { getClient() >> Mock(SchedClient); getRunResourceLabels() >> [:] }
         def handler = new SeqeraTaskHandler(taskRun, executor)
 
-        expect: 'an unusable figure leaves the axis unset so the scheduler applies and reports its own default'
+        expect: 'an unusable figure leaves the axis unset, so the scheduler applies and reports its own default'
         handler.memoryMiB() == expected
 
         where:
-        scenario   | memory                | expected
-        'declared' | MemoryUnit.of('2 GB') | 2048
-        'absent'   | null                  | null
-        'zero'     | MemoryUnit.of(0)      | null
+        scenario                            | memory                     | expected
+        'declared'                          | MemoryUnit.of('2 GB')      | 2048
+        'absent'                            | null                       | null
+        'exactly 1 MiB'                     | MemoryUnit.of('1 MB')      | 1
+        // Exactly zero is the only invalid figure that can reach here: MemoryUnit(long) asserts
+        // non-negative, and TaskConfig maps a falsy directive to null, so only the string form
+        // survives -- its *string* is truthy
+        'string-form zero, the only real 0' | MemoryUnit.of('0 GB')      | null
+        // A positive sub-MiB directive truncates to 0 and is forwarded on purpose: normalising a
+        // non-positive request is the scheduler's job, and restating it here would split one rule
+        // across two codebases. nf-core/bwa/index computes `6.B * fasta.size()`, which lands here
+        // for the small reference a test profile supplies
+        'positive but sub-MiB'              | MemoryUnit.of(6) * 100_000 | 0
+    }
+
+    def 'submit should leave memoryMiB unset when the process declares no memory'() {
+        given:
+        Task capturedTask = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> capturedTask = args[1] as Task }
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) { getMachineRequirement() >> null }
+            getRunResourceLabels() >> [:]
+        }
+        def taskConfig = Mock(TaskConfig) {
+            getCpus() >> 2
+            getMemory() >> null
+            getAccelerator() >> null
+            getDisk() >> null
+        }
+        def taskRun = Mock(TaskRun) {
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getConfig() >> taskConfig
+            getContainer() >> 'ubuntu:latest'
+            getContainerPlatform() >> null
+            lazyName() >> 'test_task'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromString('abcd1234')
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionSubmitCli() >> ['bash', '-c', 'echo hello']
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) { fusionEnv() >> [:] }
+        }
+
+        when:
+        handler.submit()
+
+        then: 'the axis reaches the scheduler absent, not as a fabricated figure'
+        capturedTask != null
+        capturedTask.getResourceRequirement().memoryMiB == null
+        capturedTask.getResourceRequirement().cpuShares == 2048
     }
 
     def 'should build resource limit from task config'() {


### PR DESCRIPTION
## Summary

The `memory` directive is optional, but the Seqera executor substituted `1024 MiB` whenever a process left it out — unchanged since the executor was introduced:

```groovy
int memoryMiB = task.config.getMemory() ? (int) (task.config.getMemory().toBytes() / (1024 * 1024)) : 1024
```

The scheduler therefore received a figure indistinguishable from a declared request, so it could neither apply its own default nor report that nothing had been asked for — and a run of unspecified tasks looked deliberately sized at 1 GiB.

## What changes

- **Absent directive** → omit `memoryMiB`, so the scheduler resolves and surfaces its own default.
- **Zero-valued directive** → omit too, with `log.warn1(…, firstOnly: true)` once per process, since unlike an absent directive it is an accident rather than a choice. Exactly zero is the only invalid figure reachable: `MemoryUnit(long)` asserts non-negative and `TaskConfig.getMemory0()` maps a falsy directive to `null`, so only the string form (`memory '0 GB'`) survives.
- **cpus untouched.** `TaskConfig.getCpus0()` already guarantees at least 1 and throws on a negative, so there is nothing to handle. The `?: 1` fallback it was wrapped in could never fire and only implied otherwise, so it is gone.

## A positive sub-MiB directive is forwarded on purpose

The conversion can still yield zero for a *positive* value under 1 MiB, and that is the case seen in production: `nf-core/bwa/index` — behind `NFCORE_SAREK:PREPARE_GENOME:BWAMEM1_INDEX` — declares `memory { 6.B * fasta.size() }`, which falls under 1 MiB for any reference below ~170 KB.

That zero is deliberately not caught here. Normalising a non-positive request is the scheduler's job, it already does it, and it reports the substituted default. Restating the rule client-side would split one normalisation across two codebases that then have to be kept in agreement — the failure this change is undoing. Recorded in the javadoc and pinned by a test.

## Ordering

Requires **seqeralabs/sched#1094** (closes seqeralabs/sched#1086), which resolves an unspecified request to a single default at admission and surfaces it on the task detail page. It is also what normalises the forwarded zero above.

**Must land after it** — the scheduler has to handle an absent axis before the plugin starts sending one. The default there is `1024 MiB`, deliberately the same figure this code substitutes today, so once both are in, behaviour is unchanged for existing pipelines; the scheduler simply knows the number is its own and says so.

## Test evidence

`where:`-driven cases on `memoryMiB()` (declared / absent / exactly 1 MiB / string-form zero / positive sub-MiB), plus a `submit()`-level test asserting an absent directive reaches the scheduler as an unset axis.

```
./gradlew :plugins:nf-seqera:test --tests '*SeqeraTaskHandlerTest*'   BUILD SUCCESSFUL
```

`SeqeraTaskHandlerTest` — 65 tests, 0 failures. `log.warn1(…, firstOnly: true)` is new to this file; the precedent is elsewhere (`FusionEnvProvider`, `TowerObserver`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)