### PR TITLE
Implement resumable staging of foreign files from HTTP sources

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.file
 
+import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
@@ -323,16 +324,28 @@ class FilePorter {
         protected Path stageForeignFile(Path filePath, Path stagePath) {
 
             int count = 0
+            boolean resume = false
             while( true ) {
                 try {
-                    return stageForeignFile0(filePath, stagePath)
+                    // only the first attempt may short-circuit on an existing (cached) target;
+                    // retries must force a download so that a partial file can be resumed
+                    return count == 0
+                            ? stageForeignFile0(filePath, stagePath)
+                            : copyForeignFile(filePath, stagePath, resume)
                 }
                 catch( IOException e ) {
-                    // remove the target file that could be have partially downloaded
-                    cleanup(stagePath)
                     // check if a stage/download retry is allowed
-                    if( count++ < maxRetries && recoverableError(e) && !Thread.currentThread().isInterrupted() ) {
-                        def message = "Unable to stage foreign file: ${filePath.toUriString()} (try ${count} of ${maxRetries}) -- Cause: $e.message"
+                    final retry = count < maxRetries && !Thread.currentThread().isInterrupted()
+                    // resume a partial download (HTTP/HTTPS only), otherwise discard the
+                    // partially downloaded file and start again from the beginning
+                    resume = retry && canResumeDownload(filePath, stagePath)
+                    if( !resume )
+                        cleanup(stagePath)
+                    if( retry ) {
+                        count++
+                        def message = resume
+                            ? "Unable to stage foreign file: ${filePath.toUriString()} (resuming, attempt ${count} of ${maxRetries}) -- Cause: $e.message"
+                            : "Unable to stage foreign file: ${filePath.toUriString()} (try ${count} of ${maxRetries}) -- Cause: $e.message"
                         log.isDebugEnabled() ? log.warn(message, e) : log.warn(message)
 
                         sleep (10 + RND.nextInt(300))
@@ -344,13 +357,15 @@ class FilePorter {
             }
         }
 
-        private boolean recoverableError(IOException e){
-            final result =
-                e !instanceof NoSuchFileException
-                && (e instanceof SocketTimeoutException || e !instanceof InterruptedIOException)
-                && e !instanceof SocketException
-            log.debug "Stage foreign file exception: recoverable=$result; type=${e.class.name}; message=${e.message}"
-            return result
+        @PackageScope
+        boolean canResumeDownload(Path source, Path target) {
+            // a resume only makes sense for a partially downloaded HTTP(S) file written to a local
+            // target, where APPEND is supported
+            if( !Files.exists(target) || Files.size(target) == 0 )
+                return false
+            if( target.fileSystem != FileSystems.getDefault() )
+                return false
+            return source.toUri().scheme in ['http', 'https']
         }
 
         private String fmtError(Path filePath, Exception e) {
@@ -367,10 +382,17 @@ class FilePorter {
                 log.debug "Local cache found for foreign file ${source.toUriString()} at ${target.toUriString()}"
                 return target
             }
+            return copyForeignFile(source, target, false)
+        }
+
+        @PackageScope
+        Path copyForeignFile(Path source, Path target, boolean resume) {
             log.debug "Copying foreign file ${source.toUriString()} to work dir: ${target.toUriString()}"
             if( debugDelay )
                 sleep ( new Random().nextInt(debugDelay) )
-            return FileHelper.copyPath(source, target)
+            return resume
+                    ? FileHelper.copyPath(source, target, HttpCopyOption.RESUME)
+                    : FileHelper.copyPath(source, target)
         }
 
         synchronized String getMessageAndClear() {

--- a/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
@@ -335,7 +335,7 @@ class FilePorter {
                 }
                 catch( IOException e ) {
                     // check if a stage/download retry is allowed
-                    final retry = count < maxRetries && !Thread.currentThread().isInterrupted()
+                    final retry = count < maxRetries && recoverableError(e) && !Thread.currentThread().isInterrupted()
                     // resume a partial download (HTTP/HTTPS only), otherwise discard the
                     // partially downloaded file and start again from the beginning
                     resume = retry && canResumeDownload(filePath, stagePath)
@@ -352,6 +352,9 @@ class FilePorter {
                         continue
                     }
 
+                    final targetProvider = stagePath.fileSystem.provider()
+                    if( targetProvider instanceof ResumableFileSystem )
+                        abortResumableUpload((ResumableFileSystem)targetProvider, stagePath)
                     throw new ProcessStageException(fmtError(filePath,e), e)
                 }
             }
@@ -359,13 +362,39 @@ class FilePorter {
 
         @PackageScope
         boolean canResumeDownload(Path source, Path target) {
-            // a resume only makes sense for a partially downloaded HTTP(S) file written to a local
-            // target, where APPEND is supported
-            if( !Files.exists(target) || Files.size(target) == 0 )
+            if( source.toUri().scheme !in ['http', 'https'] )
                 return false
-            if( target.fileSystem != FileSystems.getDefault() )
+            // local target: resume a partial file
+            if( target.fileSystem == FileSystems.getDefault() )
+                return Files.exists(target) && Files.size(target) > 0
+            // cloud target: resume an in-progress upload
+            final provider = target.fileSystem.provider()
+            if( provider !instanceof ResumableFileSystem )
                 return false
-            return source.toUri().scheme in ['http', 'https']
+            try {
+                return ((ResumableFileSystem)provider).resumeUpload(target) != null
+            }
+            catch( IOException e ) {
+                log.debug "Unable to determine resume state for ${target.toUriString()}: ${e.message}"
+                return false
+            }
+        }
+
+        private boolean recoverableError(IOException e) {
+            return e !instanceof NoSuchFileException
+                && (e instanceof SocketTimeoutException || e !instanceof InterruptedIOException);
+        }
+
+        @PackageScope
+        void abortResumableUpload(ResumableFileSystem provider, Path target) {
+            try {
+                final upload = provider.resumeUpload(target)
+                if( upload != null )
+                    upload.abort()
+            }
+            catch( IOException e ) {
+                log.debug "Unable to abort in-progress upload for ${target.toUriString()}: ${e.message}"
+            }
         }
 
         private String fmtError(Path filePath, Exception e) {

--- a/modules/nextflow/src/test/groovy/nextflow/file/FilePorterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/file/FilePorterTest.groovy
@@ -18,6 +18,7 @@ package nextflow.file
 
 import java.nio.file.FileSystems
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.util.concurrent.Semaphore
 
@@ -158,6 +159,50 @@ class FilePorterTest extends Specification {
     }
 
 
+    def 'should not retry a missing source file' () {
+        given:
+        def source = 'http://localhost:1234/file.txt' as Path
+        def folder = Files.createTempDirectory('test')
+        def target = folder.resolve('file.txt')
+
+        and:
+        def transfer = new NoSuchFileTransfer(source, target, 3)
+
+        when:
+        transfer.stageForeignFile(source, target)
+
+        then:
+        thrown(ProcessStageException)
+        transfer.attempts == 1
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    def 'should abort an in-progress upload on terminal failure' () {
+        given:
+        def provider = Mock(ResumableFileSystem)
+        def upload = Mock(ResumableUpload)
+        def source = 'http://localhost:1234/file.txt' as Path
+        def folder = Files.createTempDirectory('test')
+        def target = folder.resolve('file.txt')
+
+        and:
+        def transfer = new FilePorter.FileTransfer(source, target, 3, Mock(Semaphore))
+
+        when:
+        transfer.abortResumableUpload(provider, target)
+
+        then:
+        1 * provider.resumeUpload(target) >> upload
+        1 * upload.abort()
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
     def 'should resume a partial download via the copyPath seam' () {
 
         given:
@@ -269,6 +314,21 @@ class FilePorterTest extends Specification {
             }
             target.text = 'complete'
             return target
+        }
+    }
+
+
+    static class NoSuchFileTransfer extends FilePorter.FileTransfer {
+        int attempts = 0
+
+        NoSuchFileTransfer(Path source, Path target, int maxRetries) {
+            super(source, target, maxRetries, new Semaphore(100))
+        }
+
+        @Override
+        Path copyForeignFile(Path source, Path target, boolean resume) {
+            attempts++
+            throw new NoSuchFileException(source.toString())
         }
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/file/FilePorterTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/file/FilePorterTest.groovy
@@ -21,18 +21,25 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.Semaphore
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.exception.ProcessStageException
+import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Specification
 import test.TestHelper
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
 class FilePorterTest extends Specification {
+
+    @Rule
+    WireMockRule wireMockRule = new WireMockRule(0)
 
 
     def 'should get the max retries value' () {
@@ -49,6 +56,220 @@ class FilePorterTest extends Specification {
         then:
         porter.maxRetries == 88
 
+    }
+
+
+    def 'should determine whether a download can resume' () {
+
+        given:
+        def httpSource = 'http://localhost:1234/file.txt' as Path
+        def ftpSource = 'ftp://localhost/file.txt' as Path
+        def localSource = TestHelper.createInMemTempFile('local.txt', 'hello')
+
+        and:
+        def folder = Files.createTempDirectory('test')
+        def partial = folder.resolve('partial.txt'); partial.text = 'partial'
+        def empty = folder.resolve('empty.txt'); empty.text = ''
+        def missing = folder.resolve('missing.txt')
+
+        and:
+        def porter = new FilePorter.FileTransfer(httpSource, partial, 3, Mock(Semaphore))
+
+        expect:
+        // http source with a partial file -> resumable
+        porter.canResumeDownload(httpSource, partial)
+        // no partial file yet -> not resumable
+        !porter.canResumeDownload(httpSource, missing)
+        // empty target -> not resumable
+        !porter.canResumeDownload(httpSource, empty)
+        // ftp source -> not resumable (no byte-range resume)
+        !porter.canResumeDownload(ftpSource, partial)
+        // local source -> not resumable
+        !porter.canResumeDownload(localSource, partial)
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    def 'should keep a partial file when resuming a retry' () {
+
+        given:
+        def source = 'http://localhost:1234/file.txt' as Path
+        def folder = Files.createTempDirectory('test')
+        def target = folder.resolve('file.txt')
+
+        and:
+        def transfer = new RetryTransfer(source, target, 3)
+
+        when:
+        transfer.stageForeignFile(source, target)
+
+        then:
+        !transfer.cleaned
+        target.text == 'complete'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    def 'should discard a partial file when retries are exhausted' () {
+
+        given:
+        def source = 'http://localhost:1234/file.txt' as Path
+        def folder = Files.createTempDirectory('test')
+        def target = folder.resolve('file.txt')
+
+        and:
+        def transfer = new AlwaysFailTransfer(source, target, 3)
+
+        when:
+        transfer.stageForeignFile(source, target)
+
+        then:
+        thrown(ProcessStageException)
+        transfer.cleaned
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    def 'should retry when a socket exception interrupts the download' () {
+
+        given:
+        def source = 'http://localhost:1234/file.txt' as Path
+        def folder = Files.createTempDirectory('test')
+        def target = folder.resolve('file.txt')
+
+        and:
+        def transfer = new SocketResetTransfer(source, target, 3)
+
+        when:
+        transfer.stageForeignFile(source, target)
+
+        then:
+        !transfer.cleaned
+        target.text == 'complete'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    def 'should resume a partial download via the copyPath seam' () {
+
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'   // 20 bytes
+        def REMAINING = 'KLMNOPQRST'        // remaining 10 bytes
+
+        // first (non-ranged) request returns a truncated body with a full Content-Length
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody('ABCDEFGHIJ')))    // only 10 bytes -> truncated download
+
+        // ranged request returns the remaining bytes
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .atPriority(1)
+            .withHeader('Range', equalTo('bytes=10-'))
+            .willReturn(aResponse()
+                .withStatus(206)
+                .withHeader('Content-Range', 'bytes 10-19/20')
+                .withHeader('Content-Length', '10')
+                .withBody(REMAINING)))
+
+        def source = "${localhost}/file.txt" as Path
+        def folder = Files.createTempDirectory('test')
+        def target = folder.resolve('file.txt')
+
+        and:
+        def transfer = new FilePorter.FileTransfer(source, target, 3, new Semaphore(100))
+
+        when:
+        transfer.stageForeignFile(source, target)
+
+        then:
+        target.text == FULL
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+
+    static class RetryTransfer extends FilePorter.FileTransfer {
+        int attempts = 0
+        boolean cleaned = false
+
+        RetryTransfer(Path source, Path target, int maxRetries) {
+            super(source, target, maxRetries, new Semaphore(100))
+        }
+
+        @Override
+        protected void cleanup(Path path) {
+            cleaned = true
+            super.cleanup(path)
+        }
+
+        @Override
+        Path copyForeignFile(Path source, Path target, boolean resume) {
+            if( attempts++ == 0 ) {
+                target.text = 'partial'
+                throw new IOException('boom')
+            }
+            target.text = 'complete'
+            return target
+        }
+    }
+
+
+    static class AlwaysFailTransfer extends FilePorter.FileTransfer {
+        boolean cleaned = false
+
+        AlwaysFailTransfer(Path source, Path target, int maxRetries) {
+            super(source, target, maxRetries, new Semaphore(100))
+        }
+
+        @Override
+        protected void cleanup(Path path) {
+            cleaned = true
+            super.cleanup(path)
+        }
+
+        @Override
+        Path copyForeignFile(Path source, Path target, boolean resume) {
+            target.text = 'partial'
+            throw new IOException('boom')
+        }
+    }
+
+
+    static class SocketResetTransfer extends FilePorter.FileTransfer {
+        int attempts = 0
+        boolean cleaned = false
+
+        SocketResetTransfer(Path source, Path target, int maxRetries) {
+            super(source, target, maxRetries, new Semaphore(100))
+        }
+
+        @Override
+        protected void cleanup(Path path) {
+            cleaned = true
+            super.cleanup(path)
+        }
+
+        @Override
+        Path copyForeignFile(Path source, Path target, boolean resume) {
+            if( attempts++ == 0 ) {
+                target.text = 'partial'
+                throw new SocketException('Connection reset')
+            }
+            target.text = 'complete'
+            return target
+        }
     }
 
 

--- a/modules/nf-commons/src/main/nextflow/file/HttpCopyOption.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/HttpCopyOption.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.file
+
+import java.nio.file.CopyOption
+
+/**
+ * Copy option requesting a byte-range resume of a partially downloaded target.
+ */
+enum HttpCopyOption implements CopyOption {
+
+    RESUME
+
+}

--- a/modules/nf-commons/src/main/nextflow/file/ResumableFileSystem.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/ResumableFileSystem.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.file
+
+import java.io.IOException
+import java.nio.file.CopyOption
+import java.nio.file.Path
+
+/**
+ * A file system provider whose targets can resume an upload after an interruption.
+ *
+ * Implemented by providers that support resumable writes (e.g. S3 multipart upload). Used by a
+ * range-capable source provider to continue staging into a partially-uploaded target.
+ */
+interface ResumableFileSystem {
+
+    /**
+     * Start a fresh upload of {@code target}, returning a handle that can write and complete it.
+     */
+    ResumableUpload newUpload(Path target, CopyOption... options) throws IOException
+
+    /**
+     * Recover an in-progress upload of {@code target}, returning a handle that can continue it,
+     * or {@code null} when there is no resumable in-progress upload.
+     */
+    ResumableUpload resumeUpload(Path target) throws IOException
+
+}

--- a/modules/nf-commons/src/main/nextflow/file/ResumableUpload.groovy
+++ b/modules/nf-commons/src/main/nextflow/file/ResumableUpload.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.file
+
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * A handle to an in-progress resumable upload, produced by {@link ResumableFileSystem#resumeUpload}.
+ */
+interface ResumableUpload {
+
+    /**
+     * @return The number of bytes already committed to the upload.
+     */
+    long committedBytes()
+
+    /**
+     * @return An output stream that writes the remaining bytes of the upload.
+     */
+    OutputStream outputStream()
+
+    /**
+     * Finish the upload, making the target object visible.
+     */
+    void complete() throws IOException
+
+    /**
+     * Abandon the upload, leaving it in-progress so a later attempt can resume it.
+     */
+    void abandon() throws IOException
+
+    /**
+     * Abort the upload, discarding the in-progress upload entirely.
+     */
+    void abort() throws IOException
+
+}

--- a/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
@@ -17,6 +17,9 @@
 package nextflow.file.http
 
 import nextflow.file.CopyMoveHelper
+import nextflow.file.CopyOptions
+import nextflow.file.FileSystemTransferAware
+import nextflow.file.HttpCopyOption
 
 import static nextflow.file.http.XFileSystemConfig.*
 
@@ -26,6 +29,7 @@ import java.nio.file.AccessDeniedException
 import java.nio.file.AccessMode
 import java.nio.file.CopyOption
 import java.nio.file.DirectoryStream
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.FileStore
 import java.nio.file.FileSystem
 import java.nio.file.FileSystemNotFoundException
@@ -60,7 +64,7 @@ import sun.net.www.protocol.ftp.FtpURLConnection
 @Slf4j
 @PackageScope
 @CompileStatic
-abstract class XFileSystemProvider extends FileSystemProvider {
+abstract class XFileSystemProvider extends FileSystemProvider implements FileSystemTransferAware {
 
     private Map<URI, FileSystem> fileSystemMap = new LinkedHashMap<>(20)
 
@@ -178,18 +182,24 @@ abstract class XFileSystemProvider extends FileSystemProvider {
     }
 
     protected URLConnection toConnection(Path path) {
-        final url = path.toUri().toURL()
-        log.trace "File remote URL: $url"
-        return toConnection0(url, 0)
+        toConnection(path, 0)
     }
 
-    protected URLConnection toConnection0(URL url, int attempt) {
+    protected URLConnection toConnection(Path path, long offset) {
+        final url = path.toUri().toURL()
+        log.trace "File remote URL: $url"
+        return toConnection0(url, 0, offset)
+    }
+
+    protected URLConnection toConnection0(URL url, int attempt, long offset) {
         final conn = url.openConnection()
         conn.setRequestProperty("User-Agent", 'Nextflow/httpfs')
         if( conn instanceof HttpURLConnection ) {
             // by default HttpURLConnection does redirect only within the same host
             // disable the built-in to implement custom redirection logic (see below)
             conn.setInstanceFollowRedirects(false)
+            if( offset > 0 )
+                conn.setRequestProperty("Range", "bytes=$offset-")
         }
         if( url.userInfo ) {
             conn.setRequestProperty("Authorization", auth(url.userInfo));
@@ -204,17 +214,17 @@ abstract class XFileSystemProvider extends FileSystemProvider {
             final newUrl = new URI(absLocation(location,url)).toURL()
             if( url.protocol=='https' && newUrl.protocol=='http' )
                 throw new IOException("Refuse to follow redirection from HTTPS to HTTP (unsafe) URL - origin: $url - target: $newUrl")
-            return toConnection0(newUrl, attempt+1)
+            return toConnection0(newUrl, attempt+1, offset)
         }
         else if( conn instanceof HttpURLConnection && conn.getResponseCode() in config().retryCodes() && attempt < config().maxAttempts() ) {
             final delay = (Math.pow(config().backOffBase(), attempt) as long) * config().backOffDelay()
             log.debug "Got HTTP error=${conn.getResponseCode()} waiting for ${delay}ms (attempt=${attempt+1})"
             Thread.sleep(delay)
-            return toConnection0(url, attempt+1)
+            return toConnection0(url, attempt+1, offset)
         }
         else if( conn instanceof HttpURLConnection && conn.getResponseCode()==401 && attempt==0 ) {
             if( XAuthRegistry.instance.refreshToken(conn) ) {
-                return toConnection0(url, attempt+1)
+                return toConnection0(url, attempt+1, offset)
             }
         }
         return conn
@@ -421,6 +431,123 @@ abstract class XFileSystemProvider extends FileSystemProvider {
     @Override
     void move(Path source, Path target, CopyOption... options) throws IOException {
         throw new UnsupportedOperationException("Move not supported by ${getScheme().toUpperCase()} file system provider")
+    }
+
+    @Override
+    boolean canDownload(Path source, Path target) {
+        // byte-range resume is only supported for HTTP(S); FTP keeps the default copy path
+        return getScheme() in ['http','https']
+    }
+
+    @Override
+    boolean canUpload(Path source, Path target) {
+        return false
+    }
+
+    @Override
+    void download(Path source, Path target, CopyOption... options) throws IOException {
+        if( source.class != XPath )
+            throw new ProviderMismatchException()
+
+        if( options.contains(HttpCopyOption.RESUME) ) {
+            // resume a partially downloaded file, falling back to a full download
+            final long offset = Files.exists(target) ? Files.size(target) : 0
+            if( offset > 0 && resumeDownload(source, target, offset) )
+                return
+            downloadFromStart(source, target)
+        }
+        else {
+            // plain copy honouring the standard copy options; the target is only overwritten inside
+            // downloadFromStart after the source has responded successfully
+            final CopyOptions opts = CopyOptions.parse(options)
+            if( Files.exists(target) && !opts.replaceExisting() )
+                throw new FileAlreadyExistsException(target.toString())
+            downloadFromStart(source, target)
+        }
+    }
+
+    /**
+     * Append the remaining bytes of {@code source} to the partial file at {@code target}.
+     *
+     * @return {@code true} when the server honoured the exact requested range and the remaining
+     *         bytes were appended, {@code false} when the server ignored or rejected the range
+     *         and a full re-download is required
+     */
+    private boolean resumeDownload(Path source, Path target, long offset) throws IOException {
+        final conn = toConnection(source, offset)
+        if( conn !instanceof HttpURLConnection )
+            return false
+        try {
+            final int code = ((HttpURLConnection)conn).getResponseCode()
+            if( code != 206 )
+                return false
+            // only accept a resume when the server honoured the exact requested range through EOF
+            final long[] range = parseContentRange(conn)
+            if( range == null || range[0] != offset || range[1] + 1 != range[2] )
+                return false
+            final long remaining = range[2] - offset
+            try( InputStream in = checkedInputStream(conn, remaining) ) {
+                try( OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND) ) {
+                    copyStream(in, out)
+                }
+            }
+            return true
+        }
+        finally {
+            ((HttpURLConnection)conn).disconnect()
+        }
+    }
+
+    private void downloadFromStart(Path source, Path target) throws IOException {
+        final conn = toConnection(source)
+        if( conn !instanceof HttpURLConnection )
+            throw new IOException("Download not supported for non-HTTP source: ${FilesEx.toUriString(source)}")
+        try {
+            final int code = ((HttpURLConnection)conn).getResponseCode()
+            if( code != 200 )
+                throw new IOException("Unable to download foreign file ${FilesEx.toUriString(source)} -- unexpected HTTP status code: $code")
+            try( InputStream in = checkedInputStream(conn, conn.getContentLengthLong()) ) {
+                try( OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING) ) {
+                    copyStream(in, out)
+                }
+            }
+        }
+        finally {
+            ((HttpURLConnection)conn).disconnect()
+        }
+    }
+
+    private static InputStream checkedInputStream(URLConnection conn, long expectedLength) throws IOException {
+        return expectedLength > 0
+                ? new FixedInputStream(conn.getInputStream(), expectedLength)
+                : conn.getInputStream()
+    }
+
+    /**
+     * Parse a {@code Content-Range} response header (e.g. {@code bytes 10-19/20}).
+     *
+     * @return an array {@code [start, end, total]}, or {@code null} when the header is absent or malformed
+     */
+    private static long[] parseContentRange(URLConnection conn) {
+        final String value = conn.getHeaderField('Content-Range')
+        if( !value )
+            return null
+        final matcher = value =~ ~/^bytes\s+(\d+)-(\d+)\/(\d+)$/
+        return matcher.matches()
+                ? [matcher.group(1) as long, matcher.group(2) as long, matcher.group(3) as long] as long[]
+                : null
+    }
+
+    private static void copyStream(InputStream in, OutputStream out) throws IOException {
+        final byte[] buffer = new byte[8192]
+        int len
+        while( (len = in.read(buffer)) != -1 )
+            out.write(buffer, 0, len)
+    }
+
+    @Override
+    void upload(Path source, Path target, CopyOption... options) throws IOException {
+        throw new UnsupportedOperationException("Upload not supported by ${getScheme().toUpperCase()} file system provider")
     }
 
     @Override

--- a/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
+++ b/modules/nf-httpfs/src/main/nextflow/file/http/XFileSystemProvider.groovy
@@ -20,6 +20,8 @@ import nextflow.file.CopyMoveHelper
 import nextflow.file.CopyOptions
 import nextflow.file.FileSystemTransferAware
 import nextflow.file.HttpCopyOption
+import nextflow.file.ResumableFileSystem
+import nextflow.file.ResumableUpload
 
 import static nextflow.file.http.XFileSystemConfig.*
 
@@ -450,7 +452,18 @@ abstract class XFileSystemProvider extends FileSystemProvider implements FileSys
             throw new ProviderMismatchException()
 
         if( options.contains(HttpCopyOption.RESUME) ) {
-            // resume a partially downloaded file, falling back to a full download
+            // resume into a resumable (cloud) target when available
+            final targetProvider = target.fileSystem.provider()
+            if( targetProvider instanceof ResumableFileSystem ) {
+                final upload = ((ResumableFileSystem)targetProvider).resumeUpload(target)
+                if( upload != null ) {
+                    if( upload.committedBytes() > 0 && resumeToTarget(source, upload) )
+                        return
+                    // nothing committed to resume from: discard the stale upload and restart
+                    upload.abort()
+                }
+            }
+            // resume into a local target, otherwise fall back to a full download
             final long offset = Files.exists(target) ? Files.size(target) : 0
             if( offset > 0 && resumeDownload(source, target, offset) )
                 return
@@ -498,6 +511,47 @@ abstract class XFileSystemProvider extends FileSystemProvider implements FileSys
         }
     }
 
+    /**
+     * Resume a download into a resumable (cloud) target from the committed offset.
+     *
+     * @return {@code true} when the remaining bytes were streamed and the upload completed,
+     *         {@code false} when the source could not be resumed (and the upload was aborted)
+     */
+    @PackageScope
+    boolean resumeToTarget(Path source, ResumableUpload upload) throws IOException {
+        final long offset = upload.committedBytes()
+        final conn = toConnection(source, offset)
+        if( conn !instanceof HttpURLConnection ) {
+            upload.abort()
+            return false
+        }
+        try {
+            final int code = ((HttpURLConnection)conn).getResponseCode()
+            final long[] range = code == 206 ? parseContentRange(conn) : null
+            if( range == null || range[0] != offset || range[1] + 1 != range[2] ) {
+                // source can't be resumed — discard the stale upload and restart
+                upload.abort()
+                return false
+            }
+            final long remaining = range[2] - offset
+            try {
+                try( InputStream in = checkedInputStream(conn, remaining) ) {
+                    copyStream(in, upload.outputStream())
+                }
+                upload.complete()
+            }
+            catch( IOException e ) {
+                // mid-stream failure — leave the upload in-progress for a later retry
+                upload.abandon()
+                throw e
+            }
+            return true
+        }
+        finally {
+            ((HttpURLConnection)conn).disconnect()
+        }
+    }
+
     private void downloadFromStart(Path source, Path target) throws IOException {
         final conn = toConnection(source)
         if( conn !instanceof HttpURLConnection )
@@ -506,14 +560,38 @@ abstract class XFileSystemProvider extends FileSystemProvider implements FileSys
             final int code = ((HttpURLConnection)conn).getResponseCode()
             if( code != 200 )
                 throw new IOException("Unable to download foreign file ${FilesEx.toUriString(source)} -- unexpected HTTP status code: $code")
-            try( InputStream in = checkedInputStream(conn, conn.getContentLengthLong()) ) {
-                try( OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING) ) {
-                    copyStream(in, out)
+            final targetProvider = target.fileSystem.provider()
+            if( targetProvider instanceof ResumableFileSystem ) {
+                downloadToResumableTarget(conn, ((ResumableFileSystem)targetProvider).newUpload(target))
+            }
+            else {
+                try( InputStream in = checkedInputStream(conn, conn.getContentLengthLong()) ) {
+                    try( OutputStream out = Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING) ) {
+                        copyStream(in, out)
+                    }
                 }
             }
         }
         finally {
             ((HttpURLConnection)conn).disconnect()
+        }
+    }
+
+    /**
+     * Stream a download into a resumable (cloud) target, completing the upload on success and
+     * leaving it in-progress on a mid-stream failure so a later attempt can resume it.
+     */
+    private void downloadToResumableTarget(URLConnection conn, ResumableUpload upload) throws IOException {
+        try {
+            try( InputStream in = checkedInputStream(conn, conn.getContentLengthLong()) ) {
+                copyStream(in, upload.outputStream())
+            }
+            upload.complete()
+        }
+        catch( IOException e ) {
+            // mid-stream failure — leave the upload in-progress for a later retry
+            upload.abandon()
+            throw e
         }
     }
 

--- a/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
@@ -16,10 +16,13 @@
 
 package nextflow.file.http
 
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
+import nextflow.file.HttpCopyOption
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Specification
@@ -227,5 +230,244 @@ class XFileSystemProviderTest extends Specification {
         '/this/that'            | 'http://foo.com:123/abc'  | 'http://foo.com:123/this/that'
         'this/that'             | 'http://foo.com:123/abc'  | 'http://foo.com:123/this/that'
 
+    }
+
+    def 'should resume an http download using a byte range'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'   // 20 bytes
+        def PARTIAL = 'ABCDEFGHIJ'          // first 10 bytes
+        def REMAINING = 'KLMNOPQRST'        // remaining 10 bytes
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .withHeader('Range', equalTo('bytes=10-'))
+            .willReturn(aResponse()
+                .withStatus(206)
+                .withHeader('Content-Range', 'bytes 10-19/20')
+                .withHeader('Content-Length', '10')
+                .withBody(REMAINING)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-resume', '.txt')
+        target.text = PARTIAL
+
+        when:
+        provider.download(source, target, HttpCopyOption.RESUME)
+
+        then:
+        target.text == FULL
+
+        and:
+        wireMockRule.verify(getRequestedFor(urlEqualTo('/file.txt')).withHeader('Range', equalTo('bytes=10-')))
+
+        cleanup:
+        target?.delete()
+    }
+
+    def 'should restart an http download when the server ignores the range'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'
+        def PARTIAL = 'ABCDEFGHIJ'
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-restart', '.txt')
+        target.text = PARTIAL
+
+        when:
+        provider.download(source, target, HttpCopyOption.RESUME)
+
+        then:
+        target.text == FULL
+
+        and:
+        wireMockRule.verify(getRequestedFor(urlEqualTo('/file.txt')).withHeader('Range', equalTo('bytes=10-')))
+
+        cleanup:
+        target?.delete()
+    }
+
+    def 'should gate resume download to http and https'() {
+        given:
+        def http = new HttpFileSystemProvider()
+        def https = new HttpsFileSystemProvider()
+        def ftp = new FtpFileSystemProvider()
+
+        expect:
+        http.canDownload(null, null)
+        https.canDownload(null, null)
+        !ftp.canDownload(null, null)
+
+        and:
+        !http.canUpload(null, null)
+        !https.canUpload(null, null)
+        !ftp.canUpload(null, null)
+    }
+
+    def 'should restart when the server returns a mismatched content range'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'   // 20 bytes
+        def PARTIAL = 'ABCDEFGHIJ'          // first 10 bytes
+
+        // ranged request returns a 206 that does not start at the requested offset
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .atPriority(1)
+            .withHeader('Range', equalTo('bytes=10-'))
+            .willReturn(aResponse()
+                .withStatus(206)
+                .withHeader('Content-Range', 'bytes 0-19/20')
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        // fallback request returns the full body
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .atPriority(2)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-mismatch', '.txt')
+        target.text = PARTIAL
+
+        when:
+        provider.download(source, target, HttpCopyOption.RESUME)
+
+        then:
+        target.text == FULL
+
+        and:
+        wireMockRule.verify(getRequestedFor(urlEqualTo('/file.txt')).withHeader('Range', equalTo('bytes=10-')))
+
+        cleanup:
+        target?.delete()
+    }
+
+    def 'should restart when the server returns 416 range not satisfiable'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'
+        def PARTIAL = 'ABCDEFGHIJ'
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .atPriority(1)
+            .withHeader('Range', equalTo('bytes=10-'))
+            .willReturn(aResponse()
+                .withStatus(416)
+                .withHeader('Content-Range', 'bytes */20')))
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .atPriority(2)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-416', '.txt')
+        target.text = PARTIAL
+
+        when:
+        provider.download(source, target, HttpCopyOption.RESUME)
+
+        then:
+        target.text == FULL
+
+        and:
+        wireMockRule.verify(getRequestedFor(urlEqualTo('/file.txt')).withHeader('Range', equalTo('bytes=10-')))
+
+        cleanup:
+        target?.delete()
+    }
+
+    def 'should download a file when the target does not exist'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-fresh', '.txt')
+        Files.delete(target)
+
+        when:
+        provider.download(source, target)
+
+        then:
+        target.text == FULL
+
+        cleanup:
+        target?.delete()
+    }
+
+    def 'should replace an existing file when REPLACE_EXISTING is specified'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-replace', '.txt')
+        target.text = 'stale content'
+
+        when:
+        provider.download(source, target, StandardCopyOption.REPLACE_EXISTING)
+
+        then:
+        target.text == FULL
+
+        cleanup:
+        target?.delete()
+    }
+
+    def 'should fail when the target already exists without REPLACE_EXISTING'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def FULL = 'ABCDEFGHIJKLMNOPQRST'
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader('Content-Length', '20')
+                .withBody(FULL)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def target = Files.createTempFile('nf-exists', '.txt')
+        target.text = 'stale content'
+
+        when:
+        provider.download(source, target)
+
+        then:
+        thrown(FileAlreadyExistsException)
+        target.text == 'stale content'
+
+        cleanup:
+        target?.delete()
     }
 }

--- a/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
+++ b/modules/nf-httpfs/src/test/nextflow/file/http/XFileSystemProviderTest.groovy
@@ -23,6 +23,7 @@ import java.nio.file.StandardCopyOption
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import nextflow.file.HttpCopyOption
+import nextflow.file.ResumableUpload
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Specification
@@ -469,5 +470,68 @@ class XFileSystemProviderTest extends Specification {
 
         cleanup:
         target?.delete()
+    }
+
+    def 'should resume a download into a resumable upload'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+        def REMAINING = 'KLMNOPQRST'
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .withHeader('Range', equalTo('bytes=10-'))
+            .willReturn(aResponse()
+                .withStatus(206)
+                .withHeader('Content-Range', 'bytes 10-19/20')
+                .withHeader('Content-Length', '10')
+                .withBody(REMAINING)))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def upload = Mock(ResumableUpload)
+        def output = new ByteArrayOutputStream()
+
+        when:
+        def resumed = provider.resumeToTarget(source, upload)
+
+        then:
+        1 * upload.committedBytes() >> 10
+        1 * upload.outputStream() >> output
+        1 * upload.complete()
+        0 * upload.abort()
+        0 * upload.abandon()
+
+        and:
+        resumed
+        output.toString() == REMAINING
+    }
+
+    def 'should abandon a resumable upload when the download fails mid-stream'() {
+        given:
+        def localhost = "http://localhost:${wireMockRule.port()}"
+
+        wireMockRule.stubFor(get(urlEqualTo('/file.txt'))
+            .withHeader('Range', equalTo('bytes=10-'))
+            .willReturn(aResponse()
+                .withStatus(206)
+                .withHeader('Content-Range', 'bytes 10-19/20')
+                .withHeader('Content-Length', '10')
+                .withBody('KLMNOPQRST')))
+
+        def provider = new HttpFileSystemProvider()
+        def source = provider.getPath(new URI("${localhost}/file.txt"))
+        def upload = Mock(ResumableUpload)
+        def failingOutput = new OutputStream() {
+            void write(int b) throws IOException { throw new IOException('boom') }
+        }
+
+        when:
+        provider.resumeToTarget(source, upload)
+
+        then:
+        1 * upload.committedBytes() >> 10
+        1 * upload.outputStream() >> failingOutput
+        1 * upload.abandon()
+        0 * upload.complete()
+        thrown(IOException)
     }
 }

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
@@ -48,6 +48,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -61,6 +62,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import com.google.common.base.Preconditions;
@@ -77,6 +79,8 @@ import nextflow.extension.FilesEx;
 import nextflow.file.CopyOptions;
 import nextflow.file.FileHelper;
 import nextflow.file.FileSystemTransferAware;
+import nextflow.file.ResumableFileSystem;
+import nextflow.file.ResumableUpload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +113,7 @@ import static java.lang.String.format;
  *
  *
  */
-public class S3FileSystemProvider extends FileSystemProvider implements FileSystemTransferAware {
+public class S3FileSystemProvider extends FileSystemProvider implements FileSystemTransferAware, ResumableFileSystem {
 
     private static final Logger log = LoggerFactory.getLogger(S3FileSystemProvider.class);
 
@@ -345,20 +349,139 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
     }
 
     private S3OutputStream createUploaderOutputStream( S3Path fileToUpload ) {
+        return createUploaderOutputStream(fileToUpload, null, null);
+    }
+
+    private S3OutputStream createUploaderOutputStream( S3Path fileToUpload, String uploadId, List<CompletedPart> completedParts ) {
         S3Client s3 = fileToUpload.getFileSystem().getClient();
         Properties props = fileToUpload.getFileSystem().properties();
 
         final String storageClass = fileToUpload.getStorageClass()!=null ? fileToUpload.getStorageClass() : props.getProperty("upload_storage_class");
         final S3MultipartOptions opts = props != null ? new S3MultipartOptions(props) : new S3MultipartOptions();
         final S3ObjectId objectId = fileToUpload.toS3ObjectId();
-        S3OutputStream stream = new S3OutputStream(s3.getClient(), objectId, opts)
+        final S3OutputStream stream = uploadId == null
+                ? new S3OutputStream(s3.getClient(), objectId, opts)
+                : new S3OutputStream(s3.getClient(), objectId, opts, uploadId, completedParts);
+        return stream
                 .setCannedAcl(s3.getCannedAcl())
                 .setStorageClass(storageClass)
                 .setStorageEncryption(props.getProperty("storage_encryption"))
                 .setKmsKeyId(props.getProperty("storage_kms_key_id"))
                 .setContentType(fileToUpload.getContentType())
                 .setTags(fileToUpload.getTagsList());
-        return stream;
+    }
+
+    @Override
+    public ResumableUpload newUpload(Path target, CopyOption... options) throws IOException {
+        if( !(target instanceof S3Path) )
+            return null;
+        final S3Path s3Path = (S3Path)target;
+        final S3OutputStream stream = createUploaderOutputStream(s3Path, null, null);
+        return new S3ResumableUpload(stream, 0);
+    }
+
+    @Override
+    public ResumableUpload resumeUpload(Path target) throws IOException {
+        if( !(target instanceof S3Path) )
+            return null;
+        final S3Path s3Path = (S3Path)target;
+        final software.amazon.awssdk.services.s3.S3Client awsClient = s3Path.getFileSystem().getClient().getClient();
+        final String bucket = s3Path.getBucket();
+        final String key = s3Path.getKey();
+
+        // find the most recent in-progress multipart upload for this object, paging through all
+        // results since listMultipartUploads returns at most 1000 entries per call
+        MultipartUpload upload = null;
+        String keyMarker = null;
+        String uploadIdMarker = null;
+        ListMultipartUploadsResponse listResp;
+        do {
+            try {
+                listResp = awsClient.listMultipartUploads(
+                        ListMultipartUploadsRequest.builder()
+                                .bucket(bucket)
+                                .prefix(key)
+                                .keyMarker(keyMarker)
+                                .uploadIdMarker(uploadIdMarker)
+                                .build());
+            }
+            catch( final SdkException e ) {
+                throw new IOException("Failed to list Amazon S3 multipart uploads", e);
+            }
+            for( final MultipartUpload candidate : listResp.uploads() ) {
+                if( key.equals(candidate.key()) && (upload == null || candidate.initiated().isAfter(upload.initiated())) )
+                    upload = candidate;
+            }
+            keyMarker = listResp.nextKeyMarker();
+            uploadIdMarker = listResp.nextUploadIdMarker();
+        } while( Boolean.TRUE.equals(listResp.isTruncated()) );
+
+        if( upload == null )
+            return null;
+
+        // recover the already-uploaded parts, paging through all results since listParts returns
+        // at most 1000 entries per call
+        final List<CompletedPart> completedParts = new ArrayList<>();
+        long committedBytes = 0;
+        Integer partNumberMarker = null;
+        ListPartsResponse partsResp;
+        do {
+            try {
+                partsResp = awsClient.listParts(
+                        ListPartsRequest.builder()
+                                .bucket(bucket)
+                                .key(key)
+                                .uploadId(upload.uploadId())
+                                .partNumberMarker(partNumberMarker)
+                                .build());
+            }
+            catch( final SdkException e ) {
+                throw new IOException("Failed to list Amazon S3 multipart upload parts", e);
+            }
+            for( final Part part : partsResp.parts() ) {
+                completedParts.add(CompletedPart.builder().partNumber(part.partNumber()).eTag(part.eTag()).build());
+                committedBytes += part.size();
+            }
+            partNumberMarker = partsResp.nextPartNumberMarker();
+        } while( Boolean.TRUE.equals(partsResp.isTruncated()) );
+
+        final S3OutputStream stream = createUploaderOutputStream(s3Path, upload.uploadId(), completedParts);
+        return new S3ResumableUpload(stream, committedBytes);
+    }
+
+    private static class S3ResumableUpload implements ResumableUpload {
+        private final S3OutputStream stream;
+        private final long committedBytes;
+
+        S3ResumableUpload(S3OutputStream stream, long committedBytes) {
+            this.stream = stream;
+            this.committedBytes = committedBytes;
+        }
+
+        @Override
+        public long committedBytes() {
+            return committedBytes;
+        }
+
+        @Override
+        public OutputStream outputStream() {
+            return stream;
+        }
+
+        @Override
+        public void complete() throws IOException {
+            stream.close();
+        }
+
+        @Override
+        public void abandon() throws IOException {
+            stream.abandon();
+        }
+
+        @Override
+        public void abort() throws IOException {
+            stream.abort();
+        }
     }
 
     @Override

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3OutputStream.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3OutputStream.java
@@ -160,6 +160,22 @@ public final class S3OutputStream extends OutputStream {
         this.bufferSize = request.getBufferSize();
     }
 
+    /**
+     * Creates an {@code S3OutputStream} that continues an existing multipart upload identified by
+     * {@code uploadId}, resuming part numbering after the already-completed {@code completedParts}.
+     */
+    public S3OutputStream(final S3Client s3, S3ObjectId objectId, S3MultipartOptions request,
+                          String uploadId, List<CompletedPart> completedParts) {
+        this.s3 = requireNonNull(s3);
+        this.objectId = requireNonNull(objectId);
+        this.request = request;
+        this.bufferSize = request.getBufferSize();
+        this.uploadId = requireNonNull(uploadId);
+        this.completedParts = new LinkedBlockingQueue<>(completedParts);
+        this.partsCount = completedParts.size();
+        // executor and phaser are created lazily on the first upload (see uploadBuffer)
+    }
+
     private ByteBuffer expandBuffer(ByteBuffer byteBuffer) {
 
         final float expandFactor = 2.5f;
@@ -306,8 +322,15 @@ public final class S3OutputStream extends OutputStream {
             return false;
         }
 
-        if (partsCount == 0) {
+        if (uploadId == null) {
             init();
+        }
+        else if (executor == null) {
+            // a resumed upload already has an uploadId and completed parts, so only the
+            // background executor and phaser need to be created
+            executor = getOrCreateExecutor(request.getMaxThreads());
+            phaser = new Phaser();
+            phaser.register();
         }
 
         // set the buffer in read mode and submit for upload
@@ -388,17 +411,59 @@ public final class S3OutputStream extends OutputStream {
         }
         else {
             // -- upload remaining chunk
-            if( buf != null )
+            if( buf != null ) {
                 uploadBuffer(buf, true);
+                buf = null;
+                md5 = null;
+            }
 
             // -- shutdown upload executor and await termination
             log.trace("[S3 phaser] Close arriveAndAwaitAdvance");
-            phaser.arriveAndAwaitAdvance();
+            if( phaser != null )
+                phaser.arriveAndAwaitAdvance();
 
             // -- complete upload process
             completeMultipartUpload();
         }
 
+        closed = true;
+    }
+
+    /**
+     * Abandon the upload, leaving it in-progress so a later attempt can resume it. Flushes any
+     * buffered data that forms a full minimum part and waits for the background parts, but does
+     * not complete or abort the multipart upload.
+     */
+    public void abandon() throws IOException {
+        if( closed )
+            return;
+
+        if( uploadId != null ) {
+            // upload any remaining buffered data as a part; a tail smaller than the minimum part
+            // size is left uncommitted, since a resume would make it a middle part and S3 would
+            // reject the completion with EntityTooSmall
+            if( buf != null && buf.position() >= MIN_MULTIPART_UPLOAD ) {
+                uploadBuffer(buf, true);
+                buf = null;
+                md5 = null;
+            }
+            // wait for the background part uploads to complete
+            if( phaser != null )
+                phaser.arriveAndAwaitAdvance();
+            // do NOT complete and do NOT abort — leave the multipart upload in-progress
+        }
+
+        closed = true;
+    }
+
+    /**
+     * Abort the upload, discarding the in-progress multipart upload entirely.
+     */
+    public void abort() {
+        if( closed )
+            return;
+        if( uploadId != null )
+            abortMultipartUpload();
         closed = true;
     }
 
@@ -534,7 +599,8 @@ public final class S3OutputStream extends OutputStream {
         }
         aborted = true;
         log.trace("[S3 phaser] MultipartUpload arriveAndDeregister");
-        phaser.arriveAndDeregister();
+        if( phaser != null )
+            phaser.arriveAndDeregister();
     }
 
     /**

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3FileSystemProviderTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3FileSystemProviderTest.groovy
@@ -16,7 +16,16 @@
 
 package nextflow.cloud.aws.nio
 
+import java.time.Instant
+
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse
+import software.amazon.awssdk.services.s3.model.ListPartsRequest
+import software.amazon.awssdk.services.s3.model.ListPartsResponse
+import software.amazon.awssdk.services.s3.model.MultipartUpload
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
+import software.amazon.awssdk.services.s3.model.Part
+import software.amazon.awssdk.services.s3.model.S3Exception
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption
 import spock.lang.Specification
 
@@ -95,5 +104,119 @@ class S3FileSystemProviderTest extends Specification {
         fs.properties().getProperty('multipart_threshold') == '33554432' //32MB
     }
 
+    def 'should resume an in-progress multipart upload'() {
+        given:
+        def awsClient = Mock(software.amazon.awssdk.services.s3.S3Client)
+        def nfClient = Mock(nextflow.cloud.aws.nio.S3Client) {
+            getClient() >> awsClient
+        }
+        def fs = Mock(S3FileSystem) {
+            getClient() >> nfClient
+            properties() >> new Properties()
+        }
+        def s3Path = new S3Path(fs, '/bucket/key.txt')
+        def provider = new S3FileSystemProvider()
 
+        def upload = MultipartUpload.builder().key('key.txt').uploadId('upload-id').initiated(Instant.now()).build()
+        def part1 = Part.builder().partNumber(1).size(10).eTag('etag1').build()
+        def part2 = Part.builder().partNumber(2).size(20).eTag('etag2').build()
+
+        when:
+        def handle = provider.resumeUpload(s3Path)
+
+        then:
+        1 * awsClient.listMultipartUploads(_) >> ListMultipartUploadsResponse.builder().uploads([upload]).build()
+        1 * awsClient.listParts(_) >> ListPartsResponse.builder().parts([part1, part2]).build()
+
+        and:
+        handle != null
+        handle.committedBytes() == 30
+        handle.outputStream() instanceof S3OutputStream
+    }
+
+    def 'should paginate listParts when resuming a multipart upload'() {
+        given:
+        def awsClient = Mock(software.amazon.awssdk.services.s3.S3Client)
+        def nfClient = Mock(nextflow.cloud.aws.nio.S3Client) {
+            getClient() >> awsClient
+        }
+        def fs = Mock(S3FileSystem) {
+            getClient() >> nfClient
+            properties() >> new Properties()
+        }
+        def s3Path = new S3Path(fs, '/bucket/key.txt')
+        def provider = new S3FileSystemProvider()
+
+        def upload = MultipartUpload.builder().key('key.txt').uploadId('upload-id').initiated(Instant.now()).build()
+        def part1 = Part.builder().partNumber(1).size(10).eTag('etag1').build()
+        def part2 = Part.builder().partNumber(2).size(20).eTag('etag2').build()
+
+        when:
+        def handle = provider.resumeUpload(s3Path)
+
+        then:
+        1 * awsClient.listMultipartUploads(_) >> ListMultipartUploadsResponse.builder().uploads([upload]).build()
+        2 * awsClient.listParts(_) >> { ListPartsRequest req ->
+            req.partNumberMarker() == null
+                ? ListPartsResponse.builder().parts([part1]).isTruncated(true).nextPartNumberMarker(1).build()
+                : ListPartsResponse.builder().parts([part2]).isTruncated(false).build()
+        }
+
+        and:
+        handle != null
+        handle.committedBytes() == 30
+    }
+
+    def 'should paginate listMultipartUploads when resuming'() {
+        given:
+        def awsClient = Mock(software.amazon.awssdk.services.s3.S3Client)
+        def nfClient = Mock(nextflow.cloud.aws.nio.S3Client) {
+            getClient() >> awsClient
+        }
+        def fs = Mock(S3FileSystem) {
+            getClient() >> nfClient
+            properties() >> new Properties()
+        }
+        def s3Path = new S3Path(fs, '/bucket/key.txt')
+        def provider = new S3FileSystemProvider()
+
+        def upload = MultipartUpload.builder().key('key.txt').uploadId('upload-id').initiated(Instant.now()).build()
+        def part1 = Part.builder().partNumber(1).size(10).eTag('etag1').build()
+
+        when:
+        def handle = provider.resumeUpload(s3Path)
+
+        then:
+        2 * awsClient.listMultipartUploads(_) >> { ListMultipartUploadsRequest req ->
+            req.keyMarker() == null
+                ? ListMultipartUploadsResponse.builder().uploads([]).isTruncated(true).nextKeyMarker('key.txt').build()
+                : ListMultipartUploadsResponse.builder().uploads([upload]).isTruncated(false).build()
+        }
+        1 * awsClient.listParts(_) >> ListPartsResponse.builder().parts([part1]).build()
+
+        and:
+        handle != null
+        handle.committedBytes() == 10
+    }
+
+    def 'should propagate S3 errors when resuming'() {
+        given:
+        def awsClient = Mock(software.amazon.awssdk.services.s3.S3Client)
+        def nfClient = Mock(nextflow.cloud.aws.nio.S3Client) {
+            getClient() >> awsClient
+        }
+        def fs = Mock(S3FileSystem) {
+            getClient() >> nfClient
+            properties() >> new Properties()
+        }
+        def s3Path = new S3Path(fs, '/bucket/key.txt')
+        def provider = new S3FileSystemProvider()
+
+        when:
+        provider.resumeUpload(s3Path)
+
+        then:
+        1 * awsClient.listMultipartUploads(_) >> { throw S3Exception.builder().statusCode(503).build() }
+        thrown(IOException)
+    }
 }

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3OutputStreamTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3OutputStreamTest.groovy
@@ -21,8 +21,10 @@ import nextflow.Session
 import nextflow.cloud.aws.nio.util.S3MultipartOptions
 import nextflow.file.FileHelper
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CompletedPart
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse
+import software.amazon.awssdk.services.s3.model.S3Exception
 import software.amazon.awssdk.services.s3.model.UploadPartResponse
 import spock.lang.IgnoreIf
 import spock.lang.Requires
@@ -157,5 +159,105 @@ class S3OutputStreamTest extends Specification implements AwsS3BaseSpec {
         capturedParts[1].partNumber() == 1
         capturedParts[2].partNumber() == 2
 
+    }
+
+    def 'should resume a multipart upload'() {
+        given:
+        final path = s3path("s3://test/file.txt")
+        def multipart = new S3MultipartOptions()
+        def client = Mock(S3Client)
+        def recovered = [
+            CompletedPart.builder().partNumber(1).eTag('etag1').build(),
+            CompletedPart.builder().partNumber(2).eTag('etag2').build(),
+        ]
+
+        def writer = new S3OutputStream(client, path.toS3ObjectId(), multipart, 'upload-id', recovered)
+
+        when: 'continue uploading from the recovered state'
+        writer.uploadPart(InputStream.nullInputStream(), 25, 'checksum'.bytes, 3, true)
+        writer.completeMultipartUpload()
+
+        then: 'no new upload is initiated and the recovered parts are included'
+        0 * client.createMultipartUpload(_)
+        1 * client.uploadPart(_, _) >> { UploadPartResponse.builder().eTag('etag3').build() }
+        1 * client.completeMultipartUpload(_) >> { CompleteMultipartUploadRequest req ->
+            assert req.uploadId() == 'upload-id'
+            assert req.multipartUpload().parts()*.eTag() == ['etag1', 'etag2', 'etag3']
+            return null
+        }
+    }
+
+    def 'should leave a sub-minimum buffer uncommitted on abandon'() {
+        given:
+        final path = s3path('s3://test/file.txt')
+        def multipart = new S3MultipartOptions()
+        def client = Mock(S3Client)
+        def writer = new S3OutputStream(client, path.toS3ObjectId(), multipart)
+
+        when:
+        writer.init()
+        writer.write(new byte[1024])
+        writer.abandon()
+
+        then:
+        1 * client.createMultipartUpload(_) >> CreateMultipartUploadResponse.builder().uploadId('upload-id').build()
+        writer.partsCount == 0
+        0 * client.uploadPart(_, _)
+    }
+
+    def 'should not fail to abandon a resumed stream with no new bytes'() {
+        given:
+        final path = s3path('s3://test/file.txt')
+        def multipart = new S3MultipartOptions()
+        def client = Mock(S3Client)
+        def recovered = [CompletedPart.builder().partNumber(1).eTag('etag1').build()]
+        def writer = new S3OutputStream(client, path.toS3ObjectId(), multipart, 'upload-id', recovered)
+
+        when:
+        writer.abandon()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'should not fail to close a resumed stream with no new bytes'() {
+        given:
+        final path = s3path('s3://test/file.txt')
+        def multipart = new S3MultipartOptions()
+        def client = Mock(S3Client)
+        def recovered = [CompletedPart.builder().partNumber(1).eTag('etag1').build()]
+        def writer = new S3OutputStream(client, path.toS3ObjectId(), multipart, 'upload-id', recovered)
+
+        when:
+        writer.close()
+
+        then:
+        1 * client.completeMultipartUpload(_)
+    }
+
+    def 'should not re-upload the tail when abandoning after a failed close'() {
+        given:
+        final path = s3path('s3://test/file.txt')
+        def multipart = new S3MultipartOptions()
+        multipart.setBufferSize(5 * 1024 * 1024)
+        def client = Mock(S3Client)
+        def writer = new S3OutputStream(client, path.toS3ObjectId(), multipart)
+
+        when:
+        writer.write(new byte[5 * 1024 * 1024])
+        writer.flush()
+        writer.write(new byte[5 * 1024 * 1024])
+        try {
+            writer.close()
+        }
+        catch( IOException e ) {
+            writer.abandon()
+        }
+
+        then:
+        1 * client.createMultipartUpload(_) >> CreateMultipartUploadResponse.builder().uploadId('upload-id').build()
+        2 * client.uploadPart(_, _) >> { UploadPartResponse.builder().eTag('etag').build() }
+        1 * client.completeMultipartUpload(_) >> { throw S3Exception.builder().statusCode(500).build() }
+        0 * client.abortMultipartUpload(_)
     }
 }


### PR DESCRIPTION
## Summary

Hello, I work on the nf-core/oncoanalyser pipeline and I'm opening this PR as an extension of the (great!) work done in response to https://github.com/nextflow-io/nextflow/issues/5214

The motivation for this small PR is that during normal operation of oncoanalyser, the pipeline may retrieve a large amount of data (sometimes hundreds of GBs) from Cloudflare R2 via HTTP. This service works well for us and our users with respect to their egress-free model, however as mentioned in the linked PR, connections to R2 during download of the largest files are often interrupted

The Nextflow file staging retry functionality for HTTP does handle this in a reasonable way by deleting the partially retrieved file and then starting the download again, but often is the case for us that each successive download attempt experiences the same connection interruption, leading to complete failure of the Nextflow / oncoanalyser run. Ideally, the retry would resume the partially downloaded file so that progress is made during each retry

There was some consideration for such a feature [here](https://github.com/nextflow-io/nextflow/issues/5214#issuecomment-2324809411), but it (fairly) hadn't been picked up since

In this PR I implement an example of the retry via resume functionality for HTTP connections, and extend the mechanism to also include S3 multipart upload destinations. I would be grateful if you were to consider merging, or otherwise implementing this resume-retry feature. It would make a real difference for UX in oncoanalyser and for the use of Cloudflare R2 in general

*Disclaimer: I have used Claude Code to help create this PR, and while each line of code has been reviewed and the design carefully considered, I am still largely naive to the Nextflow codebase*

## Details of Pull Request

<details><summary><b>Click to show</b></summary>

### Resume HTTP staging downloads with a byte range

When Nextflow stages a foreign file from an HTTP(S) URL and the transfer fails partway through, the retry discards the partially-downloaded file and starts over from byte 0. For large files on unstable connections this throws away every byte already transferred when the connection is interrupted

These changes add a mechanism where on retry after connection interruption, an attempt is made to resume from the last downloaded byte using an HTTP `Range` header. If the server ignores the range (returning `200` instead of `206`), it falls back to re-downloading from the beginning matching existing behaviour. When a file is resume-retried, it still consumes a `maxRetries` count. Resume applies to HTTP/HTTPS only; FTP and other foreign sources keep the existing delete-and-restart behaviour

### Resume S3 multipart upload destinations

When the staging target is an S3 object, the same interruption leaves an in-progress multipart upload rather than a local partial file. The S3 provider now exposes that upload as a `ResumableUpload`, and the HTTP source resumes the upload from the first uncommitted part instead of aborting the multipart upload and restarting from the first byte

</details>

## Changes

<details><summary><b>Click to show</b></summary>

Top-to-bottom along the staging call path:

- `nextflow` `FilePorter`: the retry loop now retries on recoverable `IOException`s (fail-fast on a missing source and on interruption) and detects a resumable partial file (HTTP(S) source + partial target), passing the new `HttpCopyOption.RESUME` flag down; otherwise it deletes the partial file and restarts. A resume consumes a `maxRetries` count, and a terminal failure aborts any in-progress resumable upload
- `nf-commons`: new `ResumableFileSystem` and `ResumableUpload` interfaces plus the `HttpCopyOption.RESUME` flag. `FileHelper.copyPath` is unchanged; `RESUME` flows through its existing `FileSystemTransferAware` dispatch to `download()`
- `nf-httpfs` `XFileSystemProvider.download`: a plain copy honours copy options (replace, or throw if the target exists). A `RESUME` copy sends a `Range` header, validates the `Content-Range`, appends on `206`, and falls back to a full re-download on `200`/`416`/mismatch; for a resumable target it resumes the in-progress upload instead of appending to a local file
- `nf-amazon` `S3FileSystemProvider`: implements `ResumableFileSystem`. `newUpload` starts an S3 multipart upload; `resumeUpload` lists and recovers the in-progress multipart upload (with pagination) so a retry continues from the last committed byte instead of re-uploading from byte 0
- `nf-amazon` `S3OutputStream`: resumes an existing multipart upload from a set of recovered parts, and `abandon()` leaves the upload in-progress (flushing only a full minimum part) so a later attempt can resume it

Unit tests cover resume/restart and `Content-Range`/`416` edge cases (`XFileSystemProviderTest`), the resume decision (`FilePorterTest`), the S3 multipart resume and error propagation (`S3FileSystemProviderTest`), and the resumable stream (`S3OutputStreamTest`). `./gradlew :nf-httpfs:test :nextflow:test :plugins:nf-amazon:test` passes

</details>

## Testing

<details><summary><b>Click to show</b></summary>

> See below `Files` section for scripts referenced in below testing commands

A Python server simulates the mid-transfer failure: it advertises the full `Content-Length` but drops the connection mid-body, leaving a partial file. For files larger than `--part-size` (default 10 MiB, matching the fixed 10 MiB buffer of Nextflow's `S3OutputStream`) it truncates after one full multipart part plus half of the next, so an S3 multipart upload has at least one committed part to resume

The new code in this PR then makes a ranged request to which the server honours and returns the remaining bytes (or the full body with `--ignore-range`, to exercise the restart fallback)

Given requirements around size of served file, I generate a ~50 MiB payload for testing, noting its MD5 hash:

```bash
mkdir -p data/

yes 'nextflow-io/nextflow: A DSL for data-driven computational pipelines' | \
  awk '{ print NR, $0 }' | \
  awk -v bytes=$((50 * 1024 * 1024)) '{ n += length($0)+1; print; if (n >= bytes) exit }' > data/input.txt

md5sum data/input.txt | cut -f1 -d' '
#5b169a50e13cee1f0604e9edd9c7747
```

</details>

### Standard resume (HTTP server honours range request)

<details><summary><b>Click to show</b></summary>

Start the server:

```bash
./scripts/file_server.py --file data/input.txt --port 8000
```

Run:

```bash
./nextflow-src/launch.sh run scripts/main.nf -ansi-log false --url http://localhost:8000/input.txt --md5 5b169a50e13cee1f0604e9edd9c7747b
```

The logs shows a byte-range resume rather than a byte-0 restart:

```text
Nextflow:
WARN: Unable to stage foreign file: http://localhost:8000/input.txt (resuming, attempt 1 of 3) -- Cause: Premature EOF
[c6/ac8f64] Submitted process > STAGE_AND_VERIFY (1)
Input md5:    5b169a50e13cee1f0604e9edd9c7747b
Computed md5: 5b169a50e13cee1f0604e9edd9c7747b
Result: MATCH

Server:
serving input.txt (52428870 bytes, part_size=10485760, prefix=15728640, drop_count=1) on http://localhost:8000 (ignore_range=False)
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [size check]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [download (truncated)]  [chunk size: 30.0%] [total size: 30.0%]
server: "GET /input.txt HTTP/1.1" 206 -  [Range: bytes=15728640-]  [resume (complete)]  [chunk size: 70.0%] [total size: 100.0%]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [size check]
```

</details>

### Restart retry (HTTP server ignores range request)

<details><summary><b>Click to show</b></summary>

Start the server:

```bash
./scripts/file_server.py --file data/input.txt --port 8000 --ignore-range
```

Run:

```bash
./nextflow-src/launch.sh run scripts/main.nf -ansi-log false --url http://localhost:8000/input.txt --md5 5b169a50e13cee1f0604e9edd9c7747b
```

The logs shows a successful byte-0 restart rather than a resume:

```text
Nextflow:
WARN: Unable to stage foreign file: http://localhost:8000/input.txt (resuming, attempt 1 of 3) -- Cause: Premature EOF
[10/99ea7a] Submitted process > STAGE_AND_VERIFY (1)
Input md5:    5b169a50e13cee1f0604e9edd9c7747b
Computed md5: 5b169a50e13cee1f0604e9edd9c7747b
Result: MATCH

Server:
serving input.txt (52428870 bytes, part_size=10485760, prefix=15728640, drop_count=1) on http://localhost:8000 (ignore_range=True)
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [size check]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [download (truncated)]  [chunk size: 30.0%] [total size: 30.0%]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: bytes=15728640-]  [resume (rejected)]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [download (full)]  [chunk size: 100.0%] [total size: 100.0%]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [size check]
```

</details>

### AWS S3 destination

<details><summary><b>Click to show</b></summary>

To exercise the S3 multipart resume, serve a payload of at least two multipart parts (≥ 20 MiB) and stage it into an S3 work dir with `-w s3://bucket-name/work`

> Other approaches for local testing such as MinIO could be used here, but I decided to test directly on AWS S3

First create a Docker image with typical coreutils, libz (`aws` dep), and AWS CLIv2:

```bash
docker build \
  --platform linux/amd64 \
  --push \
  --file scripts/Dockerfile \
  --tag docker.io/scwatts/awscliv2:20260817--0 \
  .
```

Then place AWS credentials into BASH environment:

```bash
export AWS_ACCESS_KEY_ID=''
export AWS_SECRET_ACCESS_KEY=''
export AWS_DEFAULT_REGION=''
```

Re-launch the file server to reset drop count:

```bash
./scripts/file_server.py --file data/input.txt --port 8000
```

Then run Nextflow script, supplying the AWS Batch conifguration:

```bash
./nextflow-src/launch.sh run scripts/main.nf -ansi-log false -config scripts/aws_batch.config --url http://localhost:8000/input.txt --md5 5b169a50e13cee1f0604e9edd9c7747b
```

Log shows good resume in multipart upload context:

```text
Nextflow:
Staging foreign file: http://localhost:8000/input.txt
WARN: Unable to stage foreign file: http://localhost:8000/input.txt (resuming, attempt 1 of 3) -- Cause: Premature EOF
[12/adb37f] Submitted process > STAGE_AND_VERIFY (1)
Input md5:    5b169a50e13cee1f0604e9edd9c7747b
Computed md5: 5b169a50e13cee1f0604e9edd9c7747b
Result: MATCH

Server:
serving input.txt (52428870 bytes, part_size=10485760, prefix=15728640, drop_count=1) on http://localhost:8000 (ignore_range=False)
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [size check]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [download (truncated)]  [chunk size: 30.0%] [total size: 30.0%]
server: "GET /input.txt HTTP/1.1" 206 -  [Range: bytes=15728640-]  [resume (complete)]  [chunk size: 70.0%] [total size: 100.0%]
server: "GET /input.txt HTTP/1.1" 200 -  [Range: <none>]  [size check]
```

</details>

## Files

<details><summary><b>File: <i>scripts/file_server.py</i> (click to show)</b></summary>

```python
#!/usr/bin/env python3
import argparse
import http.server
import pathlib
import sys
import threading


def parse_args():
    parser = argparse.ArgumentParser()
    parser.add_argument('--file', required=True, type=pathlib.Path, help='payload to serve')
    parser.add_argument('--port', type=int, default=8000, help='TCP port to listen on')
    parser.add_argument('--part-size', type=int, default=10485760,
                        help='multipart part size in bytes (matches the fixed 10 MiB S3OutputStream buffer in Nextflow)')
    parser.add_argument('--ignore-range', action='store_true', help='Always return 200 on Range requests')
    parser.add_argument('--drop-count', type=int, default=1,
                        help='number of download attempts to interrupt before serving a complete response')

    args = parser.parse_args()
    if not args.file.exists():
        parser.error(f'Input file {args.file} does not exist')

    return args


def load_payload(path):
    with path.open('rb') as f:
        return f.read()


# The first (non-ranged) response is truncated at prefix_len bytes. For the truncation to be
# reliably distinguishable from a header-only read (which disconnects after reading the status and
# headers), prefix_len must exceed the OS socket send/receive buffers, so writing the truncated body
# raises BrokenPipeError when the client has already gone. 1 MiB comfortably exceeds the default
# buffers (128-256 KiB on localhost, up to a few MiB when auto-tuned). The prefix is at least half
# the file (and at least part_size for large files), so a file of 2 MiB or more is always safe.
MIN_SAFE_PREFIX = 1 * 1024 * 1024


def serve(file_name, data, port, ignore_range, part_size, drop_count):

    size = len(data)
    # Truncate inside the second multipart part, so one full part is already committed and can be
    # resumed from; fall back to half the file when it is too small to produce a multipart upload
    if size > part_size:
        prefix_len = min(size - 1, part_size + part_size // 2)
    else:
        prefix_len = max(1, size // 2)

    # Drop count remaining. Nextflow issues header-only GETs (readAttributes) that read just the status
    # and headers before the real download, so a drop is only counted when its truncated body is
    # actually delivered to a client that read it; a client that hung up mid-body is refunded.
    drops_remaining = [drop_count]
    drops_lock = threading.Lock()
    total_sent = [0]  # cumulative bytes delivered across requests

    class Handler(http.server.BaseHTTPRequestHandler):

        def _write(self, body):
            # Return False when the client disconnects mid-body (a header-only read or an abort),
            # which is expected for a truncating test server and not an error
            try:
                self.wfile.write(body)
                self.wfile.flush()
                total_sent[0] += len(body)
                return True
            except (BrokenPipeError, ConnectionResetError):
                return False


        def _send(self, code, body, extra=(), range_ignored=False):
            self._status = code
            self._payload = len(body)
            self._range_ignored = range_ignored
            self._label = 'resume (complete)' if code == 206 else 'download (full)'
            self.send_response(code)
            for k, v in extra:
                self.send_header(k, v)
            self.send_header('Content-Length', str(len(body)))
            self.end_headers()
            if self._write(body):
                if code == 200:  # fresh byte-0 download starts a new run
                    total_sent[0] = len(body)
            else:
                self._payload = 0
                self._label = 'size check'


        def _drop(self, range_header):
            # Truncate the body mid-stream and close; report whether the body was delivered
            # ignore_range means the server never honours Range, so a ranged request is treated
            # as a full byte-0 download here, exactly like a non-ranged one
            self._range_ignored = bool(range_header) and ignore_range
            if not range_header or ignore_range:
                self._status = 200
                self._payload = len(data[:prefix_len])
                self._label = 'download (truncated)'
                self.send_response(200)
                self.send_header('Content-Length', str(size))  # advertise the full size
                self.end_headers()
                delivered = self._write(data[:prefix_len])
                if delivered:
                    total_sent[0] = len(data[:prefix_len])  # fresh byte-0 download starts a new run
                else:
                    self._payload = 0
                    self._label = 'size check'
                self.connection.close()
                return delivered

            start = int(range_header.split('=')[1].split('-')[0])
            remaining = size - start
            body = data[start:start + remaining // 2]
            self._status = 206
            self._payload = len(body)
            self._label = 'resume (truncated)'
            self.send_response(206)
            self.send_header('Content-Range', f'bytes {start}-{size-1}/{size}')
            self.send_header('Content-Length', str(remaining))
            self.end_headers()
            delivered = self._write(body)
            if not delivered:
                self._payload = 0
                self._label = 'size check'
            self.connection.close()
            return delivered


        def do_GET(self):
            range_header = self.headers.get('Range')

            with drops_lock:
                drop = drops_remaining[0] > 0
            if drop:
                if self._drop(range_header):
                    with drops_lock:
                        drops_remaining[0] -= 1
            elif not range_header:
                self._send(200, data)
            else:
                start = int(range_header.split('=')[1].split('-')[0])
                if not ignore_range:
                    self._send(206, data[start:], (('Content-Range', f'bytes {start}-{size-1}/{size}'),))
                else:
                    self._send(200, data, range_ignored=True)

            self._log(range_header)

        def _log(self, range_header):
            payload = getattr(self, '_payload', 0)
            status = getattr(self, '_status', '-')
            label = getattr(self, '_label', '?')
            if payload == 0:
                # Header-only read: the client read the status and headers then disconnected.
                # readHttpAttributes (no Range) is a size check; a Range request answered 200
                # instead of 206 is resumeDownload rejecting the resume and falling back to restart
                label = 'resume (rejected)' if range_header else 'size check'
            elif getattr(self, '_range_ignored', False):
                label += ', range ignored'
            rng = f'  [Range: {range_header}]' if range_header else '  [Range: <none>]'
            if payload == 0:
                sys.stderr.write(f'server: "{self.requestline}" {status} -{rng}  [{label}]\n')
            else:
                pct = (payload / size * 100) if size else 0.0
                total_pct = (total_sent[0] / size * 100) if size else 0.0
                sys.stderr.write(f'server: "{self.requestline}" {status} -{rng}  [{label}]  [chunk size: {pct:.1f}%] [total size: {total_pct:.1f}%]\n')

        def log_message(self, fmt, *args):
            # Disable auto-log; _log() runs after the body so the cumulative total is accurate
            pass

    print(f'serving {file_name} ({size} bytes, part_size={part_size}, prefix={prefix_len}, drop_count={drop_count}) '
          f'on http://localhost:{port} (ignore_range={ignore_range})')
    http.server.ThreadingHTTPServer(('0.0.0.0', port), Handler).serve_forever()


def main():
    # Get commandline arguments and input file to serve
    args = parse_args()
    data = load_payload(args.file)

    # Require minimum size, needed for initial buffer fill
    if len(data) < 2 * MIN_SAFE_PREFIX:
        sys.exit(
            f'error: {args.file} is too small ({len(data)} bytes); need at least '
            f'{2 * MIN_SAFE_PREFIX} bytes so the truncated prefix exceeds the OS socket buffer'
        )

    # Launch file server
    serve(args.file.name, data, args.port, args.ignore_range, args.part_size, args.drop_count)


if __name__ == '__main__':
    main()
```

</details>

<details><summary><b>File: <i>scripts/main.nf</i> (click to show)</b></summary>

```Nextflow
params.url = null
params.md5 = null

process STAGE_AND_VERIFY {
    input:
    path fp

    output:
    stdout emit: hash

    script:
    """
    md5sum ${fp} | cut -d' ' -f1
    """
}

workflow {
  main:

  STAGE_AND_VERIFY(
    channel.fromPath(params.url),
  )

  STAGE_AND_VERIFY.out.hash
    .map { hash_stdout ->
      def hash = hash_stdout.trim()
      def result = hash == params.md5 ? 'MATCH' : 'MISMATCH'
      println "Input md5:    ${params.md5}"
      println "Computed md5: ${hash}"
      println "Result: ${result}"
    }
}
```

</details>

<details><summary><b>File: <i>scripts/Dockerfile</i> (click to show)</b></summary>

```Dockerfile
FROM continuumio/miniconda3:26.5.3 AS build

RUN \
    echo > ~/.condarc '\
channels:\n\
    - conda-forge\n\
    - bioconda\n\
    - defaults'

RUN \
    conda create -y -p /build/ curl unzip

RUN \
    conda create -y -p /env/ libzlib python

RUN \
    conda clean -yaf

# Move Conda environment into standard BioContainers base image
# Then install AWS CLIv2; here in this final container in order to link against correct libraries
FROM quay.io/bioconda/base-glibc-busybox-bash:3.1

COPY --from=build /env/ /env/
COPY --from=build /build/ /build/

RUN \
  mkdir -p /tmp/awscliv2/ && cd /tmp/awscliv2/ && \
    /build/bin/curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
    /build/bin/unzip awscliv2.zip && \
    ./aws/install

ENV PATH="/env/bin:${PATH}"
ENV LD_LIBRARY_PATH="/env/lib/"

RUN \
  rm -r /build/ /tmp/awscliv2/
```

</details>

<details><summary><b>File: <i>scripts/aws_batch.config</i> (click to show)</b></summary>

```Nextflow
process {
  executor = 'awsbatch'
  queue = 'batch-queue-name'
  container = 'docker.io/scwatts/awscliv2:20260817--0'
}

aws {
  region = 'aws-region-name'
}

workDir = 's3://bucket-name/object-prefix/'
```

</details>