### PR TITLE
Note the internal DSL follow-up on AgentBuilder directives

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/AgentBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/AgentBuilder.groovy
@@ -61,6 +61,9 @@ class AgentBuilder {
             throw new IllegalArgumentException("Unknown agent directive `${name}`")
     }
 
+    // NOTE: replace with internal DSL -- as done for inputs/outputs and config options
+    // -- once the v1 parser is removed. The agent primitive is only supported by the v2
+    // parser, so this dynamic dispatch is provisional and carries no v1 requirement.
     @PackageScope
     Object methodMissing(String name, Object args) {
         checkName(name)


### PR DESCRIPTION
Resolves a review comment on the agent primitive PR: https://github.com/seqeralabs/nextflow/pull/58#discussion_r3724633459

`ProcessBuilder.methodMissing` carries the note `// NOTE: replace with internal DSL after v1 parser is removed`. `AgentBuilder.methodMissing` had no equivalent marker, so this adds one, adapted to the fact that the agent primitive is implemented only in the v2 syntax parser: the internal DSL (as used for inputs/outputs and config options) is the intended end state here, and the current dynamic dispatch is provisional.

```groovy
// NOTE: replace with internal DSL -- as done for inputs/outputs and config options
// -- once the v1 parser is removed. The agent primitive is only supported by the v2
// parser, so this dynamic dispatch is provisional and carries no v1 requirement.
```

This takes the "or just add the same note" option offered in the review. The internal-DSL replacement is deliberately left for later, to be done together with the process/config ones when the v1 parser is dropped.

Comment-only change; no behavior change. Verified with `./gradlew :nextflow:compileGroovy` (BUILD SUCCESSFUL). Tagged `[ci skip]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)