### PR TITLE
Note the deferred TaskProcessor factory consolidation

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessDef.groovy
@@ -272,6 +272,10 @@ class ProcessDef extends BindableDef implements IterableDef, ChainableDef {
      * static helper so non-{@code ProcessDef} lowerings (e.g. {@code AgentDef} on
      * the tool-free task path) can drive the standard {@link TaskProcessor} pipeline
      * without duplicating the executor/factory wiring.
+     *
+     * NOTE: these static helpers overlap with {@link ProcessFactory}, whose only
+     * remaining role is to be overridden by tests. Both should be consolidated into
+     * a single static factory; deferred to keep the agent changeset small.
      */
     static TaskProcessor createTaskProcessor(Session session, BaseScript owner,
             String processName, String simpleName, String baseName,


### PR DESCRIPTION
Takes the "just add a note" option from this review comment:
https://github.com/seqeralabs/nextflow/pull/58#discussion_r3724709413

> Might be worth moving these static methods into a factory class? There is a ProcessFactory that sort of has this purpose. Now it's only used for tests. Ideal solution might be to consolidate that and these methods into a static factory
>
> I don't want to bloat the PR much more though. Maybe just add a note and then we can do it later

## What this does

Adds a two-line note to the javadoc of `ProcessDef.createTaskProcessor(...)` recording the intended end state, so the follow-up is discoverable from the code. Comment-only: no code motion, no behaviour change.

```
 * NOTE: these static helpers overlap with {@link ProcessFactory}, whose only
 * remaining role is to be overridden by tests. Both should be consolidated into
 * a single static factory; deferred to keep the agent changeset small.
```

## The deferred consolidation, for whoever picks it up

Two overlapping ways to build a `TaskProcessor` exist today:

- `ProcessDef.createTaskProcessor(...)` and `ProcessDef.createTaskProcessorResolved(...)` (static) — resolve the config, ask `session.executorFactory` for an executor, then delegate the final construction step. Made static on the agent branch so `AgentDef` can reuse the canonical task/executor pipeline on the tool-free task path.
- `nextflow/script/ProcessFactory.groovy` — a per-script instance holding `session`/`owner`/`config`/`executorFactory`, whose single method `newTaskProcessor(name, executor, config, taskBody)` just calls the `TaskProcessor` constructor.

`ProcessFactory` is still on the production path (`Session.newProcessFactory` is called from `createTaskProcessorResolved`), but the reason it is a class rather than a call is its overridability, and the only override left is `TestProcessFactory` in `modules/nextflow/src/testFixtures/groovy/test/ScriptHelper.groovy`, which swaps in a `TestTaskProcessor`. So the indirection is carried by production code purely to serve a test seam.

Suggested end state: one static factory owning executor lookup plus `TaskProcessor` construction, with `ProcessDef` and `AgentDef` as its callers, and the test fixture switched to whatever seam the new factory offers instead of subclassing.

## Verification

Comment-only, so scoped to a compile:

```
$ ./gradlew :nextflow:compileGroovy
BUILD SUCCESSFUL in 11s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)