### PR TITLE
Cache the task context for `exec` tasks

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskRun.groovy
@@ -435,6 +435,14 @@ class TaskRun implements Cloneable {
         if( config?.isDynamic() )
             return true
 
+        // An `exec` task is the only kind whose context must be persisted: the process body *is*
+        // the task execution, therefore whatever it computed lives only in `task.context` and
+        // cannot be re-derived on a cache hit. A script task instead re-evaluates its body -- and
+        // therefore rebuilds its context -- in TaskProcessor.invokeTask, before the cache is
+        // consulted.
+        if( type == ScriptType.GROOVY )
+            return true
+
         for( OutParam it : outputs.keySet() ) {
             if( it.class == ValueOutParam ) return true
             if( it.class == FileOutParam && ((FileOutParam)it).isDynamic() ) return true

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskRunTest.groovy
@@ -31,6 +31,7 @@ import nextflow.executor.Executor
 import nextflow.file.FileHolder
 import nextflow.script.BodyDef
 import nextflow.script.ScriptBinding
+import nextflow.script.ScriptType
 import nextflow.script.TaskClosure
 import nextflow.script.TokenVar
 import nextflow.script.params.EnvInParam
@@ -202,6 +203,28 @@ class TaskRunTest extends Specification {
         then:
         task6.hasCacheableValues()
 
+    }
+
+    def 'should have cacheable values for an exec task'() {
+        given:
+        def binding = new Binding()
+        def list = []
+        // a plain file output, i.e. nothing cacheable in the declared outputs
+        def out = new FileOutParam(binding,list).bind('file_out.beta')
+
+        when:
+        // an `exec` task computes its result into the task context, hence it must be cached
+        def task1 = new TaskRun(type: ScriptType.GROOVY)
+        task1.setOutput(out)
+        then:
+        task1.hasCacheableValues()
+
+        when:
+        // a script task rebuilds its context when the body is resolved, hence there's nothing to cache
+        def task2 = new TaskRun(type: ScriptType.SCRIPTLET)
+        task2.setOutput(out)
+        then:
+        !task2.hasCacheableValues()
     }
 
 


### PR DESCRIPTION
### What

`TaskRun.hasCacheableValues()` decides whether the task context is persisted in the cache DB (`CacheDB.writeTaskEntry0`) and whether a missing cached context must force a cache miss (`TaskProcessor.checkCachedOutput`). Today it decides that purely from the *shape* of the declared outputs (plus dynamic directives).

This adds an early return for `exec` (i.e. `ScriptType.GROOVY`) tasks:

```groovy
// An `exec` task is the only kind whose context must be persisted: the process body *is*
// the task execution, therefore whatever it computed lives only in `task.context` and
// cannot be re-derived on a cache hit. A script task instead re-evaluates its body -- and
// therefore rebuilds its context -- in TaskProcessor.invokeTask, before the cache is
// consulted.
if( type == ScriptType.GROOVY )
    return true
```

### Why

The context of an `exec` task cannot be re-derived: the process body *is* the task execution, so whatever it computed lives only in `task.context`. A script task has no such problem, because `TaskProcessor.invokeTask` calls `task.resolve(taskBody)` — which invokes the body closure and therefore rebuilds the context — *before* the cache is consulted.

So an `exec` task that declares no `val` output (nor a dynamic file glob) and has no dynamic directive currently has its context dropped on the write side, and the resumed run starts from an empty context rather than replaying the values the original run computed.

### Why the rest of the method is kept

The obvious follow-up is to reduce the whole method to `type == ScriptType.GROOVY`, since a script task always rebuilds its context before the cache read. That is *not* equivalent, so it is deliberately left out of this PR:

- On a cache hit, `checkCachedOutput` overwrites the freshly rebuilt context with the cached one (`task.context = entry.context`, `task.config.context = entry.context`). For a script task with a `val` output or a dynamic file glob, that is what replays the exact values emitted by the original run. Dropping the `ValueOutParam`/dynamic-`FileOutParam` branches would stop persisting those contexts, so a resumed run would emit whatever the *re-evaluated* body computes — identical for a perfectly deterministic body, different for anything reading a timestamp, a random value, or mutable global state.
- Likewise for `config?.isDynamic()`: the cached context is what dynamic directives are re-resolved against on a cache hit.
- The read-side guard `task.hasCacheableValues() && !entry.context` currently forces a cache miss for such script tasks when the persisted context is missing; reducing the method would silently turn those into hits.

Changing that is a behaviour change to script-task resume semantics and out of scope here.

### Tests

New `TaskRunTest` case `'should have cacheable values for an exec task'`: a `GROOVY`-type task with only a plain (non-dynamic) file output returns `true`, while the same task as `SCRIPTLET` still returns `false`. `./gradlew :nextflow:test --tests 'nextflow.processor.TaskRunTest'` → 48 tests, 0 failures.

### Context

Split out of #7477 (the `agent` primitive) at review request, so that PR can drop this hunk from its diff — the in-JVM `agent` body is an `exec`-type task and depends on this behaviour.

Review comment: https://github.com/seqeralabs/nextflow/pull/58#discussion_r3724560855

🤖 Generated with [Claude Code](https://claude.com/claude-code)
