### PR TITLE
Do not treat an empty path argument as a missing input

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/agent/ModuleToolBridge.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/agent/ModuleToolBridge.groovy
@@ -639,6 +639,38 @@ class ModuleToolBridge implements ToolDispatcher {
         return (Map) parsed
     }
 
+    /**
+     * Return {@code args} without the file/path entries whose value is an empty (or blank) string.
+     *
+     * <p>A spec-derived tool schema marks EVERY module input {@code required} - neither a
+     * {@code meta.yml} nor the registry metadata declares optionality - so a model with nothing
+     * to supply for an input that the module treats as optional tends to send {@code ""} rather
+     * than omit the key. Skipping an optional path input means supplying NOTHING, the way a CLI
+     * tool behaves: the binding in {@link ProcessEntryHandler} defaults an ABSENT path arg to an
+     * empty list and does not accept an empty value as a stand-in. So the empty value is dropped
+     * HERE, at the producer, instead of being interpreted downstream.
+     */
+    @PackageScope
+    static Map dropEmptyPathArgs(Map args, ModuleSpec spec) {
+        if( !args || spec == null )
+            return args
+        final Map result = new LinkedHashMap(args)
+        final inputs = spec.inputs ?: Collections.<ModuleParam>emptyList()
+        for( final param : inputs ) {
+            final List<ModuleParam> components = param.isTuple() ? param.components : Collections.singletonList(param)
+            for( final comp : components ) {
+                if( !ToolSchema.isFileType(comp.type?.toLowerCase()) )
+                    continue
+                final value = result.get(comp.name)
+                if( value instanceof CharSequence && value.toString().trim().isEmpty() ) {
+                    log.debug "Agent tool arg `${comp.name}` is empty - omitting it (optional path input not provided)"
+                    result.remove(comp.name)
+                }
+            }
+        }
+        return result
+    }
+
     private void startScalarInvocation(Session session, ToolCall request) {
         final tool = request.tool
         final parsed = request.arguments
@@ -656,8 +688,8 @@ class ModuleToolBridge implements ToolDispatcher {
 
     private void startSpecInvocation(Session session, ToolCall request) {
         final tool = request.tool
-        final parsed = request.arguments
         final spec = tool.spec
+        final parsed = dropEmptyPathArgs(request.arguments, spec)
 
         // -- marshal the flattened LLM args into one channel value per input channel using the
         //    SAME logic as `nextflow module run` (ProcessEntryHandler.getProcessArguments): the

--- a/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ProcessEntryHandler.groovy
@@ -312,12 +312,14 @@ class ProcessEntryHandler {
         final type = paramTypes.get(name)
         final value = namedArgs.get(name)
 
-        // File/path inputs: a null OR blank-string value means "not provided". nf-core path
-        // inputs are optional by convention and default to an empty list (the process script
-        // handles the empty case); treating "" like null also prevents file("") from throwing
-        // when a caller (e.g. an LLM tool call) passes an empty string for an optional path.
+        // File/path inputs: an ABSENT value means "not provided". nf-core path inputs are
+        // optional by convention and default to an empty list (the process script handles the
+        // empty case). An empty value is NOT a stand-in for an absent one: as with most CLI
+        // tools, an optional path input is skipped by supplying nothing at all, not by
+        // supplying the option with an empty value. An empty value therefore falls through to
+        // `file('')`, which fails loudly.
         if( param instanceof FileInParam ) {
-            if( value == null || value.toString().trim().isEmpty() ) {
+            if( value == null ) {
                 log.warn "Path input '--${name}' not provided, defaulting to empty list"
                 return []
             }

--- a/modules/nextflow/src/test/groovy/nextflow/agent/ModuleToolBridgeBindingTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/agent/ModuleToolBridgeBindingTest.groovy
@@ -148,4 +148,75 @@ class ModuleToolBridgeBindingTest extends Dsl2Spec {
         then: 'the binding throws -- the bridge dispatcher turns this into a {"error":...} tool result'
         thrown(IllegalArgumentException)
     }
+
+    def 'should omit an empty-valued path arg so the optional path input is bound as not provided'() {
+        given:
+        final dir = Files.createTempDirectory('test')
+        final modPath = dir.resolve('main.nf')
+        modPath.text = '''
+            process echo_tool {
+                input:
+                tuple val(meta), path(reads)
+                path fasta
+
+                output:
+                tuple val(meta), path("out.txt"), emit: report
+
+                script:
+                """
+                cat ${reads} > out.txt
+                """
+            }
+            '''.stripIndent()
+
+        and: 'a sibling meta.yml declaring a second, optional-by-convention path input'
+        final metaPath = dir.resolve('meta.yml')
+        metaPath.text = '''\
+            name: echo_tool
+            input:
+              - - name: meta
+                  type: map
+                - name: reads
+                  type: file
+              - name: fasta
+                type: file
+            '''.stripIndent()
+
+        and:
+        final ProcessDef proc = loadModuleProcess(modPath)
+        final ModuleSpec spec = ModuleSpecFactory.fromYaml(metaPath)
+
+        when: 'the model sends "" for the path input it has nothing to supply for'
+        final args0 = ModuleToolBridge.dropEmptyPathArgs([meta: [id: 's1'], reads: '/abs/x', fasta: ''], spec)
+
+        then: 'the empty path arg is OMITTED, never passed on as an empty value'
+        !args0.containsKey('fasta')
+        args0.reads == '/abs/x'
+
+        when:
+        final args = ProcessEntryHandler.getProcessArguments(proc, args0, spec)
+
+        then: 'the absent path input binds to an empty list (the "not provided" contract)'
+        args.size() == 2
+        (args[0] as List)[1] == Nextflow.file('/abs/x')
+        args[1] == []
+    }
+
+    def 'should leave non-path args untouched when their value is empty'() {
+        given:
+        final dir = Files.createTempDirectory('test')
+        final metaPath = dir.resolve('meta.yml')
+        metaPath.text = '''\
+            name: echo_tool
+            input:
+              - name: label
+                type: string
+              - name: fasta
+                type: file
+            '''.stripIndent()
+        final ModuleSpec spec = ModuleSpecFactory.fromYaml(metaPath)
+
+        expect: 'only file/path args are dropped -- an empty string is a legit value for a val input'
+        ModuleToolBridge.dropEmptyPathArgs([label: '', fasta: '  '], spec) == [label: '']
+    }
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ProcessEntryHandlerTest.groovy
@@ -348,7 +348,7 @@ class ProcessEntryHandlerTest extends Specification {
         result == []
     }
 
-    def 'should treat a blank-string path input as not provided (v1)' () {
+    def 'should reject an empty-string path input instead of treating it as not provided (v1)' () {
         given:
         def session = Mock(Session)
         def script = Mock(BaseScript)
@@ -358,11 +358,12 @@ class ProcessEntryHandlerTest extends Specification {
         def handler = new ProcessEntryHandler(script, session, meta)
         def pathParam = Mock(FileInParam) { getName() >> 'proteins' }
 
-        expect: 'an empty/blank path arg is treated like "not provided" -> empty list (never file(""))'
-        handler.getValueForInputV1(pathParam, [proteins: VALUE], [:]) == []
+        when: 'an empty value is supplied for a path input'
+        handler.getValueForInputV1(pathParam, [proteins: ''], [:])
 
-        where:
-        VALUE << ['', '   ', '\t']
+        then: 'it is NOT a stand-in for "not provided" -- an optional path is skipped by omitting the arg'
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('cannot be')
     }
 
     def 'should throw error for missing val input (v1)' () {


### PR DESCRIPTION
Resolves review comment https://github.com/seqeralabs/nextflow/pull/58#discussion_r3724738442

> Don't think we should do this. It does not match the way most CLI tools behave -- skip a missing optional file input by supplying nothing, not by supplying the option with an empty value

## Behavior change

`ProcessEntryHandler.getValueForInputV1` treated a blank-string value for a `path` input as equivalent to a missing one, warning and binding an empty list. That half of the condition is removed:

- **absent** path argument -> still warns and binds `[]` (unchanged, this is the pre-existing `module run` behavior from #7163)
- **empty/blank** path argument -> no longer accepted as a stand-in for "not provided". It falls through to `file('')`, which throws `IllegalArgumentException: Argument of `file()` function cannot be empty`. On the agent path the bridge dispatcher turns that into a `{"error":...}` tool result, so the model can recover.
- non-path inputs are unaffected: an empty string is still a legitimate `val`/`string` value.

## Why the branch existed, and where it is handled now

The blank-string branch was added by the agent primitive commit for the LLM tool-call case. A spec-derived tool schema marks **every** module input `required` (`ModuleSpecToolSchema.inputSchema` and `ModuleMetadataToolSchema.inputSchema` both push every flattened property into `required`, because neither a `meta.yml` nor the registry metadata declares optionality), so a model with nothing to supply for an optional-by-convention path input tends to emit `""` rather than omit the key. So `""` genuinely can reach this code.

That is now fixed at the **producer**: `ModuleToolBridge.startSpecInvocation` runs the parsed tool arguments through a new `dropEmptyPathArgs(args, spec)`, which removes file/path-typed entries whose value is an empty (or blank) string before they are marshalled. The key is omitted, which is exactly "supply nothing" — so the consumer keeps one meaning for "not provided" and no interpretation of `""` is needed downstream.

## Tests

- `ProcessEntryHandlerTest`: the old `should treat a blank-string path input as not provided (v1)` spec is replaced by `should reject an empty-string path input instead of treating it as not provided (v1)`, asserting the throw. The absent-value spec (`should return empty list for missing path input (v1)`) is unchanged.
- `ModuleToolBridgeBindingTest`: two new specs — an empty-valued path arg is omitted by `dropEmptyPathArgs` and then binds to `[]` end-to-end through `ProcessEntryHandler.getProcessArguments`; and non-path args with empty values are left untouched.

Ran, narrowly scoped:

```
./gradlew :nextflow:test --tests 'nextflow.script.ProcessEntryHandlerTest' --tests 'nextflow.agent.ModuleToolBridgeBindingTest'
BUILD SUCCESSFUL in 8s
nextflow.script.ProcessEntryHandlerTest: tests="30" skipped="0" failures="0" errors="0"
nextflow.agent.ModuleToolBridgeBindingTest: tests="4" skipped="0" failures="0" errors="0"
```

```
./gradlew :nextflow:test --tests 'nextflow.agent.ModuleToolDescriptorPinTest' --tests 'nextflow.agent.AgentModuleSpecToolTest' --tests 'nextflow.agent.ModuleToolBridgeFilesystemTest'
BUILD SUCCESSFUL in 5s
ModuleToolDescriptorPinTest: tests="5" skipped="0" failures="0" errors="0"
AgentModuleSpecToolTest: tests="4" skipped="0" failures="0" errors="0"
ModuleToolBridgeFilesystemTest: tests="14" skipped="0" failures="0" errors="0"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
