### PR TITLE
Drop the unused main-binding hook from ScriptLoaderV2

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/parser/v2/ScriptLoaderV2.groovy
@@ -40,8 +40,6 @@ class ScriptLoaderV2 implements ScriptLoader {
 
     private BaseScript mainScript
 
-    private ScriptBinding mainBinding
-
     private boolean skipEntryFlow
 
     private Object result
@@ -60,19 +58,6 @@ class ScriptLoaderV2 implements ScriptLoader {
     @Override
     ScriptLoaderV2 setModule(boolean value) {
         this.skipEntryFlow = value
-        return this
-    }
-
-    /**
-     * Opt-in: use the given {@link ScriptBinding} as the main script's binding instead
-     * of the shared {@code session.binding}. This isolates per-load script state (e.g.
-     * {@code moduleDir}) so loading a module here does not corrupt the shared session
-     * binding -- mirroring the isolated binding that {@code IncludeDef.loadModuleV2}
-     * relies on for included modules. When not set, the shared {@code session.binding}
-     * is used (existing behavior, unchanged for all current callers).
-     */
-    ScriptLoaderV2 setMainBinding(ScriptBinding binding) {
-        this.mainBinding = binding
         return this
     }
 
@@ -129,7 +114,7 @@ class ScriptLoaderV2 implements ScriptLoader {
                 ? compiler.compile(scriptPath.toFile())
                 : compiler.compile(scriptText)
 
-            this.mainScript = createScript(compileResult.main(), mainBinding ?: session.binding, scriptPath, skipEntryFlow)
+            this.mainScript = createScript(compileResult.main(), session.binding, scriptPath, skipEntryFlow)
 
             compileResult.modules().forEach((path, clazz) -> {
                 createScript(clazz, new ScriptBinding(), path, true)


### PR DESCRIPTION
Follow-up to https://github.com/seqeralabs/nextflow/pull/58#discussion_r3724608186, where @bentsherman asked why `ScriptLoaderV2.setMainBinding` is related to the agent primitive at all, and suspected a cleaner way or a broader issue. Both instincts were right — the answer is that the hook is now dead code, so this PR deletes it instead of justifying it.

**Why it existed.** It was introduced for `AgentDef.compileModuleProcess`, which compiled each registry/file tool module as a *main* script. A main script gets the shared `session.binding`, and `BaseScript.setup()` writes `moduleDir` into whatever binding the script holds — last write wins. With more than one tool, every tool's `conda "${moduleDir}/environment.yml"` therefore resolved to the last-compiled module's directory, so unrelated tools ended up sharing one Wave container.

**Why it is no longer needed.** `compileModuleProcess` does not exist on this branch: agent tools are namespaced `nf:module_run` references over `include`d modules, and `ScriptLoaderV2.parse0` already hands every included module its own `ScriptBinding`. The isolation the hook provided is now structural.

**Dead-code check on `llm-agent-primitive`:**

```
$ git grep -n "setMainBinding\|mainBinding" -- '*.groovy' '*.java'
.../parser/v2/ScriptLoaderV2.groovy:43:    private ScriptBinding mainBinding
.../parser/v2/ScriptLoaderV2.groovy:74:    ScriptLoaderV2 setMainBinding(ScriptBinding binding) {
.../parser/v2/ScriptLoaderV2.groovy:75:        this.mainBinding = binding
.../parser/v2/ScriptLoaderV2.groovy:132:            ... mainBinding ?: session.binding ...
```

Declaration, assignment and the `?:` fallback — no callers.

**No upstream (master) PR either.** On `master`, `ScriptLoaderV2` is instantiated exactly once per session (`ScriptRunner.parseScript`), so there is no reachable path where a second main-script load clobbers the shared binding; the clobber only reproduces if the second loader is manufactured by hand. That is a latent hazard for a hypothetical future caller, not a defect in shipped behavior, and not worth API surface on the loader. Always isolating non-entry loads was also considered and rejected: it would change `setModule(true)` semantics for `ContainerInspectMode` (`ScriptRunner.groovy:214`), which does want the shared session binding.

**Verification:** `./gradlew :nextflow:compileGroovy` succeeds; `./gradlew :nextflow:test --tests 'nextflow.script.parser.v2.*'` passes — `ScriptLoaderV2Test` 13 tests, `AgentScriptLoadingTest` 7 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
