### PR TITLE
Fix independently-verified findings from a security audit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazoncorretto:25-al2023
-RUN yum install -y procps-ng shadow-utils which
+RUN yum install -y procps-ng shadow-utils which util-linux
 
 ENV NXF_HOME=/.nextflow
 ARG TARGETPLATFORM=linux/amd64

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -36,9 +36,6 @@
 # enable debugging
 [[ "$NXF_DEBUG_ENTRY" ]] && set -x
 
-# wrap cli args with single quote to avoid wildcard expansion
-cli=''; for x in "$@"; do cli+="'$x' "; done
-
 # the NXF_USRMAP hold the user ID in the host environment
 if [[ "$NXF_USRMAP" ]]; then
 # create a `nextflow` user with the provided ID
@@ -50,13 +47,19 @@ useradd -u "$NXF_USRMAP" -G docker -s /bin/bash nextflow
 chown nextflow /var/run/docker.sock
 chown -R nextflow /.nextflow
 
+# `su` only accepts a command string, so re-quote each arg with `%q`
+# (not a hand-rolled `'$x'` wrap, which breaks — and lets the arg escape
+# the quoting — the moment an arg contains a single quote).
+cli=''; for x in "$@"; do printf -v esc '%q' "$x"; cli+="$esc "; done
+
 # finally run the target command with `nextflow` user
 su nextflow << EOF
 [[ "$NXF_DEBUG_ENTRY" ]] && set -x
 exec bash -c "$cli"
 EOF
 
-# otherwise just execute the command
+# otherwise just execute the command directly — no string round-trip, no
+# quoting to get wrong
 else
-exec bash -c "$cli"
+exec "$@"
 fi

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -25,8 +25,8 @@
 # with such ID and adds it to the `docker` group, then assigns the docker
 # socket file ownership to that user.
 #
-# Finally it switches the `nextflow` user using the `su` command and
-# executes the original target command line.
+# Finally it switches to the `nextflow` user and executes the original
+# target command line.
 #
 # authors:
 #  Paolo Di Tommaso
@@ -47,16 +47,8 @@ useradd -u "$NXF_USRMAP" -G docker -s /bin/bash nextflow
 chown nextflow /var/run/docker.sock
 chown -R nextflow /.nextflow
 
-# `su` only accepts a command string, so re-quote each arg with `%q`
-# (not a hand-rolled `'$x'` wrap, which breaks — and lets the arg escape
-# the quoting — the moment an arg contains a single quote).
-cli=''; for x in "$@"; do printf -v esc '%q' "$x"; cli+="$esc "; done
-
-# finally run the target command with `nextflow` user
-su nextflow << EOF
-[[ "$NXF_DEBUG_ENTRY" ]] && set -x
-exec bash -c "$cli"
-EOF
+# run the target command as `nextflow`, passing argv through (no shell)
+exec runuser -u nextflow -- "$@"
 
 # otherwise just execute the command
 else

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -58,8 +58,7 @@ su nextflow << EOF
 exec bash -c "$cli"
 EOF
 
-# otherwise just execute the command directly — no string round-trip, no
-# quoting to get wrong
+# otherwise just execute the command
 else
 exec "$@"
 fi

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0

--- a/modules/nextflow/src/main/groovy/nextflow/util/RemoteSession.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/RemoteSession.groovy
@@ -149,6 +149,8 @@ class RemoteSession implements Serializable, Closeable {
         while( (entry=zip.getNextEntry()) != null ) {
 
             def file = target.resolve(entry.getName());
+            if( !file.normalize().startsWith(target.normalize()) )
+                throw new IllegalArgumentException("Unsafe zip entry path: ${entry.getName()}")
             if(entry.isDirectory()) {
                 continue
             }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
@@ -97,9 +97,11 @@ class TowerXAuth implements XAuthProvider {
                 .build()
 
         final resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString())
-        log.debug "Refresh cookie response: [${resp.statusCode()}]"
-        if( resp.statusCode() != 200 )
+        if( resp.statusCode() != 200 ) {
+            log.debug "Refresh cookie response: [${resp.statusCode()}] ${resp.body()}"
             return false
+        }
+        log.debug "Refresh cookie response: [${resp.statusCode()}]"
 
         final authCookie = getCookie('JWT')
         final refreshCookie = getCookie('JWT_REFRESH_TOKEN')

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
@@ -27,6 +27,7 @@ import groovy.util.logging.Slf4j
 import io.seqera.http.HxProxyConfig
 import nextflow.file.http.XAuthProvider
 import nextflow.util.ProxyConfig
+import nextflow.util.StringUtils
 
 /**
  * Implements Tower authentication strategy for resources accessed
@@ -96,7 +97,7 @@ class TowerXAuth implements XAuthProvider {
                 .build()
 
         final resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString())
-        log.debug "Refresh cookie response: [${resp.statusCode()}] ${resp.body()}"
+        log.debug "Refresh cookie response: [${resp.statusCode()}]"
         if( resp.statusCode() != 200 )
             return false
 
@@ -105,7 +106,7 @@ class TowerXAuth implements XAuthProvider {
 
         // set the new bearer token in the current client session
         if( authCookie?.value ) {
-            log.trace "Updating http client bearer token=$authCookie.value"
+            log.trace "Updating http client bearer token=${StringUtils.redact(authCookie.value)}"
             accessToken = authCookie.value
         }
         else {
@@ -114,7 +115,7 @@ class TowerXAuth implements XAuthProvider {
 
         // set the new refresh token
         if( refreshCookie?.value ) {
-            log.trace "Updating http client refresh token=$refreshCookie.value"
+            log.trace "Updating http client refresh token=${StringUtils.redact(refreshCookie.value)}"
             refreshToken = refreshCookie.value
         }
         else {


### PR DESCRIPTION
A security audit of this repo surfaced a handful of latent issues. I reproduced each one independently before touching anything, and only fixed what I could confirm was real.

Why these matter, not just what changed:

- Nextflow's Docker entrypoint builds a shell command from arbitrary caller-supplied arguments. If that reconstruction isn't airtight, anything able to influence those args (a container invoker, an orchestration layer) can break out of the intended command and run its own — the difference between "runs the pipeline task" and "runs whatever it wants as root inside the container."
- Debug/trace logging exists so people can troubleshoot connectivity problems, and troubleshooting logs get shared — pasted into tickets, Slack, screen shares — far more casually than anyone treats a credential. A JWT sitting in a trace line means a support workflow doubles as an exfiltration path.
- Zip extraction that trusts entry names is a well-known class of bug (Zip Slip): a crafted archive can write outside its intended target directory. The code path isn't wired up to anything today, but "nothing calls it yet" is a property of the current codebase, not a property of the function — it's exploitable the moment something does.
- The Gradle wrapper fetches a distribution over HTTPS but never checked what it got matched what was intended. That's the whole point of pinning a build tool's checksum: it turns "trust the network and the upstream host forever" into "trust it once, verify it every time after."

None of these needed new dependencies or behavior changes — each was a small, targeted correction once confirmed.