### PR TITLE
Disable resource prediction for processes with dynamic command directives

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -123,6 +123,82 @@ class TaskConfig extends LazyMap implements Cloneable {
         return eval0( result, path.subList(1,path.size()), key )
     }
 
+    /**
+     * Report whether any of the given directives holds a *dynamic* value i.e. a closure
+     * or a lazy GString e.g. {@code ext.args = { "-Xmx${task.memory.toGiga()}g" }}.
+     *
+     * This is a conservative proxy for "the value of this directive may depend on the task
+     * resources". A dynamic value defined in the config file carries no source at runtime --
+     * config closures are only rendered as text by {@code ClosureToStringVisitor}, which runs
+     * for {@code nextflow config} and {@code kuberun} -- so the actual expression cannot be
+     * inspected. Conversely a *static* value cannot reference the task resources at all: the
+     * config scope does not define {@code task}, therefore {@code ext.args = "${task.memory}g"}
+     * is rejected when the config is parsed. Hence a closure is the only shape that can carry
+     * such a reference, and one must be treated as suspect.
+     *
+     * The caller decides which directives matter, because that depends on what the executor
+     * actually does with them e.g. a dynamic {@code clusterOptions} is meaningless to an
+     * executor that never reads it.
+     *
+     * Note the *raw* values are inspected, so that nothing is resolved -- and therefore no
+     * user closure is evaluated -- as a side effect of the check.
+     *
+     * @param names The directive names to inspect e.g. {@code ['ext','beforeScript']}
+     * @return {@code true} when at least one of the given directives holds a dynamic value
+     */
+    boolean hasDynamicDirective(Collection<String> names) {
+        if( !names )
+            return false
+        final target = getTarget()
+        if( !target )
+            return false
+        for( String name : names ) {
+            // Only the named directives are looked up, therefore the `withName:`/`withLabel:`
+            // selector blocks are never inspected. This matters because
+            // `ProcessConfigBuilder#applyConfigDefaults` copies *every* key of the `process`
+            // config scope into each process config, including the selector blocks that were
+            // not applied to it -- those hold the directives of *other* processes. A selector
+            // that *does* match is merged into the top-level directives by then, so true
+            // positives are unaffected.
+            if( isDynamicValue(target.get(name)) )
+                return true
+        }
+        return false
+    }
+
+    /**
+     * Determine whether a raw directive value is dynamic. The values are nested in several
+     * shapes, hence the recursion.
+     */
+    private static boolean isDynamicValue(Object value) {
+        // a dynamic directive e.g. `beforeScript = { ... }`
+        if( value instanceof Closure )
+            return true
+        // a lazy GString e.g. `beforeScript = "echo ${-> task.memory}"` -- same test as
+        // LazyMap#put, which flags exactly these two shapes as dynamic
+        if( value instanceof GString ) {
+            for( Object it : ((GString)value).getValues() )
+                if( it instanceof Closure )
+                    return true
+            return false
+        }
+        // `ext` is re-wrapped as a nested lazy map on put, so its entries are one level down
+        // and must be taken from the target to avoid resolving them -- see #put
+        if( value instanceof LazyMap )
+            return isDynamicValue(((LazyMap)value).getTarget()?.values())
+        // a directive declared with named parameters e.g. `publishDir path: {..}`
+        if( value instanceof Map )
+            return isDynamicValue(((Map)value).values())
+        // a repeatable directive e.g. several `publishDir`, held as a list of values
+        if( value instanceof Collection ) {
+            for( Object it : (Collection)value )
+                if( isDynamicValue(it) )
+                    return true
+            return false
+        }
+        return false
+    }
+
     def getProperty(String name) {
 
         def meta = metaClass.getMetaProperty(name)

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -741,4 +741,111 @@ class TaskConfigTest extends Specification {
         [arch:'arm64']      | new Architecture(name:'arm64')
     }
 
+    // ---------------------------------------------------------------------
+    // hasDynamicDirective
+    // ---------------------------------------------------------------------
+
+    def 'should detect a dynamic ext directive' () {
+        given:
+        def config = new TaskConfig(ext: [args: { "-Xmx${task.memory.toGiga()}g" }])
+
+        expect:
+        config.hasDynamicDirective(['ext'])
+    }
+
+    def 'should not detect a static ext directive' () {
+        given:
+        // a static value cannot reference `task`: the config scope does not define it,
+        // therefore `ext.args = "-Xmx${task.memory}g"` is rejected when the config is parsed
+        def config = new TaskConfig(ext: [args: '--threads 4'])
+
+        expect:
+        !config.hasDynamicDirective(['ext'])
+    }
+
+    def 'should detect a dynamic script directive' () {
+        given:
+        def config = new TaskConfig(beforeScript: { "echo ${task.cpus}" })
+
+        expect:
+        config.hasDynamicDirective(['beforeScript'])
+        !config.hasDynamicDirective(['afterScript'])
+    }
+
+    def 'should ignore a directive that is not in the given set' () {
+        given:
+        // the nf-core institutional profiles set `clusterOptions` dynamically, and the
+        // directive is only read by the grid executors -- see SeqeraTaskHandler.COMMAND_DIRECTIVES
+        def config = new TaskConfig(clusterOptions: { "-l h_vmem=${task.memory.toGiga()}G" })
+
+        expect:
+        !config.hasDynamicDirective(['ext', 'beforeScript', 'afterScript'])
+        and:
+        config.hasDynamicDirective(['clusterOptions'])
+    }
+
+    def 'should ignore the config selector blocks' () {
+        given:
+        // `ProcessConfigBuilder#applyConfigDefaults` copies *every* key of the `process` config
+        // scope into each process config, including the `withName:`/`withLabel:` blocks that
+        // were not applied to it -- those hold the directives of *other* processes
+        def config = new TaskConfig(
+            'ext': [args: '--threads 4'],
+            'withName:OTHER': [ext: [args: { "-Xmx${task.memory.toGiga()}g" }]],
+            'withLabel:big': [beforeScript: { "echo ${task.memory}" }] )
+
+        expect:
+        !config.hasDynamicDirective(['ext', 'beforeScript', 'afterScript'])
+    }
+
+    def 'should detect a dynamic named parameter' () {
+        given:
+        def config = new TaskConfig(publishDir: [path: { "/data/${task.cpus}" }, mode: 'copy'])
+
+        expect:
+        config.hasDynamicDirective(['publishDir'])
+    }
+
+    def 'should detect a dynamic value in a repeated directive' () {
+        given:
+        def config = new TaskConfig(module: ['foo/1.0', { "bar/${task.cpus}" }])
+
+        expect:
+        config.hasDynamicDirective(['module'])
+    }
+
+    def 'should detect a lazy gstring directive value' () {
+        given:
+        def config = new TaskConfig(beforeScript: "echo ${-> task.memory}")
+
+        expect:
+        config.hasDynamicDirective(['beforeScript'])
+    }
+
+    def 'should return false when no directive name is given' () {
+        given:
+        def config = new TaskConfig(ext: [args: { 'x' }])
+
+        expect:
+        !config.hasDynamicDirective(null)
+        !config.hasDynamicDirective([])
+    }
+
+    def 'should not resolve any directive value' () {
+        given:
+        // the check must inspect the *raw* values: resolving them would evaluate the user
+        // closures as a side effect, before the task context is even available
+        def resolved = false
+        def config = new TaskConfig(
+            ext: [args: { resolved = true; throw new IllegalStateException('should not be evaluated') }],
+            beforeScript: { resolved = true; throw new IllegalStateException('should not be evaluated') } )
+
+        when:
+        def result = config.hasDynamicDirective(['ext', 'beforeScript', 'afterScript'])
+        then:
+        noExceptionThrown()
+        result
+        !resolved
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/dsl/ProcessConfigBuilderTest.groovy
@@ -264,4 +264,27 @@ class ProcessConfigBuilderTest extends Specification {
         !config.disk
 
     }
+
+    def 'should report a dynamic directive only for the process matched by the selector' () {
+        given:
+        def settings = [
+                'withName:FOO': [ ext: [args: { "-Xmx${task.memory.toGiga()}g" }] ]
+        ]
+
+        when: 'the selector matches the process'
+        def foo = new ProcessConfig([:])
+        new ProcessConfigBuilder(foo).applyConfig(settings, 'FOO', 'FOO', 'FOO')
+        then:
+        foo.createTaskConfig().hasDynamicDirective(['ext'])
+
+        when: 'the selector does not match the process'
+        // `applyConfigDefaults` still copies the `withName:FOO` block into the config of
+        // *every* process, therefore the check must skip the selector blocks
+        def bar = new ProcessConfig([:])
+        new ProcessConfigBuilder(bar).applyConfig(settings, 'BAR', 'BAR', 'BAR')
+        then:
+        bar.containsKey('withName:FOO')
+        and:
+        !bar.createTaskConfig().hasDynamicDirective(['ext'])
+    }
 }

--- a/plugins/nf-seqera/README.md
+++ b/plugins/nf-seqera/README.md
@@ -109,6 +109,18 @@ seqera {
 
 > NOTE: When a process references `task.memory` in the script (e.g. `-Xmx${task.memory.toGiga()}g`), resource prediction is disabled for that process. Otherwise, the scheduler could reduce the memory allocation, and the task would try to allocate more memory than is available, and fail with an out-of-memory error.
 
+The same reference can be hidden in a dynamic directive, where it cannot be inspected:
+
+```groovy
+process {
+    withName: FOO {
+        ext.args = { "-Xmx${task.memory.toGiga()}g" }
+    }
+}
+```
+
+Resource prediction is therefore also disabled for a process that defines `ext`, `beforeScript` or `afterScript` with a closure, whether or not the closure actually depends on the task resources. Use a static value, or set the `seqera/predictionModel` hint explicitly, to keep the prediction enabled.
+
 Set the `seqera/predictionModel` hint explicitly on the process to override this behaviour:
 
 ```groovy

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraTaskHandler.groovy
@@ -59,6 +59,32 @@ import nextflow.trace.TraceRecord
 @CompileStatic
 class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
 
+    /**
+     * The directives whose value is rendered into the command executed by this executor, and
+     * that therefore freeze a resource value when they are defined with a closure -- see
+     * {@link #shouldDisablePrediction()}.
+     *
+     * The set is deliberately narrow, because a directive listed here disables the resource
+     * prediction for the whole process as soon as it is dynamic:
+     *
+     * - {@code ext} reaches the command through the script template e.g. {@code ${task.ext.args}}
+     * - {@code beforeScript} and {@code afterScript} are rendered verbatim into the wrapper
+     *   script by {@link nextflow.executor.BashWrapperBuilder}
+     *
+     * Notably excluded:
+     *
+     * - {@code clusterOptions}, {@code queue} and {@code penv} are only read by the grid
+     *   executors. The nf-core institutional profiles set {@code clusterOptions} dynamically
+     *   on every process e.g. {@code { "-l h_vmem=${task.memory}" }}, so tripping on it would
+     *   disable the prediction for an entire pipeline over a directive this executor ignores
+     * - {@code containerOptions} never reaches the command either: {@code BashWrapperBuilder}
+     *   only applies it when {@code containerEnabled && !containerNative}, and
+     *   {@link SeqeraExecutor#isContainerNative()} is always {@code true}
+     * - the resource directives themselves ({@code cpus}, {@code memory}, ...) are resolved at
+     *   submit time, after the command has been rendered, so they carry no stale value
+     */
+    protected static final List<String> COMMAND_DIRECTIVES = List.of('ext', 'beforeScript', 'afterScript')
+
     private SchedClient client
 
     private SeqeraExecutor executor
@@ -190,16 +216,33 @@ class SeqeraTaskHandler extends TaskHandler implements FusionAwareTask {
         final runModel = executor.getSeqeraConfig()?.predictionModel
         if( !runModel || runModel == PredictionModel.NONE.getValue() )
             return false
+        final processName = task.processor?.name ?: task.lazyName()
         // Note only `memory` is checked. The scheduler can adjust the cpus as well, but a
         // stale `task.cpus` costs an over-subscribed thread pool whereas a stale
         // `task.memory` fails the task, and `task.cpus` is referenced by nearly every
         // process -- disabling the prediction for those would defeat the feature
-        if( !task.isDirectiveReferenced('memory') )
-            return false
-        // warn once per process rather than once per task: the reference belongs to the
-        // process definition, so every one of its tasks would otherwise report it
-        log.warn1("Process `${task.processor?.name ?: task.lazyName()}` depends on the `task.memory` value -- resource prediction has been disabled for this process to prevent an under-allocation of the requested memory", firstOnly: true)
-        return true
+        if( task.isDirectiveReferenced('memory') ) {
+            // warn once per process rather than once per task: the reference belongs to the
+            // process definition, so every one of its tasks would otherwise report it
+            log.warn1("Process `${processName}` depends on the `task.memory` value -- resource prediction has been disabled for this process to prevent an under-allocation of the requested memory", firstOnly: true)
+            return true
+        }
+        // The check above only sees the *script*. A directive defined with a closure can hide
+        // the same reference where it cannot be inspected, e.g.
+        //
+        //     process.withName:FOO.ext.args = { "-Xmx${task.memory.toGiga()}g" }
+        //
+        // The script then merely shows `task.ext.args`, and the closure is resolved by the
+        // task config at run time carrying no source. Since a *static* directive value cannot
+        // reference `task` at all -- the config scope does not define it -- a dynamic value is
+        // the only shape that can carry such a reference, and is conservatively treated as one.
+        // This over-triggers: `ext.args = { "--threads ${task.cpus}" }` also disables the
+        // prediction even though it never mentions the memory
+        if( task.config?.hasDynamicDirective(COMMAND_DIRECTIVES) ) {
+            log.warn1("Process `${processName}` defines a dynamic command directive that may depend on the `task.memory` value -- resource prediction has been disabled for this process to prevent an under-allocation of the requested memory", firstOnly: true)
+            return true
+        }
+        return false
     }
 
     protected int maxSpotAttempts(MachineRequirementOpts opts) {

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -1336,19 +1336,113 @@ class SeqeraTaskHandlerTest extends Specification {
         captured.getPredictionModel() == PredictionModel.QR_V1
     }
 
+    def 'submit disables the prediction model when a command directive is dynamic'() {
+        given:
+        Task captured = null
+        def handler = createSubmitHandler(
+            predictionModel: 'qr/v2',
+            // the script itself does not mention `task.memory`: the reference is hidden in a
+            // config closure, which carries no source at runtime
+            memoryReferenced: false,
+            directives: [ext: [args: { "-Xmx${task.memory.toGiga()}g" }]],
+            onSubmit: { captured = it },
+        )
+
+        when:
+        handler.submit()
+        then:
+        captured.getPredictionModel() == PredictionModel.NONE
+    }
+
+    def 'submit keeps the prediction model when only an out-of-scope directive is dynamic'() {
+        given:
+        Task captured = null
+        def handler = createSubmitHandler(
+            predictionModel: 'qr/v2',
+            memoryReferenced: false,
+            // `clusterOptions` is only read by the grid executors -- the nf-core institutional
+            // profiles set it dynamically on *every* process, so tripping on it would disable
+            // the prediction for the whole pipeline
+            directives: [clusterOptions: { "-l h_vmem=${task.memory.toGiga()}G" }],
+            onSubmit: { captured = it },
+        )
+
+        when:
+        handler.submit()
+        then:
+        captured.getPredictionModel() == null
+    }
+
+    def 'submit keeps the prediction model when the command directives are static'() {
+        given:
+        Task captured = null
+        def handler = createSubmitHandler(
+            predictionModel: 'qr/v2',
+            memoryReferenced: false,
+            directives: [ext: [args: '--threads 4'], beforeScript: 'echo hello'],
+            onSubmit: { captured = it },
+        )
+
+        when:
+        handler.submit()
+        then:
+        captured.getPredictionModel() == null
+    }
+
+    def 'submit does not resolve the dynamic directives while checking them'() {
+        given:
+        Task captured = null
+        def handler = createSubmitHandler(
+            predictionModel: 'qr/v2',
+            memoryReferenced: false,
+            // the check inspects the raw values, therefore a closure that cannot be evaluated
+            // yet -- there is no task context at this point -- must not break the submission
+            directives: [ext: [args: { throw new IllegalStateException('should not be evaluated') }]],
+            onSubmit: { captured = it },
+        )
+
+        when:
+        handler.submit()
+        then:
+        noExceptionThrown()
+        captured.getPredictionModel() == PredictionModel.NONE
+    }
+
+    def 'submit lets an explicit predictionModel hint win over the dynamic directive check'() {
+        given:
+        Task captured = null
+        def handler = createSubmitHandler(
+            predictionModel: 'qr/v2',
+            memoryReferenced: false,
+            directives: [ext: [args: { "-Xmx${task.memory.toGiga()}g" }]],
+            hints: ['seqera/predictionModel': 'qr/v1'],
+            onSubmit: { captured = it },
+        )
+
+        when:
+        handler.submit()
+        then:
+        captured.getPredictionModel() == PredictionModel.QR_V1
+    }
+
     private SeqeraTaskHandler createSubmitHandler(Map args) {
         final hints = args.hints as Map<String,Object> ?: [:]
         final baseMachineReq = args.baseMachineReq as MachineRequirementOpts
         final Closure onSubmit = args.onSubmit as Closure ?: {}
         final memoryReferenced = args.memoryReferenced as boolean
         final runPredictionModel = args.predictionModel as String
+        final directives = args.directives as Map<String,Object>
 
-        def taskConfig = Mock(TaskConfig) {
-            getCpus() >> 1
-            getResourceLabels() >> [:]
-            getResourceLimit(_) >> null
-            getHints() >> hints
-        }
+        // when `directives` is given, use a *real* task config so that the dynamic directive
+        // check runs against the actual raw values rather than a stubbed answer
+        def taskConfig = directives != null
+            ? new TaskConfig(directives + [cpus: 1, hints: hints])
+            : Mock(TaskConfig) {
+                getCpus() >> 1
+                getResourceLabels() >> [:]
+                getResourceLimit(_) >> null
+                getHints() >> hints
+            }
         def taskRun = Mock(TaskRun) {
             getConfig() >> taskConfig
             getWorkDir() >> Paths.get('/work/ab/cd1234')


### PR DESCRIPTION
> **Stacked on #7505** (`directive-refs-valrefs`). Review that one first; the diff here is only the two commits on top.

## The gap

#7505 detects a `task.memory` reference in the task **script**, and submits those tasks with prediction model `none` so the scheduler cannot allocate less memory than the already-rendered command assumes.

It does not see the reference when it lives in a **config closure**:

```groovy
process {
    withName: FOO {
        ext.args = { "-Xmx${task.memory.toGiga()}g" }
    }
}
```

The script only shows `task.ext.args`. The closure is resolved by `LazyMap` at run time and carries **no source**: `ClosureToStringVisitor` only runs when `renderClosureAsString` is set (`nextflow config`, `kuberun`), and `TaskClosure` is only applied to `when`/`stub`. So the expression cannot be recovered the way the script references are.

#7483 closes the same gap with a compile-time AST transform (a new reference collector, a `Closure` subclass carrying the names, and config visitor changes). **This PR is the opposite trade-off: a conservative runtime heuristic with zero compiler changes.**

## The heuristic

`TaskConfig#hasDynamicDirective(Collection<String> names)` walks the **raw** `LazyMap` target and answers: does any of the named directives hold a `Closure` (or a lazy `GString`)?

The reasoning:

* A **static** directive value cannot reference the task resources at all — the config scope does not define `task`. Verified against both parsers:
  * v2 → `ConfigParseException: Config parsing failed` / `MultipleCompilationErrorsException`
  * v1 → `MissingMethodException: No signature of method: groovy.util.ConfigObject.toGiga()` (`task.memory` resolves to an empty `ConfigObject`)
* Therefore a **closure is the only shape** that can carry such a reference — and a closure whose source we cannot inspect must be treated as suspect.

Two properties the implementation is careful about, both covered by tests:

* **It resolves nothing.** Only `getTarget()` is read, never `get()`, so no user closure is evaluated as a side effect of the check. A directive whose closure throws on evaluation does not blow up the check (`should not resolve any directive value`, `submit does not resolve the dynamic directives while checking them`).
* **It skips the config selector blocks.** `ProcessConfigBuilder#applyConfigDefaults` copies *every* key of the `process` scope into each process config, including the `withName:`/`withLabel:` blocks that were **not** applied to it. Here that falls out for free: only the *named* directives are looked up, so a `withName:OTHER` key is never inspected. A selector that *does* match has already been merged into the top-level directives, so true positives are unaffected. (This was the bug found in review of #7483; there is an end-to-end test through `ProcessConfigBuilder.applyConfig` for both the matching and the non-matching process.)

## Scoping: which directives count

The set is a **parameter of the API**, not a constant in core — which directives matter depends on what the executor does with them. `SeqeraTaskHandler.COMMAND_DIRECTIVES` is deliberately narrow:

| directive | in | why |
|---|---|---|
| `ext` | ✅ | reaches the command through the script template, e.g. `${task.ext.args}` |
| `beforeScript`, `afterScript` | ✅ | rendered verbatim into the wrapper by `BashWrapperBuilder` |
| `clusterOptions`, `queue`, `penv` | ❌ | read only by the grid executors (`AbstractGridExecutor`, `Lsf/Pbs/PbsPro`, `TaskArrayCollector`); nothing under `plugins/nf-seqera/src/main` touches them |
| `containerOptions` | ❌ | `BashWrapperBuilder` applies it only when `containerEnabled && !containerNative` — `SeqeraExecutor.isContainerNative()` is always `true` |
| `cpus`, `memory`, … | ❌ | resolved at submit time, *after* the command is rendered, so they carry no stale value |

`clusterOptions` is the load-bearing exclusion. The nf-core institutional profiles set it dynamically on *every* process:

```groovy
process { clusterOptions = { "-l h_vmem=${task.memory.toString().replaceAll(/[\sB]/, '')}" } }
```

Tripping on that would disable resource prediction for an entire pipeline over a directive this executor ignores — defeating the feature. There is a test for it.

## API shape

I kept this **separate** from `TaskRun#isDirectiveReferenced(String)` rather than folding it in, because the heuristic does not know *which* directive is referenced — it only knows a value is dynamic. Hiding that behind a name that promises `memory` would be dishonest, and would silently make `isDirectiveReferenced('cpus')` true for any process with a dynamic `ext`. `SeqeraTaskHandler#shouldDisablePrediction()` ORs the two, with a distinct warning for each.

## The trade-off — please read this before merging

**This over-triggers, and the measured rate is high.**

A dynamic `ext.args = { "--threads ${task.cpus}" }` that never mentions memory disables prediction too. That is the deliberate cost of needing no compiler support. But the dominant driver in practice is not `ext.args` — it is **`ext.prefix`**, which nf-core sets dynamically almost everywhere:

```groovy
ext.prefix = { "${meta.id}.Lb.sorted" }
```

A filename prefix that cannot possibly reference `task.memory`. Counting `withName:` blocks holding at least one dynamic `ext`/`beforeScript`/`afterScript` value in real `conf/modules.config` files:

| pipeline | `withName:` blocks | would trip | dyn `ext.prefix` | dyn `ext.args` |
|---|---|---|---|---|
| nf-core/atacseq | 70 | **40 (57%)** | 32 | 2 |
| nf-core/rnaseq | 77 | **20 (26%)** | 19 | 3 |
| nf-sentieon | 12 | **7 (58%)** | 1 | 6 |
| nf-dragen | 8 | 0 (0%) | 0 | 0 |

So on a typical nf-core pipeline this disables resource prediction for a quarter to a half of all processes. That is the same order of damage as the `clusterOptions` case this PR is careful to avoid, and it is arguably not acceptable as-is.

I could not find a *principled* runtime narrowing that avoids it:

* Narrowing to `ext.args`/`ext.args2`/`ext.args3` by name would cut atacseq to 3% and rnaseq to 4%, but it bakes nf-core naming convention into the executor and misses any custom `ext` key that does reach the command.
* Intersecting with the `task.ext.*` names #7505 already collects from the script does not help: nf-core scripts interpolate `task.ext.prefix` too, so it stays a hit.

**Recommendation:** merge this only if the over-trigger is acceptable, otherwise prefer #7483, which knows the actual referenced names and has no false positives. I am filing it as the honest comparison point, not as the obviously-better option.

## The upside over the compile-time approach

No AST hook is needed, so it works with **both config parsers**, including `NXF_SYNTAX_PARSER=v1` — `ConfigParserFactory.groovy:37` selects `ConfigParserV1`, which has no `ConfigToGroovyVisitor` and therefore no place for #7483's collector to run. It also catches directives declared with a closure in the **process body**, not just in the config file.

## Test evidence

```
./gradlew :nextflow:compileGroovy                                     BUILD SUCCESSFUL

./gradlew :nextflow:test --tests "*TaskConfig*" --tests "*ProcessConfig*" \
          --tests "*TaskRun*" --tests "*TaskHasher*" --tests "*ProcessDirectiveRefs*"
  TaskConfigTest              105 tests, 0 failures
  ProcessConfigTest            17 tests, 0 failures
  ProcessConfigBuilderTest     16 tests, 0 failures
  TaskRunTest                  48 tests, 0 failures
  TaskHasherTest                5 tests, 0 failures   (no hash/resume regression)
  ProcessDirectiveRefsTest      4 tests, 0 failures   (#7505's tests still green)

./gradlew :plugins:nf-seqera:test --tests "*SeqeraTaskHandler*"
  SeqeraTaskHandlerTest        76 tests, 0 failures

NXF_SMOKE=1 ./gradlew :nextflow:test :plugins:nf-seqera:test           BUILD SUCCESSFUL
  modules/nextflow   4198 tests, 135 skipped, 0 failures, 0 errors
  plugins/nf-seqera   278 tests,   0 skipped, 0 failures, 0 errors
```

New tests: dynamic `ext.args` → hit; static `ext.args` → no hit; dynamic `beforeScript` → hit; dynamic `clusterOptions` → no hit for the command set; unapplied `withName:` selector → no hit (unit and end-to-end through `applyConfigBuilder`); matching selector → hit; named-parameter and repeated-directive shapes; lazy GString; empty name set; and the throwing-closure test proving nothing is resolved.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
