### PR TITLE
Fix S3 directory upload skipping symbolic links

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3Client.java
@@ -568,11 +568,21 @@ public class S3Client {
         return porBuilder;
     }
 
-    public void uploadDirectory(File source, S3Path target) throws IOException {
+    /**
+     * Upload the content of a local directory to the given S3 path.
+     *
+     * The {@code followLinks} flag must be set explicitly because the SDK v2 transfer manager
+     * defaults to *not* following symbolic links, unlike the SDK v1 {@code TransferManager} which
+     * always dereferenced them. Leaving the default in place makes a source directory that is
+     * itself a symlink fail as "not a directory", and silently skips symlinked files contained
+     * in the uploaded directory. See https://github.com/nextflow-io/nextflow/issues/7509
+     */
+    public void uploadDirectory(File source, S3Path target, boolean followLinks) throws IOException {
         UploadDirectoryRequest request = UploadDirectoryRequest.builder()
                 .bucket(target.getBucket())
                 .s3Prefix(target.getKey())
                 .source(source.toPath())
+                .followSymbolicLinks(followLinks)
                 .uploadFileRequestTransformer(transformUploadRequest(target.getTagsList()))
                 .build();
 

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/S3FileSystemProvider.java
@@ -337,7 +337,7 @@ public class S3FileSystemProvider extends FileSystemProvider implements FileSyst
         log.debug("S3 upload {} from={} to={}", type, localFile, FilesEx.toUriString(target));
         final S3Client s3Client = target.getFileSystem().getClient();
         if( isDir ) {
-            s3Client.uploadDirectory(localFile.toFile(), target);
+            s3Client.uploadDirectory(localFile.toFile(), target, opts.followLinks());
         }
         else {
             s3Client.uploadFile(localFile.toFile(), target);

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
@@ -23,6 +23,7 @@ import java.nio.file.DirectoryNotEmptyException
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -1198,6 +1199,10 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         local.resolve('cache/foo/bar/file-2').text = 'File two'
         local.resolve('cache/foo/baz/file-3').text = 'File three'
         local.resolve('cache/foo/baz/file-4').text = 'File four'
+        and:
+        // symlinks must be dereferenced when the directory is uploaded
+        Files.createSymbolicLink(local.resolve('cache/foo/link-file-1'), local.resolve('cache/foo/file-1'))
+        Files.createSymbolicLink(local.resolve('cache/foo/link-baz'), local.resolve('cache/foo/baz'))
 
         when:
         CopyMoveHelper.copyToForeignTarget(local.resolve('cache/foo'), s3path("s3://$bucketName/cache1"))
@@ -1206,6 +1211,10 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         Files.exists(s3path("s3://$bucketName/cache1/bar/file-2"))
         Files.exists(s3path("s3://$bucketName/cache1/baz/file-3"))
         Files.exists(s3path("s3://$bucketName/cache1/baz/file-4"))
+        and:
+        readObject(s3path("s3://$bucketName/cache1/link-file-1")) == 'File one'
+        readObject(s3path("s3://$bucketName/cache1/link-baz/file-3")) == 'File three'
+        Files.exists(s3path("s3://$bucketName/cache1/link-baz/file-4"))
 
         when:
         FileHelper.copyPath(local.resolve('cache/foo'), s3path("s3://$bucketName/cache2"))
@@ -1214,6 +1223,78 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         Files.exists(s3path("s3://$bucketName/cache2/bar/file-2"))
         Files.exists(s3path("s3://$bucketName/cache2/baz/file-3"))
         Files.exists(s3path("s3://$bucketName/cache2/baz/file-4"))
+        and:
+        readObject(s3path("s3://$bucketName/cache2/link-file-1")) == 'File one'
+        readObject(s3path("s3://$bucketName/cache2/link-baz/file-3")) == 'File three'
+        Files.exists(s3path("s3://$bucketName/cache2/link-baz/file-4"))
+
+        cleanup:
+        local?.deleteDir()
+        deleteBucket(bucketName)
+    }
+
+    def 'should upload a symlink to a local dir to s3 directory' () {
+        given:
+        def bucketName = createBucket()
+        def local = Files.createTempDirectory('test')
+        local.resolve('cache/foo/bar').mkdirs()
+        and:
+        local.resolve('cache/foo/file-1').text = 'File one'
+        local.resolve('cache/foo/bar/file-2').text = 'File two'
+        and:
+        // the source directory itself is a symlink
+        def link = Files.createSymbolicLink(local.resolve('cache/foo-link'), local.resolve('cache/foo'))
+
+        when:
+        FileHelper.copyPath(link, s3path("s3://$bucketName/cache1"))
+        then:
+        readObject(s3path("s3://$bucketName/cache1/file-1")) == 'File one'
+        readObject(s3path("s3://$bucketName/cache1/bar/file-2")) == 'File two'
+
+        cleanup:
+        local?.deleteDir()
+        deleteBucket(bucketName)
+    }
+
+    def 'should upload a symlink to a local file to s3 file' () {
+        given:
+        def bucketName = createBucket()
+        def local = Files.createTempDirectory('test')
+        local.resolve('cache').mkdirs()
+        and:
+        local.resolve('cache/file-1').text = 'File one'
+        and:
+        def link = Files.createSymbolicLink(local.resolve('cache/link-file-1'), local.resolve('cache/file-1'))
+
+        when:
+        FileHelper.copyPath(link, s3path("s3://$bucketName/cache1/file-1"))
+        then:
+        readObject(s3path("s3://$bucketName/cache1/file-1")) == 'File one'
+
+        cleanup:
+        local?.deleteDir()
+        deleteBucket(bucketName)
+    }
+
+    def 'should not follow symlinks uploading a local dir to s3 directory' () {
+        given:
+        def bucketName = createBucket()
+        def local = Files.createTempDirectory('test')
+        local.resolve('cache/foo/bar').mkdirs()
+        and:
+        local.resolve('cache/foo/file-1').text = 'File one'
+        local.resolve('cache/foo/bar/file-2').text = 'File two'
+        and:
+        Files.createSymbolicLink(local.resolve('cache/foo/link-file-1'), local.resolve('cache/foo/file-1'))
+
+        when:
+        FileHelper.copyPath(local.resolve('cache/foo'), s3path("s3://$bucketName/cache1"), LinkOption.NOFOLLOW_LINKS)
+        then:
+        Files.exists(s3path("s3://$bucketName/cache1/file-1"))
+        Files.exists(s3path("s3://$bucketName/cache1/bar/file-2"))
+        and:
+        // symlinks are not dereferenced, therefore they are not uploaded
+        !Files.exists(s3path("s3://$bucketName/cache1/link-file-1"))
 
         cleanup:
         local?.deleteDir()


### PR DESCRIPTION
Closes #7509

## Problem

The AWS SDK v1 → v2 migration in 25.10.0 changed symlink semantics when publishing directories to S3. SDK v1's `TransferManager` always dereferenced symlinks; SDK v2's `S3TransferManager.uploadDirectory()` defaults to `followSymbolicLinks(false)`, and `S3Client.uploadDirectory` never set the flag. Confirmed against `UploadDirectoryHelper` (s3-transfer-manager 2.53.1):

- **Hard failure** — `validateDirectory()` asserts `Files.isDirectory(dir, NOFOLLOW_LINKS)`, so a task output that *is* a symlink to a directory fails with `The source directory provided (...) is not a directory`.
- **Silent data loss** — `listFiles()` filters with `Files.isRegularFile(path, NOFOLLOW_LINKS)`, so symlinked files inside a published directory are dropped with no error at all.

The second case is the dangerous one: staged inputs are symlinks by default, so re-publishing a directory of staged files silently lost its content. Affects 25.10.0 through 26.04.6, with no configuration workaround.

## Fix

- `S3Client.uploadDirectory` takes a `followLinks` argument and sets `.followSymbolicLinks(followLinks)`
- `S3FileSystemProvider.upload` passes `opts.followLinks()` — the value it already parses

The flag is plumbed from the copy options rather than hardcoded to `true`, because `publishDir mode: 'copyNoFollow'` deliberately passes `LinkOption.NOFOLLOW_LINKS` and the local/generic copy path (`CopyMoveHelper`) honours it. Hardcoding would have made that mode start dereferencing symlinks.

## Tests

Extended `AwsS3NioTest`:

- `'should upload local dir to s3 directory'` now includes a symlinked file and a symlinked subdirectory, asserting dereferenced content via `readObject` on both the `CopyMoveHelper` leg and the S3 fast-path leg
- `'should upload a symlink to a local dir to s3 directory'` — covers the hard failure
- `'should upload a symlink to a local file to s3 file'` — regression guard for the `uploadFile` branch
- `'should not follow symlinks uploading a local dir to s3 directory'` — asserts symlinks are *not* uploaded under `NOFOLLOW_LINKS`, pinning the plumbing rather than a hardcoded `true`

All four were run against real S3 buckets and pass. Reverting only the two main-source changes makes 2 of the 4 fail, reproducing both reported symptoms:

```
Caused by: java.lang.IllegalArgumentException: The source directory provided
  (/tmp/.../cache/foo-link) is not a directory
  at UploadDirectoryHelper.validateDirectory(UploadDirectoryHelper.java:131)
```

```
readObject(s3path("s3://$bucketName/cache2/link-file-1")) == 'File one'
NoSuchKeyException: The specified key does not exist. (404)
```

## Note

Following symlinks means `Files.walk(..., FOLLOW_LINKS)` can now surface `FileSystemLoopException` on cyclic symlinks. SDK v1 behaved the same way, so this restores pre-25.10 behaviour rather than regressing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)