### PR TITLE
Fix workflow output publishing to S3 with the default path

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -148,7 +148,7 @@ class PublishOp {
         // the base output directory
         final outputDir = session.outputDir
         if( pathResolver == null )
-            return outputDir.resolve(path)
+            return outputDir.resolve(path).normalize()
 
         // if the publish path is a closure, invoke it on the
         // published value
@@ -162,12 +162,12 @@ class PublishOp {
         // the resulting mapping to create a saveAs closure
         final mapping = dsl.build()
         if( mapping instanceof Map<String,String> )
-            return { filename -> filename in mapping ? outputDir.resolve(mapping[filename]) : null }
+            return { filename -> filename in mapping ? outputDir.resolve(mapping[filename]).normalize() : null }
 
         // if the resolved publish path is a string, resolve it
         // against the base output directory
         if( resolvedPath instanceof CharSequence )
-            return outputDir.resolve(resolvedPath.toString())
+            return outputDir.resolve(resolvedPath.toString()).normalize()
 
         final invalid = mapping ?: resolvedPath
         throw new ScriptRuntimeException("Invalid `path` directive for workflow output '${name}' -- expected a string or publish statements, but received: ${invalid} [${invalid.class.simpleName}]")

--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -556,7 +556,9 @@ class PublishDir {
     }
 
     protected void makeDirs(Path dir) {
-        if( !dir || makeCache.containsKey(dir) )
+        // nameCount==0 means a filesystem root e.g. an S3 bucket, which
+        // always exists and cannot be created
+        if( !dir || dir.nameCount==0 || makeCache.containsKey(dir) )
             return
 
         try {

--- a/modules/nextflow/src/test/groovy/nextflow/extension/PublishOpTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/extension/PublishOpTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.extension
+
+import java.nio.file.Path
+
+import nextflow.Session
+import spock.lang.Specification
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+class PublishOpTest extends Specification {
+
+    def 'should normalize the target directory' () {
+        given:
+        def session = Mock(Session) { getOutputDir() >> Path.of('/work/results') }
+
+        when:
+        def op = new PublishOp(session, 'foo', null, [path: PATH])
+        then:
+        op.getTargetDir(null) == Path.of(EXPECTED)
+
+        where:
+        PATH        | EXPECTED
+        '.'         | '/work/results'
+        './'        | '/work/results'
+        'bam'       | '/work/results/bam'
+        './bam'     | '/work/results/bam'
+        'bam/../bam'| '/work/results/bam'
+    }
+
+    def 'should normalize the target directory returned by a closure' () {
+        given:
+        def session = Mock(Session) { getOutputDir() >> Path.of('/work/results') }
+        def resolver = { v -> '.' }
+
+        when:
+        def op = new PublishOp(session, 'foo', null, [path: '.', pathResolver: resolver])
+        then:
+        op.getTargetDir(null) == Path.of('/work/results')
+    }
+
+}


### PR DESCRIPTION
Closes #7517

### Problem

The workflow output `path` directive [defaults to `'.'`](https://github.com/nextflow-io/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/script/OutputDsl.groovy#L97), so an empty output declaration gets it implicitly:

```nextflow
output {
    result {}
}
```

`PublishOp.getTargetDir()` resolved that against the output directory *without normalizing*, so the publish directory handed to `PublishDir` literally ended in `/.`, e.g. `s3://bucket/results/.`.

A local filesystem treats `results/.` as `results`, so nothing breaks there. On S3 it becomes a directory-marker object with the key `results/./`:

- **AWS S3** accepts that key, so the run succeeds but silently leaves a bogus `results/./` object in the bucket.
- **S3-compatible stores that reject `.`/`..` path components** — MinIO, Ceph RGW, and S3 Express One Zone directory buckets — reject the `PutObject`, and the run aborts with the error from the issue:

  ```
  java.lang.IllegalStateException: Failed to create publish directory: s3://bucket/results/.
  	at nextflow.processor.PublishDir.createPublishDir(PublishDir.groovy:542)
  	at nextflow.processor.PublishDir.apply0(PublishDir.groovy:240)
  	at nextflow.extension.PublishOp.onNext(PublishOp.groovy:130)
  ```

The published *file* always landed in the right place, because the per-file destination already calls `.normalize()` ([`PublishOp.groovy:322`](https://github.com/nextflow-io/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy#L322) and `:332`). Only the directory Nextflow eagerly created was wrong — that asymmetry is the bug.

### Changes

- **`PublishOp.getTargetDir()`** — normalize all three resolved publish paths, so `'.'` collapses into the output directory itself.
- **`PublishDir.makeDirs()`** — skip filesystem roots (`nameCount == 0`). Normalizing makes `-output-dir s3://bucket` resolve to the bucket root, and `S3FileSystemProvider.createDirectory()` throws `UnsupportedOperationException("Creating a bucket is not supported")` for it. That case previously "worked" on AWS only by accident, via the same junk `./` key, and already failed on MinIO — so this fixes a second, latent failure mode.
- **`PublishOpTest`** (new) — asserts `getTargetDir()` normalizes `.`, `./`, `./bam` and `bam/../bam`, for both the static and closure forms of `path`.

### Verification

Built with `make compile` and ran via `./launch.sh`, against both real AWS S3 (eu-west-1) and a local MinIO endpoint.

| Check | Result |
|---|---|
| MinIO, `-output-dir s3://bucket/results`, `result {}` | was `Failed to create publish directory` → now succeeds; keys are `results/`, `results/test.txt` |
| Real AWS S3, same workflow | succeeds; the `results/./` junk key is gone |
| MinIO, `-output-dir s3://bucket` (bucket root) | failed both before *and* after the normalize change → now succeeds, publishes at the root |
| Local filesystem `-output-dir results` | unchanged |
| Explicit `path 'sub'` and dynamic `path { -> 'dyn/' }` on MinIO | unchanged, publish correctly |
| New `PublishOpTest` | 6 pass with the fix; 5 of 6 fail without it |
| `PublishDirTest` / `OutputDslTest` | 20 and 9 tests, no failures |
| Full `./gradlew :nextflow:test` | 4217 tests, 1 failure — `MultiRevisionRepositoryStrategyTest.should pick up force-pushed branch on subsequent fetch`, which fails identically on clean `master` |
