### PR TITLE
Sort includes when formatting

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/CommentAttacher.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/CommentAttacher.java
@@ -146,6 +146,29 @@ public class CommentAttacher {
     }
 
     /**
+     * The source line at which a node's leading block begins: the line of its
+     * first own-line leading comment if it has one, otherwise the node's own
+     * line. Used to place blank lines above a reordered node.
+     */
+    public int leadingLine(ASTNode node) {
+        var leading = leading(node);
+        return !leading.isEmpty() && leading.get(0).ownLine
+            ? leading.get(0).line
+            : node.getLineNumber();
+    }
+
+    /**
+     * Move the leading comments of one node to the front of another node's leading
+     * comments, used when reordering declarations so a group header stays on top.
+     */
+    public void moveLeadingComments(ASTNode from, ASTNode to) {
+        var fromList = leading.remove(from);
+        if( fromList == null || fromList.isEmpty() )
+            return;
+        leading.computeIfAbsent(to, (k) -> new ArrayList<>()).addAll(0, fromList);
+    }
+
+    /**
      * Get the comments that were attached but never printed. Should always
      * be empty -- a non-empty result is a formatter bug that would silently
      * delete source.

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
@@ -141,6 +141,40 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     /**
+     * Emit the blank lines that precede a node's leading block, for a node whose
+     * source position no longer matches its output position (e.g. a reordered
+     * declaration). The blank count is taken from the node's first own-line leading
+     * comment if it has one, otherwise from the node itself.
+     *
+     * @param node
+     */
+    public void appendBlankLinesBefore(ASTNode node) {
+        appendBlankLines(comments.leadingLine(node));
+    }
+
+    /**
+     * Append the comments that precede a reordered node, preserving the blank
+     * lines between the comments and between the last comment and the node, but
+     * not the blank lines above the first comment -- those separate the node's
+     * group from what precedes it and are placed by the caller, since the node's
+     * source position no longer matches its output position.
+     *
+     * @param node
+     */
+    public void appendInnerComments(ASTNode node) {
+        var leading = comments.leading(node);
+        for( int i = 0; i < leading.size(); i++ ) {
+            if( i > 0 )
+                appendBlankLines(leading.get(i).line);
+            appendComment(leading.get(i));
+        }
+        // within a group only a comment-to-node blank reaches here; a bare blank
+        // above the node would have started a new group
+        if( !leading.isEmpty() )
+            appendBlankLines(node.getLineNumber());
+    }
+
+    /**
      * Append the comments that belong to a construct but not to any
      * particular child, e.g. a comment before a closing brace.
      *

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -15,6 +15,7 @@
  */
 package nextflow.script.formatter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -38,6 +39,7 @@ import nextflow.script.ast.ScriptNode;
 import nextflow.script.ast.ScriptVisitorSupport;
 import nextflow.script.ast.TupleParameter;
 import nextflow.script.ast.WorkflowNode;
+import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
@@ -129,7 +131,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 .max(Integer::compare).orElse(0);
         }
 
-        for( var decl : declarations ) {
+        for( int i = 0; i < declarations.size(); i++ ) {
+            var decl = declarations.get(i);
             if( decl instanceof AgentNode an )
                 visitAgent(an);
             else if( decl instanceof ClassNode cn && cn.isEnum() )
@@ -138,8 +141,13 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 visitFeatureFlag(ffn);
             else if( decl instanceof FunctionNode fn )
                 visitFunction(fn);
-            else if( decl instanceof IncludeNode in )
+            else if( decl instanceof IncludeNode in ) {
+                if( options.sortDeclarations() ) {
+                    i = visitIncludeRun(declarations, i);
+                    continue;
+                }
                 visitInclude(in);
+            }
             else if( decl instanceof OutputBlockNode obn )
                 visitOutputs(obn);
             else if( decl instanceof ParamBlockNode pbn )
@@ -175,8 +183,63 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitInclude(IncludeNode node) {
-        var wrap = node.getLineNumber() < node.getLastLineNumber();
         fmt.appendLeadingComments(node);
+        emitInclude(node);
+    }
+
+    /**
+     * Emit the contiguous run of includes that starts at {@code start}, sorted
+     * alphabetically by source path within each blank-line-separated group.
+     * Groups are emitted in their original order; only membership within a
+     * group is sorted. When sorting moves a different include to the front of a
+     * group, the original first include's leading comments (the group header)
+     * move with it.
+     *
+     * @param declarations
+     * @param start
+     * @return the index of the last include in the run
+     */
+    private int visitIncludeRun(List<ASTNode> declarations, int start) {
+        var comments = fmt.getComments();
+
+        // -- collect the run, split into blank-line-separated groups
+        var groups = new ArrayList<List<IncludeNode>>();
+        List<IncludeNode> group = null;
+        int i = start;
+        while( i < declarations.size() && declarations.get(i) instanceof IncludeNode in ) {
+            if( group == null || comments.blankLinesBefore(comments.leadingLine(in)) > 0 ) {
+                group = new ArrayList<>();
+                groups.add(group);
+            }
+            group.add(in);
+            i++;
+        }
+
+        // -- sort each group independently and emit
+        var comparator = Comparator.comparing((IncludeNode in) -> in.source.getText(), String.CASE_INSENSITIVE_ORDER)
+            .thenComparing(in -> in.source.getText());
+
+        for( var g : groups ) {
+            // the blank lines above the group belong to its original first
+            // include's source position, so emit them before sorting moves it
+            var originalFirst = g.get(0);
+            fmt.appendBlankLinesBefore(originalFirst);
+
+            g.sort(comparator);
+            var newFirst = g.get(0);
+            if( newFirst != originalFirst )
+                comments.moveLeadingComments(originalFirst, newFirst);
+
+            for( var in : g ) {
+                fmt.appendInnerComments(in);
+                emitInclude(in);
+            }
+        }
+        return i - 1;
+    }
+
+    private void emitInclude(IncludeNode node) {
+        var wrap = node.getLineNumber() < node.getLastLineNumber();
         fmt.append("include {");
         if( wrap )
             fmt.incIndent();

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -61,6 +61,25 @@ class ScriptFormatterTest extends Specification {
         return true
     }
 
+    String formatSorted(String contents) {
+        scriptParser.compiler().getSources().clear()
+        def source = scriptParser.parse('main.nf', contents)
+        new ScriptResolveVisitor(source, scriptParser.compiler().compilationUnit(), Types.DEFAULT_SCRIPT_IMPORTS, Collections.emptyList()).visit()
+        assert !TestUtils.hasSyntaxErrors(source)
+        def formatter = new ScriptFormattingVisitor(source, new FormattingOptions(4, true, false, false, true))
+        formatter.visit()
+        assert formatter.getMissingComments().isEmpty()
+        return formatter.toString()
+    }
+
+    boolean checkFormatSorted(String input, String output) {
+        input = input.stripIndent()
+        output = output.stripIndent()
+        assert formatSorted(input) == output
+        assert formatSorted(output) == output
+        return true
+    }
+
     def 'should format a code snippet' () {
         expect:
         checkFormat(
@@ -96,6 +115,204 @@ class ScriptFormatterTest extends Specification {
                 foo ;
                 bar
             } from './foobar.nf'
+            '''
+        )
+    }
+
+    def 'should sort includes alphabetically by source path' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf'
+            include { bar } from './a.nf'
+            ''',
+            '''\
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+            '''
+        )
+    }
+
+    def 'should leave already-sorted includes unchanged' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { alpha } from './alpha.nf'
+            include { beta } from './beta.nf'
+            ''',
+            '''\
+            include { alpha } from './alpha.nf'
+            include { beta } from './beta.nf'
+            '''
+        )
+    }
+
+    def 'should sort includes independently within blank-line-separated groups' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf'
+            include { bar } from './a.nf'
+
+            include { zed } from './z.nf'
+            include { yak } from './y.nf'
+            ''',
+            '''\
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+
+            include { yak } from './y.nf'
+            include { zed } from './z.nf'
+            '''
+        )
+    }
+
+    def 'should move a per-include leading comment with its include when sorted' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf'
+            // comment about bar
+            include { bar } from './a.nf'
+            ''',
+            '''\
+            // comment about bar
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+            '''
+        )
+    }
+
+    def 'should keep a group-header comment at the top of its group when the first include changes' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            // group header
+            include { foo } from './b.nf'
+            include { bar } from './a.nf'
+            ''',
+            '''\
+            // group header
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+            '''
+        )
+    }
+
+    def 'should preserve a trailing comment on an include when sorted' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf' // foo comment
+            include { bar } from './a.nf'
+            ''',
+            '''\
+            include { bar } from './a.nf'
+            include { foo } from './b.nf' // foo comment
+            '''
+        )
+    }
+
+    def 'should not sort includes when sortDeclarations is disabled' () {
+        expect:
+        checkFormat(
+            '''\
+            include { foo } from './b.nf'
+            include { bar } from './a.nf'
+            '''
+        )
+    }
+
+    def 'should be idempotent when sorting includes across multiple groups' () {
+        given:
+        def output =
+            '''\
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+
+            include { yak } from './y.nf'
+            include { zed } from './z.nf'
+            '''.stripIndent()
+
+        expect:
+        formatSorted(output) == output
+        formatSorted(formatSorted(output)) == output
+    }
+
+    def 'should preserve the blank line above the include block when the first include is reordered' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            nextflow.preview.output = true
+
+            include { foo } from './b.nf'
+            include { bar } from './a.nf'
+            ''',
+            '''\
+            nextflow.preview.output = true
+
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+            '''
+        )
+    }
+
+    def 'should preserve multiple blank lines between include groups' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf'
+            include { bar } from './a.nf'
+
+
+            include { zed } from './z.nf'
+            include { yak } from './y.nf'
+            ''',
+            '''\
+            include { bar } from './a.nf'
+            include { foo } from './b.nf'
+
+
+            include { yak } from './y.nf'
+            include { zed } from './z.nf'
+            '''
+        )
+    }
+
+    def 'should preserve a blank line within an include leading comment block when sorted' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            // header
+
+            // note
+            include { aaa } from './a.nf'
+            include { bbb } from './b.nf'
+            ''',
+            '''\
+            // header
+
+            // note
+            include { aaa } from './a.nf'
+            include { bbb } from './b.nf'
+            '''
+        )
+    }
+
+    def 'should preserve a blank line between an include comment and its include when sorted' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { bbb } from './b.nf'
+            // note
+
+            include { aaa } from './a.nf'
+            ''',
+            '''\
+            // note
+
+            include { aaa } from './a.nf'
+            include { bbb } from './b.nf'
             '''
         )
     }


### PR DESCRIPTION
Adds include sorting to the `nf-lang` formatter, resolving nextflow-io/language-server#54. When the sort-declarations option is enabled, `include { ... } from '...'` statements are sorted alphabetically by their source path. This is one of the formatter follow-ups deferred from #7346.

Sorting happens **within blank-line-separated groups**: groups stay in place and keep their blank-line separators, and only the includes inside a group are reordered. This preserves the common convention of grouping includes (e.g. local modules vs nf-core modules) rather than collapsing everything into one alphabetised block.

The main subtlety is that, in the current comment architecture, blank lines are derived from each node's original source line, so naively reordering nodes misplaces the surrounding blank lines. The sorted path therefore emits group separators and leading comments explicitly (via small `Formatter`/`CommentAttacher` helpers) instead of relying on source positions. Comments travel with their include; a comment above the first include of a group is treated as a group header and pinned to the top of the group. That header heuristic is the one debatable behaviour here — it favours the common "section header above a group" case at the cost of a first-include-specific comment, and is easy to drop if reviewers prefer comments always stick to their include.

This is the first of a short stack of formatter follow-up PRs (the others cover blank-line normalisation, line wrapping, and `fmt:` directives).

Assisted-by: Claude Opus 4.8 (Claude Code)

## Example

With `-sort-declarations` enabled, each blank-line-separated block of includes is sorted alphabetically by source path, independently of the others — so the two blocks below are each ordered internally but never merged.

Before:

```nextflow
include { MULTIQC } from './modules/local/multiqc.nf'
include { FASTQC } from './modules/local/fastqc.nf'
include { TRIMGALORE } from './modules/local/trimgalore.nf'

// sorting happens within each blank-line-separated block, never across blocks
include { SAMTOOLS_SORT } from './modules/nf-core/samtools/sort'
include { BWA_MEM } from './modules/nf-core/bwa/mem'
include { PICARD_MARKDUPLICATES } from './modules/nf-core/picard/markduplicates'
```

After:

```nextflow
include { FASTQC } from './modules/local/fastqc.nf'
include { MULTIQC } from './modules/local/multiqc.nf'
include { TRIMGALORE } from './modules/local/trimgalore.nf'

// sorting happens within each blank-line-separated block, never across blocks
include { BWA_MEM } from './modules/nf-core/bwa/mem'
include { PICARD_MARKDUPLICATES } from './modules/nf-core/picard/markduplicates'
include { SAMTOOLS_SORT } from './modules/nf-core/samtools/sort'
```
