### PR TITLE
Wrap long lines in the formatter

### DIFF
--- a/docs/reference/cli/lint.mdx
+++ b/docs/reference/cli/lint.mdx
@@ -35,6 +35,10 @@ Read list of paths to lint from a text file. Use `-` to read from standard input
 
 Format scripts and config files that have no errors.
 
+##### `-line-length`
+
+Maximum line length for formatting (default: `120`). Use `0` to disable line wrapping.
+
 ##### `-o, -output`
 
 Output mode for reporting errors: `full`, `extended`, `concise`, `json`, `markdown` (default: `full`).

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/cli/CmdLint.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/cli/CmdLint.groovy
@@ -102,6 +102,12 @@ class CmdLint extends CmdBase {
     @Parameter(names = ['-harshil-alignment'], description = 'Use Harshil alignment')
     boolean harhsilAlignment
 
+    // JCommander only overwrites this field when `-line-length` is given on the
+    // command line, so the default here is used whenever the flag is unset, while
+    // an explicit `-line-length 0` still comes through as zero (disables wrapping).
+    @Parameter(names = ['-line-length'], description = 'Maximum line length for formatting (0 to disable line wrapping)')
+    int lineLength = FormattingOptions.DEFAULT_MAX_LINE_LENGTH
+
     @Parameter(names = ['-sort-declarations'], description = 'Sort script declarations in Nextflow scripts')
     boolean sortDeclarations
 
@@ -152,7 +158,13 @@ class CmdLint extends CmdBase {
             case 'markdown' -> new MarkdownErrorListener()
             default -> new StandardErrorListener(outputMode, launcher.options.ansiLog, launcher.options.quiet)
         }
-        formattingOptions = new FormattingOptions(spaces, !tabs, harhsilAlignment, false, sortDeclarations)
+        if( lineLength < 0 )
+            throw new AbortOperationException("Error: `-line-length` must be zero or greater")
+
+        // with `-tabs`, `spaces` is 0; use a conventional tab display width so
+        // that line-length measurement counts indentation rather than ignoring it
+        final indentWidth = tabs ? 4 : spaces
+        formattingOptions = new FormattingOptions(indentWidth, !tabs, harhsilAlignment, false, sortDeclarations, lineLength)
 
         errorListener.beforeAll()
 

--- a/modules/nf-lang/src/main/java/nextflow/config/formatter/ConfigFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/formatter/ConfigFormattingVisitor.java
@@ -109,19 +109,21 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
     @Override
     public void visitConfigAssign(ConfigAssignNode node) {
         fmt.appendLeadingComments(node);
-        fmt.appendIndent();
-        var name = String.join(".", node.names);
-        fmt.append(name);
-        if( currentAlignmentWidth > 0 ) {
-            var padding = currentAlignmentWidth - name.length();
-            fmt.append(" ".repeat(padding));
-        }
-        fmt.append(" = ");
-        var sid = fmt.beginStatement(node);
-        fmt.visit(node.value);
-        fmt.endStatement(sid);
-        fmt.appendTrailingComment(node);
-        fmt.appendNewLine();
+        fmt.emitWrappable(() -> {
+            fmt.appendIndent();
+            var name = String.join(".", node.names);
+            fmt.append(name);
+            if( currentAlignmentWidth > 0 ) {
+                var padding = currentAlignmentWidth - name.length();
+                fmt.append(" ".repeat(padding));
+            }
+            fmt.append(" = ");
+            var sid = fmt.beginStatement(node);
+            fmt.visit(node.value);
+            fmt.endStatement(sid);
+            fmt.appendTrailingComment(node);
+            fmt.appendNewLine();
+        });
     }
 
     private static final Pattern IDENTIFIER = Pattern.compile("[a-zA-Z_]+[a-zA-Z0-9_]*");

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
@@ -291,6 +291,110 @@ public class Formatter extends CodeVisitorSupport {
         return builder.toString();
     }
 
+    // line-length wrapping
+
+    /**
+     * How aggressively expressions are being wrapped onto multiple lines,
+     * on top of preserving the wrapping in the source:
+     *
+     * NONE -- only expressions that were wrapped in the source are wrapped;
+     * TOP  -- the outermost wrappable construct of the statement is wrapped;
+     * ALL  -- every wrappable construct of the statement is wrapped.
+     */
+    private enum WrapMode {
+        NONE,
+        TOP,
+        ALL
+    }
+
+    private WrapMode wrapMode = WrapMode.NONE;
+
+    private int exprDepth = 0;
+
+    /**
+     * Emit a line of output, and if it exceeds the maximum line length,
+     * roll it back and re-emit it with expressions wrapped onto multiple
+     * lines -- first only the outermost construct, then, if the result
+     * still has an over-long line (e.g. deeply nested arguments), every
+     * construct.
+     */
+    public void emitWrappable(Runnable body) {
+        if( options.maxLineLength() <= 0 || wrapMode != WrapMode.NONE ) {
+            body.run();
+            return;
+        }
+        // wrapping depth is measured from this statement, so reset it for the
+        // outermost wrappable (nested statements inherit this baseline during a
+        // wrap pass, where the guard above makes them run inline)
+        var savedDepth = exprDepth;
+        exprDepth = 0;
+        var mark = builder.length();
+        body.run();
+        if( exceedsMaxLineLength(mark) ) {
+            builder.setLength(mark);
+            wrapMode = WrapMode.TOP;
+            body.run();
+            if( exceedsMaxLineLength(mark) ) {
+                builder.setLength(mark);
+                wrapMode = WrapMode.ALL;
+                body.run();
+            }
+            wrapMode = WrapMode.NONE;
+        }
+        exprDepth = savedDepth;
+    }
+
+    /**
+     * Determine whether any line emitted after the given position exceeds
+     * the maximum line length.
+     */
+    private boolean exceedsMaxLineLength(int from) {
+        var max = options.maxLineLength();
+        var lineStart = builder.lastIndexOf("\n", from - 1) + 1;
+        var col = 0;
+        for( int i = lineStart; i < builder.length(); i++ ) {
+            var c = builder.charAt(i);
+            if( c == '\n' )
+                col = 0;
+            else if( c == '\t' )
+                col += options.tabSize();
+            else
+                col++;
+            if( col > max )
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Determine whether the current construct should be wrapped because of
+     * the line-length limit.
+     *
+     * In TOP mode only the outermost wrappable construct of the statement is
+     * broken. "Outermost" is {@code exprDepth <= 2} because a statement reaches
+     * its top construct at depth 0 (a bare directive), 1 (a bare call, return,
+     * throw or config assignment) or 2 (the right-hand side of an assignment,
+     * whose value expression is visited one level deeper).
+     */
+    private boolean forceWrap() {
+        if( wrapMode == WrapMode.ALL )
+            return true;
+        if( wrapMode == WrapMode.TOP )
+            return exprDepth <= 2;
+        return false;
+    }
+
+    /**
+     * Determine whether a collection-like construct with the given number of
+     * elements should be force-wrapped by the line-length limit. A single-element
+     * collection is left inline (there is nothing to gain by breaking it); a
+     * single-argument method call is not, hence {@link #shouldWrapMethodCall}
+     * uses its own threshold.
+     */
+    public boolean forceWrap(int elementCount) {
+        return forceWrap() && elementCount > 1;
+    }
+
     // statements
 
     @Override
@@ -348,17 +452,19 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitExpressionStatement(ExpressionStatement node) {
-        var cre = currentRootExpr;
-        currentRootExpr = node.getExpression();
         appendLeadingComments(node);
-        appendIndent();
-        var sid = beginStatement(node);
-        visitStatementLabels(node);
-        visit(node.getExpression());
-        endStatement(sid);
-        appendTrailingComment(node);
-        appendNewLine();
-        currentRootExpr = cre;
+        emitWrappable(() -> {
+            var cre = currentRootExpr;
+            currentRootExpr = node.getExpression();
+            appendIndent();
+            var sid = beginStatement(node);
+            visitStatementLabels(node);
+            visit(node.getExpression());
+            endStatement(sid);
+            appendTrailingComment(node);
+            appendNewLine();
+            currentRootExpr = cre;
+        });
     }
 
     private void visitStatementLabels(ExpressionStatement node) {
@@ -372,33 +478,37 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitReturnStatement(ReturnStatement node) {
-        var cre = currentRootExpr;
-        currentRootExpr = node.getExpression();
         appendLeadingComments(node);
-        appendIndent();
-        var sid = beginStatement(node);
-        append("return ");
-        visit(node.getExpression());
-        endStatement(sid);
-        appendTrailingComment(node);
-        appendNewLine();
-        currentRootExpr = cre;
+        emitWrappable(() -> {
+            var cre = currentRootExpr;
+            currentRootExpr = node.getExpression();
+            appendIndent();
+            var sid = beginStatement(node);
+            append("return ");
+            visit(node.getExpression());
+            endStatement(sid);
+            appendTrailingComment(node);
+            appendNewLine();
+            currentRootExpr = cre;
+        });
     }
 
     @Override
     public void visitAssertStatement(AssertStatement node) {
         appendLeadingComments(node);
-        appendIndent();
-        var sid = beginStatement(node);
-        append("assert ");
-        visit(node.getBooleanExpression());
-        if( !(node.getMessageExpression() instanceof ConstantExpression ce && ce.isNullExpression()) ) {
-            append(" : ");
-            visit(node.getMessageExpression());
-        }
-        endStatement(sid);
-        appendTrailingComment(node);
-        appendNewLine();
+        emitWrappable(() -> {
+            appendIndent();
+            var sid = beginStatement(node);
+            append("assert ");
+            visit(node.getBooleanExpression());
+            if( !(node.getMessageExpression() instanceof ConstantExpression ce && ce.isNullExpression()) ) {
+                append(" : ");
+                visit(node.getMessageExpression());
+            }
+            endStatement(sid);
+            appendTrailingComment(node);
+            appendNewLine();
+        });
     }
 
     @Override
@@ -421,13 +531,15 @@ public class Formatter extends CodeVisitorSupport {
     @Override
     public void visitThrowStatement(ThrowStatement node) {
         appendLeadingComments(node);
-        appendIndent();
-        var sid = beginStatement(node);
-        append("throw ");
-        visit(node.getExpression());
-        endStatement(sid);
-        appendTrailingComment(node);
-        appendNewLine();
+        emitWrappable(() -> {
+            appendIndent();
+            var sid = beginStatement(node);
+            append("throw ");
+            visit(node.getExpression());
+            endStatement(sid);
+            appendTrailingComment(node);
+            appendNewLine();
+        });
     }
 
     @Override
@@ -536,27 +648,36 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     public void visitDirective(ASTNode owner, MethodCallExpression call) {
-        appendIndent();
-        var sid = beginStatement(owner);
-        append(call.getMethodAsString());
-        var arguments = asMethodCallArguments(call);
-        if( !arguments.isEmpty() ) {
-            var wrap = hasComments(call, arguments);
-            if( wrap )
-                incIndent();
-            else
-                append(' ');
-            visitArguments(arguments, wrap);
-            if( wrap ) {
-                appendNewLine();
-                appendDanglingComments(call);
-                decIndent();
-                appendIndent();
+        emitWrappable(() -> {
+            appendIndent();
+            var sid = beginStatement(owner);
+            append(call.getMethodAsString());
+            var arguments = asMethodCallArguments(call);
+            if( !arguments.isEmpty() ) {
+                var wrap = hasComments(call, arguments) || forceWrap();
+                // a bare directive call has no parens to hold a trailing comma
+                // or a comment on its own line, so wrapping adds them, just
+                // like a regular method call
+                if( wrap ) {
+                    append('(');
+                    incIndent();
+                }
+                else {
+                    append(' ');
+                }
+                visitArguments(arguments, wrap);
+                if( wrap ) {
+                    appendNewLine();
+                    appendDanglingComments(call);
+                    decIndent();
+                    appendIndent();
+                    append(')');
+                }
             }
-        }
-        endStatement(sid);
-        appendTrailingComment(owner);
-        appendNewLine();
+            endStatement(sid);
+            appendTrailingComment(owner);
+            appendNewLine();
+        });
     }
 
     public void visitArguments(List<Expression> args, boolean wrap) {
@@ -717,7 +838,7 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitTupleExpression(TupleExpression node) {
-        var wrap = hasTrailingComma(node) || hasComments(node, node.getExpressions());
+        var wrap = hasTrailingComma(node) || hasComments(node, node.getExpressions()) || forceWrap(node.getExpressions().size());
         append('(');
         if( wrap )
             incIndent();
@@ -733,7 +854,7 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitListExpression(ListExpression node) {
-        var wrap = hasTrailingComma(node) || hasComments(node, node.getExpressions());
+        var wrap = hasTrailingComma(node) || hasComments(node, node.getExpressions()) || forceWrap(node.getExpressions().size());
         append('[');
         if( wrap )
             incIndent();
@@ -771,7 +892,7 @@ public class Formatter extends CodeVisitorSupport {
             append("[:]");
             return;
         }
-        var wrap = hasTrailingComma(node) || hasComments(node, node.getMapEntryExpressions());
+        var wrap = hasTrailingComma(node) || hasComments(node, node.getMapEntryExpressions()) || forceWrap(node.getMapEntryExpressions().size());
         append('[');
         if( wrap )
             incIndent();
@@ -902,7 +1023,13 @@ public class Formatter extends CodeVisitorSupport {
                 append(tripleQuoted ? reindentString(text) : text);
             if( i < vs.size() ) {
                 append("${");
+                // never force-wrap inside a string interpolation: a newline
+                // here would be injected into the string literal itself (e.g. a
+                // process script block). Source-driven wrapping still applies.
+                var savedWrapMode = wrapMode;
+                wrapMode = WrapMode.NONE;
                 visit(vs.get(i));
+                wrapMode = savedWrapMode;
                 append('}');
             }
         }
@@ -914,7 +1041,9 @@ public class Formatter extends CodeVisitorSupport {
         var number = (Number) node.getNodeMetaData(ASTNodeMarker.INSIDE_PARENTHESES_LEVEL);
         if( number != null && number.intValue() > 0 )
             append('(');
+        exprDepth++;
         super.visit(node);
+        exprDepth--;
         if( number != null && number.intValue() > 0 )
             append(')');
     }
@@ -966,11 +1095,13 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     private boolean shouldWrapExpression(Expression node) {
-        return node.getLineNumber() < node.getLastLineNumber();
+        return node.getLineNumber() < node.getLastLineNumber() || forceWrap();
     }
 
     private boolean shouldWrapMethodCall(MethodCallExpression node) {
         if( hasTrailingComma(node.getArguments()) )
+            return true;
+        if( forceWrap() && asMethodCallArguments(node).size() > 0 )
             return true;
         var start = node.getMethod();
         var end = node.getArguments();
@@ -992,6 +1123,9 @@ public class Formatter extends CodeVisitorSupport {
             root = mce.getObjectExpression();
             depth += 1;
         }
+
+        if( wrapMode != WrapMode.NONE )
+            return depth >= 2;
 
         return shouldWrapExpression(root)
             ? false

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/FormattingOptions.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/FormattingOptions.java
@@ -15,14 +15,25 @@
  */
 package nextflow.script.formatter;
 
+/**
+ * @param maxLineLength the maximum line length used by line wrapping
+ *                      (0 to disable line wrapping)
+ */
 public record FormattingOptions(
     int tabSize,
     boolean insertSpaces,
     boolean harshilAlignment,
     boolean maheshForm,
-    boolean sortDeclarations
+    boolean sortDeclarations,
+    int maxLineLength
 ) {
+    public static final int DEFAULT_MAX_LINE_LENGTH = 120;
+
     public FormattingOptions(int tabSize, boolean insertSpaces) {
         this(tabSize, insertSpaces, false, false, false);
+    }
+
+    public FormattingOptions(int tabSize, boolean insertSpaces, boolean harshilAlignment, boolean maheshForm, boolean sortDeclarations) {
+        this(tabSize, insertSpaces, harshilAlignment, maheshForm, sortDeclarations, DEFAULT_MAX_LINE_LENGTH);
     }
 }

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -290,18 +290,20 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         fmt.incIndent();
         for( var param : node.declarations ) {
             fmt.appendLeadingComments(param);
-            fmt.appendIndent();
-            fmt.append(param.getName());
-            if( fmt.hasType(param) ) {
-                fmt.append(": ");
-                fmt.visitTypeAnnotation(param.getType());
-            }
-            if( param.hasInitialExpression() ) {
-                fmt.append(" = ");
-                fmt.visit(param.getInitialExpression());
-            }
-            fmt.appendTrailingComment(param);
-            fmt.appendNewLine();
+            fmt.emitWrappable(() -> {
+                fmt.appendIndent();
+                fmt.append(param.getName());
+                if( fmt.hasType(param) ) {
+                    fmt.append(": ");
+                    fmt.visitTypeAnnotation(param.getType());
+                }
+                if( param.hasInitialExpression() ) {
+                    fmt.append(" = ");
+                    fmt.visit(param.getInitialExpression());
+                }
+                fmt.appendTrailingComment(param);
+                fmt.appendNewLine();
+            });
         }
         fmt.appendDanglingComments(node);
         fmt.decIndent();
@@ -313,16 +315,18 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
     @Override
     public void visitParamV1(ParamNodeV1 node) {
         fmt.appendLeadingComments(node);
-        fmt.appendIndent();
-        fmt.visit(node.target);
-        if( maxParamWidth > 0 ) {
-            var padding = maxParamWidth - parameterWidth(node);
-            fmt.append(" ".repeat(padding));
-        }
-        fmt.append(" = ");
-        fmt.visit(node.value);
-        fmt.appendTrailingComment(node);
-        fmt.appendNewLine();
+        fmt.emitWrappable(() -> {
+            fmt.appendIndent();
+            fmt.visit(node.target);
+            if( maxParamWidth > 0 ) {
+                var padding = maxParamWidth - parameterWidth(node);
+                fmt.append(" ".repeat(padding));
+            }
+            fmt.append(" = ");
+            fmt.visit(node.value);
+            fmt.appendTrailingComment(node);
+            fmt.appendNewLine();
+        });
     }
 
     private static int parameterWidth(ParamNodeV1 node) {
@@ -389,21 +393,23 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
     private void visitTypedInputs(Parameter[] inputs) {
         for( var input : inputs ) {
             fmt.appendLeadingComments(input);
-            fmt.appendIndent();
-            if( input instanceof TupleParameter tp ) {
-                visitStructuredInput(tp);
-            }
-            else {
-                visitTypedInput(input);
-            }
-            fmt.appendTrailingComment(input);
-            fmt.appendNewLine();
+            fmt.emitWrappable(() -> {
+                fmt.appendIndent();
+                if( input instanceof TupleParameter tp ) {
+                    visitStructuredInput(tp);
+                }
+                else {
+                    visitTypedInput(input);
+                }
+                fmt.appendTrailingComment(input);
+                fmt.appendNewLine();
+            });
         }
     }
 
     private void visitStructuredInput(TupleParameter tp) {
         var isRecord = "Record".equals(tp.getType().getNameWithoutPackage());
-        var wrap = isRecord;
+        var wrap = isRecord || fmt.forceWrap(tp.components.length);
 
         fmt.append(isRecord ? "record" : "tuple");
         fmt.append('(');
@@ -457,10 +463,12 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
             if( target != null ) {
                 fmt.appendLeadingComments(stmt);
-                fmt.appendIndent();
-                visitOutputAssignment(target, source, alignmentWidth);
-                fmt.appendTrailingComment(stmt);
-                fmt.appendNewLine();
+                fmt.emitWrappable(() -> {
+                    fmt.appendIndent();
+                    visitOutputAssignment(target, source, alignmentWidth);
+                    fmt.appendTrailingComment(stmt);
+                    fmt.appendNewLine();
+                });
             }
             else {
                 fmt.visit(stmt);
@@ -480,10 +488,12 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             var source = emit.getRightExpression();
 
             fmt.appendLeadingComments(stmt);
-            fmt.appendIndent();
-            visitOutputAssignment(target, source, alignmentWidth);
-            fmt.appendTrailingComment(stmt);
-            fmt.appendNewLine();
+            fmt.emitWrappable(() -> {
+                fmt.appendIndent();
+                visitOutputAssignment(target, source, alignmentWidth);
+                fmt.appendTrailingComment(stmt);
+                fmt.appendNewLine();
+            });
         }
     }
 

--- a/modules/nf-lang/src/test/groovy/nextflow/config/formatter/ConfigFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/formatter/ConfigFormatterTest.groovy
@@ -57,6 +57,23 @@ class ConfigFormatterTest extends Specification {
         return true
     }
 
+    String formatWrapped(String contents, int lineLength) {
+        def source = parser.parse('main.nf', contents)
+        assert !source.getErrorCollector().hasErrors()
+        def formatter = new ConfigFormattingVisitor(source, new FormattingOptions(4, true, false, false, false, lineLength))
+        formatter.visit()
+        assert formatter.getMissingComments().isEmpty()
+        return formatter.toString()
+    }
+
+    boolean checkFormatWrapped(String input, String output, int lineLength = 40) {
+        input = input.stripIndent()
+        output = output.stripIndent()
+        assert formatWrapped(input, lineLength) == output
+        assert formatWrapped(output, lineLength) == output
+        return true
+    }
+
     def 'should format a config assignment' () {
         expect:
         checkFormat(
@@ -147,6 +164,48 @@ class ConfigFormatterTest extends Specification {
                 """
             }
             '''
+        )
+    }
+
+    // -- line-length wrapping (issue #26)
+
+    def 'should wrap a long config assignment and leave a short one alone' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            process.ext.args = [alpha, beta, gamma, delta, epsilon, zeta]
+            ''',
+            '''\
+            process.ext.args = [
+                alpha,
+                beta,
+                gamma,
+                delta,
+                epsilon,
+                zeta,
+            ]
+            '''
+        )
+        checkFormatWrapped(
+            '''\
+            process.ext.args = [alpha, beta]
+            ''',
+            '''\
+            process.ext.args = [alpha, beta]
+            '''
+        )
+    }
+
+    def 'should not wrap a long config assignment when maxLineLength is disabled' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            process.ext.args = [alpha, beta, gamma, delta, epsilon, zeta]
+            ''',
+            '''\
+            process.ext.args = [alpha, beta, gamma, delta, epsilon, zeta]
+            ''',
+            0
         )
     }
 

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -80,6 +80,31 @@ class ScriptFormatterTest extends Specification {
         return true
     }
 
+    String formatWrapped(String contents, int lineLength) {
+        scriptParser.compiler().getSources().clear()
+        def source = scriptParser.parse('main.nf', contents)
+        new ScriptResolveVisitor(source, scriptParser.compiler().compilationUnit(), Types.DEFAULT_SCRIPT_IMPORTS, Collections.emptyList()).visit()
+        assert !TestUtils.hasSyntaxErrors(source)
+        def formatter = new ScriptFormattingVisitor(source, new FormattingOptions(4, true, false, false, false, lineLength))
+        formatter.visit()
+        assert formatter.getMissingComments().isEmpty()
+        return formatter.toString()
+    }
+
+    boolean checkFormatWrapped(String input, String output, int lineLength = 40) {
+        input = input.stripIndent()
+        output = output.stripIndent()
+        assert formatWrapped(input, lineLength) == output
+        assert formatWrapped(output, lineLength) == output
+        return true
+    }
+
+    boolean checkFormatWrapped(String source, int lineLength = 40) {
+        source = source.stripIndent()
+        assert formatWrapped(source, lineLength) == source
+        return true
+    }
+
     def 'should format a code snippet' () {
         expect:
         checkFormat(
@@ -1514,6 +1539,236 @@ class ScriptFormatterTest extends Specification {
                     }
             }
             '''
+        )
+    }
+
+    // -- line-length wrapping (issue #26)
+
+    def 'should wrap a long function call and leave a short one alone' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            workflow {
+                ALIGN_AND_SORT(samples_channel, reference_genome, annotation_file, params.threads)
+            }
+            ''',
+            '''\
+            workflow {
+                ALIGN_AND_SORT(
+                    samples_channel,
+                    reference_genome,
+                    annotation_file,
+                    params.threads,
+                )
+            }
+            ''',
+            60
+        )
+        checkFormatWrapped(
+            '''\
+            workflow {
+                x = foo(a, b)
+            }
+            ''',
+            '''\
+            workflow {
+                x = foo(a, b)
+            }
+            ''',
+            60
+        )
+    }
+
+    def 'should wrap a long list literal and leave a short one alone' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            workflow {
+                x = [alpha, beta, gamma, delta, epsilon, zeta]
+            }
+            ''',
+            '''\
+            workflow {
+                x = [
+                    alpha,
+                    beta,
+                    gamma,
+                    delta,
+                    epsilon,
+                    zeta,
+                ]
+            }
+            '''
+        )
+        checkFormatWrapped(
+            '''\
+            workflow {
+                x = [alpha, beta, gamma]
+            }
+            ''',
+            '''\
+            workflow {
+                x = [alpha, beta, gamma]
+            }
+            '''
+        )
+    }
+
+    def 'should wrap a long map literal' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            workflow {
+                x = [alpha: 1, beta: 2, gamma: 3, delta: 4]
+            }
+            ''',
+            '''\
+            workflow {
+                x = [
+                    alpha: 1,
+                    beta: 2,
+                    gamma: 3,
+                    delta: 4,
+                ]
+            }
+            '''
+        )
+    }
+
+    def 'should wrap a long process directive' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            process FOO {
+                publishDir params.outdir, mode: 'copy', overwrite: true
+
+                script:
+                """
+                echo hi
+                """
+            }
+            ''',
+            '''\
+            process FOO {
+                publishDir(
+                    params.outdir,
+                    mode: 'copy',
+                    overwrite: true,
+                )
+
+                script:
+                """
+                echo hi
+                """
+            }
+            '''
+        )
+    }
+
+    def 'should wrap a long structured process input' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            nextflow.enable.types = true
+
+            process FOO {
+                input:
+                tuple(identifier: String, someInputFile: Path)
+
+                script:
+                'echo hi'
+            }
+            ''',
+            '''\
+            nextflow.enable.types = true
+
+            process FOO {
+                input:
+                tuple(
+                    identifier: String,
+                    someInputFile: Path
+                )
+
+                script:
+                'echo hi'
+            }
+            '''
+        )
+    }
+
+    def 'should escalate to wrapping every construct when the outer wrap alone is not enough' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            workflow {
+                x = foo(alpha, [nested_one, nested_two, nested_three, nested_four])
+            }
+            ''',
+            '''\
+            workflow {
+                x = foo(
+                    alpha,
+                    [
+                        nested_one,
+                        nested_two,
+                        nested_three,
+                        nested_four,
+                    ],
+                )
+            }
+            '''
+        )
+    }
+
+    def 'should preserve a comment inside a force-wrapped list' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            workflow {
+                x = [alpha, beta, gamma, delta, epsilon, zeta] // the letters
+            }
+            ''',
+            '''\
+            workflow {
+                x = [
+                    alpha,
+                    beta,
+                    gamma,
+                    delta,
+                    epsilon,
+                    zeta,
+                ] // the letters
+            }
+            '''
+        )
+    }
+
+    def 'should not wrap inside a string interpolation' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            process FOO {
+                script:
+                "echo ${[alpha, beta, gamma].join(' ')} and some more text past the limit"
+            }
+            '''
+        )
+    }
+
+    def 'should not wrap a long line when maxLineLength is disabled' () {
+        expect:
+        checkFormatWrapped(
+            '''\
+            workflow {
+                ALIGN_AND_SORT(samples_channel, reference_genome, annotation_file, params.threads)
+            }
+            ''',
+            '''\
+            workflow {
+                ALIGN_AND_SORT(samples_channel, reference_genome, annotation_file, params.threads)
+            }
+            ''',
+            0
         )
     }
 


### PR DESCRIPTION
Adds line-length-based wrapping to the `nf-lang` formatter, resolving nextflow-io/language-server#26. When a formatted line would exceed the maximum length, it is re-emitted with its expressions — lists, maps, function-call arguments and directives — broken across multiple lines. Another formatter follow-up deferred from #7346.

The mechanism is emit-measure-rewrap: a statement is emitted normally, and if any resulting line is too long it is rolled back and re-emitted, first wrapping only the outermost construct and then, if still too long, every construct. This "produce, measure, redo" approach is the one suggested in the issue, and it reuses the existing per-construct wrap logic rather than duplicating layout rules.

**Stacked PR** — targets `formatter-sort-includes` (nextflow-io/language-server#54), not `master`. Review/merge that one first; the diff here is only the wrapping change.

Decisions worth a look in review:

- **Default maximum is 120 columns and wrapping is on by default.** The default lives in `FormattingOptions`, so every caller that does not opt out — including the language server (the VS Code "Format Document" action, which is what the issue is about) and `GroovyFormatter` — now wraps at 120. It only affects lines that exceed the limit; code under the limit is untouched. Configurable via `nextflow lint -line-length` (0 disables). Easy to flip to off-by-default if preferred.
- **Wrapping is best-effort.** It never wraps inside a string interpolation (so process `script:` blocks are never mangled), and a line whose length comes from an unsplittable token — a long string literal, a trailing comment — or from a single-element collection may remain over-long. The formatter does not guarantee every emitted line fits.
- **A wrapped directive gains parentheses** (`publishDir(...)` instead of a bare `publishDir ...`), because a bare directive call has no bracket to hold the wrapped arguments' trailing comma or an own-line comment — the same shape a regular method call already uses.

Assisted-by: Claude Opus 4.8 (Claude Code)

## Example

A directive whose arguments push the line past the maximum (120 columns by default) is broken onto one argument per line. A bare directive gains parentheses to hold the wrapped arguments.

Before:

```nextflow
process ALIGN {
    publishDir params.outdir, mode: 'copy', overwrite: true, saveAs: { filename -> "aligned/${task.process}/${filename}" }

    script:
    "bwa mem ref.fa reads.fq > out.sam"
}
```

After:

```nextflow
process ALIGN {
    publishDir(
        params.outdir,
        mode: 'copy',
        overwrite: true,
        saveAs: { filename -> "aligned/${task.process}/${filename}" },
    )

    script:
    "bwa mem ref.fa reads.fq > out.sam"
}
```

A line that already fits within the limit is left untouched.
