### PR TITLE
Support fmt: skip / off / on directives in the formatter

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/config/formatter/ConfigFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/formatter/ConfigFormattingVisitor.java
@@ -27,10 +27,10 @@ import nextflow.config.ast.ConfigNode;
 import nextflow.config.ast.ConfigVisitorSupport;
 import nextflow.script.formatter.Comment;
 import nextflow.script.formatter.CommentAttacher;
+import nextflow.script.formatter.FmtDirectives;
 import nextflow.script.formatter.FormattingOptions;
 import nextflow.script.formatter.Formatter;
 import org.codehaus.groovy.control.SourceUnit;
-import org.codehaus.groovy.runtime.IOGroovyMethods;
 
 import static nextflow.script.ast.ASTUtils.*;
 
@@ -51,7 +51,9 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
         this.sourceUnit = sourceUnit;
         this.options = options;
         this.fmt = new Formatter(options);
-        this.fmt.setComments(CommentAttacher.of(sourceUnit.getAST()));
+        var commentAttacher = CommentAttacher.of(sourceUnit.getAST());
+        this.fmt.setComments(commentAttacher);
+        this.fmt.setFmtDirectives(FmtDirectives.of(sourceUnit.getAST(), () -> FmtDirectives.readSourceText(sourceUnit), commentAttacher));
     }
 
     /**
@@ -83,6 +85,8 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigApplyBlock(ConfigApplyBlockNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.appendIndent();
         fmt.append(node.name);
@@ -102,12 +106,16 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigApply(ConfigApplyNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.visitDirective(node);
     }
 
     @Override
     public void visitConfigAssign(ConfigAssignNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.emitWrappable(() -> {
             fmt.appendIndent();
@@ -132,6 +140,8 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigBlock(ConfigBlockNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.appendIndent();
         if( node.kind != null ) {
@@ -179,6 +189,8 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigInclude(ConfigIncludeNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.appendIndent();
         fmt.append("includeConfig ");

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/FmtDirectives.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/FmtDirectives.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.formatter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import nextflow.config.ast.ConfigApplyBlockNode;
+import nextflow.config.ast.ConfigAssignNode;
+import nextflow.config.ast.ConfigBlockNode;
+import nextflow.config.ast.ConfigIncludeNode;
+import nextflow.config.ast.ConfigNode;
+import nextflow.config.ast.ConfigStatement;
+import nextflow.script.ast.ASTNodeMarker;
+import nextflow.script.ast.AgentNode;
+import nextflow.script.ast.FunctionNode;
+import nextflow.script.ast.OutputBlockNode;
+import nextflow.script.ast.ProcessNodeV1;
+import nextflow.script.ast.ProcessNodeV2;
+import nextflow.script.ast.ScriptNode;
+import nextflow.script.ast.WorkflowNode;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.stmt.AssertStatement;
+import org.codehaus.groovy.ast.stmt.EmptyStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.IfStatement;
+import org.codehaus.groovy.ast.stmt.ReturnStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.ast.stmt.ThrowStatement;
+import org.codehaus.groovy.ast.stmt.TryCatchStatement;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.runtime.IOGroovyMethods;
+
+import static nextflow.script.ast.ASTUtils.*;
+import static nextflow.script.formatter.Comment.*;
+
+/**
+ * Resolve `// fmt: skip` and `// fmt: off` ... `// fmt: on` directives into
+ * the source ranges they exclude from formatting, following the semantics of
+ * Black (language-server issue #75).
+ *
+ * Like {@link CommentAttacher}, this is derived fresh for each formatting
+ * pass rather than stored in node metadata, since the same AST may be
+ * formatted many times.
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+public class FmtDirectives {
+
+    private static final FmtDirectives EMPTY = new FmtDirectives();
+
+    private static final Pattern FMT_DIRECTIVE = Pattern.compile("//\\s*fmt:\\s*(skip|off|on)\\s*");
+
+    private final Map<ASTNode,String> verbatimSource = new IdentityHashMap<>();
+
+    /**
+     * The first source line of the verbatim text assigned to an anchor --
+     * usually the anchor's own line, but for `fmt: off` it is the line of the
+     * `off` comment, which may precede the anchor's own leading comments.
+     * Used by {@link Formatter#appendVerbatim} to avoid re-printing (or
+     * double-counting the blank lines above) a leading comment that is
+     * already part of the verbatim text.
+     */
+    private final Map<ASTNode,Integer> verbatimStart = new IdentityHashMap<>();
+
+    private final Set<ASTNode> suppressed = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    /**
+     * The comments whose own line falls within some verbatim range -- they
+     * are printed as part of the raw text rather than individually, so the
+     * normal comment-printing paths (dangling, trailing, a non-anchor's
+     * leading comments) must not print them again.
+     *
+     * This is tracked separately from {@code CommentAttacher.markEmitted},
+     * which is also (re-)called by the normal printing paths themselves --
+     * including, harmlessly, more than once per comment when
+     * {@code Formatter.emitWrappable} retries a statement with wrapping
+     * enabled. Reusing that as a "already printed, skip it" signal would
+     * make the first (rolled-back) attempt suppress the comment on retry.
+     */
+    private final Set<Comment> verbatimComments = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    private FmtDirectives() {
+    }
+
+    /**
+     * Derive the verbatim regions for a module. As with {@link CommentAttacher},
+     * the result belongs to a single formatting pass.
+     *
+     * The raw source text is supplied lazily and read only when the file
+     * actually contains a fmt directive, so the common case (no directives)
+     * never pays for reading the whole file.
+     *
+     * @param moduleNode
+     * @param sourceText supplies the raw source text; may return null if it
+     *                   could not be read, in which case directives are inactive
+     * @param comments
+     */
+    public static FmtDirectives of(ModuleNode moduleNode, Supplier<String> sourceText, CommentAttacher comments) {
+        if( moduleNode == null || sourceText == null )
+            return EMPTY;
+        var commentsMeta = (Comments) moduleNode.getNodeMetaData(ASTNodeMarker.COMMENTS);
+        if( commentsMeta == null || commentsMeta.getComments().isEmpty() )
+            return EMPTY;
+        var ranges = computeRanges(commentsMeta.getComments());
+        if( ranges.isEmpty() )
+            return EMPTY;
+        var text = sourceText.get();
+        if( text == null )
+            return EMPTY;
+        var result = new FmtDirectives();
+        result.apply(moduleNode, text, ranges, commentsMeta, comments);
+        return result;
+    }
+
+    /**
+     * Read the raw source text of a compilation unit, or null if it cannot be
+     * read (in which case fmt directives are simply inactive).
+     *
+     * @param sourceUnit
+     */
+    public static String readSourceText(SourceUnit sourceUnit) {
+        try {
+            var reader = sourceUnit.getSource().getReader();
+            return reader != null ? IOGroovyMethods.getText(reader) : null;
+        }
+        catch( Exception e ) {
+            return null;
+        }
+    }
+
+    public String verbatimText(ASTNode node) {
+        return verbatimSource.get(node);
+    }
+
+    /**
+     * The first source line covered by an anchor's verbatim text (see
+     * {@link #verbatimStart}), or -1 if the anchor has none.
+     */
+    public int verbatimStartLine(ASTNode node) {
+        var line = verbatimStart.get(node);
+        return line != null ? line : -1;
+    }
+
+    public boolean isSuppressed(ASTNode node) {
+        return suppressed.contains(node);
+    }
+
+    /**
+     * Determine whether a comment's own line falls within some verbatim
+     * range, i.e. it is already printed as part of a verbatim text.
+     */
+    public boolean coversComment(Comment comment) {
+        return verbatimComments.contains(comment);
+    }
+
+    /**
+     * Whether any comment at all is covered by a verbatim region. Lets the
+     * common (no-directive) case skip the per-comment {@link #coversComment}
+     * filtering entirely.
+     */
+    public boolean coversAnyComment() {
+        return !verbatimComments.isEmpty();
+    }
+
+    /// RANGE RESOLUTION
+
+    private void apply(ModuleNode moduleNode, String sourceText, List<int[]> ranges, Comments commentsMeta, CommentAttacher comments) {
+        var sourceLines = sourceText.replace("\r\n", "\n").replace("\r", "\n").split("\n", -1);
+
+        var anchors = new ArrayList<ASTNode>();
+        collectAnchors(moduleNode, anchors);
+        anchors.sort(Comparator.comparingLong(node -> start(node)));
+
+        for( var range : ranges )
+            applyRange(range, anchors, sourceLines, commentsMeta.getComments(), comments);
+    }
+
+    /**
+     * Turn the `fmt: skip` / `fmt: off` / `fmt: on` comments into line ranges
+     * excluded from formatting: `off` opens a range at its own line, closed by
+     * the next `on` (or the end of the file if there is none); `skip` is a
+     * one-line range.
+     */
+    private static List<int[]> computeRanges(List<Comment> allComments) {
+        var ranges = new ArrayList<int[]>();
+        int rangeStart = -1;
+        for( var comment : allComments ) {
+            var directive = fmtDirective(comment);
+            if( directive == null )
+                continue;
+            if( rangeStart >= 0 ) {
+                if( "on".equals(directive) ) {
+                    ranges.add(new int[] { rangeStart, comment.line, 0 });
+                    rangeStart = -1;
+                }
+                // a further "off" or "skip" while already excluded is a no-op
+            }
+            else if( "off".equals(directive) ) {
+                rangeStart = comment.line;
+            }
+            else if( "skip".equals(directive) ) {
+                ranges.add(new int[] { comment.line, comment.line, 1 });
+            }
+        }
+        if( rangeStart >= 0 )
+            ranges.add(new int[] { rangeStart, Integer.MAX_VALUE, 0 });
+        return ranges;
+    }
+
+    private static String fmtDirective(Comment comment) {
+        if( comment.line != comment.lastLine )
+            return null;
+        var matcher = FMT_DIRECTIVE.matcher(comment.text);
+        return matcher.matches() ? matcher.group(1) : null;
+    }
+
+    /**
+     * Resolve a single excluded range against the anchors (sorted in source
+     * order): find the anchors it intersects, extend the range to cover them
+     * completely, and assign the resulting verbatim text to the first of them
+     * -- the rest are marked suppressed, since they emit nothing themselves.
+     *
+     * Every comment whose own line falls within the final range is marked as
+     * emitted: it is printed as part of the raw verbatim text rather than via
+     * the normal comment-printing path, so without this the `-format` safety
+     * check ({@code getMissingComments()}) would see it as lost.
+     */
+    private void applyRange(int[] range, List<ASTNode> anchors, String[] sourceLines, List<Comment> allComments, CommentAttacher comments) {
+        var startLine = range[0];
+        var endLine = range[1];
+        var skip = range[2] == 1;
+
+        List<ASTNode> intersecting;
+        if( skip ) {
+            // `fmt: skip` applies to the outermost statement or declaration that
+            // ENDS on the directive's line. A nested statement that merely shares
+            // that last line (e.g. a closure body in `x = foo(bar { baz() }) // fmt: skip`)
+            // must not steal the directive from the multi-line statement it is part of.
+            ASTNode target = null;
+            for( var anchor : anchors ) {
+                if( anchor.getLineNumber() > endLine )
+                    break;
+                if( anchor.getLastLineNumber() == endLine && (target == null || start(anchor) < start(target)) )
+                    target = anchor;
+            }
+            if( target == null )
+                return;
+            intersecting = List.of(target);
+        }
+        else {
+            var overlapping = new ArrayList<ASTNode>();
+            for( var anchor : anchors ) {
+                // anchors are sorted by start, so once one begins past the range
+                // no later one can intersect it either
+                if( anchor.getLineNumber() > endLine )
+                    break;
+                if( anchor.getLastLineNumber() >= startLine )
+                    overlapping.add(anchor);
+            }
+
+            // an anchor that merely encloses the range (e.g. the workflow around a
+            // `fmt: off` region) is not part of it -- keep enclosing anchors only
+            // when the range covers them entirely
+            var maximal = new ArrayList<ASTNode>();
+            for( var anchor : overlapping ) {
+                var coveredByRange = anchor.getLineNumber() >= range[0] && anchor.getLastLineNumber() <= range[1];
+                if( !coveredByRange && containsAnother(anchor, overlapping) )
+                    continue;
+                maximal.add(anchor);
+            }
+            intersecting = maximal;
+        }
+        if( intersecting.isEmpty() )
+            return;
+
+        for( var anchor : intersecting ) {
+            startLine = Math.min(startLine, anchor.getLineNumber());
+            endLine = Math.max(endLine, anchor.getLastLineNumber());
+        }
+        endLine = Math.min(endLine, sourceLines.length);
+        // drop trailing empty lines (e.g. past the end of the file)
+        while( endLine > startLine && sourceLines[endLine - 1].isEmpty() )
+            endLine--;
+
+        for( var comment : allComments ) {
+            if( comment.line >= startLine && comment.line <= endLine ) {
+                comments.markEmitted(comment);
+                verbatimComments.add(comment);
+            }
+        }
+
+        var text = String.join("\n", Arrays.copyOfRange(sourceLines, startLine - 1, endLine));
+        var first = intersecting.get(0);
+        verbatimSource.put(first, text);
+        verbatimStart.put(first, startLine);
+        for( int i = 1; i < intersecting.size(); i++ )
+            suppressed.add(intersecting.get(i));
+    }
+
+    private static boolean containsAnother(ASTNode anchor, List<ASTNode> anchors) {
+        for( var other : anchors ) {
+            if( other == anchor )
+                continue;
+            if( start(anchor) <= start(other) && end(other) <= end(anchor) )
+                return true;
+        }
+        return false;
+    }
+
+    /// ANCHOR COLLECTION
+    //
+    // An anchor is an AST node that the formatter emits through one of the
+    // hooked emitters (see Formatter.appendVerbatim and its call sites): a
+    // top-level script/config declaration, or a statement within a block body
+    // (including a process/agent/config-apply directive line). This mirrors
+    // CommentAttacher's traversal of containers and children, but only the
+    // nodes that can themselves be printed verbatim need to be collected --
+    // individual typed parameters, record fields and other finer-grained
+    // constructs are out of scope for this PR (deferred, as noted in the spec).
+
+    private final CodeVisitorSupport exprWalker = new CodeVisitorSupport() {
+        @Override
+        public void visitClosureExpression(ClosureExpression node) {
+            collectStatements(node.getCode());
+        }
+    };
+
+    private List<ASTNode> anchors;
+
+    private void collectAnchors(ModuleNode moduleNode, List<ASTNode> anchors) {
+        this.anchors = anchors;
+        if( moduleNode instanceof ScriptNode sn )
+            collectScript(sn);
+        else if( moduleNode instanceof ConfigNode cn )
+            collectConfigStatements(cn.getConfigStatements());
+    }
+
+    private void addAnchor(ASTNode node) {
+        if( hasPosition(node) )
+            anchors.add(node);
+    }
+
+    private void collectScript(ScriptNode node) {
+        for( var decl : node.getDeclarations() ) {
+            // a code snippet is an implicit entry workflow with no position
+            if( decl instanceof WorkflowNode wn && wn.isCodeSnippet() ) {
+                collectStatements(wn.main);
+                continue;
+            }
+            if( !hasPosition(decl) )
+                continue;
+            anchors.add(decl);
+            collectScriptDeclaration(decl);
+        }
+    }
+
+    private void collectScriptDeclaration(ASTNode decl) {
+        if( decl instanceof AgentNode an ) {
+            collectDirectives(an.directives);
+            collectStatements(an.prompt);
+            // an.outputs uses typed-output formatting (not hooked) -- deferred
+        }
+        else if( decl instanceof FunctionNode fn ) {
+            collectStatements(fn.getCode());
+        }
+        else if( decl instanceof OutputBlockNode obn ) {
+            for( var on : obn.declarations )
+                collectOutputBody(on.body);
+        }
+        else if( decl instanceof ProcessNodeV1 pn ) {
+            collectDirectives(pn.directives);
+            collectDirectives(pn.inputs);
+            collectDirectives(pn.outputs);
+            collectStatements(pn.exec);
+            collectStatements(pn.stub);
+        }
+        else if( decl instanceof ProcessNodeV2 pn ) {
+            collectDirectives(pn.directives);
+            collectDirectives(pn.stagers);
+            collectStatements(pn.exec);
+            collectStatements(pn.stub);
+            // pn.inputs/outputs/topics use typed formatting (not hooked) -- deferred
+        }
+        else if( decl instanceof WorkflowNode wn ) {
+            collectStatements(wn.main);
+            collectStatements(wn.onComplete);
+            collectStatements(wn.onError);
+            // wn.emits/publishers use typed-output formatting (not hooked) -- deferred
+        }
+        // ClassNode (enum), FeatureFlagNode, IncludeNode, ParamBlockNode,
+        // ParamNodeV1 and RecordNode are leaf declarations with no nested
+        // verbatim-hookable statements
+    }
+
+    /**
+     * A block of directive-style statements (a bare method call per line,
+     * e.g. a process directive), emitted through {@code Formatter.visitDirective}.
+     */
+    private void collectDirectives(Statement statement) {
+        for( var stmt : asBlockStatements(statement) ) {
+            if( asMethodCallX(stmt) != null )
+                addAnchor(stmt);
+        }
+    }
+
+    /**
+     * The body of an `output` block declaration: a block of directives, except
+     * for an `index { ... }` statement, whose own line is not individually
+     * hookable but whose nested directives are.
+     */
+    private void collectOutputBody(Statement body) {
+        for( var stmt : asBlockStatements(body) ) {
+            var call = asMethodCallX(stmt);
+            if( call == null )
+                continue;
+            if( "index".equals(call.getMethodAsString()) ) {
+                var args = asMethodCallArguments(call);
+                if( args.size() == 1 && args.get(0) instanceof ClosureExpression ce ) {
+                    collectDirectives(ce.getCode());
+                    continue;
+                }
+            }
+            addAnchor(stmt);
+        }
+    }
+
+    private void collectStatements(Statement node) {
+        if( node == null )
+            return;
+        for( var stmt : asBlockStatements(node) )
+            collectStatement(stmt);
+    }
+
+    private void collectStatement(Statement node) {
+        if( node instanceof IfStatement is ) {
+            addAnchor(is);
+            collectStatements(is.getIfBlock());
+            var elseBlock = is.getElseBlock();
+            if( elseBlock instanceof IfStatement chained )
+                collectElseIfChain(chained);
+            else if( !(elseBlock instanceof EmptyStatement) )
+                collectStatements(elseBlock);
+            return;
+        }
+        if( node instanceof TryCatchStatement tcs ) {
+            addAnchor(tcs);
+            collectStatements(tcs.getTryStatement());
+            for( var cs : tcs.getCatchStatements() )
+                collectStatements(cs.getCode());
+            return;
+        }
+        if( node instanceof ExpressionStatement || node instanceof ReturnStatement
+                || node instanceof AssertStatement || node instanceof ThrowStatement ) {
+            addAnchor(node);
+        }
+        // descend into the expression tree to reach any nested closure body
+        node.visit(exprWalker);
+    }
+
+    /**
+     * An `else if` link of a chain: unlike the root `if`, it is never
+     * dispatched through {@code Formatter.visitIfElse} on its own (the parent
+     * prints it inline), so it is not itself an anchor -- only the statements
+     * in its branches are.
+     */
+    private void collectElseIfChain(IfStatement node) {
+        collectStatements(node.getIfBlock());
+        var elseBlock = node.getElseBlock();
+        if( elseBlock instanceof IfStatement chained )
+            collectElseIfChain(chained);
+        else if( !(elseBlock instanceof EmptyStatement) )
+            collectStatements(elseBlock);
+    }
+
+    /// CONFIG STATEMENTS
+
+    private void collectConfigStatements(List<ConfigStatement> statements) {
+        for( var stmt : statements ) {
+            if( !hasPosition(stmt) )
+                continue;
+            anchors.add(stmt);
+            if( stmt instanceof ConfigApplyBlockNode cabn ) {
+                for( var apply : cabn.statements )
+                    addAnchor(apply);
+            }
+            else if( stmt instanceof ConfigAssignNode can ) {
+                can.value.visit(exprWalker);
+            }
+            else if( stmt instanceof ConfigBlockNode cbn ) {
+                collectConfigStatements(cbn.statements);
+            }
+            else if( stmt instanceof ConfigIncludeNode cin ) {
+                cin.source.visit(exprWalker);
+            }
+        }
+    }
+
+}

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
@@ -80,6 +80,8 @@ public class Formatter extends CodeVisitorSupport {
 
     private CommentAttacher comments = CommentAttacher.of(null);
 
+    private FmtDirectives fmtDirectives = FmtDirectives.of(null, null, comments);
+
     private int stringIndentDelta = 0;
 
     public Formatter(FormattingOptions options) {
@@ -92,6 +94,50 @@ public class Formatter extends CodeVisitorSupport {
 
     public CommentAttacher getComments() {
         return comments;
+    }
+
+    public void setFmtDirectives(FmtDirectives fmtDirectives) {
+        this.fmtDirectives = fmtDirectives;
+    }
+
+    /**
+     * Emit a node excluded from formatting by a `fmt: skip` or `fmt: off`
+     * ... `fmt: on` directive verbatim from the source text, or nothing if
+     * the node is part of a verbatim region emitted by an earlier node.
+     * Returns false if the node is not part of any verbatim region, in
+     * which case the caller should format it normally.
+     *
+     * A leading comment of the node that falls within the verbatim text
+     * (e.g. the `fmt: off` comment itself) is already part of that text, so
+     * it -- and its blank-line gap -- is skipped here just like
+     * {@link #appendLeadingComments}, except that the final blank-line gap
+     * is measured up to the text's own first line rather than the node's,
+     * since the two can differ (`fmt: off` may precede the node by several
+     * lines, and that gap is already part of the text).
+     */
+    public boolean appendVerbatim(ASTNode node) {
+        if( fmtDirectives.isSuppressed(node) )
+            return true;
+        var text = fmtDirectives.verbatimText(node);
+        if( text == null )
+            return false;
+        for( var comment : visible(comments.leading(node)) ) {
+            appendBlankLines(comment.line);
+            appendComment(comment);
+        }
+        appendBlankLines(fmtDirectives.verbatimStartLine(node));
+        append(text);
+        appendNewLine();
+        return true;
+    }
+
+    /**
+     * Determine whether a node is excluded from formatting by a fmt directive,
+     * either because it carries verbatim text itself or because it is part of
+     * a verbatim region emitted by an earlier node.
+     */
+    public boolean isVerbatim(ASTNode node) {
+        return fmtDirectives.isSuppressed(node) || fmtDirectives.verbatimText(node) != null;
     }
 
     public void append(char c) {
@@ -114,13 +160,29 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     /**
+     * The comments in a list that are not already printed as part of a
+     * verbatim region (see {@link FmtDirectives#coversComment}) -- e.g. the
+     * `fmt: on` that closes a region, attached as a leading comment of the
+     * node that follows. Filtering them out up front keeps the blank-line
+     * accounting in the callers indexed against what is actually printed.
+     * The blank lines around a skipped comment are handled correctly anyway,
+     * since {@link #appendBlankLines} measures the gap from the source rather
+     * than from what was printed.
+     */
+    private List<Comment> visible(List<Comment> list) {
+        if( !fmtDirectives.coversAnyComment() )
+            return list;
+        return list.stream().filter(c -> !fmtDirectives.coversComment(c)).toList();
+    }
+
+    /**
      * Append the comments that precede a node, along with any blank lines
      * that separate them from each other and from the node.
      *
      * @param node
      */
     public void appendLeadingComments(ASTNode node) {
-        for( var comment : comments.leading(node) ) {
+        for( var comment : visible(comments.leading(node)) ) {
             appendBlankLines(comment.line);
             appendComment(comment);
         }
@@ -136,7 +198,7 @@ public class Formatter extends CodeVisitorSupport {
      * @param node
      */
     public void appendCommentsBefore(ASTNode node) {
-        for( var comment : comments.leading(node) )
+        for( var comment : visible(comments.leading(node)) )
             appendComment(comment);
     }
 
@@ -162,7 +224,7 @@ public class Formatter extends CodeVisitorSupport {
      * @param node
      */
     public void appendInnerComments(ASTNode node) {
-        var leading = comments.leading(node);
+        var leading = visible(comments.leading(node));
         for( int i = 0; i < leading.size(); i++ ) {
             if( i > 0 )
                 appendBlankLines(leading.get(i).line);
@@ -176,12 +238,16 @@ public class Formatter extends CodeVisitorSupport {
 
     /**
      * Append the comments that belong to a construct but not to any
-     * particular child, e.g. a comment before a closing brace.
+     * particular child, e.g. a comment before a closing brace. A comment
+     * already printed as part of a verbatim region (e.g. one that falls
+     * between a `fmt: off` and its matching `fmt: on` but has no following
+     * statement of its own) is skipped, since re-emitting it here -- after
+     * the verbatim text that already contains it -- would duplicate it.
      *
      * @param node
      */
     public void appendDanglingComments(ASTNode node) {
-        for( var comment : comments.dangling(node) ) {
+        for( var comment : visible(comments.dangling(node)) ) {
             appendBlankLines(comment.line);
             appendComment(comment);
         }
@@ -192,7 +258,7 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     public void appendTrailingComment(ASTNode node) {
-        for( var comment : comments.trailing(node) ) {
+        for( var comment : visible(comments.trailing(node)) ) {
             this.comments.markEmitted(comment);
             append(' ');
             append(comment.text.replace('\n', ' '));
@@ -405,6 +471,8 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitIfElse(IfStatement node) {
+        if( appendVerbatim(node) )
+            return;
         visitIfElse(node, true);
     }
 
@@ -452,6 +520,8 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitExpressionStatement(ExpressionStatement node) {
+        if( appendVerbatim(node) )
+            return;
         appendLeadingComments(node);
         emitWrappable(() -> {
             var cre = currentRootExpr;
@@ -478,6 +548,8 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitReturnStatement(ReturnStatement node) {
+        if( appendVerbatim(node) )
+            return;
         appendLeadingComments(node);
         emitWrappable(() -> {
             var cre = currentRootExpr;
@@ -495,6 +567,8 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitAssertStatement(AssertStatement node) {
+        if( appendVerbatim(node) )
+            return;
         appendLeadingComments(node);
         emitWrappable(() -> {
             appendIndent();
@@ -513,6 +587,8 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitTryCatchFinally(TryCatchStatement node) {
+        if( appendVerbatim(node) )
+            return;
         appendLeadingComments(node);
         appendIndent();
         append("try {\n");
@@ -530,6 +606,8 @@ public class Formatter extends CodeVisitorSupport {
 
     @Override
     public void visitThrowStatement(ThrowStatement node) {
+        if( appendVerbatim(node) )
+            return;
         appendLeadingComments(node);
         emitWrappable(() -> {
             appendIndent();
@@ -648,6 +726,8 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     public void visitDirective(ASTNode owner, MethodCallExpression call) {
+        if( appendVerbatim(owner) )
+            return;
         emitWrappable(() -> {
             appendIndent();
             var sid = beginStatement(owner);

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -76,7 +76,9 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         this.sourceUnit = sourceUnit;
         this.options = options;
         this.fmt = new Formatter(options);
-        this.fmt.setComments(CommentAttacher.of(sourceUnit.getAST()));
+        var commentAttacher = CommentAttacher.of(sourceUnit.getAST());
+        this.fmt.setComments(commentAttacher);
+        this.fmt.setFmtDirectives(FmtDirectives.of(sourceUnit.getAST(), () -> FmtDirectives.readSourceText(sourceUnit), commentAttacher));
     }
 
     /**
@@ -173,6 +175,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitFeatureFlag(FeatureFlagNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append(node.name);
         fmt.append(" = ");
@@ -183,6 +187,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitInclude(IncludeNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         emitInclude(node);
     }
@@ -202,17 +208,33 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
     private int visitIncludeRun(List<ASTNode> declarations, int start) {
         var comments = fmt.getComments();
 
-        // -- collect the run, split into blank-line-separated groups
+        // -- find the end of the run
+        int i = start;
+        while( i < declarations.size() && declarations.get(i) instanceof IncludeNode )
+            i++;
+
+        // a verbatim include (`fmt: skip` / `fmt: off` ... `fmt: on`), or one
+        // suppressed by an earlier verbatim region, must not be reordered or
+        // lost -- fall back to emitting the run in its original order rather
+        // than sorting it
+        for( int j = start; j < i; j++ ) {
+            if( fmt.isVerbatim(declarations.get(j)) ) {
+                for( int k = start; k < i; k++ )
+                    visitInclude((IncludeNode) declarations.get(k));
+                return i - 1;
+            }
+        }
+
+        // -- split the run into blank-line-separated groups
         var groups = new ArrayList<List<IncludeNode>>();
         List<IncludeNode> group = null;
-        int i = start;
-        while( i < declarations.size() && declarations.get(i) instanceof IncludeNode in ) {
+        for( int j = start; j < i; j++ ) {
+            var in = (IncludeNode) declarations.get(j);
             if( group == null || comments.blankLinesBefore(comments.leadingLine(in)) > 0 ) {
                 group = new ArrayList<>();
                 groups.add(group);
             }
             group.add(in);
-            i++;
         }
 
         // -- sort each group independently and emit
@@ -285,6 +307,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitParams(ParamBlockNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("params {\n");
         fmt.incIndent();
@@ -314,6 +338,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitParamV1(ParamNodeV1 node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.emitWrappable(() -> {
             fmt.appendIndent();
@@ -337,6 +363,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitWorkflow(WorkflowNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("workflow");
         if( !node.isEntry() ) {
@@ -537,6 +565,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitAgent(AgentNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("agent ");
         fmt.append(node.getName());
@@ -569,6 +599,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitProcessV2(ProcessNodeV2 node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("process ");
         fmt.append(node.getName());
@@ -649,6 +681,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitProcessV1(ProcessNodeV1 node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("process ");
         fmt.append(node.getName());
@@ -704,6 +738,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitFunction(FunctionNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("def ");
         fmt.append(node.getName());
@@ -726,6 +762,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitRecord(RecordNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("record ");
         fmt.append(node.getName());
@@ -756,6 +794,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitEnum(ClassNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("enum ");
         fmt.append(node.getName());
@@ -778,6 +818,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitOutputs(OutputBlockNode node) {
+        if( fmt.appendVerbatim(node) )
+            return;
         fmt.appendLeadingComments(node);
         fmt.append("output {\n");
         fmt.incIndent();
@@ -838,6 +880,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             }
 
             // treat as regular directive
+            if( fmt.appendVerbatim(stmt) )
+                return;
             fmt.appendLeadingComments(stmt);
             fmt.visitDirective(stmt, call);
         });
@@ -847,6 +891,8 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         asBlockStatements(statement).forEach((stmt) -> {
             var call = asMethodCallX(stmt);
             if( call == null )
+                return;
+            if( fmt.appendVerbatim(stmt) )
                 return;
             fmt.appendLeadingComments(stmt);
             fmt.visitDirective(stmt, call);

--- a/modules/nf-lang/src/test/groovy/nextflow/config/formatter/ConfigFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/formatter/ConfigFormatterTest.groovy
@@ -209,4 +209,37 @@ class ConfigFormatterTest extends Specification {
         )
     }
 
+    // -- fmt: skip / fmt: off / fmt: on directives (issue #75)
+
+    def 'should keep a config assignment verbatim with fmt: skip' () {
+        expect:
+        checkFormat(
+            '''\
+            process.cpus=2  // fmt: skip
+            process.memory='4 GB'
+            ''',
+            '''\
+            process.cpus=2  // fmt: skip
+            process.memory = '4 GB'
+            '''
+        )
+    }
+
+    def 'should keep a region of a config file verbatim between fmt: off and fmt: on' () {
+        expect:
+        checkFormat(
+            '''\
+            process.cpus = 2
+
+            // fmt: off
+            docker{
+            enabled=true
+            }
+            // fmt: on
+
+            process.memory = '4 GB'
+            '''
+        )
+    }
+
 }

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -1772,4 +1772,209 @@ class ScriptFormatterTest extends Specification {
         )
     }
 
+    // -- fmt: skip / fmt: off / fmt: on directives (issue #75)
+
+    def 'should keep a statement verbatim with fmt: skip' () {
+        expect:
+        checkFormat(
+            '''\
+            v=42
+            w  =   1+2  // fmt: skip
+            x=100
+            ''',
+            '''\
+            v = 42
+            w  =   1+2  // fmt: skip
+            x = 100
+            '''
+        )
+    }
+
+    def 'should keep a multi-line statement verbatim with fmt: skip on its last line' () {
+        expect:
+        checkFormat(
+            '''\
+            workflow {
+                Channel.of(1, 2)
+                    .map { v -> foo(v) }  // fmt: skip
+                y=1+2
+            }
+            ''',
+            '''\
+            workflow {
+                Channel.of(1, 2)
+                    .map { v -> foo(v) }  // fmt: skip
+                y = 1 + 2
+            }
+            '''
+        )
+    }
+
+    def 'should keep a top-level declaration verbatim with fmt: skip' () {
+        expect:
+        checkFormat(
+            '''\
+            process  foo {
+            input:
+            val   x
+            script:
+            'echo hi'
+            } // fmt: skip
+
+            process bar{
+            script:'echo bar'
+            }
+            ''',
+            '''\
+            process  foo {
+            input:
+            val   x
+            script:
+            'echo hi'
+            } // fmt: skip
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            '''
+        )
+    }
+
+    def 'should keep a region verbatim between fmt: off and fmt: on' () {
+        expect:
+        checkFormat(
+            '''\
+            v=42
+            // fmt: off
+            w  =   1+2
+            x=3
+            // fmt: on
+            y=4
+            ''',
+            '''\
+            v = 42
+            // fmt: off
+            w  =   1+2
+            x=3
+            // fmt: on
+            y = 4
+            '''
+        )
+    }
+
+    def 'should keep everything verbatim after an unterminated fmt: off' () {
+        expect:
+        checkFormat(
+            '''\
+            v = 1
+            // fmt: off
+            w  =   2
+            x=3
+            '''
+        )
+    }
+
+    def 'should preserve a comment inside a fmt: off region with no following statement' () {
+        expect:
+        checkFormat(
+            '''\
+            workflow {
+                // fmt: off
+                x = 1
+                // dangling note
+                // fmt: on
+                y=2
+            }
+            ''',
+            '''\
+            workflow {
+                // fmt: off
+                x = 1
+                // dangling note
+                // fmt: on
+                y = 2
+            }
+            '''
+        )
+    }
+
+    def 'should be idempotent when a leading comment and blank line precede fmt: off' () {
+        expect:
+        checkFormat(
+            '''\
+            v = 42
+
+            // genuine comment
+
+            // fmt: off
+            w  =   1+2
+            x=3
+            // fmt: on
+            y=4
+            ''',
+            '''\
+            v = 42
+
+            // genuine comment
+
+            // fmt: off
+            w  =   1+2
+            x=3
+            // fmt: on
+            y = 4
+            '''
+        )
+    }
+
+    def 'should do nothing harmful with a lone fmt: on directive' () {
+        expect:
+        checkFormat(
+            '''\
+            v=1
+            // fmt: on
+            w=2
+            ''',
+            '''\
+            v = 1
+            // fmt: on
+            w = 2
+            '''
+        )
+    }
+
+    def 'should not reorder or lose a verbatim include when sorting' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf' // fmt: skip
+            include { bar } from './a.nf'
+            ''',
+            '''\
+            include { foo } from './b.nf' // fmt: skip
+            include { bar } from './a.nf'
+            '''
+        )
+    }
+
+    def 'should preserve blank-line groups when a verbatim include disables sorting of the run' () {
+        expect:
+        checkFormatSorted(
+            '''\
+            include { foo } from './b.nf' // fmt: skip
+            include { bar } from './a.nf'
+
+            include { zed } from './z.nf'
+            include { yak } from './y.nf'
+            ''',
+            '''\
+            include { foo } from './b.nf' // fmt: skip
+            include { bar } from './a.nf'
+
+            include { zed } from './z.nf'
+            include { yak } from './y.nf'
+            '''
+        )
+    }
+
 }


### PR DESCRIPTION
Lets users exclude code from formatting with `// fmt: skip` and `// fmt: off` ... `// fmt: on`, following Black's semantics, resolving nextflow-io/language-server#75. `fmt: skip` at the end of a line keeps the statement or declaration ending on that line verbatim; `fmt: off` ... `fmt: on` keeps everything between them verbatim (an unterminated `fmt: off` runs to end of file). Excluded code is emitted byte-for-byte from the source, comments and blank lines included. Works in scripts and config files. The last of the formatter follow-ups deferred from #7346 in this stack.

**Stacked PR** — targets `formatter-line-wrapping` (nextflow-io/language-server#26), which targets `formatter-sort-includes` (nextflow-io/language-server#54). Review/merge those first; the diff here is only the directive support.

Approach: directive regions are resolved once per formatting pass in a new `FmtDirectives` class, built alongside the existing `CommentAttacher` (the same per-pass, not-in-node-metadata design). It scans comments for directives, maps the excluded line ranges to the statement/declaration nodes the formatter emits, and hands each region's verbatim text to the first such node while suppressing the rest. The raw source is read lazily — only when a file actually contains a directive — so the common case pays nothing.

The one subtlety worth a look in review: a verbatim region's comments are marked as emitted up front, otherwise the `nextflow lint -format` comment-preservation safety check would treat the comments printed inside the raw text as lost and refuse to format the file.

Known limitations, deferred to follow-ups (none lose code — the safety check still guards against that):

- Finer-grained directives on individual section labels, process directives sub-lines, or record/output fields are not supported (a whole directive line works, since it is a statement).
- A directive inside a `for` / `while` / `switch` body is not precisely scoped (its enclosing declaration is kept verbatim, or a `skip` there is ignored).
- An `fmt: off` ... `fmt: on` region that straddles two sibling top-level declarations can be misplaced when `-sort-declarations` is also enabled, since the two features disagree on ordering.

Assisted-by: Claude Opus 4.8 (Claude Code)

## Example

The point of these directives is that the formatter leaves the marked code exactly as you wrote it — so the examples below show what the formatter produces **without** the directive versus **with** it.

`// fmt: skip` — without it the formatter collapses a hand-aligned matrix onto one line; with it your layout is kept:

Without the directive:

```nextflow
identity = [1, 0, 0, 0, 1, 0, 0, 0, 1]
```

With `// fmt: skip`:

```nextflow
identity = [1, 0, 0,
            0, 1, 0,
            0, 0, 1]  // fmt: skip
```

`// fmt: off` ... `// fmt: on` — without it the formatter reduces the aligned `=` to single spaces; with it the whole block is preserved:

Without the directive:

```nextflow
params.input = null
params.outdir = 'results'
params.max_memory = '128.GB'
```

With the directive:

```nextflow
// fmt: off
params.input       = null
params.outdir      = 'results'
params.max_memory  = '128.GB'
// fmt: on
```
