### PR TITLE
Standardise blank lines in the formatter

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/config/formatter/ConfigFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/formatter/ConfigFormattingVisitor.java
@@ -16,6 +16,7 @@
 package nextflow.config.formatter;
 
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import nextflow.config.ast.ConfigApplyNode;
@@ -24,12 +25,14 @@ import nextflow.config.ast.ConfigAssignNode;
 import nextflow.config.ast.ConfigBlockNode;
 import nextflow.config.ast.ConfigIncludeNode;
 import nextflow.config.ast.ConfigNode;
+import nextflow.config.ast.ConfigStatement;
 import nextflow.config.ast.ConfigVisitorSupport;
 import nextflow.script.formatter.Comment;
 import nextflow.script.formatter.CommentAttacher;
 import nextflow.script.formatter.FmtDirectives;
 import nextflow.script.formatter.FormattingOptions;
 import nextflow.script.formatter.Formatter;
+import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.control.SourceUnit;
 
 import static nextflow.script.ast.ASTUtils.*;
@@ -72,7 +75,7 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
     public void visit() {
         var moduleNode = sourceUnit.getAST();
         if( moduleNode instanceof ConfigNode cn ) {
-            super.visit(cn);
+            visitStatements(cn.getConfigStatements(), (stmt) -> visit(stmt));
             fmt.appendDanglingComments(cn);
         }
     }
@@ -81,20 +84,69 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
         return fmt.toString();
     }
 
+    /**
+     * Emit a list of sibling config statements, with the blank line above
+     * each one owned by this loop rather than by the statement's own
+     * (source-derived) leading-comment logic -- mirrors the top-level
+     * declaration loop in {@code ScriptFormattingVisitor}. Used both for the
+     * top level of the file and for the body of a config block, since config
+     * has no separate "top-level" concept.
+     *
+     * @param statements
+     */
+    private <T extends ASTNode> void visitStatements(List<T> statements, Consumer<T> visit) {
+        T prev = null;
+        for( var stmt : statements ) {
+            // a statement suppressed inside a verbatim region emits nothing,
+            // so it must not get a blank line above it
+            if( !fmt.isSuppressed(stmt) )
+                fmt.blankLines(blankLinesBetween(prev, stmt));
+            visit.accept(stmt);
+            prev = stmt;
+        }
+    }
+
+    /**
+     * The blank lines that belong above a config statement, given its
+     * previous sibling (or {@code null} for the first statement of the file
+     * or block): a config block is set off by exactly 1 blank line (config is
+     * denser than a script's top-level definitions, which get 2); two
+     * statements of the same kind (e.g. consecutive assignments) keep their
+     * source grouping, capped at 1; of different kinds, exactly 1.
+     *
+     * @param prev
+     * @param decl
+     */
+    private int blankLinesBetween(ASTNode prev, ASTNode decl) {
+        if( prev == null )
+            return 0;
+        if( isConfigBlock(prev) || isConfigBlock(decl) )
+            return 1;
+        if( prev.getClass() != decl.getClass() )
+            return 1;
+        var comments = fmt.getComments();
+        return Math.min(1, comments.blankLinesBefore(comments.leadingLine(decl)));
+    }
+
+    private static boolean isConfigBlock(ASTNode node) {
+        return node instanceof ConfigBlockNode || node instanceof ConfigApplyBlockNode;
+    }
+
     // config statements
 
     @Override
     public void visitConfigApplyBlock(ConfigApplyBlockNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.appendIndent();
         fmt.append(node.name);
         fmt.append(" {");
         fmt.appendNewLine();
+        fmt.markBlockStart();
 
         fmt.incIndent();
-        super.visitConfigApplyBlock(node);
+        visitStatements(node.statements, (stmt) -> visitConfigApply(stmt));
         fmt.appendDanglingComments(node);
         fmt.decIndent();
 
@@ -106,17 +158,17 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigApply(ConfigApplyNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.visitDirective(node);
     }
 
     @Override
     public void visitConfigAssign(ConfigAssignNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.emitWrappable(() -> {
             fmt.appendIndent();
             var name = String.join(".", node.names);
@@ -140,9 +192,9 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigBlock(ConfigBlockNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.appendIndent();
         if( node.kind != null ) {
             fmt.append(node.kind);
@@ -159,6 +211,7 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
         }
         fmt.append(" {");
         fmt.appendNewLine();
+        fmt.markBlockStart();
 
         int caw = currentAlignmentWidth;
         if( options.harshilAlignment() ) {
@@ -174,7 +227,7 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
         }
 
         fmt.incIndent();
-        super.visitConfigBlock(node);
+        visitStatements(node.statements, (stmt) -> visit(stmt));
         fmt.appendDanglingComments(node);
         fmt.decIndent();
 
@@ -189,9 +242,9 @@ public class ConfigFormattingVisitor extends ConfigVisitorSupport {
 
     @Override
     public void visitConfigInclude(ConfigIncludeNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.appendIndent();
         fmt.append("includeConfig ");
         fmt.visit(node.source);

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/Formatter.java
@@ -84,8 +84,32 @@ public class Formatter extends CodeVisitorSupport {
 
     private int stringIndentDelta = 0;
 
+    /**
+     * Set immediately after a block or section opener (an indented `{` or a
+     * `label:` line) so that the next blank-line check -- whichever of
+     * {@link #appendBlankLines} or {@link #blankLines} runs first -- emits
+     * none and clears it, stripping a source blank at the start of a block
+     * or section regardless of what the source had there.
+     */
+    private boolean atBlockStart;
+
     public Formatter(FormattingOptions options) {
         this.options = options;
+    }
+
+    /**
+     * Mark that a block or section was just opened, so the next thing
+     * printed inside it starts with no blank line above.
+     *
+     * INVARIANT: every {@code markBlockStart()} must be consumed by the next
+     * {@link #appendBlankLines} / {@link #blankLines} call, or force-cleared by
+     * {@link #appendDanglingComments} (which every block/section calls at close,
+     * covering an empty block). Adding a new block/section opener means routing
+     * its first child's spacing through one of those, or the flag leaks and a
+     * blank line is silently dropped at an unrelated later site.
+     */
+    public void markBlockStart() {
+        atBlockStart = true;
     }
 
     public void setComments(CommentAttacher comments) {
@@ -116,16 +140,37 @@ public class Formatter extends CodeVisitorSupport {
      * lines, and that gap is already part of the text).
      */
     public boolean appendVerbatim(ASTNode node) {
+        return appendVerbatim(node, true);
+    }
+
+    /**
+     * Like {@link #appendVerbatim}, but for a node dispatched from a loop
+     * that already owns the blank line above it (a top-level script
+     * declaration or config statement) -- mirrors the
+     * {@link #appendLeadingComments}/{@link #appendInnerComments} split, so
+     * the loop's policy-driven blank is not doubled by this method's own
+     * source-derived blank before the verbatim text or its first comment.
+     *
+     * @param node
+     */
+    public boolean appendVerbatimInner(ASTNode node) {
+        return appendVerbatim(node, false);
+    }
+
+    private boolean appendVerbatim(ASTNode node, boolean ownsBlankAbove) {
         if( fmtDirectives.isSuppressed(node) )
             return true;
         var text = fmtDirectives.verbatimText(node);
         if( text == null )
             return false;
-        for( var comment : visible(comments.leading(node)) ) {
-            appendBlankLines(comment.line);
-            appendComment(comment);
+        var leading = visible(comments.leading(node));
+        for( int i = 0; i < leading.size(); i++ ) {
+            if( ownsBlankAbove || i > 0 )
+                appendBlankLines(leading.get(i).line);
+            appendComment(leading.get(i));
         }
-        appendBlankLines(fmtDirectives.verbatimStartLine(node));
+        if( ownsBlankAbove || !leading.isEmpty() )
+            appendBlankLines(fmtDirectives.verbatimStartLine(node));
         append(text);
         appendNewLine();
         return true;
@@ -138,6 +183,15 @@ public class Formatter extends CodeVisitorSupport {
      */
     public boolean isVerbatim(ASTNode node) {
         return fmtDirectives.isSuppressed(node) || fmtDirectives.verbatimText(node) != null;
+    }
+
+    /**
+     * Whether a node emits nothing because it is part of a verbatim region
+     * printed by an earlier node. A declaration loop must not emit blank lines
+     * above such a node, since that would inject blanks into the region.
+     */
+    public boolean isSuppressed(ASTNode node) {
+        return fmtDirectives.isSuppressed(node);
     }
 
     public void append(char c) {
@@ -182,11 +236,30 @@ public class Formatter extends CodeVisitorSupport {
      * @param node
      */
     public void appendLeadingComments(ASTNode node) {
-        for( var comment : visible(comments.leading(node)) ) {
-            appendBlankLines(comment.line);
-            appendComment(comment);
+        appendLeading(node, true);
+    }
+
+    /**
+     * Like {@link #appendLeadingComments}, but for a node dispatched from a
+     * loop that already owns the blank line above it (a top-level declaration):
+     * the blank lines between the comments and between the last comment and the
+     * node are preserved, but the blank above the first comment is not, since
+     * the caller places it from policy rather than the source position.
+     *
+     * @param node
+     */
+    public void appendInnerComments(ASTNode node) {
+        appendLeading(node, false);
+    }
+
+    private void appendLeading(ASTNode node, boolean ownsBlankAbove) {
+        var leading = visible(comments.leading(node));
+        for( int i = 0; i < leading.size(); i++ ) {
+            if( ownsBlankAbove || i > 0 )
+                appendBlankLines(leading.get(i).line);
+            appendComment(leading.get(i));
         }
-        if( node != null )
+        if( node != null && (ownsBlankAbove || !leading.isEmpty()) )
             appendBlankLines(node.getLineNumber());
     }
 
@@ -200,40 +273,6 @@ public class Formatter extends CodeVisitorSupport {
     public void appendCommentsBefore(ASTNode node) {
         for( var comment : visible(comments.leading(node)) )
             appendComment(comment);
-    }
-
-    /**
-     * Emit the blank lines that precede a node's leading block, for a node whose
-     * source position no longer matches its output position (e.g. a reordered
-     * declaration). The blank count is taken from the node's first own-line leading
-     * comment if it has one, otherwise from the node itself.
-     *
-     * @param node
-     */
-    public void appendBlankLinesBefore(ASTNode node) {
-        appendBlankLines(comments.leadingLine(node));
-    }
-
-    /**
-     * Append the comments that precede a reordered node, preserving the blank
-     * lines between the comments and between the last comment and the node, but
-     * not the blank lines above the first comment -- those separate the node's
-     * group from what precedes it and are placed by the caller, since the node's
-     * source position no longer matches its output position.
-     *
-     * @param node
-     */
-    public void appendInnerComments(ASTNode node) {
-        var leading = visible(comments.leading(node));
-        for( int i = 0; i < leading.size(); i++ ) {
-            if( i > 0 )
-                appendBlankLines(leading.get(i).line);
-            appendComment(leading.get(i));
-        }
-        // within a group only a comment-to-node blank reaches here; a bare blank
-        // above the node would have started a new group
-        if( !leading.isEmpty() )
-            appendBlankLines(node.getLineNumber());
     }
 
     /**
@@ -251,6 +290,10 @@ public class Formatter extends CodeVisitorSupport {
             appendBlankLines(comment.line);
             appendComment(comment);
         }
+        // a block/section that turned out to have no content to consume the
+        // opener's markBlockStart() (e.g. an empty block) must not leak it
+        // into whatever is printed next
+        atBlockStart = false;
     }
 
     public boolean hasTrailingComment(ASTNode node) {
@@ -266,11 +309,45 @@ public class Formatter extends CodeVisitorSupport {
     }
 
     private void appendBlankLines(int line) {
-        if( builder.length() == 0 )
+        if( skipBlankLines() )
             return;
-        var count = comments.blankLinesBefore(line);
+        // collapse any run of source blank lines to at most one -- this must
+        // stay a stateless re-derivation from the source position given, not
+        // a running count of newlines already emitted, since the coversComment
+        // skip-guards in the comment-printing methods rely on this measuring the
+        // gap from the source even when a comment in between was not printed
+        var count = Math.min(1, comments.blankLinesBefore(line));
         for( int i = 0; i < count; i++ )
             appendNewLine();
+    }
+
+    /**
+     * Emit exactly {@code count} blank lines, for a caller (a top-level
+     * declaration loop) that computes the count itself from policy rather
+     * than measuring it from the source.
+     *
+     * @param count
+     */
+    public void blankLines(int count) {
+        if( skipBlankLines() )
+            return;
+        for( int i = 0; i < count; i++ )
+            appendNewLine();
+    }
+
+    /**
+     * Whether the blank lines a caller is about to emit should be dropped:
+     * at the very start of the output, or at the start of a block/section
+     * (consuming the {@link #markBlockStart} flag).
+     */
+    private boolean skipBlankLines() {
+        if( builder.length() == 0 )
+            return true;
+        if( atBlockStart ) {
+            atBlockStart = false;
+            return true;
+        }
+        return false;
     }
 
     private void appendComment(Comment comment) {
@@ -890,6 +967,7 @@ public class Formatter extends CodeVisitorSupport {
         }
         else {
             appendNewLine();
+            markBlockStart();
             incIndent();
             visit(code);
             appendDanglingComments(node);

--- a/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/formatter/ScriptFormattingVisitor.java
@@ -99,8 +99,10 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         if( !(moduleNode instanceof ScriptNode) )
             return;
         var scriptNode = (ScriptNode) moduleNode;
-        if( scriptNode.getShebang() != null ) {
-            fmt.append(scriptNode.getShebang());
+        var shebang = scriptNode.getShebang();
+        hasShebang = shebang != null;
+        if( hasShebang ) {
+            fmt.append(shebang);
             fmt.appendNewLine();
         }
 
@@ -133,8 +135,25 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 .max(Integer::compare).orElse(0);
         }
 
+        ASTNode prevDecl = null;
         for( int i = 0; i < declarations.size(); i++ ) {
             var decl = declarations.get(i);
+            if( decl instanceof IncludeNode in ) {
+                if( options.sortDeclarations() ) {
+                    i = visitIncludeRun(declarations, prevDecl, i);
+                    prevDecl = declarations.get(i);
+                    continue;
+                }
+                if( !fmt.isSuppressed(in) )
+                    fmt.blankLines(blankLinesBetween(prevDecl, in));
+                visitInclude(in);
+                prevDecl = in;
+                continue;
+            }
+            // a declaration suppressed inside a verbatim region emits nothing,
+            // so it must not get a blank line above it
+            if( !fmt.isSuppressed(decl) )
+                fmt.blankLines(blankLinesBetween(prevDecl, decl));
             if( decl instanceof AgentNode an )
                 visitAgent(an);
             else if( decl instanceof ClassNode cn && cn.isEnum() )
@@ -143,13 +162,6 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 visitFeatureFlag(ffn);
             else if( decl instanceof FunctionNode fn )
                 visitFunction(fn);
-            else if( decl instanceof IncludeNode in ) {
-                if( options.sortDeclarations() ) {
-                    i = visitIncludeRun(declarations, i);
-                    continue;
-                }
-                visitInclude(in);
-            }
             else if( decl instanceof OutputBlockNode obn )
                 visitOutputs(obn);
             else if( decl instanceof ParamBlockNode pbn )
@@ -162,9 +174,54 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 visitRecord(rn);
             else if( decl instanceof WorkflowNode wn )
                 visitWorkflow(wn);
+            prevDecl = decl;
         }
 
         fmt.appendDanglingComments(scriptNode);
+    }
+
+    private boolean hasShebang;
+
+    /**
+     * The blank lines that belong above a top-level declaration, given its
+     * previous sibling (or {@code null} for the first declaration): PEP8/Ruff
+     * -style, a block definition (process, workflow, function, ...) is set
+     * off from what surrounds it by exactly 2 blank lines, even when the
+     * neighbor is a simple declaration; two simple declarations of the same
+     * kind (e.g. consecutive includes) keep their source grouping, capped at
+     * 1; of different kinds, exactly 1.
+     *
+     * @param prev
+     * @param decl
+     */
+    private int blankLinesBetween(ASTNode prev, ASTNode decl) {
+        if( prev == null )
+            return hasShebang ? 1 : 0;
+        var pk = declKind(prev);
+        var dk = declKind(decl);
+        if( pk == DeclKind.BLOCK || dk == DeclKind.BLOCK )
+            return 2;
+        if( pk != dk )
+            return 1;
+        var comments = fmt.getComments();
+        return Math.min(1, comments.blankLinesBefore(comments.leadingLine(decl)));
+    }
+
+    private enum DeclKind {
+        BLOCK,
+        INCLUDE,
+        FEATURE_FLAG,
+        PARAM_V1
+    }
+
+    private static DeclKind declKind(ASTNode node) {
+        if( node instanceof IncludeNode )
+            return DeclKind.INCLUDE;
+        if( node instanceof FeatureFlagNode )
+            return DeclKind.FEATURE_FLAG;
+        if( node instanceof ParamNodeV1 )
+            return DeclKind.PARAM_V1;
+        return DeclKind.BLOCK;
     }
 
     public String toString() {
@@ -175,9 +232,9 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitFeatureFlag(FeatureFlagNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append(node.name);
         fmt.append(" = ");
         fmt.visit(node.value);
@@ -187,9 +244,9 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitInclude(IncludeNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         emitInclude(node);
     }
 
@@ -202,10 +259,11 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
      * move with it.
      *
      * @param declarations
+     * @param prevDecl the declaration preceding the run, for the blank line above it
      * @param start
      * @return the index of the last include in the run
      */
-    private int visitIncludeRun(List<ASTNode> declarations, int start) {
+    private int visitIncludeRun(List<ASTNode> declarations, ASTNode prevDecl, int start) {
         var comments = fmt.getComments();
 
         // -- find the end of the run
@@ -219,8 +277,14 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         // than sorting it
         for( int j = start; j < i; j++ ) {
             if( fmt.isVerbatim(declarations.get(j)) ) {
-                for( int k = start; k < i; k++ )
-                    visitInclude((IncludeNode) declarations.get(k));
+                var prev = prevDecl;
+                for( int k = start; k < i; k++ ) {
+                    var in = (IncludeNode) declarations.get(k);
+                    if( !fmt.isSuppressed(in) )
+                        fmt.blankLines(blankLinesBetween(prev, in));
+                    visitInclude(in);
+                    prev = in;
+                }
                 return i - 1;
             }
         }
@@ -241,11 +305,14 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         var comparator = Comparator.comparing((IncludeNode in) -> in.source.getText(), String.CASE_INSENSITIVE_ORDER)
             .thenComparing(in -> in.source.getText());
 
-        for( var g : groups ) {
+        for( int gi = 0; gi < groups.size(); gi++ ) {
+            var g = groups.get(gi);
             // the blank lines above the group belong to its original first
-            // include's source position, so emit them before sorting moves it
+            // include's source position, so compute them before sorting moves it;
+            // the first group's blank was already emitted by the caller (the blank
+            // above the whole run), a later group is a same-kind separator capped at 1
             var originalFirst = g.get(0);
-            fmt.appendBlankLinesBefore(originalFirst);
+            fmt.blankLines(gi == 0 ? blankLinesBetween(prevDecl, originalFirst) : 1);
 
             g.sort(comparator);
             var newFirst = g.get(0);
@@ -307,10 +374,11 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitParams(ParamBlockNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("params {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         for( var param : node.declarations ) {
             fmt.appendLeadingComments(param);
@@ -338,9 +406,9 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitParamV1(ParamNodeV1 node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.emitWrappable(() -> {
             fmt.appendIndent();
             fmt.visit(node.target);
@@ -363,20 +431,22 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitWorkflow(WorkflowNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("workflow");
         if( !node.isEntry() ) {
             fmt.append(' ');
             fmt.append(node.getName());
         }
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         var takes = node.getParameters();
         if( takes.length > 0 ) {
             fmt.appendIndent();
             fmt.append("take:\n");
+            fmt.markBlockStart();
             visitTypedInputs(takes);
         }
         if( !node.main.isEmpty() ) {
@@ -384,6 +454,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
                 fmt.appendNewLine();
                 fmt.appendIndent();
                 fmt.append("main:\n");
+                fmt.markBlockStart();
             }
             fmt.visit(node.main);
         }
@@ -391,24 +462,28 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             fmt.appendNewLine();
             fmt.appendIndent();
             fmt.append("emit:\n");
+            fmt.markBlockStart();
             visitTypedOutputs(asBlockStatements(node.emits));
         }
         if( !node.publishers.isEmpty() ) {
             fmt.appendNewLine();
             fmt.appendIndent();
             fmt.append("publish:\n");
+            fmt.markBlockStart();
             visitWorkflowPublishers(asBlockStatements(node.publishers));
         }
         if( !node.onComplete.isEmpty() ) {
             fmt.appendNewLine();
             fmt.appendIndent();
             fmt.append("onComplete:\n");
+            fmt.markBlockStart();
             fmt.visit(node.onComplete);
         }
         if( !node.onError.isEmpty() ) {
             fmt.appendNewLine();
             fmt.appendIndent();
             fmt.append("onError:\n");
+            fmt.markBlockStart();
             fmt.visit(node.onError);
         }
         fmt.appendDanglingComments(node);
@@ -565,12 +640,13 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitAgent(AgentNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("agent ");
         fmt.append(node.getName());
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         if( !node.directives.isEmpty() ) {
             visitDirectives(node.directives);
@@ -580,6 +656,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         if( inputs.length > 0 ) {
             fmt.appendIndent();
             fmt.append("input:\n");
+            fmt.markBlockStart();
             visitTypedInputs(inputs);
             fmt.appendNewLine();
         }
@@ -589,6 +666,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         }
         fmt.appendIndent();
         fmt.append("prompt:\n");
+        fmt.markBlockStart();
         fmt.visit(node.prompt);
         fmt.appendDanglingComments(node);
         fmt.decIndent();
@@ -599,12 +677,13 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitProcessV2(ProcessNodeV2 node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("process ");
         fmt.append(node.getName());
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         if( !node.directives.isEmpty() ) {
             visitDirectives(node.directives);
@@ -614,12 +693,14 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         if( inputs.length > 0 ) {
             fmt.appendIndent();
             fmt.append("input:\n");
+            fmt.markBlockStart();
             visitTypedInputs(inputs);
             fmt.appendNewLine();
         }
         if( !node.stagers.isEmpty() ) {
             fmt.appendIndent();
             fmt.append("stage:\n");
+            fmt.markBlockStart();
             visitDirectives(node.stagers);
             fmt.appendNewLine();
         }
@@ -636,6 +717,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         if( !(node.when instanceof EmptyExpression) ) {
             fmt.appendIndent();
             fmt.append("when:\n");
+            fmt.markBlockStart();
             fmt.appendIndent();
             fmt.visit(node.when);
             fmt.append("\n\n");
@@ -643,11 +725,13 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         fmt.appendIndent();
         fmt.append(node.type);
         fmt.append(":\n");
+        fmt.markBlockStart();
         fmt.visit(node.exec);
         if( !node.stub.isEmpty() ) {
             fmt.appendNewLine();
             fmt.appendIndent();
             fmt.append("stub:\n");
+            fmt.markBlockStart();
             fmt.visit(node.stub);
         }
         if( options.maheshForm() ) {
@@ -670,23 +754,26 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
     private void visitProcessOutputs(Statement outputs) {
         fmt.appendIndent();
         fmt.append("output:\n");
+        fmt.markBlockStart();
         visitTypedOutputs(asBlockStatements(outputs));
     }
 
     private void visitProcessTopics(Statement topics) {
         fmt.appendIndent();
         fmt.append("topic:\n");
+        fmt.markBlockStart();
         fmt.visit(topics);
     }
 
     @Override
     public void visitProcessV1(ProcessNodeV1 node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("process ");
         fmt.append(node.getName());
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         if( !node.directives.isEmpty() ) {
             visitDirectives(node.directives);
@@ -695,6 +782,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         if( !node.inputs.isEmpty() ) {
             fmt.appendIndent();
             fmt.append("input:\n");
+            fmt.markBlockStart();
             visitDirectives(node.inputs);
             fmt.appendNewLine();
         }
@@ -705,6 +793,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         if( !(node.when instanceof EmptyExpression) ) {
             fmt.appendIndent();
             fmt.append("when:\n");
+            fmt.markBlockStart();
             fmt.appendIndent();
             fmt.visit(node.when);
             fmt.append("\n\n");
@@ -712,11 +801,13 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
         fmt.appendIndent();
         fmt.append(node.type);
         fmt.append(":\n");
+        fmt.markBlockStart();
         fmt.visit(node.exec);
         if( !node.stub.isEmpty() ) {
             fmt.appendNewLine();
             fmt.appendIndent();
             fmt.append("stub:\n");
+            fmt.markBlockStart();
             fmt.visit(node.stub);
         }
         if( options.maheshForm() && !node.outputs.isEmpty() ) {
@@ -733,14 +824,15 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
     private void visitProcessOutputsV1(Statement outputs) {
         fmt.appendIndent();
         fmt.append("output:\n");
+        fmt.markBlockStart();
         visitDirectives(outputs);
     }
 
     @Override
     public void visitFunction(FunctionNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("def ");
         fmt.append(node.getName());
         fmt.append('(');
@@ -751,6 +843,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
             fmt.visitTypeAnnotation(node.getReturnType());
         }
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         fmt.visit(node.getCode());
         fmt.appendDanglingComments(node);
@@ -762,9 +855,9 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitRecord(RecordNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("record ");
         fmt.append(node.getName());
         visitRecordBody(node);
@@ -774,6 +867,7 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     private void visitRecordBody(RecordNode node) {
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         for( var fn : node.getFields() ) {
             fmt.appendLeadingComments(fn);
@@ -794,12 +888,13 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitEnum(ClassNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("enum ");
         fmt.append(node.getName());
         fmt.append(" {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         for( var fn : node.getFields() ) {
             fmt.appendLeadingComments(fn);
@@ -818,10 +913,11 @@ public class ScriptFormattingVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitOutputs(OutputBlockNode node) {
-        if( fmt.appendVerbatim(node) )
+        if( fmt.appendVerbatimInner(node) )
             return;
-        fmt.appendLeadingComments(node);
+        fmt.appendInnerComments(node);
         fmt.append("output {\n");
+        fmt.markBlockStart();
         fmt.incIndent();
         super.visitOutputs(node);
         fmt.appendDanglingComments(node);

--- a/modules/nf-lang/src/test/groovy/nextflow/config/formatter/ConfigFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/config/formatter/ConfigFormatterTest.groovy
@@ -242,4 +242,117 @@ class ConfigFormatterTest extends Specification {
         )
     }
 
+    // -- blank lines (issue #115)
+
+    def 'should normalize any number of blank lines between config blocks to exactly one' () {
+        expect:
+        checkFormat(
+            '''\
+            process {
+                cpus = 1
+            }
+            docker {
+                enabled = true
+            }
+            ''',
+            '''\
+            process {
+                cpus = 1
+            }
+
+            docker {
+                enabled = true
+            }
+            '''
+        )
+        checkFormat(
+            '''\
+            process {
+                cpus = 1
+            }
+
+
+
+            docker {
+                enabled = true
+            }
+            ''',
+            '''\
+            process {
+                cpus = 1
+            }
+
+            docker {
+                enabled = true
+            }
+            '''
+        )
+    }
+
+    def 'should keep grouped config assignments together and collapse a larger gap to one blank line' () {
+        expect:
+        checkFormat(
+            '''\
+            process.cpus = 1
+            process.memory = '2 GB'
+            '''
+        )
+        checkFormat(
+            '''\
+            process.cpus = 1
+            process.memory = '2 GB'
+
+
+
+            process.disk = '10 GB'
+            ''',
+            '''\
+            process.cpus = 1
+            process.memory = '2 GB'
+
+            process.disk = '10 GB'
+            '''
+        )
+    }
+
+    def 'should strip a blank line at the start of a config block' () {
+        expect:
+        checkFormat(
+            '''\
+            process {
+
+                cpus = 1
+            }
+            ''',
+            '''\
+            process {
+                cpus = 1
+            }
+            '''
+        )
+    }
+
+    def 'should be idempotent when formatting a mixed config file' () {
+        given:
+        def source =
+            '''\
+            includeConfig './base.config'
+
+            process.cpus = 1
+            process.memory = '2 GB'
+
+            process {
+                disk = '10 GB'
+            }
+
+            plugins {
+                id 'nf-hello'
+            }
+            '''.stripIndent()
+
+        expect:
+        format(source) == source
+        format(format(source)) == source
+    }
+
 }

--- a/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/formatter/ScriptFormatterTest.groovy
@@ -282,7 +282,7 @@ class ScriptFormatterTest extends Specification {
         )
     }
 
-    def 'should preserve multiple blank lines between include groups' () {
+    def 'should collapse multiple blank lines between include groups to one' () {
         expect:
         checkFormatSorted(
             '''\
@@ -296,7 +296,6 @@ class ScriptFormatterTest extends Specification {
             '''\
             include { bar } from './a.nf'
             include { foo } from './b.nf'
-
 
             include { yak } from './y.nf'
             include { zed } from './z.nf'
@@ -409,6 +408,7 @@ class ScriptFormatterTest extends Specification {
             '''\
             nextflow.enable.types = true
 
+
             workflow hello {
                 take:
                 x: Integer
@@ -463,6 +463,7 @@ class ScriptFormatterTest extends Specification {
             '''\
             nextflow.enable.types = true
 
+
             process hello {
                 debug true
 
@@ -493,6 +494,7 @@ class ScriptFormatterTest extends Specification {
             '''\
             nextflow.enable.types = true
 
+
             process hello {
                 input:
                 record(
@@ -515,6 +517,7 @@ class ScriptFormatterTest extends Specification {
         checkFormat(
             '''\
             nextflow.enable.types = true
+
 
             agent reporter {
                 model 'openai/gpt-4o'
@@ -627,6 +630,7 @@ class ScriptFormatterTest extends Specification {
             workflow {
             }
 
+
             output {
                 foo {
                     path 'foo'
@@ -653,6 +657,7 @@ class ScriptFormatterTest extends Specification {
             workflow {
             }
 
+
             output {
                 foo: Path {
                     path 'foo'
@@ -676,16 +681,20 @@ class ScriptFormatterTest extends Specification {
 
             include { foo ; bar } from './foobar.nf'
 
+
             process hello {
                 script:
                 'echo true'
             }
 
+
             workflow hello {
             }
 
+
             workflow {
             }
+
 
             output {
             }
@@ -1193,6 +1202,7 @@ class ScriptFormatterTest extends Specification {
             '''\
             nextflow.enable.types = true
 
+
             agent reporter {
                 // a directive
                 model 'openai/gpt-4o'
@@ -1271,6 +1281,7 @@ class ScriptFormatterTest extends Specification {
         checkFormat(
             '''\
             #!/usr/bin/env nextflow
+
             /*
              * Copyright 2013-2024, Seqera Labs
              */
@@ -1297,6 +1308,7 @@ class ScriptFormatterTest extends Specification {
                 // Whether to save intermediate outputs.
                 save_intermeds: Boolean = false
             }
+
 
             workflow {
                 println(params.input)
@@ -1682,6 +1694,7 @@ class ScriptFormatterTest extends Specification {
             '''\
             nextflow.enable.types = true
 
+
             process FOO {
                 input:
                 tuple(
@@ -1833,6 +1846,7 @@ class ScriptFormatterTest extends Specification {
             'echo hi'
             } // fmt: skip
 
+
             process bar {
                 script:
                 'echo bar'
@@ -1859,6 +1873,80 @@ class ScriptFormatterTest extends Specification {
             x=3
             // fmt: on
             y = 4
+            '''
+        )
+    }
+
+    def 'should not inject blank lines into a fmt: off region spanning multiple declarations' () {
+        expect:
+        checkFormat(
+            '''\
+            // fmt: off
+            process foo {
+                script:
+                'echo foo'
+            }
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            // fmt: on
+            params.x=1
+            ''',
+            '''\
+            // fmt: off
+            process foo {
+                script:
+                'echo foo'
+            }
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            // fmt: on
+
+
+            params.x = 1
+            '''
+        )
+    }
+
+    def 'should separate a process when section from the script section by one blank line' () {
+        expect:
+        checkFormat(
+            '''\
+            process foo {
+                when:
+                x > 1
+
+                script:
+                'echo'
+            }
+            '''
+        )
+    }
+
+    def 'should strip a blank line at the start of a closure body' () {
+        expect:
+        checkFormat(
+            '''\
+            workflow {
+                channel.map { v ->
+
+                    foo(v)
+                    bar(v)
+                }
+            }
+            ''',
+            '''\
+            workflow {
+                channel.map { v ->
+                    foo(v)
+                    bar(v)
+                }
+            }
             '''
         )
     }
@@ -1975,6 +2063,324 @@ class ScriptFormatterTest extends Specification {
             include { yak } from './y.nf'
             '''
         )
+    }
+
+    /// BLANK LINES (issue #115 / #150)
+
+    def 'should normalize any number of blank lines between two processes to exactly two' () {
+        expect:
+        checkFormat(
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+            process bar {
+                script:
+                'echo bar'
+            }
+            ''',
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            '''
+        )
+        checkFormat(
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            ''',
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            '''
+        )
+        checkFormat(
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+
+
+
+
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            ''',
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+
+
+            process bar {
+                script:
+                'echo bar'
+            }
+            '''
+        )
+    }
+
+    def 'should separate a process and a following function by two blank lines' () {
+        expect:
+        checkFormat(
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+            def bar() {
+                return 1
+            }
+            ''',
+            '''\
+            process foo {
+                script:
+                'echo foo'
+            }
+
+
+            def bar() {
+                return 1
+            }
+            '''
+        )
+    }
+
+    def 'should separate an include block and a following workflow by two blank lines' () {
+        expect:
+        checkFormat(
+            '''\
+            include { foo } from './foo.nf'
+            workflow {
+            }
+            ''',
+            '''\
+            include { foo } from './foo.nf'
+
+
+            workflow {
+            }
+            '''
+        )
+    }
+
+    def 'should keep grouped includes together and collapse a larger gap to one blank line' () {
+        expect:
+        checkFormat(
+            '''\
+            include { foo } from './foo.nf'
+            include { bar } from './bar.nf'
+            '''
+        )
+        checkFormat(
+            '''\
+            include { foo } from './foo.nf'
+
+
+
+            include { bar } from './bar.nf'
+            ''',
+            '''\
+            include { foo } from './foo.nf'
+
+            include { bar } from './bar.nf'
+            '''
+        )
+    }
+
+    def 'should strip a blank line at the start of a process body and a section' () {
+        expect:
+        checkFormat(
+            '''\
+            process foo {
+
+                input:
+
+                val x
+
+                script:
+                'echo hi'
+            }
+            ''',
+            '''\
+            process foo {
+                input:
+                val x
+
+                script:
+                'echo hi'
+            }
+            '''
+        )
+    }
+
+    def 'should separate process and workflow sections by exactly one blank line regardless of source spacing' () {
+        expect:
+        checkFormat(
+            '''\
+            process foo {
+                input:
+                val x
+                output:
+                path 'out.txt'
+                script:
+                'echo hi'
+            }
+            ''',
+            '''\
+            process foo {
+                input:
+                val x
+
+                output:
+                path 'out.txt'
+
+                script:
+                'echo hi'
+            }
+            '''
+        )
+        checkFormat(
+            '''\
+            workflow hello {
+                take:
+                x
+
+
+
+                main:
+                y = x
+            }
+            ''',
+            '''\
+            workflow hello {
+                take:
+                x
+
+                main:
+                y = x
+            }
+            '''
+        )
+    }
+
+    def 'should collapse runs of blank lines inside a workflow body to one' () {
+        expect:
+        checkFormat(
+            '''\
+            workflow {
+                a = 1
+
+
+
+                b = 2
+            }
+            ''',
+            '''\
+            workflow {
+                a = 1
+
+                b = 2
+            }
+            '''
+        )
+    }
+
+    def 'should follow a shebang with exactly one blank line regardless of source spacing' () {
+        expect:
+        checkFormat(
+            '''\
+            #!/usr/bin/env nextflow
+            workflow {
+            }
+            ''',
+            '''\
+            #!/usr/bin/env nextflow
+
+            workflow {
+            }
+            '''
+        )
+        checkFormat(
+            '''\
+            #!/usr/bin/env nextflow
+
+
+
+            workflow {
+            }
+            ''',
+            '''\
+            #!/usr/bin/env nextflow
+
+            workflow {
+            }
+            '''
+        )
+    }
+
+    def 'should be idempotent when formatting a mixed file of declaration kinds' () {
+        given:
+        def source =
+            '''\
+            #!/usr/bin/env nextflow
+
+            include { foo } from './foo.nf'
+            include { bar } from './bar.nf'
+
+            include { baz } from './baz.nf'
+
+            params.x = 1
+
+
+            process greet {
+                script:
+                'echo hi'
+            }
+
+
+            def helper() {
+                return 1
+            }
+
+
+            workflow {
+                greet()
+            }
+            '''.stripIndent()
+
+        expect:
+        format(source) == source
+        format(format(source)) == source
     }
 
 }


### PR DESCRIPTION
- Standardises the number of blank lines the formatter emits, resolving nextflow-io/language-server#115 and nextflow-io/language-server#150.
- The last of the formatter follow-ups deferred from #7346 in this stack.

The policy (PEP8/Ruff-style):

- exactly **2** blank lines around top-level block definitions (process, workflow, function, params, output, record, enum, agent), and between a definition and any adjacent declaration;
- simple declarations (includes, feature flags, legacy params) stay grouped, with runs of blank lines collapsed to at most one;
- process and workflow sections stay separated by exactly **1** blank line (this is nextflow-io/language-server#150);
- blank lines at the **start** of a block or section are removed;
- a shebang is followed by exactly 1 blank line;
- runs of blank lines anywhere else collapse to at most 1.
- Verbatim regions (`fmt: off` / `fmt: skip`, from the PR below this one) keep their original spacing untouched.

Notes:

- **Stacked PR** — targets `formatter-fmt-directives` (see nextflow-io/language-server#75 ), which stacks on the wrapping and sort PRs below it. Review/merge those first; the diff here is only the blank-line change.

Two decisions worth a look in review, both intentional and easy to change:

- **Exactly 2 blank lines around top-level definitions**, and the feature is **always on** (not behind an option) — this is the most opinionated part and follows the PEP8 mapping requested in the issue.
- Config blocks are set off by **1** blank line rather than 2, since config files are denser than script definitions.

Mechanically, top-level spacing is now driven by policy in the declaration loop (`blankLinesBetween(prev, decl)`) rather than derived from each node's source position; the within-line collapse stays a stateless re-derivation from the source, and blank lines at a block/section start are dropped via a small `atBlockStart` flag set by each opener.

## Example

Before:

```nextflow
include { FOO } from './modules/foo.nf'
process ALIGN {
    input:
    path reads


    script:
    'echo'
}



workflow {
    ALIGN(reads)
}
```

After:

```nextflow
include { FOO } from './modules/foo.nf'


process ALIGN {
    input:
    path reads

    script:
    'echo'
}


workflow {
    ALIGN(reads)
}
```

The include block is separated from the process by 2 blank lines (a definition), the run of blanks before `script:` collapses to the single blank that separates sections, and the 3 blank lines before `workflow` normalise to 2.

Assisted-by: Claude Opus 4.8 (Claude Code)
