### PR TITLE
Change default k8s compute resource type to Job

### DIFF
--- a/docs/executor/kubernetes.mdx
+++ b/docs/executor/kubernetes.mdx
@@ -5,7 +5,7 @@ description: Reference for the k8s executor, which submits tasks to a Kubernetes
 
 # Kubernetes
 
-The `k8s` executor runs pipeline tasks on a [Kubernetes](http://kubernetes.io/) cluster. It submits each task as a Kubernetes pod, or as a Kubernetes job when [`k8s.computeResourceType`][config-k8s] is set to `Job`.
+The `k8s` executor runs pipeline tasks on a [Kubernetes](http://kubernetes.io/) cluster. It submits each task as a Kubernetes job, or as a Kubernetes pod when [`k8s.computeResourceType`][config-k8s] is set to `Pod`.
 
 Use the following process directives to control resource requests and other job characteristics:
 

--- a/docs/reference/config/k8s.mdx
+++ b/docs/reference/config/k8s.mdx
@@ -44,7 +44,11 @@ This setting is useful when the Kubernetes authentication token has a limited li
 
 ##### `k8s.computeResourceType`
 
-Whether to use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`).
+<ChangedInVersion version="26.10">
+The default value was changed from `Pod` to `Job`.
+</ChangedInVersion>
+
+Whether to use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Job`).
 
 ##### `k8s.context`
 

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sConfig.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sConfig.groovy
@@ -62,7 +62,7 @@ class K8sConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
-        Whether to use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Pod`).
+        Whether to use Kubernetes `Pod` or `Job` resource type to carry out Nextflow tasks (default: `Job`).
     """)
     final String computeResourceType
 
@@ -221,7 +221,7 @@ class K8sConfig implements ConfigScope {
         cleanup = opts.cleanup as Boolean
         client = opts.client as Map
         clientRefreshInterval = opts.clientRefreshInterval as Duration ?: Duration.of('50m')
-        computeResourceType = opts.computeResourceType
+        computeResourceType = opts.computeResourceType ?: ResourceType.Job.name()
         context = opts.context
         cpuLimits = opts.cpuLimits as boolean
         debug = new K8sDebug(opts.debug as Map ?: Collections.emptyMap())

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sConfigTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sConfigTest.groovy
@@ -321,12 +321,12 @@ class K8sConfigTest extends Specification {
         when:
         def cfg = new K8sConfig()
         then:
-        !cfg.useJobResource()
+        cfg.useJobResource()
 
         when:
-        cfg = new K8sConfig(computeResourceType: 'Job')
+        cfg = new K8sConfig(computeResourceType: 'Pod')
         then:
-        cfg.useJobResource()
+        !cfg.useJobResource()
 
     }
 


### PR DESCRIPTION
Kubernetes tasks are now submitted as `Job` resources by default instead of `Pod`.

Set `k8s.computeResourceType = 'Pod'` to restore the previous behavior. Docs get a `ChangedInVersion` callout for 26.10.