### PR TITLE
Add NXF_CONFIG environment variable for a default config file

### DIFF
--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -14,7 +14,8 @@ When you launch a pipeline script, Nextflow detects configuration files from mul
 1. `$NXF_HOME/config` (defaults to `$HOME/.nextflow/config`)
 2. `nextflow.config` in the project directory
 3. `nextflow.config` in the launch directory
-4. Config files specified with `-c <config-files>`
+4. The config file specified by the `NXF_CONFIG` environment variable
+5. Config files specified with `-c <config-files>`
 
 :::tip
 You can use the `-C <config-file>` option to specify a fixed set of configuration files and ignore all other files.

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -92,6 +92,12 @@ Directory where Conda environments are stored. When using a computing cluster it
 
 Enable the use of Conda recipes defined by using the [conda][process-conda] directive. (default: `false`).
 
+##### `NXF_CONFIG`
+
+<AddedInVersion version="26.08" />
+
+Defines the path to a configuration file that is applied to every pipeline run. The path can be absolute or relative to the launch directory. When set, the file is loaded with a higher priority than the default configuration files but lower than config files specified with `-c`. See [Configuration files][config-files] for the full priority order.
+
 ##### `NXF_CONTAINER_ENTRYPOINT_OVERRIDE`
 
 <DeprecatedInVersion version="22.10" />
@@ -487,6 +493,7 @@ Forces the terminal width of ANSI-formatted log output. Overrides automatic term
 
 [agent-page]: ../agent
 [agent-provider]: ../agent#the-api-provider
+[config-files]: ../config#configuration-files
 [process-conda]: ./process/directives/conda
 [process-publishdir]: ./process/directives/publish-dir
 [process-spack]: ./process/directives/spack

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
@@ -200,6 +200,16 @@ class ConfigCmdAdapter {
             result << local
         }
 
+        /**
+         * Config file specified with the `NXF_CONFIG` environment variable
+         */
+        final nxfConfig = SysEnv.get('NXF_CONFIG')
+        if( nxfConfig ) {
+            final configFile = currentDir.resolve(nxfConfig)
+            log.debug "Found config from NXF_CONFIG: $configFile"
+            result << configFile
+        }
+
         final customConfigs = []
         if( userConfigFiles )
             customConfigs.addAll(userConfigFiles)

--- a/modules/nf-cli-v1/src/test/groovy/nextflow/config/ConfigCmdAdapterTest.groovy
+++ b/modules/nf-cli-v1/src/test/groovy/nextflow/config/ConfigCmdAdapterTest.groovy
@@ -258,6 +258,50 @@ class ConfigCmdAdapterTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should fetch the config file from NXF_CONFIG env var' () {
+        given:
+        def folder = File.createTempDir()
+        def adminConfig = new File(folder,'admin.config').absoluteFile
+        adminConfig.text = '''
+        process.name = 'admin'
+        params.one = 'x'
+        params.two = 'y'
+        '''
+
+        // relative path to current dir
+        when:
+        SysEnv.push(NXF_CONFIG: 'admin.config')
+        def config = new ConfigCmdAdapter() .setCurrentDir(folder.toPath()) .build()
+        SysEnv.pop()
+        then:
+        config.params.one == 'x'
+        config.params.two == 'y'
+        config.process.name == 'admin'
+
+        // absolute path
+        when:
+        SysEnv.push(NXF_CONFIG: adminConfig.toString())
+        config = new ConfigCmdAdapter() .build()
+        SysEnv.pop()
+        then:
+        config.params.one == 'x'
+        config.params.two == 'y'
+        config.process.name == 'admin'
+
+        // NXF_CONFIG should take precedence over the local nextflow.config
+        when:
+        new File(folder,'nextflow.config').text = 'process.name = "local"; params.one = "local"'
+        SysEnv.push(NXF_CONFIG: 'admin.config')
+        config = new ConfigCmdAdapter() .setCurrentDir(folder.toPath()) .build()
+        SysEnv.pop()
+        then:
+        config.params.one == 'x'
+        config.process.name == 'admin'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'CLI params should overrides the ones in one or more profiles' () {
 
         setup:


### PR DESCRIPTION
Adds support for the `NXF_CONFIG` environment variable, which points to a config file applied to every pipeline run.

## Motivation

Fixes #6151. Currently there is no way to inject a config file via environment variable (e.g. for an admin-provided config on a shared cluster). This makes it possible to point to a config file in a read-only location.

## Changes

- `ConfigCmdAdapter.resolveConfigFiles()`: when `NXF_CONFIG` is set, resolve the referenced file (absolute or relative to the launch directory) and add it to the config file list, after the default config files and before `-c` config files.
- Added a Spock test covering relative path, absolute path, and precedence over the local `nextflow.config`.
- Documented the new priority order in `docs/config.mdx` and added an `NXF_CONFIG` entry to `docs/reference/env-vars.mdx`.

## Test log

```
$ ./gradlew :nf-cli-v1:test --tests "nextflow.config.ConfigCmdAdapterTest"
...
BUILD SUCCESSFUL in 1m 20s
```

`ConfigCmdAdapterTest`: 69 tests, 0 failures, 0 errors, 0 skipped.
