### PR TITLE
Add automatic resource labels for any executor

### DIFF
--- a/adr/20260821-auto-resource-labels.md
+++ b/adr/20260821-auto-resource-labels.md
@@ -51,7 +51,9 @@ Three properties of the existing code shape the design:
    Kubernetes label key, but an illegal Google Cloud label key (lowercase `[a-z0-9_-]` only,
    must start with a letter). Values are worse: a Kubernetes label value rejects
    `https://github.com/foo/bar`, so `repository`, `revision` and `workflowUrl` cannot be applied
-   verbatim. None of the four executors sanitise today; each passes the map straight to its API.
+   verbatim. Three of the four executors pass the map straight to its API; only Kubernetes
+   sanitises, and it does so for *all* pod labels — `PodSpecBuilder.sanitize` rewrites declared
+   labels too, and throws for a key holding more than one `/`.
 
 3. **Timing is already correct.** `session.start()` fires `notifyFlowCreate()` before the script is
    parsed, and `TowerObserver.onFlowCreate` populates `workflowMetadata.platform` there. Every
@@ -158,6 +160,9 @@ Two accessors result:
   report reflects what was actually applied.
 - `getResourceLabels(ResourceLabelPolicy)` — the same merge, with the *auto* entries sanitised by
   the given policy and the declared entries passed through untouched. Executors call this overload.
+  The collision is decided *before* the sanitisation, so that a label declared with the canonical
+  key (`nextflow.io/runName`) overrides the auto one on a policy that mangles that key, instead of
+  the two turning into distinct entries.
 
 The overload exists because the two requirements meet here: sanitisation is per-executor, but only
 auto-labels may be sanitised. Once the maps are merged an executor can no longer tell one from the
@@ -178,7 +183,7 @@ call site:
 | --- | --- | --- |
 | AWS Batch | permissive charset (`+ - = . _ : / @`), key <= 128, value <= 256 | unchanged |
 | Google Batch | lowercase, `[a-z0-9_-]`, leading letter, <= 63 | `nextflow_io_runname` |
-| Kubernetes | key unchanged; values stripped of scheme and slashes, <= 63 | unchanged (value fixed) |
+| Kubernetes | key prefix kept, any `/` after the first replaced with `_`; values stripped of scheme and slashes, <= 63 | unchanged (value fixed) |
 | Azure Batch | near-identity, minus the reserved `microsoft` name prefix | unchanged |
 | Seqera | identity | unchanged |
 

--- a/adr/20260821-auto-resource-labels.md
+++ b/adr/20260821-auto-resource-labels.md
@@ -1,0 +1,254 @@
+# Automatic resource labels for any executor
+
+- Authors: Paolo Di Tommaso
+- Status: draft
+- Deciders: Paolo Di Tommaso
+- Date: 2026-08-21
+- Tags: executor, labels, platform, seqera
+
+## Summary
+
+The `seqera.executor.autoLabels` option derives resource labels from workflow metadata, but only the
+Seqera executor honours it. Promote that mapping to the runtime so that every executor supporting
+`resourceLabels` — AWS Batch, Azure Batch, Google Batch, Kubernetes, Seqera — attaches the same
+labels, driven by a new `tower.autoLabels` option.
+
+## Problem Statement
+
+`resourceLabels` attaches name-value pairs to the compute resources backing a task, for operational
+purposes such as cloud cost attribution. Today the user must write those pairs by hand, and the
+values that matter most for attribution — run name, session id, project, Platform workspace and
+compute environment — are only known to Nextflow at runtime.
+
+The Seqera executor already solves this. `seqera.executor.autoLabels` selects from thirteen
+workflow-metadata fields, which `Labels.withWorkflowMetadata` maps to `nextflow.io/*` and
+`seqera.io/platform/*` keys, and `SeqeraExecutor.createRun` attaches to the scheduler run object.
+Per task, `SeqeraTaskHandler` sends only the delta against that run-level baseline.
+
+That leaves a user running the same pipeline on AWS Batch, Azure Batch, Google Batch or Kubernetes
+with no equivalent, even though those executors all consume resource labels through one accessor:
+
+| Executor | Call site | Target |
+| --- | --- | --- |
+| AWS Batch | `AwsBatchTaskHandler:833` | Batch job tags |
+| Azure Batch | `AzBatchService:755` | auto-pool metadata |
+| Google Batch | `GoogleBatchTaskHandler:538,595` | allocation policy and job labels |
+| Kubernetes | `K8sTaskHandler:298` | pod labels |
+| Seqera | `SeqeraTaskHandler:163` | scheduler task labels |
+
+Every one of them reads `task.config.getResourceLabels()`, so a single merge point in
+`TaskConfig` reaches all five.
+
+Three properties of the existing code shape the design:
+
+1. **Injecting into the config scope does not work.** `resourceLabels` is not in
+   `REPEATABLE_DIRECTIVES`, so `ProcessConfigBuilder.applyConfigDefaults` skips it whenever the
+   process declares its own value, and a `withName:`/`withLabel:` selector replaces it outright. A
+   plugin writing into `session.config.process.resourceLabels` would therefore lose the labels for
+   exactly the processes that customise them.
+
+2. **Label syntax is not portable.** `nextflow.io/runName` is a legal AWS tag key and a legal
+   Kubernetes label key, but an illegal Google Cloud label key (lowercase `[a-z0-9_-]` only,
+   must start with a letter). Values are worse: a Kubernetes label value rejects
+   `https://github.com/foo/bar`, so `repository`, `revision` and `workflowUrl` cannot be applied
+   verbatim. None of the four executors sanitise today; each passes the map straight to its API.
+
+3. **Timing is already correct.** `session.start()` fires `notifyFlowCreate()` before the script is
+   parsed, and `TowerObserver.onFlowCreate` populates `workflowMetadata.platform` there. Every
+   process definition, and therefore every `TaskConfig`, is built afterwards.
+
+## Goals or Decision Drivers
+
+- One implementation of the metadata-to-label mapping, shared by all executors.
+- No behaviour change for a user who does not opt in; the feature is off by default.
+- User-declared labels are never altered — not rewritten, not reordered away, not dropped.
+- Labels emitted to a cloud API must be valid for that API.
+- No new task-hash inputs: enabling the feature must not invalidate a resumed run.
+- Do not regress the Seqera executor's run-level baseline and per-task delta.
+
+## Non-goals
+
+- Platform *run* labels (`PlatformMetadata.labels`, fetched by `TowerObserver` as a
+  `List<String>`). A different concept, untouched here.
+- Enforcing per-cloud label cardinality ceilings (AWS 50 tags, Google 64 labels). Thirteen
+  auto-labels plus user labels stays well under; the limits are documented, not policed.
+- Making `resourceLabels` a repeatable directive.
+- Recording resource labels in lineage metadata. Verified absent from `nf-lineage`, and the
+  directive documentation's claim that they are not recorded remains accurate.
+
+## Considered Options
+
+- **A. Runtime computes the labels; nf-tower only supplies metadata.**
+- **B. New plugin extension point** (`ResourceLabelsProvider extends ExtensionPoint`).
+- **C. Mutable session registry** pushed from `TowerObserver.onFlowCreate`.
+
+## Pros and Cons of the Options
+
+### A. Runtime computes, plugin supplies metadata
+
+Both halves are already in the runtime: `PlatformMetadata` is a runtime class that nf-tower fills
+in at `onFlowCreate`, and `PlatformHelper.config()` already reads the `tower` config scope from the
+runtime. A runtime helper can therefore read `tower.autoLabels` and map `WorkflowMetadata` to
+labels with no new plugin machinery at all.
+
+- Good, because it adds no service-provider interface for what has one producer.
+- Good, because nf-tower's only change is declaring the config option.
+- Good, because nf-seqera and every other executor consume one identical implementation.
+- Good, because the core metadata labels still work when nf-tower is inactive.
+- Bad, because the runtime reads a config key declared by a plugin scope — mitigated by the
+  precedent of `tower.accessToken` and friends, already read this way through `PlatformHelper`.
+
+### B. New plugin extension point
+
+- Good, because third-party plugins could contribute labels.
+- Good, because layering is explicit: the runtime declares, the plugin implements.
+- Bad, because it is discovery, ordering and conflict-resolution machinery for one implementation.
+- Bad, because nf-seqera must either implement the interface or consume it, adding indirection to
+  code that already has the answer.
+- Bad, because labels then depend on plugin load state.
+
+### C. Mutable session registry
+
+- Good, because there is no discovery mechanism and the push point is an explicit lifecycle event.
+- Bad, because label content becomes dependent on observer ordering.
+- Bad, because paths that never fire `onFlowCreate` (preview, inspect) silently yield no labels.
+
+## Solution or decision outcome
+
+Adopt option A: a runtime `AutoLabels` helper plus a merge in `TaskConfig`, with per-executor
+sanitisation applied to the auto-derived entries only. nf-seqera drops its private copy of the
+mapping and consumes the runtime one.
+
+## Rationale & discussion
+
+### Runtime: the mapping
+
+New `nextflow.platform.AutoLabels` in `modules/nextflow`, holding what is today private to
+nf-seqera:
+
+- `VALID_NAMES` — the thirteen short names: `projectName`, `userName`, `runName`, `sessionId`,
+  `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`, `workflowId`,
+  `workspaceId`, `computeEnvId`.
+- `parse(Object) -> Set<String>` — accepts `true` (all names), `false` (none), a list, or a
+  comma-separated string; rejects unknown names with the existing error text. Moved from
+  `ExecutorOpts.parseAutoLabels`.
+- `labelsFor(WorkflowMetadata, Set<String>) -> Map<String,String>` — the canonical
+  `nextflow.io/*` and `seqera.io/platform/*` mapping, including the `userName` fallback from the
+  Platform user to the OS user. Moved from `Labels.withWorkflowMetadata`.
+
+`Session` gains a memoized `getAutoResourceLabels()` that reads
+`PlatformHelper.config().autoLabels`, parses it, and maps the metadata; it returns an empty map when
+the option is unset. The computation is lazy on first access, not eager in `init()`: the Platform
+fields are only populated at `notifyFlowCreate`, and any earlier snapshot would capture nulls.
+Entries whose source value is absent are omitted, so a run without nf-tower active still gets the
+metadata labels the runtime knows on its own.
+
+### Runtime: the merge
+
+`TaskConfig` holds no session reference, and reaching for `Global.session` inside it would make the
+result depend on hidden global state. Instead `TaskConfig` gains an explicit transient field and
+setter — the same shape as its existing `cache` field — assigned at the two sites in
+`TaskProcessor` that already initialise `config.process` and `config.executor`:
+`createTaskRun` (`TaskProcessor:758`) and `createTaskPreview` (`TaskProcessor:399`).
+
+Two accessors result:
+
+- `getResourceLabels()` — auto labels merged under declared labels, **declared wins on key
+  collision**. This is what `TaskBean`, trace records and the execution report observe, so the
+  report reflects what was actually applied.
+- `getResourceLabels(ResourceLabelPolicy)` — the same merge, with the *auto* entries sanitised by
+  the given policy and the declared entries passed through untouched. Executors call this overload.
+
+The overload exists because the two requirements meet here: sanitisation is per-executor, but only
+auto-labels may be sanitised. Once the maps are merged an executor can no longer tell one from the
+other, so the distinction has to be preserved at the merge — hence the policy travels inward rather
+than the auto subset travelling outward.
+
+`resourceLabels` is absent from `TaskHasher`, so nothing here alters a task hash or invalidates
+resume. It is already listed in `TaskArrayCollector.ARRAY_DIRECTIVES`, so job arrays inherit the
+merged value from the first task, as they do today.
+
+### Per-executor sanitisation
+
+`ResourceLabelPolicy` (runtime) describes a key/value charset, case folding, maximum length, and
+what to do with a value that sanitises to empty. One policy per executor, applied at its existing
+call site:
+
+| Executor | Policy | `nextflow.io/runName` becomes |
+| --- | --- | --- |
+| AWS Batch | permissive charset (`+ - = . _ : / @`), key <= 128, value <= 256 | unchanged |
+| Google Batch | lowercase, `[a-z0-9_-]`, leading letter, <= 63 | `nextflow_io_runname` |
+| Kubernetes | key unchanged; values stripped of scheme and slashes, <= 63 | unchanged (value fixed) |
+| Azure Batch | near-identity, minus the reserved `microsoft` name prefix | unchanged |
+| Seqera | identity | unchanged |
+
+### nf-seqera convergence
+
+nf-seqera stops owning the mapping:
+
+- Delete `Labels.withWorkflowMetadata` and `ExecutorOpts.parseAutoLabels`; both now live in the
+  runtime. `Labels.toStringMap` and `Labels.delta` stay — they are scheduler-specific.
+- `SeqeraExecutor.createRun` builds the run label set from `session.autoResourceLabels` plus
+  config-level `process.resourceLabels`.
+- `runResourceLabels` becomes the **complete** run baseline (auto plus config) rather than
+  config-only. This is load-bearing: `Labels.delta` compares the task label set against that
+  baseline, so leaving it config-only would make the runtime merge re-send all thirteen auto-labels
+  on every task. With the full baseline the delta collapses to empty unless the task genuinely
+  overrides something.
+
+### Config surface and precedence
+
+- `tower.autoLabels`, declared in `TowerConfig` with `@ConfigOption` and `@Description`, accepting
+  the same forms as the existing option: `true`, `false` (default), a list, or a comma-separated
+  string.
+- `seqera.executor.autoLabels` is retained for backward compatibility and marked deprecated in its
+  description.
+- One set is resolved per session, with `seqera.executor.autoLabels` taking precedence when the key
+  is present in the configuration (including when set to `false`) and `tower.autoLabels` otherwise.
+  Off by default when neither is set.
+
+Resolving a single session-wide set, rather than one per executor, is deliberate. It keeps
+`Session.autoResourceLabels` the only source of truth, and it is what guarantees the nf-seqera
+per-task delta collapses to empty: the run baseline and the merged task labels derive from the same
+map. The cost is that a run mixing the Seqera executor with another one honours the legacy
+Seqera-scoped option globally — acceptable for a deprecated option that defaults to off.
+
+The runtime merge applies to the Seqera executor as well; it is not special-cased. Its per-task
+delta absorbs the duplication, which is why the full-baseline change described above is a
+prerequisite rather than an optimisation.
+
+### Testing
+
+- Runtime: `AutoLabelsTest` for parsing and mapping — largely the existing nf-seqera `LabelsTest`
+  cases relocated; `TaskConfigTest` for merge precedence and the policy overload; `SessionTest`
+  for lazy computation and for the no-Platform case.
+- Per executor: policy unit tests covering the hostile inputs (a `repository` URL under the
+  Kubernetes value rules, mixed-case and dotted keys under the Google rules), plus one handler test
+  each asserting that auto-labels arrive sanitised and user labels arrive byte-identical.
+- nf-seqera: existing tests updated for the moved code, plus one pinning that the per-task delta is
+  empty when a task declares no labels of its own.
+
+### Documentation
+
+- `docs/reference/config/tower.mdx` — the new option.
+- `docs/reference/config/seqera.mdx` — deprecation note on the existing option.
+- `docs/reference/process/directives/resource-labels.mdx` — an auto-labels section and the
+  per-executor key-mangling table above.
+
+### Risks
+
+**Azure pool churn.** `AzBatchService.specFromAutoPool` derives the pool id from
+`CacheHelper.hasher([vmType.name, opts, metadata])`, where `metadata` is the resource label map.
+Any label that varies per run — `runName`, `sessionId`, `workflowId` — therefore produces a fresh
+auto-pool for every execution, and pools accumulate unless
+`azure.batch.deletePoolsOnCompletion` is set. This is inherent to Azure applying labels at pool
+rather than task granularity. Documented as a caveat, with the recommendation to select a stable
+subset (for example `projectName`, `workspaceId`, `computeEnvId`) on Azure. Gating volatile labels
+out of the Azure policy is a possible follow-up, deliberately not done here.
+
+**Cloud tag visibility.** Enabling the option changes tags on cloud resources, which can affect
+cost reports and any tag-based IAM condition. Mitigated by the feature being off by default.
+
+## Links
+
+- Refines [scheduler run identifier propagation](20260609-scheduler-run-identifier-propagation.md)

--- a/adr/20260821-auto-resource-labels.md
+++ b/adr/20260821-auto-resource-labels.md
@@ -81,7 +81,7 @@ A new `AutoLabels` class provides what is today private to nf-seqera:
 - `parse(Object) -> Set<String>`, which accepts `true` (all names), `false` (none), a list, or a comma-separated string, and rejects unknown names with the existing error text.
 - `labelsFor(WorkflowMetadata, Set<String>) -> Map<String,String>`, the canonical `nextflow.io/*` and `seqera.io/platform/*` mapping, including the `userName` fallback from the Platform user to the OS user.
 
-`Session` gains a memoized `getAutoResourceLabels()` that reads `PlatformHelper.config().autoLabels`, parses it, and maps the metadata; it returns an empty map when the option is unset. The computation is lazy on first access, not eager in `init()`, because the Platform fields are only populated at `notifyFlowCreate` and any earlier snapshot would capture nulls. Entries whose source value is absent are omitted, so a run without nf-tower active still gets the metadata labels the runtime knows on its own.
+`Session` gains a memoized `getAutoResourceLabels()` that loads the auto-labels config and maps the workflow metadata. The computation is lazy on first access, not eager in `init()`, because the Platform fields aren't populated until `notifyFlowCreate`. Entries with no source value are omitted, so a run without nf-tower still gets the metadata labels from the core runtime.
 
 ### Runtime: the merge
 
@@ -89,8 +89,8 @@ A new `AutoLabels` class provides what is today private to nf-seqera:
 
 Two accessors result:
 
-- `getResourceLabels()`, auto labels merged under declared labels, where a declared label wins on key collision. This is what `TaskBean`, trace records and the execution report observe, so the report reflects what was actually applied.
-- `getResourceLabels(ResourceLabelPolicy)`, the same merge, with the *auto* entries sanitized by the given policy and the declared entries passed through untouched. Executors call this overload. The collision is decided *before* the sanitization, so that a label declared with the canonical key (`nextflow.io/runName`) overrides the auto one on a policy that mangles that key, instead of the two turning into distinct entries.
+- `getResourceLabels()`, auto labels merged under declared labels, where a declared label wins on key collision.
+- `getResourceLabels(ResourceLabelPolicy)`, the same merge, with the *auto* entries sanitized by the given policy and the declared entries passed through untouched. Executors call this overload. The collision is decided *before* the sanitization, so that a label declared with the canonical key (`nextflow.io/runName`) overrides the auto one on a policy that mangles that key.
 
 The overload exists because the two requirements meet here: sanitization is per-executor, but only auto-labels may be sanitized. Once the maps are merged an executor can no longer tell one from the other, so the distinction has to be preserved at the merge. The policy travels inward rather than the auto subset traveling outward.
 

--- a/adr/20260821-auto-resource-labels.md
+++ b/adr/20260821-auto-resource-labels.md
@@ -1,32 +1,21 @@
 # Automatic resource labels for any executor
 
 - Authors: Paolo Di Tommaso
-- Status: draft
-- Deciders: Paolo Di Tommaso
+- Status: accepted
 - Date: 2026-08-21
 - Tags: executor, labels, platform, seqera
 
 ## Summary
 
-The `seqera.executor.autoLabels` option derives resource labels from workflow metadata, but only the
-Seqera executor honours it. Promote that mapping to the runtime so that every executor supporting
-`resourceLabels` — AWS Batch, Azure Batch, Google Batch, Kubernetes, Seqera — attaches the same
-labels, driven by a new `tower.autoLabels` option.
+The `seqera.executor.autoLabels` option derives resource labels from workflow metadata, but only the Seqera executor honors it. Move that mapping into the runtime so that every executor supporting `resourceLabels` (AWS Batch, Azure Batch, Google Batch, Kubernetes, Seqera) attaches the same labels, driven by a new `tower.autoLabels` option.
 
-## Problem Statement
+## Problem statement
 
-`resourceLabels` attaches name-value pairs to the compute resources backing a task, for operational
-purposes such as cloud cost attribution. Today the user must write those pairs by hand, and the
-values that matter most for attribution — run name, session id, project, Platform workspace and
-compute environment — are only known to Nextflow at runtime.
+The `resourceLabels` directive attaches name-value pairs to the compute resources backing a task, for operational purposes such as cloud cost attribution. Today the user must write those pairs by hand, and the values that matter most for attribution (run name, session id, project, Platform workspace, compute environment) are only known to Nextflow at runtime.
 
-The Seqera executor already solves this. `seqera.executor.autoLabels` selects from thirteen
-workflow-metadata fields, which `Labels.withWorkflowMetadata` maps to `nextflow.io/*` and
-`seqera.io/platform/*` keys, and `SeqeraExecutor.createRun` attaches to the scheduler run object.
-Per task, `SeqeraTaskHandler` sends only the delta against that run-level baseline.
+The Seqera executor already solves this. `seqera.executor.autoLabels` selects from thirteen workflow-metadata fields, maps them to `nextflow.io/*` and `seqera.io/platform/*` keys, and attaches them to the scheduler run. Each task sends only the delta against that run-level baseline.
 
-That leaves a user running the same pipeline on AWS Batch, Azure Batch, Google Batch or Kubernetes
-with no equivalent, even though those executors all consume resource labels through one accessor:
+That leaves a user running the same pipeline on AWS Batch, Azure Batch, Google Batch or Kubernetes with no equivalent, even though those executors all consume resource labels through one accessor:
 
 | Executor | Call site | Target |
 | --- | --- | --- |
@@ -36,77 +25,40 @@ with no equivalent, even though those executors all consume resource labels thro
 | Kubernetes | `K8sTaskHandler:298` | pod labels |
 | Seqera | `SeqeraTaskHandler:163` | scheduler task labels |
 
-Every one of them reads `task.config.getResourceLabels()`, so a single merge point in
-`TaskConfig` reaches all five.
-
-Three properties of the existing code shape the design:
-
-1. **Injecting into the config scope does not work.** `resourceLabels` is not in
-   `REPEATABLE_DIRECTIVES`, so `ProcessConfigBuilder.applyConfigDefaults` skips it whenever the
-   process declares its own value, and a `withName:`/`withLabel:` selector replaces it outright. A
-   plugin writing into `session.config.process.resourceLabels` would therefore lose the labels for
-   exactly the processes that customise them.
-
-2. **Label syntax is not portable.** `nextflow.io/runName` is a legal AWS tag key and a legal
-   Kubernetes label key, but an illegal Google Cloud label key (lowercase `[a-z0-9_-]` only,
-   must start with a letter). Values are worse: a Kubernetes label value rejects
-   `https://github.com/foo/bar`, so `repository`, `revision` and `workflowUrl` cannot be applied
-   verbatim. Three of the four executors pass the map straight to its API; only Kubernetes
-   sanitises, and it does so for *all* pod labels — `PodSpecBuilder.sanitize` rewrites declared
-   labels too, and throws for a key holding more than one `/`.
-
-3. **Timing is already correct.** `session.start()` fires `notifyFlowCreate()` before the script is
-   parsed, and `TowerObserver.onFlowCreate` populates `workflowMetadata.platform` there. Every
-   process definition, and therefore every `TaskConfig`, is built afterwards.
-
-## Goals or Decision Drivers
+## Goals
 
 - One implementation of the metadata-to-label mapping, shared by all executors.
-- No behaviour change for a user who does not opt in; the feature is off by default.
-- User-declared labels are never altered — not rewritten, not reordered away, not dropped.
+- No behavior change for a user who does not opt in; the feature is off by default.
+- User-declared labels are never altered or dropped.
 - Labels emitted to a cloud API must be valid for that API.
-- No new task-hash inputs: enabling the feature must not invalidate a resumed run.
+- No new task-hash inputs. Enabling the feature must not invalidate a resumed run.
 - Do not regress the Seqera executor's run-level baseline and per-task delta.
 
 ## Non-goals
 
-- Platform *run* labels (`PlatformMetadata.labels`, fetched by `TowerObserver` as a
-  `List<String>`). A different concept, untouched here.
-- Enforcing per-cloud label cardinality ceilings (AWS 50 tags, Google 64 labels). Thirteen
-  auto-labels plus user labels stays well under; the limits are documented, not policed.
+- Platform *run* labels. A different concept, untouched here.
+- Enforcing per-cloud label cardinality ceilings (AWS 50 tags, Google 64 labels). Thirteen auto-labels plus user labels stays well under.
 - Making `resourceLabels` a repeatable directive.
-- Recording resource labels in lineage metadata. Verified absent from `nf-lineage`, and the
-  directive documentation's claim that they are not recorded remains accurate.
+- Recording resource labels in lineage metadata.
 
-## Considered Options
-
-- **A. Runtime computes the labels; nf-tower only supplies metadata.**
-- **B. New plugin extension point** (`ResourceLabelsProvider extends ExtensionPoint`).
-- **C. Mutable session registry** pushed from `TowerObserver.onFlowCreate`.
-
-## Pros and Cons of the Options
+## Considered options
 
 ### A. Runtime computes, plugin supplies metadata
 
-Both halves are already in the runtime: `PlatformMetadata` is a runtime class that nf-tower fills
-in at `onFlowCreate`, and `PlatformHelper.config()` already reads the `tower` config scope from the
-runtime. A runtime helper can therefore read `tower.autoLabels` and map `WorkflowMetadata` to
-labels with no new plugin machinery at all.
+Both halves are already in the runtime. `PlatformMetadata` is a runtime class that nf-tower fills in at `onFlowCreate`, and `PlatformHelper.config()` already reads the `tower` config scope from the runtime. A runtime helper can therefore read `tower.autoLabels` and map `WorkflowMetadata` to labels with no new plugin machinery at all.
 
 - Good, because it adds no service-provider interface for what has one producer.
 - Good, because nf-tower's only change is declaring the config option.
 - Good, because nf-seqera and every other executor consume one identical implementation.
 - Good, because the core metadata labels still work when nf-tower is inactive.
-- Bad, because the runtime reads a config key declared by a plugin scope — mitigated by the
-  precedent of `tower.accessToken` and friends, already read this way through `PlatformHelper`.
+- Bad, because the runtime reads a config key declared by a plugin scope. Mitigated by the precedent of `tower.accessToken` and friends, already read this way through `PlatformHelper`.
 
 ### B. New plugin extension point
 
 - Good, because third-party plugins could contribute labels.
 - Good, because layering is explicit: the runtime declares, the plugin implements.
 - Bad, because it is discovery, ordering and conflict-resolution machinery for one implementation.
-- Bad, because nf-seqera must either implement the interface or consume it, adding indirection to
-  code that already has the answer.
+- Bad, because nf-seqera must either implement the interface or consume it, adding indirection to code that already has the answer.
 - Bad, because labels then depend on plugin load state.
 
 ### C. Mutable session registry
@@ -115,69 +67,36 @@ labels with no new plugin machinery at all.
 - Bad, because label content becomes dependent on observer ordering.
 - Bad, because paths that never fire `onFlowCreate` (preview, inspect) silently yield no labels.
 
-## Solution or decision outcome
+## Solution
 
-Adopt option A: a runtime `AutoLabels` helper plus a merge in `TaskConfig`, with per-executor
-sanitisation applied to the auto-derived entries only. nf-seqera drops its private copy of the
-mapping and consumes the runtime one.
+Adopt option A: a runtime `AutoLabels` helper plus a merge in `TaskConfig`, with per-executor sanitization applied to the auto-derived entries only. nf-seqera drops its private copy of the mapping and consumes the runtime one.
 
-## Rationale & discussion
+## Rationale and discussion
 
 ### Runtime: the mapping
 
-New `nextflow.platform.AutoLabels` in `modules/nextflow`, holding what is today private to
-nf-seqera:
+A new `AutoLabels` class provides what is today private to nf-seqera:
 
-- `VALID_NAMES` — the thirteen short names: `projectName`, `userName`, `runName`, `sessionId`,
-  `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`, `workflowId`,
-  `workspaceId`, `computeEnvId`.
-- `parse(Object) -> Set<String>` — accepts `true` (all names), `false` (none), a list, or a
-  comma-separated string; rejects unknown names with the existing error text. Moved from
-  `ExecutorOpts.parseAutoLabels`.
-- `labelsFor(WorkflowMetadata, Set<String>) -> Map<String,String>` — the canonical
-  `nextflow.io/*` and `seqera.io/platform/*` mapping, including the `userName` fallback from the
-  Platform user to the OS user. Moved from `Labels.withWorkflowMetadata`.
+- `VALID_NAMES`, the thirteen short names: `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`, `workflowId`, `workspaceId`, `computeEnvId`.
+- `parse(Object) -> Set<String>`, which accepts `true` (all names), `false` (none), a list, or a comma-separated string, and rejects unknown names with the existing error text.
+- `labelsFor(WorkflowMetadata, Set<String>) -> Map<String,String>`, the canonical `nextflow.io/*` and `seqera.io/platform/*` mapping, including the `userName` fallback from the Platform user to the OS user.
 
-`Session` gains a memoized `getAutoResourceLabels()` that reads
-`PlatformHelper.config().autoLabels`, parses it, and maps the metadata; it returns an empty map when
-the option is unset. The computation is lazy on first access, not eager in `init()`: the Platform
-fields are only populated at `notifyFlowCreate`, and any earlier snapshot would capture nulls.
-Entries whose source value is absent are omitted, so a run without nf-tower active still gets the
-metadata labels the runtime knows on its own.
+`Session` gains a memoized `getAutoResourceLabels()` that reads `PlatformHelper.config().autoLabels`, parses it, and maps the metadata; it returns an empty map when the option is unset. The computation is lazy on first access, not eager in `init()`, because the Platform fields are only populated at `notifyFlowCreate` and any earlier snapshot would capture nulls. Entries whose source value is absent are omitted, so a run without nf-tower active still gets the metadata labels the runtime knows on its own.
 
 ### Runtime: the merge
 
-`TaskConfig` holds no session reference, and reaching for `Global.session` inside it would make the
-result depend on hidden global state. Instead `TaskConfig` gains an explicit transient field and
-setter — the same shape as its existing `cache` field — assigned at the two sites in
-`TaskProcessor` that already initialise `config.process` and `config.executor`:
-`createTaskRun` (`TaskProcessor:758`) and `createTaskPreview` (`TaskProcessor:399`).
+`TaskConfig` holds no session reference, and reaching for `Global.session` inside it would make the result depend on hidden global state. Instead `TaskConfig` gains an explicit transient field and setter, the same shape as its existing `cache` field.
 
 Two accessors result:
 
-- `getResourceLabels()` — auto labels merged under declared labels, **declared wins on key
-  collision**. This is what `TaskBean`, trace records and the execution report observe, so the
-  report reflects what was actually applied.
-- `getResourceLabels(ResourceLabelPolicy)` — the same merge, with the *auto* entries sanitised by
-  the given policy and the declared entries passed through untouched. Executors call this overload.
-  The collision is decided *before* the sanitisation, so that a label declared with the canonical
-  key (`nextflow.io/runName`) overrides the auto one on a policy that mangles that key, instead of
-  the two turning into distinct entries.
+- `getResourceLabels()`, auto labels merged under declared labels, where a declared label wins on key collision. This is what `TaskBean`, trace records and the execution report observe, so the report reflects what was actually applied.
+- `getResourceLabels(ResourceLabelPolicy)`, the same merge, with the *auto* entries sanitized by the given policy and the declared entries passed through untouched. Executors call this overload. The collision is decided *before* the sanitization, so that a label declared with the canonical key (`nextflow.io/runName`) overrides the auto one on a policy that mangles that key, instead of the two turning into distinct entries.
 
-The overload exists because the two requirements meet here: sanitisation is per-executor, but only
-auto-labels may be sanitised. Once the maps are merged an executor can no longer tell one from the
-other, so the distinction has to be preserved at the merge — hence the policy travels inward rather
-than the auto subset travelling outward.
+The overload exists because the two requirements meet here: sanitization is per-executor, but only auto-labels may be sanitized. Once the maps are merged an executor can no longer tell one from the other, so the distinction has to be preserved at the merge. The policy travels inward rather than the auto subset traveling outward.
 
-`resourceLabels` is absent from `TaskHasher`, so nothing here alters a task hash or invalidates
-resume. It is already listed in `TaskArrayCollector.ARRAY_DIRECTIVES`, so job arrays inherit the
-merged value from the first task, as they do today.
+### Per-executor sanitization
 
-### Per-executor sanitisation
-
-`ResourceLabelPolicy` (runtime) describes a key/value charset, case folding, maximum length, and
-what to do with a value that sanitises to empty. One policy per executor, applied at its existing
-call site:
+`ResourceLabelPolicy` describes a key/value charset, case folding, maximum length, and what to do with a value that sanitizes to empty. One policy per executor, applied at its existing call site:
 
 | Executor | Policy | `nextflow.io/runName` becomes |
 | --- | --- | --- |
@@ -189,70 +108,21 @@ call site:
 
 ### nf-seqera convergence
 
-nf-seqera stops owning the mapping:
-
-- Delete `Labels.withWorkflowMetadata` and `ExecutorOpts.parseAutoLabels`; both now live in the
-  runtime. `Labels.toStringMap` and `Labels.delta` stay — they are scheduler-specific.
-- `SeqeraExecutor.createRun` builds the run label set from `session.autoResourceLabels` plus
-  config-level `process.resourceLabels`.
-- `runResourceLabels` becomes the **complete** run baseline (auto plus config) rather than
-  config-only. This is load-bearing: `Labels.delta` compares the task label set against that
-  baseline, so leaving it config-only would make the runtime merge re-send all thirteen auto-labels
-  on every task. With the full baseline the delta collapses to empty unless the task genuinely
-  overrides something.
+The mapping logic is moved from nf-seqera to the core runtime. The Seqera executor builds the run label set from `session.autoResourceLabels` plus config-level `process.resourceLabels`. This way, the auto labels are not re-sent by the task delta.
 
 ### Config surface and precedence
 
-- `tower.autoLabels`, declared in `TowerConfig` with `@ConfigOption` and `@Description`, accepting
-  the same forms as the existing option: `true`, `false` (default), a list, or a comma-separated
-  string.
-- `seqera.executor.autoLabels` is retained for backward compatibility and marked deprecated in its
-  description.
-- One set is resolved per session, with `seqera.executor.autoLabels` taking precedence when the key
-  is present in the configuration (including when set to `false`) and `tower.autoLabels` otherwise.
-  Off by default when neither is set.
+`tower.autoLabels` accepts the same forms as the existing option: `true`, `false` (default), a list, or a comma-separated string.
 
-Resolving a single session-wide set, rather than one per executor, is deliberate. It keeps
-`Session.autoResourceLabels` the only source of truth, and it is what guarantees the nf-seqera
-per-task delta collapses to empty: the run baseline and the merged task labels derive from the same
-map. The cost is that a run mixing the Seqera executor with another one honours the legacy
-Seqera-scoped option globally — acceptable for a deprecated option that defaults to off.
+`seqera.executor.autoLabels` is retained for backward compatibility and marked as deprecated. It takes precedence over `tower.autoLabels` when present.
 
-The runtime merge applies to the Seqera executor as well; it is not special-cased. Its per-task
-delta absorbs the duplication, which is why the full-baseline change described above is a
-prerequisite rather than an optimisation.
-
-### Testing
-
-- Runtime: `AutoLabelsTest` for parsing and mapping — largely the existing nf-seqera `LabelsTest`
-  cases relocated; `TaskConfigTest` for merge precedence and the policy overload; `SessionTest`
-  for lazy computation and for the no-Platform case.
-- Per executor: policy unit tests covering the hostile inputs (a `repository` URL under the
-  Kubernetes value rules, mixed-case and dotted keys under the Google rules), plus one handler test
-  each asserting that auto-labels arrive sanitised and user labels arrive byte-identical.
-- nf-seqera: existing tests updated for the moved code, plus one pinning that the per-task delta is
-  empty when a task declares no labels of its own.
-
-### Documentation
-
-- `docs/reference/config/tower.mdx` — the new option.
-- `docs/reference/config/seqera.mdx` — deprecation note on the existing option.
-- `docs/reference/process/directives/resource-labels.mdx` — an auto-labels section and the
-  per-executor key-mangling table above.
+Resolving a single session-wide set, rather than one per executor, guarantees the nf-seqera per-task delta collapses to empty. The run baseline and the merged task labels derive from the same map. The consequence is that `seqera.executor.autoLabels` now applies globally, which is acceptable for a deprecated option that is off by default.
 
 ### Risks
 
-**Azure pool churn.** `AzBatchService.specFromAutoPool` derives the pool id from
-`CacheHelper.hasher([vmType.name, opts, metadata])`, where `metadata` is the resource label map.
-Any label that varies per run — `runName`, `sessionId`, `workflowId` — therefore produces a fresh
-auto-pool for every execution, and pools accumulate unless
-`azure.batch.deletePoolsOnCompletion` is set. This is inherent to Azure applying labels at pool
-rather than task granularity. Documented as a caveat, with the recommendation to select a stable
-subset (for example `projectName`, `workspaceId`, `computeEnvId`) on Azure. Gating volatile labels
-out of the Azure policy is a possible follow-up, deliberately not done here.
+Azure pool churn. `AzBatchService.specFromAutoPool` derives the pool id from `CacheHelper.hasher([vmType.name, opts, metadata])`, where `metadata` is the resource label map. Any label that varies per run (`runName`, `sessionId`, `workflowId`) therefore produces a fresh auto-pool for every execution, and pools accumulate unless `azure.batch.deletePoolsOnCompletion` is set. This is inherent to Azure applying labels at pool rather than task granularity. Documented as a caveat, with the recommendation to select a stable subset (for example `projectName`, `workspaceId`, `computeEnvId`) on Azure. Gating volatile labels out of the Azure policy is a possible follow-up, deliberately not done here.
 
-**Cloud tag visibility.** Enabling the option changes tags on cloud resources, which can affect
-cost reports and any tag-based IAM condition. Mitigated by the feature being off by default.
+Cloud tag visibility. Enabling the option changes tags on cloud resources, which can affect cost reports and any tag-based IAM condition. Mitigated by the feature being off by default.
 
 ## Links
 

--- a/docs/reference/config/seqera.mdx
+++ b/docs/reference/config/seqera.mdx
@@ -19,9 +19,15 @@ The `seqera` scope controls the interactions with Seqera services, including the
 Use [`tower.autoLabels`][config-tower-autoLabels] instead.
 </DeprecatedInVersion>
 
-Automatically derive [resource labels][process-resource-labels] from the workflow metadata, and attach them to the compute resources created by the executor (default: `false`). Can be specified as `true` (all available metadata labels), `false`, or a list or comma-separated string of short names, e.g. `['runName', 'projectName']`. See [`tower.autoLabels`][config-tower-autoLabels] for the valid names and the resulting label keys.
+Derive [resource labels][process-resource-labels] from the workflow metadata and attach them to the compute resources that the executor creates (default: `false`). Accepts the same values as [`tower.autoLabels`][config-tower-autoLabels]: `true` (all available metadata labels), `false`, or a list or comma-separated string of short names, for example `['runName', 'projectName']`. That entry also lists the valid names and the resulting label keys.
 
-This option is not limited to the Seqera executor: the labels are attached by every executor supporting the `resourceLabels` directive. When this option is specified in the configuration it takes precedence over `tower.autoLabels`, including when it is set to `false`. Otherwise `tower.autoLabels` is used, and the feature is disabled when neither option is specified.
+This option is not limited to the Seqera executor. Every executor that supports the `resourceLabels` directive attaches the labels.
+
+Precedence:
+
+- If `seqera.executor.autoLabels` is set, it takes precedence over `tower.autoLabels`, including when set to `false`.
+- If only `tower.autoLabels` is set, that value applies.
+- If neither option is set, no labels are derived.
 
 ##### `seqera.executor.computeEnvId`
 

--- a/docs/reference/config/seqera.mdx
+++ b/docs/reference/config/seqera.mdx
@@ -15,7 +15,13 @@ The `seqera` scope controls the interactions with Seqera services, including the
 
 ##### `seqera.executor.autoLabels`
 
-When `true`, automatically adds workflow metadata labels to the session with the `nextflow.io/` prefix (default: `false`). The following labels are added: `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`. A `seqera.io/runId` label is also added, computed as a SipHash of the session ID and run name. The `userName` label reports the Seqera Platform user that submitted the run, falling back to the OS user running the Nextflow launcher when no Platform identity is available.
+<DeprecatedInVersion version="26.10">
+Use [`tower.autoLabels`][config-tower-autoLabels] instead.
+</DeprecatedInVersion>
+
+Automatically derive [resource labels][process-resource-labels] from the workflow metadata, and attach them to the compute resources created by the executor (default: `false`). Can be specified as `true` (all available metadata labels), `false`, or a list or comma-separated string of short names, e.g. `['runName', 'projectName']`. See [`tower.autoLabels`][config-tower-autoLabels] for the valid names and the resulting label keys.
+
+This option is not limited to the Seqera executor: the labels are attached by every executor supporting the `resourceLabels` directive. When this option is specified in the configuration it takes precedence over `tower.autoLabels`, including when it is set to `false`. Otherwise `tower.autoLabels` is used, and the feature is disabled when neither option is specified.
 
 ##### `seqera.executor.computeEnvId`
 
@@ -133,4 +139,6 @@ The jitter factor for randomizing retry delays (default: `0.25`).
 
 The multiplier for exponential backoff (default: `2.0`).
 
+[config-tower-autoLabels]: ./tower#towerautolabels
+[process-resource-labels]: ../process/directives/resource-labels
 [seqera-executor]: ../../executor/seqera

--- a/docs/reference/config/seqera.mdx
+++ b/docs/reference/config/seqera.mdx
@@ -21,13 +21,7 @@ Use [`tower.autoLabels`][config-tower-autoLabels] instead.
 
 Derive [resource labels][process-resource-labels] from the workflow metadata and attach them to the compute resources that the executor creates (default: `false`). Accepts the same values as [`tower.autoLabels`][config-tower-autoLabels]: `true` (all available metadata labels), `false`, or a list or comma-separated string of short names, for example `['runName', 'projectName']`. That entry also lists the valid names and the resulting label keys.
 
-This option is not limited to the Seqera executor. Every executor that supports the `resourceLabels` directive attaches the labels.
-
-Precedence:
-
-- If `seqera.executor.autoLabels` is set, it takes precedence over `tower.autoLabels`, including when set to `false`.
-- If only `tower.autoLabels` is set, that value applies.
-- If neither option is set, no labels are derived.
+This option applies to every executor that supports the `resourceLabels` directive, not just the Seqera executor. It takes precedence over `tower.autoLabels` when set, including when set to `false`.
 
 ##### `seqera.executor.computeEnvId`
 

--- a/docs/reference/config/tower.mdx
+++ b/docs/reference/config/tower.mdx
@@ -17,15 +17,20 @@ Your `accessToken` can be obtained from your Seqera Platform instance in the [To
 
 <AddedInVersion version="26.10" />
 
-Automatically derive [resource labels][process-resource-labels] from the workflow metadata, and attach them to the compute resources created by the executor (default: `false`). Can be specified as:
+Derive [resource labels][process-resource-labels] from the workflow metadata and attach them to the compute resources that the executor creates (default: `false`). Accepted values:
 
-- `true`: include all available metadata labels
-- `false`: disable
-- a list or comma-separated string of short names, e.g. `['runName', 'projectName']` or `'runName,projectName'`
+- `true`: attach all available metadata labels.
+- `false`: attach no labels.
+- A list or comma-separated string of short names: attach only the named labels. For example, `['runName', 'projectName']` or `'runName,projectName'`.
 
-The valid names are `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`, `workflowId`, `workspaceId`, and `computeEnvId`. They are attached with the `nextflow.io/` prefix, apart from `workflowId`, `workspaceId` and `computeEnvId` which use the `seqera.io/platform/` prefix. The `userName` label reports the Seqera Platform user that submitted the run, falling back to the OS user running the Nextflow launcher when no Platform identity is available.
+Valid short names, by label prefix:
 
-The labels derived from the workflow metadata are attached by every executor supporting the `resourceLabels` directive, and are normalized as required by the corresponding cloud API. Labels declared with the `resourceLabels` directive always take precedence. See [resourceLabels][process-resource-labels] for details.
+- `nextflow.io/`: `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`
+- `seqera.io/platform/`: `workflowId`, `workspaceId`, `computeEnvId`
+
+The `userName` label reports the Seqera Platform user who submitted the run. When no Platform identity is available, the label reports the OS user that runs the Nextflow launcher.
+
+Every executor that supports the `resourceLabels` directive attaches these labels and normalizes them as the corresponding cloud API requires. Labels declared with the [`resourceLabels`][process-resource-labels] directive always take precedence.
 
 ##### `tower.computeEnvId`
 

--- a/docs/reference/config/tower.mdx
+++ b/docs/reference/config/tower.mdx
@@ -13,6 +13,20 @@ The unique access token for your Seqera Platform account.
 
 Your `accessToken` can be obtained from your Seqera Platform instance in the [Tokens page](https://cloud.seqera.io/tokens).
 
+##### `tower.autoLabels`
+
+<AddedInVersion version="26.10" />
+
+Automatically derive [resource labels][process-resource-labels] from the workflow metadata, and attach them to the compute resources created by the executor (default: `false`). Can be specified as:
+
+- `true`: include all available metadata labels
+- `false`: disable
+- a list or comma-separated string of short names, e.g. `['runName', 'projectName']` or `'runName,projectName'`
+
+The valid names are `projectName`, `userName`, `runName`, `sessionId`, `resume`, `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`, `workflowId`, `workspaceId`, and `computeEnvId`. They are attached with the `nextflow.io/` prefix, apart from `workflowId`, `workspaceId` and `computeEnvId` which use the `seqera.io/platform/` prefix. The `userName` label reports the Seqera Platform user that submitted the run, falling back to the OS user running the Nextflow launcher when no Platform identity is available.
+
+The labels derived from the workflow metadata are attached by every executor supporting the `resourceLabels` directive, and are normalized as required by the corresponding cloud API. Labels declared with the `resourceLabels` directive always take precedence. See [resourceLabels][process-resource-labels] for details.
+
 ##### `tower.computeEnvId`
 
 The compute environment ID in your Seqera Platform account used to launch pipelines (default: the primary compute environment in the selected workspace).
@@ -42,3 +56,5 @@ The HTTP read timeout for Seqera Platform API requests (default: `'60s'`).
 The workspace ID in Seqera Platform in which to save the run (default: the launching user's personal workspace).
 
 The workspace ID can also be specified using the environment variable `TOWER_WORKSPACE_ID` (config file has priority over the environment variable).
+
+[process-resource-labels]: ../process/directives/resource-labels

--- a/docs/reference/process/directives/resource-labels.mdx
+++ b/docs/reference/process/directives/resource-labels.mdx
@@ -93,22 +93,22 @@ The Kubernetes executor sanitizes every pod label, including declared labels, an
 
 ### Label normalization
 
-The automatic labels are normalized as required by the API of the corresponding executor. The normalization is applied to the automatic labels only.
+The executor normalizes automatic labels to meet the requirements of its API. Declared labels are not normalized.
 
-| Executor           | Normalization                                                                                               | `nextflow.io/runName` becomes |
-| ------------------ | ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| AWS Batch          | Letters, digits, spaces and `+ - = . _ : / @`; key up to 128 characters, value up to 256                    | unchanged                     |
-| Azure Batch        | Applied as-is, apart from the reserved `microsoft` name prefix                                              | unchanged                     |
-| Google Cloud Batch | Lowercase letters, digits, `_` and `-`; the key must start with a letter; key and value up to 63 characters | `nextflow_io_runname`         |
-| Kubernetes         | Key prefix up to the first `/` preserved, any further `/` replaced with `_`; values stripped of their URL scheme and slashes, up to 63 characters | unchanged |
-| Seqera executor    | Applied as-is                                                                                               | unchanged                     |
+| Executor           | Normalization                                                                                                                               | `nextflow.io/runName` becomes |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| AWS Batch          | Letters, digits, spaces, and `+ - = . _ : / @`. Key up to 128 characters, value up to 256.                                                   | unchanged                     |
+| Azure Batch        | None, apart from the reserved `microsoft` name prefix.                                                                                       | unchanged                     |
+| Google Cloud Batch | Lowercase letters, digits, `_`, and `-`. The key must start with a letter. Key and value up to 63 characters.                                | `nextflow_io_runname`         |
+| Kubernetes         | The key prefix up to the first `/` is preserved, and any further `/` becomes `_`. Values are stripped of their URL scheme and slashes, up to 63 characters. | unchanged      |
+| Seqera executor    | None.                                                                                                                                        | unchanged                     |
 
-Values are normalized in the same way. For example, a `repository` value such as `https://github.com/foo/bar` becomes `github.com_foo_bar` on Kubernetes and `https___github_com_foo_bar` on Google Cloud Batch.
+The same rules apply to label values. For example, the `repository` value `https://github.com/foo/bar` becomes `github.com_foo_bar` on Kubernetes and `https___github_com_foo_bar` on Google Cloud Batch.
 
-The two-segment `seqera.io/platform/*` keys are not valid Kubernetes label keys, therefore on Kubernetes they are applied as `seqera.io/platform_workflowId`, `seqera.io/platform_workspaceId` and `seqera.io/platform_computeEnvId`.
+The two-segment `seqera.io/platform/*` keys are not valid Kubernetes label keys. The Kubernetes executor applies them as `seqera.io/platform_workflowId`, `seqera.io/platform_workspaceId`, and `seqera.io/platform_computeEnvId`.
 
 :::warning
-On Azure Batch the resource labels are applied as metadata of the auto-pool, and the pool identifier is derived from that metadata. A label that changes on every execution — such as `runName`, `sessionId` or `workflowId` — therefore creates a new pool for each run, and the pools accumulate unless [`azure.batch.deletePoolsOnCompletion`][config-azure-deletePoolsOnCompletion] is enabled. Selecting a stable subset, such as `['projectName', 'workspaceId', 'computeEnvId']`, is recommended on Azure Batch.
+On Azure Batch, the executor applies resource labels as metadata of the auto-pool and derives the pool identifier from that metadata. A label that changes on every run, such as `runName`, `sessionId`, or `workflowId`, creates a new pool for each run. The pools accumulate unless you enable [`azure.batch.deletePoolsOnCompletion`][config-azure-deletePoolsOnCompletion]. Select a stable subset instead, for example `['projectName', 'workspaceId', 'computeEnvId']`.
 :::
 
 ## See also

--- a/docs/reference/process/directives/resource-labels.mdx
+++ b/docs/reference/process/directives/resource-labels.mdx
@@ -56,17 +56,16 @@ Resource labels in Azure are added to auto-pools, rather than jobs, to support c
 
 <AddedInVersion version="26.10" />
 
-Nextflow can also derive resource labels from the workflow metadata and attach them to the task compute resources, in addition to the labels declared with the `resourceLabels` directive. The feature is disabled by default and is enabled with the [`tower.autoLabels`][config-tower-autoLabels] config option:
+Nextflow can derive resource labels from the workflow metadata and attach them to the compute resources for each task, in addition to the labels declared with the `resourceLabels` directive. Automatic labels are disabled by default. Enable them with the [`tower.autoLabels`][config-tower-autoLabels] config option:
 
 ```groovy
 // attach all of the available metadata labels
 tower.autoLabels = true
-
 // or select the ones to be attached
 tower.autoLabels = ['projectName', 'runName', 'workspaceId']
 ```
 
-The following names can be selected:
+Available names and their label keys:
 
 | Name             | Label key                         |
 | ---------------- | --------------------------------- |
@@ -84,12 +83,12 @@ The following names can be selected:
 | `workspaceId`    | `seqera.io/platform/workspaceId`  |
 | `computeEnvId`   | `seqera.io/platform/computeEnvId` |
 
-A label whose metadata value is not available is omitted, so the `seqera.io/platform/*` labels are only attached when workflow monitoring with Seqera Platform is enabled.
+Nextflow omits any label whose metadata value is not available. The `seqera.io/platform/*` labels are attached only when workflow monitoring with Seqera Platform is enabled.
 
-Labels declared with the `resourceLabels` directive always take precedence: when a declared label has the same key as an automatic one, the declared value is used. Declared labels are never modified by the normalization described below, even when they are not valid for the target executor.
+Labels declared with the `resourceLabels` directive always take precedence. When a declared label has the same key as an automatic label, Nextflow uses the declared value. The normalization described later never modifies declared labels, even when they are not valid for the target executor.
 
 :::note
-The Kubernetes executor sanitizes every pod label, including the declared ones, and rejects a label key containing more than one `/` character. It also applies its own `nextflow.io/app`, `nextflow.io/runName`, `nextflow.io/taskName`, `nextflow.io/processName`, `nextflow.io/sessionId` and `nextflow.io/queue` pod labels last, so a resource label using one of those keys is overridden.
+The Kubernetes executor sanitizes every pod label, including declared labels, and rejects a label key that contains more than one `/` character. The executor applies its own `nextflow.io/app`, `nextflow.io/runName`, `nextflow.io/taskName`, `nextflow.io/processName`, `nextflow.io/sessionId`, and `nextflow.io/queue` pod labels last, so these override any resource label that uses the same key.
 :::
 
 ### Label normalization

--- a/docs/reference/process/directives/resource-labels.mdx
+++ b/docs/reference/process/directives/resource-labels.mdx
@@ -52,6 +52,60 @@ Consider the limits and syntax of the corresponding executor when using resource
 Resource labels in Azure are added to auto-pools, rather than jobs, to support cost analysis. A new pool is created for each new set of resource labels. Setting `azure.batch.deletePoolsOnCompletion = true` is recommended when using process-specific resource labels.
 </AddedInVersion>
 
+## Automatic resource labels
+
+<AddedInVersion version="26.10" />
+
+Nextflow can also derive resource labels from the workflow metadata and attach them to the task compute resources, in addition to the labels declared with the `resourceLabels` directive. The feature is disabled by default and is enabled with the [`tower.autoLabels`][config-tower-autoLabels] config option:
+
+```groovy
+// attach all of the available metadata labels
+tower.autoLabels = true
+
+// or select the ones to be attached
+tower.autoLabels = ['projectName', 'runName', 'workspaceId']
+```
+
+The following names can be selected:
+
+| Name             | Label key                         |
+| ---------------- | --------------------------------- |
+| `projectName`    | `nextflow.io/projectName`         |
+| `userName`       | `nextflow.io/userName`            |
+| `runName`        | `nextflow.io/runName`             |
+| `sessionId`      | `nextflow.io/sessionId`           |
+| `resume`         | `nextflow.io/resume`              |
+| `revision`       | `nextflow.io/revision`            |
+| `commitId`       | `nextflow.io/commitId`            |
+| `repository`     | `nextflow.io/repository`          |
+| `manifestName`   | `nextflow.io/manifestName`        |
+| `runtimeVersion` | `nextflow.io/runtimeVersion`      |
+| `workflowId`     | `seqera.io/platform/workflowId`   |
+| `workspaceId`    | `seqera.io/platform/workspaceId`  |
+| `computeEnvId`   | `seqera.io/platform/computeEnvId` |
+
+A label whose metadata value is not available is omitted, so the `seqera.io/platform/*` labels are only attached when workflow monitoring with Seqera Platform is enabled.
+
+Labels declared with the `resourceLabels` directive always take precedence: when a declared label has the same key as an automatic one, the declared value is used. Declared labels are never modified, even when they are not valid for the target executor.
+
+### Label normalization
+
+The automatic labels are normalized as required by the API of the corresponding executor. The normalization is applied to the automatic labels only.
+
+| Executor           | Normalization                                                                                               | `nextflow.io/runName` becomes |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| AWS Batch          | Letters, digits, spaces and `+ - = . _ : / @`; key up to 128 characters, value up to 256                    | unchanged                     |
+| Azure Batch        | Applied as-is, apart from the reserved `microsoft` name prefix                                              | unchanged                     |
+| Google Cloud Batch | Lowercase letters, digits, `_` and `-`; the key must start with a letter; key and value up to 63 characters | `nextflow_io_runname`         |
+| Kubernetes         | Key applied verbatim; values stripped of their URL scheme and slashes, up to 63 characters                  | unchanged                     |
+| Seqera executor    | Applied as-is                                                                                               | unchanged                     |
+
+Values are normalized in the same way. For example, a `repository` value such as `https://github.com/foo/bar` becomes `github.com_foo_bar` on Kubernetes and `https___github_com_foo_bar` on Google Cloud Batch.
+
+:::warning
+On Azure Batch the resource labels are applied as metadata of the auto-pool, and the pool identifier is derived from that metadata. A label that changes on every execution — such as `runName`, `sessionId` or `workflowId` — therefore creates a new pool for each run, and the pools accumulate unless [`azure.batch.deletePoolsOnCompletion`][config-azure-deletePoolsOnCompletion] is enabled. Selecting a stable subset, such as `['projectName', 'workspaceId', 'computeEnvId']`, is recommended on Azure Batch.
+:::
+
 ## See also
 
 - [label](./label) (for shared process configuration)
@@ -59,6 +113,8 @@ Resource labels in Azure are added to auto-pools, rather than jobs, to support c
 
 [awsbatch-executor]: ../../../executor/aws-batch
 [azurebatch-executor]: ../../../executor/azure-batch
+[config-azure-deletePoolsOnCompletion]: ../../config/azure#azurebatchdeletepoolsoncompletion
+[config-tower-autoLabels]: ../../config/tower#towerautolabels
 [google-batch-executor]: ../../../executor/google-batch
 [k8s-executor]: ../../../executor/kubernetes
 [seqera-executor]: ../../../executor/seqera

--- a/docs/reference/process/directives/resource-labels.mdx
+++ b/docs/reference/process/directives/resource-labels.mdx
@@ -86,7 +86,11 @@ The following names can be selected:
 
 A label whose metadata value is not available is omitted, so the `seqera.io/platform/*` labels are only attached when workflow monitoring with Seqera Platform is enabled.
 
-Labels declared with the `resourceLabels` directive always take precedence: when a declared label has the same key as an automatic one, the declared value is used. Declared labels are never modified, even when they are not valid for the target executor.
+Labels declared with the `resourceLabels` directive always take precedence: when a declared label has the same key as an automatic one, the declared value is used. Declared labels are never modified by the normalization described below, even when they are not valid for the target executor.
+
+:::note
+The Kubernetes executor sanitizes every pod label, including the declared ones, and rejects a label key containing more than one `/` character. It also applies its own `nextflow.io/app`, `nextflow.io/runName`, `nextflow.io/taskName`, `nextflow.io/processName`, `nextflow.io/sessionId` and `nextflow.io/queue` pod labels last, so a resource label using one of those keys is overridden.
+:::
 
 ### Label normalization
 
@@ -97,10 +101,12 @@ The automatic labels are normalized as required by the API of the corresponding 
 | AWS Batch          | Letters, digits, spaces and `+ - = . _ : / @`; key up to 128 characters, value up to 256                    | unchanged                     |
 | Azure Batch        | Applied as-is, apart from the reserved `microsoft` name prefix                                              | unchanged                     |
 | Google Cloud Batch | Lowercase letters, digits, `_` and `-`; the key must start with a letter; key and value up to 63 characters | `nextflow_io_runname`         |
-| Kubernetes         | Key applied verbatim; values stripped of their URL scheme and slashes, up to 63 characters                  | unchanged                     |
+| Kubernetes         | Key prefix up to the first `/` preserved, any further `/` replaced with `_`; values stripped of their URL scheme and slashes, up to 63 characters | unchanged |
 | Seqera executor    | Applied as-is                                                                                               | unchanged                     |
 
 Values are normalized in the same way. For example, a `repository` value such as `https://github.com/foo/bar` becomes `github.com_foo_bar` on Kubernetes and `https___github_com_foo_bar` on Google Cloud Batch.
+
+The two-segment `seqera.io/platform/*` keys are not valid Kubernetes label keys, therefore on Kubernetes they are applied as `seqera.io/platform_workflowId`, `seqera.io/platform_workspaceId` and `seqera.io/platform_computeEnvId`.
 
 :::warning
 On Azure Batch the resource labels are applied as metadata of the auto-pool, and the pool identifier is derived from that metadata. A label that changes on every execution — such as `runName`, `sessionId` or `workflowId` — therefore creates a new pool for each run, and the pools accumulate unless [`azure.batch.deletePoolsOnCompletion`][config-azure-deletePoolsOnCompletion] is enabled. Selecting a stable subset, such as `['projectName', 'workspaceId', 'computeEnvId']`, is recommended on Azure Batch.

--- a/docs/reference/process/directives/resource-labels.mdx
+++ b/docs/reference/process/directives/resource-labels.mdx
@@ -87,10 +87,6 @@ Nextflow omits any label whose metadata value is not available. The `seqera.io/p
 
 Labels declared with the `resourceLabels` directive always take precedence. When a declared label has the same key as an automatic label, Nextflow uses the declared value. The normalization described later never modifies declared labels, even when they are not valid for the target executor.
 
-:::note
-The Kubernetes executor sanitizes every pod label, including declared labels, and rejects a label key that contains more than one `/` character. The executor applies its own `nextflow.io/app`, `nextflow.io/runName`, `nextflow.io/taskName`, `nextflow.io/processName`, `nextflow.io/sessionId`, and `nextflow.io/queue` pod labels last, so these override any resource label that uses the same key.
-:::
-
 ### Label normalization
 
 The executor normalizes automatic labels to meet the requirements of its API. Declared labels are not normalized.

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -60,6 +60,7 @@ import nextflow.extension.CH
 import nextflow.extension.FilesEx
 import nextflow.file.FileHelper
 import nextflow.file.FilePorter
+import nextflow.platform.AutoLabels
 import nextflow.plugin.Plugins
 import nextflow.processor.ErrorStrategy
 import nextflow.processor.TaskFault
@@ -1269,6 +1270,30 @@ class Session implements ISession {
     SpackConfig getSpackConfig() {
         final opts = config.spack as Map ?: Collections.emptyMap()
         return new SpackConfig(opts, getSystemEnv())
+    }
+
+    /**
+     * The resource labels derived from the workflow metadata, as selected by the
+     * {@code tower.autoLabels} option, or by the deprecated {@code seqera.executor.autoLabels}
+     * when the latter is given in the configuration.
+     *
+     * Note the labels are computed on first access instead of at initialisation, because the
+     * Platform metadata is only filled in when the {@code onFlowCreate} event is fired i.e.
+     * after the session is created and before the script is parsed.
+     *
+     * @return The auto-derived labels, or an empty map when the option is not enabled
+     */
+    @Memoized
+    Map<String,String> getAutoResourceLabels() {
+        final legacy = config.navigate('seqera.executor') as Map
+        // the deprecated Seqera executor option wins when explicitly given, even as `false`
+        final legacyGiven = legacy != null && legacy.containsKey('autoLabels')
+        final optionName = legacyGiven ? 'seqera.executor.autoLabels' : 'tower.autoLabels'
+        final value = legacyGiven ? legacy.get('autoLabels') : config.navigate('tower.autoLabels')
+        final names = AutoLabels.parse(value, optionName)
+        if( !names )
+            return Collections.<String,String>emptyMap()
+        return AutoLabels.labelsFor(workflowMetadata, names)
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -970,6 +970,9 @@ class Session implements ISession {
     ExecutorService getExecService() { execService }
 
     @PackageScope void checkConfig() {
+        // validate the auto-labels option up-front, so an invalid value aborts the run here
+        // -- before any task is created -- instead of lazily during task creation
+        resolveAutoResourceLabelNames()
         final enabled = config.navigate('nextflow.enable.configProcessNamesValidation', true) as boolean
         if( enabled ) {
             final names = ScriptMeta.allProcessNames()
@@ -1285,15 +1288,27 @@ class Session implements ISession {
      */
     @Memoized
     Map<String,String> getAutoResourceLabels() {
+        final names = resolveAutoResourceLabelNames()
+        if( !names )
+            return Collections.<String,String>emptyMap()
+        return AutoLabels.labelsFor(workflowMetadata, names)
+    }
+
+    /**
+     * Resolve and validate the auto-labels option, returning the selected workflow metadata
+     * short names. Unlike {@link #getAutoResourceLabels()} this does not read the Platform
+     * metadata, so it can be invoked at config-check time (see {@link #checkConfig()}) to fail
+     * fast on an invalid value, before the pipeline starts creating tasks.
+     *
+     * @return The selected short names, empty when the feature is disabled
+     */
+    protected Set<String> resolveAutoResourceLabelNames() {
         final legacy = config.navigate('seqera.executor') as Map
         // the deprecated Seqera executor option wins when explicitly given, even as `false`
         final legacyGiven = legacy != null && legacy.containsKey('autoLabels')
         final optionName = legacyGiven ? 'seqera.executor.autoLabels' : 'tower.autoLabels'
         final value = legacyGiven ? legacy.get('autoLabels') : config.navigate('tower.autoLabels')
-        final names = AutoLabels.parse(value, optionName)
-        if( !names )
-            return Collections.<String,String>emptyMap()
-        return AutoLabels.labelsFor(workflowMetadata, names)
+        return AutoLabels.parse(value, optionName)
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/platform/AutoLabels.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/platform/AutoLabels.groovy
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.platform
+
+import groovy.transform.CompileStatic
+import nextflow.NextflowMeta
+import nextflow.script.WorkflowMetadata
+
+/**
+ * Derive resource labels from the workflow metadata.
+ *
+ * The labels are selected by short name (e.g. {@code runName}) via the
+ * {@code tower.autoLabels} option — or the deprecated {@code seqera.executor.autoLabels} —
+ * and mapped to the canonical {@code nextflow.io/*} and {@code seqera.io/platform/*} keys.
+ *
+ * Entries whose source metadata is absent are omitted, therefore a run without
+ * Seqera Platform still gets the labels the runtime knows on its own.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class AutoLabels {
+
+    /**
+     * The workflow metadata short names that can be turned into resource labels
+     */
+    static final Set<String> VALID_NAMES = Collections.unmodifiableSet(new LinkedHashSet<>([
+        'projectName', 'userName', 'runName', 'sessionId', 'resume',
+        'revision', 'commitId', 'repository', 'manifestName',
+        'runtimeVersion', 'workflowId', 'workspaceId', 'computeEnvId'
+    ]))
+
+    /**
+     * Parse the value of an auto-labels config option.
+     *
+     * @param value
+     *      The config value: {@code null} or {@code false} (none), {@code true} (all names),
+     *      a list of short names, or a comma-separated string of short names
+     * @param optionName
+     *      The name of the config option being parsed, used to make the error message actionable
+     * @return
+     *      The set of selected short names, empty when the feature is disabled
+     */
+    static Set<String> parse(Object value, String optionName='autoLabels') {
+        if( value == null || value == false )
+            return Collections.<String>emptySet()
+        if( value == true )
+            return VALID_NAMES
+        List<String> raw
+        if( value instanceof CharSequence )
+            raw = value.toString().tokenize(',').collect { String s -> s.trim() }.findAll { String s -> s }
+        else if( value instanceof List )
+            raw = ((List) value).collect { it?.toString()?.trim() }.findAll { String s -> s } as List<String>
+        else
+            throw new IllegalArgumentException("Invalid '${optionName}' value '${value}' - expected true, false, a list, or a comma-separated string")
+        final invalid = raw.findAll { String s -> !(s in VALID_NAMES) }
+        if( invalid )
+            throw new IllegalArgumentException("Invalid '${optionName}' name(s) ${invalid} - valid names are: ${VALID_NAMES.join(', ')}")
+        return Collections.unmodifiableSet(new LinkedHashSet<>(raw))
+    }
+
+    /**
+     * Map the workflow metadata to the corresponding resource labels.
+     *
+     * @param workflow
+     *      The current {@link WorkflowMetadata} object
+     * @param include
+     *      The set of short names to be included, as returned by {@link #parse}
+     * @return
+     *      The labels map, holding only the entries whose metadata value is available
+     */
+    static Map<String,String> labelsFor(WorkflowMetadata workflow, Set<String> include) {
+        if( !workflow || !include )
+            return Collections.<String,String>emptyMap()
+        final entries = new LinkedHashMap<String,String>(20)
+        if( include.contains('projectName') && workflow.projectName )
+            entries.put('nextflow.io/projectName', workflow.projectName)
+        // the Platform user that submitted the run, falling back to the OS user running the launcher
+        final userName = workflow.platform?.user?.userName ?: workflow.userName
+        if( include.contains('userName') && userName )
+            entries.put('nextflow.io/userName', userName)
+        if( include.contains('runName') && workflow.runName )
+            entries.put('nextflow.io/runName', workflow.runName)
+        if( include.contains('sessionId') && workflow.sessionId )
+            entries.put('nextflow.io/sessionId', workflow.sessionId.toString())
+        if( include.contains('resume') )
+            entries.put('nextflow.io/resume', String.valueOf(workflow.resume))
+        if( include.contains('revision') && workflow.revision )
+            entries.put('nextflow.io/revision', workflow.revision)
+        if( include.contains('commitId') && workflow.commitId )
+            entries.put('nextflow.io/commitId', workflow.commitId)
+        if( include.contains('repository') && workflow.repository )
+            entries.put('nextflow.io/repository', workflow.repository)
+        if( include.contains('manifestName') && workflow.manifest?.name )
+            entries.put('nextflow.io/manifestName', workflow.manifest.name)
+        if( include.contains('runtimeVersion') && NextflowMeta.instance.version )
+            entries.put('nextflow.io/runtimeVersion', NextflowMeta.instance.version.toString())
+        if( include.contains('workflowId') && workflow.platform?.workflowId )
+            entries.put('seqera.io/platform/workflowId', workflow.platform.workflowId)
+        if( include.contains('workspaceId') && workflow.platform?.workspace?.id )
+            entries.put('seqera.io/platform/workspaceId', workflow.platform.workspace.id)
+        if( include.contains('computeEnvId') && workflow.platform?.computeEnv?.id )
+            entries.put('seqera.io/platform/computeEnvId', workflow.platform.computeEnv.id)
+        return Collections.unmodifiableMap(entries)
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
@@ -204,7 +204,9 @@ abstract class ResourceLabelPolicy {
     /**
      * Kubernetes label syntax: the key is an optional DNS subdomain prefix followed by
      * {@code /} and a name matching {@code [A-Za-z0-9]([-_.A-Za-z0-9]*)} of at most 63
-     * characters — so {@code nextflow.io/runName} is applied verbatim. Values follow the
+     * characters — so {@code nextflow.io/runName} is applied verbatim, while a key holding a
+     * second {@code /}, such as {@code seqera.io/platform/workflowId}, becomes
+     * {@code seqera.io/platform_workflowId}. Values follow the
      * name syntax, therefore a URL value such as {@code https://github.com/foo/bar} is
      * stripped of its scheme and of its slashes.
      */

--- a/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.platform
+
+import java.util.regex.Pattern
+
+import groovy.transform.CompileStatic
+
+/**
+ * Describe how resource label keys and values must be normalised to be accepted
+ * by the API of a given executor backend.
+ *
+ * One policy is provided for each backend consuming the {@code resourceLabels}
+ * directive, and it is meant to be applied to the labels derived from the workflow
+ * metadata only — see {@link nextflow.processor.TaskConfig#getResourceLabels(ResourceLabelPolicy)}.
+ * User-declared labels are never rewritten: an invalid value there is the user's own
+ * responsibility, and silently changing it would be worse than the API error.
+ *
+ * Two rules are common to all policies:
+ * <li>An entry whose key sanitises to an empty string is dropped, since there is no
+ *   key left to apply it under.
+ * <li>An entry whose *value* sanitises to an empty string is dropped only by the
+ *   policies rejecting empty values in the position where the labels are applied,
+ *   namely {@link #GOOGLE} (Batch resource labels) and {@link #K8S} (pod labels).
+ *   AWS and Azure accept an empty value, therefore the entry is retained.
+ *
+ * Truncation is applied last and never leaves an invalid trailing character.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+abstract class ResourceLabelPolicy {
+
+    /** No-op policy, for a backend accepting the labels verbatim e.g. the Seqera scheduler */
+    static final ResourceLabelPolicy IDENTITY = new IdentityPolicy()
+
+    /** AWS Batch job tags: permissive charset, key up to 128 chars, value up to 256 */
+    static final ResourceLabelPolicy AWS = new AwsPolicy()
+
+    /** Google Batch labels: lowercase {@code [a-z0-9_-]}, key starting with a letter, up to 63 chars */
+    static final ResourceLabelPolicy GOOGLE = new GooglePolicy()
+
+    /** Kubernetes pod labels: optional DNS subdomain prefix, alphanumeric bounded name and value */
+    static final ResourceLabelPolicy K8S = new K8sPolicy()
+
+    /** Azure Batch pool metadata: near identity, minus the reserved {@code microsoft} name prefix */
+    static final ResourceLabelPolicy AZURE = new AzurePolicy()
+
+    private final String name
+
+    protected ResourceLabelPolicy(String name) {
+        this.name = name
+    }
+
+    String getName() { name }
+
+    /**
+     * @param key The label key to be normalised
+     * @return The key accepted by the target API, or an empty string when nothing is left of it
+     */
+    abstract String sanitizeKey(String key)
+
+    /**
+     * @param value The label value to be normalised
+     * @return The value accepted by the target API, possibly empty
+     */
+    abstract String sanitizeValue(String value)
+
+    /**
+     * @return {@code true} when the target API rejects an empty label value
+     */
+    protected boolean dropEmptyValues() { false }
+
+    /**
+     * Normalise the given labels, dropping the entries that cannot be represented.
+     *
+     * @param labels The labels to be normalised
+     * @return A new map holding the normalised entries, in the same order as the source map
+     */
+    Map<String,String> sanitize(Map<String,String> labels) {
+        if( labels == null )
+            return Collections.<String,String>emptyMap()
+        if( labels.isEmpty() )
+            return labels
+        final result = new LinkedHashMap<String,String>(labels.size())
+        for( Map.Entry<String,String> entry : labels.entrySet() ) {
+            final key = sanitizeKey(entry.key)
+            // no key, no label
+            if( !key )
+                continue
+            final value = sanitizeValue(entry.value)
+            if( !value && dropEmptyValues() )
+                continue
+            result.put(key, value)
+        }
+        return result
+    }
+
+    @Override
+    String toString() {
+        return "ResourceLabelPolicy[$name]"
+    }
+
+    /**
+     * Truncate the given string to the specified maximum length
+     */
+    protected static String truncate(String value, int max) {
+        return value.length() > max ? value.substring(0, max) : value
+    }
+
+    /**
+     * Strip the leading and trailing characters that are not alphanumeric, as required
+     * by the Kubernetes label syntax
+     */
+    protected static String trimNonAlphanumeric(String value) {
+        int start = 0
+        int end = value.length()
+        while( start < end && !Character.isLetterOrDigit(value.charAt(start)) )
+            start++
+        while( end > start && !Character.isLetterOrDigit(value.charAt(end-1)) )
+            end--
+        return value.substring(start, end)
+    }
+
+    /**
+     * AWS Batch tag syntax: letters, digits, spaces and {@code + - = . _ : / @},
+     * key up to 128 characters, value up to 256.
+     */
+    @CompileStatic
+    private static class AwsPolicy extends ResourceLabelPolicy {
+
+        private static final Pattern INVALID = ~/[^A-Za-z0-9 +\-=._:\/@]/
+
+        AwsPolicy() { super('aws') }
+
+        @Override
+        String sanitizeKey(String key) {
+            return scrub(key, 128)
+        }
+
+        @Override
+        String sanitizeValue(String value) {
+            return scrub(value, 256)
+        }
+
+        private static String scrub(String value, int max) {
+            if( !value )
+                return ''
+            final result = INVALID.matcher(value).replaceAll('_')
+            // a trailing blank left over by the truncation would be dropped by the API anyway
+            return truncate(result, max).stripTrailing()
+        }
+    }
+
+    /**
+     * Google Cloud label syntax: lowercase letters, digits, underscores and dashes;
+     * the key must start with a lowercase letter; key and value up to 63 characters.
+     * Therefore {@code nextflow.io/runName} becomes {@code nextflow_io_runname}.
+     */
+    @CompileStatic
+    private static class GooglePolicy extends ResourceLabelPolicy {
+
+        private static final Pattern INVALID = ~/[^a-z0-9_-]/
+
+        GooglePolicy() { super('google') }
+
+        @Override
+        String sanitizeKey(String key) {
+            if( !key )
+                return ''
+            final scrubbed = INVALID.matcher(key.toLowerCase()).replaceAll('_')
+            // the key must begin with a letter, hence drop whatever comes before the first one
+            int start = 0
+            while( start < scrubbed.length() && !Character.isLetter(scrubbed.charAt(start)) )
+                start++
+            return truncate(scrubbed.substring(start), 63)
+        }
+
+        @Override
+        String sanitizeValue(String value) {
+            if( !value )
+                return ''
+            return truncate(INVALID.matcher(value.toLowerCase()).replaceAll('_'), 63)
+        }
+
+        @Override
+        protected boolean dropEmptyValues() { true }
+    }
+
+    /**
+     * Kubernetes label syntax: the key is an optional DNS subdomain prefix followed by
+     * {@code /} and a name matching {@code [A-Za-z0-9]([-_.A-Za-z0-9]*)} of at most 63
+     * characters — so {@code nextflow.io/runName} is applied verbatim. Values follow the
+     * name syntax, therefore a URL value such as {@code https://github.com/foo/bar} is
+     * stripped of its scheme and of its slashes.
+     */
+    @CompileStatic
+    private static class K8sPolicy extends ResourceLabelPolicy {
+
+        private static final Pattern SCHEME = ~/^[A-Za-z][A-Za-z0-9+.\-]*:\/\//
+        private static final Pattern NAME_INVALID = ~/[^A-Za-z0-9_.\-]/
+        private static final Pattern PREFIX_INVALID = ~/[^a-z0-9.\-]/
+
+        K8sPolicy() { super('k8s') }
+
+        @Override
+        String sanitizeKey(String key) {
+            if( !key )
+                return ''
+            final p = key.indexOf('/')
+            if( p == -1 )
+                return name0(key)
+            final prefix = prefix0(key.substring(0, p))
+            final name = name0(key.substring(p+1))
+            if( !name )
+                return ''
+            return prefix ? prefix + '/' + name : name
+        }
+
+        @Override
+        String sanitizeValue(String value) {
+            if( !value )
+                return ''
+            return name0(SCHEME.matcher(value).replaceFirst(''))
+        }
+
+        @Override
+        protected boolean dropEmptyValues() { true }
+
+        private static String name0(String value) {
+            final scrubbed = trimNonAlphanumeric(NAME_INVALID.matcher(value).replaceAll('_'))
+            // trim again, since the truncation can uncover a non alphanumeric trailing char
+            return trimNonAlphanumeric(truncate(scrubbed, 63))
+        }
+
+        private static String prefix0(String value) {
+            final scrubbed = trimNonAlphanumeric(PREFIX_INVALID.matcher(value.toLowerCase()).replaceAll('-'))
+            return trimNonAlphanumeric(truncate(scrubbed, 253))
+        }
+    }
+
+    /**
+     * Azure Batch pool metadata syntax: the labels are applied as-is, apart from the
+     * {@code microsoft} name prefix which is reserved by the service.
+     */
+    @CompileStatic
+    private static class AzurePolicy extends ResourceLabelPolicy {
+
+        private static final Pattern RESERVED = ~/(?i)^microsoft[\s._\-\/]*/
+
+        AzurePolicy() { super('azure') }
+
+        @Override
+        String sanitizeKey(String key) {
+            if( !key )
+                return ''
+            return RESERVED.matcher(key).replaceFirst('')
+        }
+
+        @Override
+        String sanitizeValue(String value) {
+            return value ?: ''
+        }
+    }
+
+    /**
+     * Identity policy for a backend applying the labels verbatim
+     */
+    @CompileStatic
+    private static class IdentityPolicy extends ResourceLabelPolicy {
+
+        IdentityPolicy() { super('identity') }
+
+        @Override
+        String sanitizeKey(String key) {
+            return key ?: ''
+        }
+
+        @Override
+        String sanitizeValue(String value) {
+            return value ?: ''
+        }
+
+        @Override
+        Map<String,String> sanitize(Map<String,String> labels) {
+            return labels != null ? labels : Collections.<String,String>emptyMap()
+        }
+    }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
@@ -182,12 +182,10 @@ abstract class ResourceLabelPolicy {
         String sanitizeKey(String key) {
             if( !key )
                 return ''
-            final scrubbed = INVALID.matcher(key.toLowerCase(Locale.ROOT)).replaceAll('_')
             // the key must begin with a letter, hence drop whatever comes before the first one
-            int start = 0
-            while( start < scrubbed.length() && !Character.isLetter(scrubbed.charAt(start)) )
-                start++
-            return truncate(scrubbed.substring(start), 63)
+            // -- safe as an ASCII regex since INVALID has already reduced it to [a-z0-9_-]
+            final scrubbed = INVALID.matcher(key.toLowerCase(Locale.ROOT)).replaceAll('_').replaceFirst(/^[^a-z]+/, '')
+            return truncate(scrubbed, 63)
         }
 
         @Override

--- a/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/platform/ResourceLabelPolicy.groovy
@@ -182,7 +182,7 @@ abstract class ResourceLabelPolicy {
         String sanitizeKey(String key) {
             if( !key )
                 return ''
-            final scrubbed = INVALID.matcher(key.toLowerCase()).replaceAll('_')
+            final scrubbed = INVALID.matcher(key.toLowerCase(Locale.ROOT)).replaceAll('_')
             // the key must begin with a letter, hence drop whatever comes before the first one
             int start = 0
             while( start < scrubbed.length() && !Character.isLetter(scrubbed.charAt(start)) )
@@ -194,7 +194,7 @@ abstract class ResourceLabelPolicy {
         String sanitizeValue(String value) {
             if( !value )
                 return ''
-            return truncate(INVALID.matcher(value.toLowerCase()).replaceAll('_'), 63)
+            return truncate(INVALID.matcher(value.toLowerCase(Locale.ROOT)).replaceAll('_'), 63)
         }
 
         @Override
@@ -250,7 +250,7 @@ abstract class ResourceLabelPolicy {
         }
 
         private static String prefix0(String value) {
-            final scrubbed = trimNonAlphanumeric(PREFIX_INVALID.matcher(value.toLowerCase()).replaceAll('-'))
+            final scrubbed = trimNonAlphanumeric(PREFIX_INVALID.matcher(value.toLowerCase(Locale.ROOT)).replaceAll('-'))
             return trimNonAlphanumeric(truncate(scrubbed, 253))
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskArrayCollector.groovy
@@ -173,6 +173,9 @@ class TaskArrayCollector {
         taskArray.config.context = taskArray.context
         taskArray.config.process = taskArray.processor.name
         taskArray.config.executor = taskArray.processor.executor.name
+        // the array job is submitted as a task on its own, therefore it needs the auto-derived
+        // resource labels as much as the tasks it wraps -- see TaskProcessor#createTaskRun
+        taskArray.config.setAutoResourceLabels(processor.session?.getAutoResourceLabels())
 
         return taskArray
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -625,10 +625,14 @@ class TaskConfig extends LazyMap implements Cloneable {
         final declared = get('resourceLabels') as Map<String, String> ?: Collections.<String,String>emptyMap()
         if( !autoResourceLabels )
             return declared
-        final auto = policy.sanitize(autoResourceLabels)
+        // the collision is decided *before* the normalisation, so that a label declared with the
+        // canonical key overrides the auto one even when the policy mangles that key
+        final overridden = autoResourceLabels.findAll { k, v -> !declared.containsKey(k) } as Map<String,String>
+        final auto = policy.sanitize(overridden)
         final result = new LinkedHashMap<String, String>(auto.size() + declared.size())
         result.putAll(auto)
-        // the declared labels are applied last, so that they win on a key collision
+        // the declared labels are applied last, so that they win also when the key collision
+        // only shows up once the auto key has been mangled by the policy
         result.putAll(declared)
         return result
     }

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -30,6 +30,7 @@ import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.BashWrapperBuilder
 import nextflow.executor.res.AcceleratorResource
 import nextflow.executor.res.DiskResource
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.script.TaskClosure
 import nextflow.util.CmdLineHelper
 import nextflow.util.CmdLineOptionMap
@@ -51,6 +52,16 @@ class TaskConfig extends LazyMap implements Cloneable {
     /** The directive names accessed while {@link #trackingAccess} is enabled */
     private transient Set<String> accessedDirectives = new HashSet<>(10)
 
+    /**
+     * The resource labels derived from the workflow metadata, assigned by the task processor
+     * -- see {@link nextflow.Session#getAutoResourceLabels()}.
+     *
+     * Note it is held aside from the directives map on purpose: it is not a directive, it must
+     * not take part in the directive resolution and it must not shadow a `resourceLabels`
+     * declared by the process.
+     */
+    private transient Map<String,String> autoResourceLabels = Collections.<String,String>emptyMap()
+
     private transient boolean trackingAccess
 
     TaskConfig() {  }
@@ -66,6 +77,8 @@ class TaskConfig extends LazyMap implements Cloneable {
         // copied, not reset: the copy carries over the command rendered from them
         // -- see TaskRun#clone -- therefore it depends on the same directives
         copy.accessedDirectives = new HashSet<>(this.accessedDirectives)
+        // note: the auto labels map is immutable, therefore the copy can share it
+        copy.autoResourceLabels = this.autoResourceLabels
         return copy
     }
 
@@ -580,8 +593,44 @@ class TaskConfig extends LazyMap implements Cloneable {
         return get('hints') as Map<String, Object> ?: Collections.<String,Object>emptyMap()
     }
 
+    /**
+     * Assign the resource labels derived from the workflow metadata. They are merged *under*
+     * the labels declared by the process -- see {@link #getResourceLabels()}.
+     *
+     * @param labels The auto-derived labels, or {@code null} when the feature is disabled
+     */
+    void setAutoResourceLabels(Map<String,String> labels) {
+        this.autoResourceLabels = labels ?: Collections.<String,String>emptyMap()
+    }
+
+    /**
+     * @return
+     *      The resource labels declared by the process, merged over the labels derived from
+     *      the workflow metadata. A label declared by the process always wins, therefore this
+     *      is what the trace records and the execution report observe
+     */
     Map<String, String> getResourceLabels() {
-        return get('resourceLabels') as Map<String, String> ?: Collections.<String,String>emptyMap()
+        return getResourceLabels(ResourceLabelPolicy.IDENTITY)
+    }
+
+    /**
+     * Same as {@link #getResourceLabels()} but the auto-derived labels are normalised by the
+     * given policy, so that they can be applied by the target executor backend. The labels
+     * declared by the process are passed through untouched.
+     *
+     * @param policy The {@link ResourceLabelPolicy} of the executor backend applying the labels
+     * @return The resource labels to be applied to the task compute resources
+     */
+    Map<String, String> getResourceLabels(ResourceLabelPolicy policy) {
+        final declared = get('resourceLabels') as Map<String, String> ?: Collections.<String,String>emptyMap()
+        if( !autoResourceLabels )
+            return declared
+        final auto = policy.sanitize(autoResourceLabels)
+        final result = new LinkedHashMap<String, String>(auto.size() + declared.size())
+        result.putAll(auto)
+        // the declared labels are applied last, so that they win on a key collision
+        result.putAll(declared)
+        return result
     }
 
     String getResourceLabelsAsString() {

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskConfig.groovy
@@ -77,8 +77,7 @@ class TaskConfig extends LazyMap implements Cloneable {
         // copied, not reset: the copy carries over the command rendered from them
         // -- see TaskRun#clone -- therefore it depends on the same directives
         copy.accessedDirectives = new HashSet<>(this.accessedDirectives)
-        // note: the auto labels map is immutable, therefore the copy can share it
-        copy.autoResourceLabels = this.autoResourceLabels
+        // note: the immutable auto labels map is already carried over by super.clone(), so it is shared as-is
         return copy
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy
@@ -402,6 +402,7 @@ class TaskProcessor {
         task.config.context = task.context
         task.config.process = task.processor.name
         task.config.executor = task.processor.executor.name
+        task.config.setAutoResourceLabels(session?.getAutoResourceLabels())
 
         return task
     }
@@ -763,6 +764,7 @@ class TaskProcessor {
         task.config.index = task.index
         task.config.process = task.processor.name
         task.config.executor = task.processor.executor.name
+        task.config.setAutoResourceLabels(session?.getAutoResourceLabels())
 
         if( config instanceof ProcessConfigV1 )
             initializeTaskRunV1(task)

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -476,6 +476,77 @@ class SessionTest extends Specification {
 
     }
 
+    def 'should compute the auto resource labels lazily and memoize them' () {
+        given:
+        def session = new Session([tower: [autoLabels: 'runName']])
+        // the Platform metadata is only filled in at `notifyFlowCreate` i.e. after the session is created
+        def meta = Mock(WorkflowMetadata)
+        session.@workflowMetadata = meta
+
+        when:
+        def labels = session.getAutoResourceLabels()
+        then:
+        // the metadata is only read on the first access
+        (1.._) * meta.getRunName() >> 'crazy_darwin'
+        and:
+        labels == ['nextflow.io/runName': 'crazy_darwin']
+
+        when:
+        def again = session.getAutoResourceLabels()
+        then:
+        0 * meta.getRunName()
+        and:
+        again.is(labels)
+    }
+
+    def 'should return no auto resource labels when the option is not set' () {
+        given:
+        def session = new Session()
+        session.@workflowMetadata = Mock(WorkflowMetadata)
+
+        expect:
+        session.getAutoResourceLabels() == [:]
+    }
+
+    @Unroll
+    def 'should resolve the auto resource labels option scope' () {
+        given:
+        def session = new Session(CONFIG)
+        session.@workflowMetadata = Mock(WorkflowMetadata) {
+            getRunName() >> 'crazy_darwin'
+            getProjectName() >> 'nf-core/rnaseq'
+        }
+
+        expect:
+        session.getAutoResourceLabels().keySet() as List == EXPECTED
+
+        where:
+        CONFIG                                                                          | EXPECTED
+        [tower: [autoLabels: 'runName']]                                                | ['nextflow.io/runName']
+        [tower: [autoLabels: ['runName','projectName']]]                                | ['nextflow.io/projectName','nextflow.io/runName']
+        [tower: [autoLabels: false]]                                                    | []
+        [seqera: [executor: [autoLabels: 'runName']]]                                   | ['nextflow.io/runName']
+        // the deprecated option wins when given, even as `false`
+        [seqera: [executor: [autoLabels: 'projectName']], tower: [autoLabels:'runName']]| ['nextflow.io/projectName']
+        [seqera: [executor: [autoLabels: false]], tower: [autoLabels: true]]            | []
+        // ... and only when given
+        [seqera: [executor: [endpoint: 'http://foo']], tower: [autoLabels: 'runName']]  | ['nextflow.io/runName']
+    }
+
+    def 'should report the offending option name for an invalid auto labels value' () {
+        when:
+        new Session([tower: [autoLabels: 'foo']]).getAutoResourceLabels()
+        then:
+        def e1 = thrown(IllegalArgumentException)
+        e1.message.contains("'tower.autoLabels'")
+
+        when:
+        new Session([seqera: [executor: [autoLabels: 'foo']]]).getAutoResourceLabels()
+        then:
+        def e2 = thrown(IllegalArgumentException)
+        e2.message.contains("'seqera.executor.autoLabels'")
+    }
+
     def 'should notify flow complete only once when abort and destroy race' () {
         given:
         def observer = Mock(TraceObserverV2)

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -547,6 +547,14 @@ class SessionTest extends Specification {
         e2.message.contains("'seqera.executor.autoLabels'")
     }
 
+    def 'should fail fast on an invalid auto labels value at config check' () {
+        when: 'the config is checked, before any task is created'
+        new Session([tower: [autoLabels: 'foo']]).checkConfig()
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("'tower.autoLabels'")
+    }
+
     def 'should notify flow complete only once when abort and destroy race' () {
         given:
         def observer = Mock(TraceObserverV2)

--- a/modules/nextflow/src/test/groovy/nextflow/platform/AutoLabelsTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/platform/AutoLabelsTest.groovy
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.platform
+
+import nextflow.NextflowMeta
+import nextflow.config.Manifest
+import nextflow.script.PlatformMetadata
+import nextflow.script.WorkflowMetadata
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for the auto resource labels helper
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class AutoLabelsTest extends Specification {
+
+    def 'should hold all the valid names in order'() {
+        expect:
+        AutoLabels.VALID_NAMES as List == [
+            'projectName', 'userName', 'runName', 'sessionId', 'resume',
+            'revision', 'commitId', 'repository', 'manifestName',
+            'runtimeVersion', 'workflowId', 'workspaceId', 'computeEnvId'
+        ]
+    }
+
+    def 'should parse a disabled value'() {
+        expect:
+        AutoLabels.parse(null) == [] as Set
+        AutoLabels.parse(false) == [] as Set
+    }
+
+    def 'should parse a true value as all names'() {
+        expect:
+        AutoLabels.parse(true) == AutoLabels.VALID_NAMES
+    }
+
+    @Unroll
+    def 'should parse a subset of names'() {
+        expect:
+        AutoLabels.parse(VALUE) == EXPECTED as Set
+
+        where:
+        VALUE                           | EXPECTED
+        'runName'                       | ['runName']
+        'runName,projectName'           | ['runName', 'projectName']
+        ' runName , projectName '       | ['runName', 'projectName']
+        'runName,,projectName'          | ['runName', 'projectName']
+        ['runName', 'projectName']      | ['runName', 'projectName']
+        [' runName ', null]             | ['runName']
+        []                              | []
+        ''                              | []
+    }
+
+    def 'should reject an unknown name'() {
+        when:
+        AutoLabels.parse('runName,foo')
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('foo')
+        e.message.contains('valid names are')
+    }
+
+    def 'should report the option name in the error message'() {
+        when:
+        AutoLabels.parse('foo', 'tower.autoLabels')
+        then:
+        def e1 = thrown(IllegalArgumentException)
+        e1.message.contains("'tower.autoLabels'")
+
+        when:
+        AutoLabels.parse(new Object(), 'seqera.executor.autoLabels')
+        then:
+        def e2 = thrown(IllegalArgumentException)
+        e2.message.contains("'seqera.executor.autoLabels'")
+        e2.message.contains('expected true, false, a list, or a comma-separated string')
+    }
+
+    def 'should reject an unsupported value type'() {
+        when:
+        AutoLabels.parse(123)
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'should map all workflow metadata to labels'() {
+        given:
+        def sessionId = UUID.randomUUID()
+        def platform = new PlatformMetadata('wf-abc123')
+        platform.workspace = new PlatformMetadata.Workspace(workspaceId: '1234')
+        platform.computeEnv = new PlatformMetadata.ComputeEnv(id: 'ce-abc')
+        def workflow = Mock(WorkflowMetadata) {
+            getProjectName() >> 'nf-core/rnaseq'
+            getUserName() >> 'pditommaso'
+            getRunName() >> 'crazy_darwin'
+            getSessionId() >> sessionId
+            isResume() >> true
+            getRevision() >> '3.12.0'
+            getCommitId() >> 'abc1234'
+            getRepository() >> 'https://github.com/nf-core/rnaseq'
+            getManifest() >> new Manifest([name: 'nf-core/rnaseq'])
+            getPlatform() >> platform
+        }
+
+        when:
+        def labels = AutoLabels.labelsFor(workflow, AutoLabels.VALID_NAMES)
+
+        then:
+        labels == [
+            'nextflow.io/projectName': 'nf-core/rnaseq',
+            'nextflow.io/userName': 'pditommaso',
+            'nextflow.io/runName': 'crazy_darwin',
+            'nextflow.io/sessionId': sessionId.toString(),
+            'nextflow.io/resume': 'true',
+            'nextflow.io/revision': '3.12.0',
+            'nextflow.io/commitId': 'abc1234',
+            'nextflow.io/repository': 'https://github.com/nf-core/rnaseq',
+            'nextflow.io/manifestName': 'nf-core/rnaseq',
+            'nextflow.io/runtimeVersion': NextflowMeta.instance.version.toString(),
+            'seqera.io/platform/workflowId': 'wf-abc123',
+            'seqera.io/platform/workspaceId': '1234',
+            'seqera.io/platform/computeEnvId': 'ce-abc'
+        ]
+    }
+
+    @Unroll
+    def 'should prefer the platform user name over the OS user name'() {
+        given:
+        def platform = new PlatformMetadata()
+        if( PLATFORM_USER )
+            platform.user = new PlatformMetadata.User(id: '1', userName: PLATFORM_USER)
+        def workflow = Mock(WorkflowMetadata) {
+            getUserName() >> 'ec2-user'
+            getPlatform() >> platform
+        }
+
+        expect:
+        AutoLabels.labelsFor(workflow, ['userName'] as Set) == ['nextflow.io/userName': EXPECTED]
+
+        where:
+        PLATFORM_USER   | EXPECTED
+        'jane.doe'      | 'jane.doe'
+        null            | 'ec2-user'
+    }
+
+    def 'should omit the labels whose metadata is absent'() {
+        given:
+        def workflow = Mock(WorkflowMetadata) {
+            getProjectName() >> 'hello'
+            getUserName() >> 'user1'
+            getRunName() >> 'happy_turing'
+            getSessionId() >> UUID.randomUUID()
+            isResume() >> false
+            getRevision() >> null
+            getCommitId() >> null
+            getRepository() >> null
+            getManifest() >> new Manifest([:])
+            getPlatform() >> new PlatformMetadata()
+        }
+
+        when:
+        def labels = AutoLabels.labelsFor(workflow, AutoLabels.VALID_NAMES)
+
+        then:
+        labels.containsKey('nextflow.io/projectName')
+        labels.containsKey('nextflow.io/userName')
+        labels.containsKey('nextflow.io/runName')
+        labels.containsKey('nextflow.io/sessionId')
+        labels['nextflow.io/resume'] == 'false'
+        and:
+        !labels.containsKey('nextflow.io/revision')
+        !labels.containsKey('nextflow.io/commitId')
+        !labels.containsKey('nextflow.io/repository')
+        !labels.containsKey('nextflow.io/manifestName')
+        !labels.containsKey('seqera.io/platform/workflowId')
+        !labels.containsKey('seqera.io/platform/workspaceId')
+        !labels.containsKey('seqera.io/platform/computeEnvId')
+        and:
+        // no entry ever carries an empty value
+        labels.values().every { it }
+    }
+
+    def 'should omit the platform labels when the metadata is missing altogether'() {
+        given:
+        def workflow = Mock(WorkflowMetadata) {
+            getRunName() >> 'happy_turing'
+            isResume() >> false
+            getManifest() >> new Manifest([:])
+            getPlatform() >> null
+        }
+
+        when:
+        def labels = AutoLabels.labelsFor(workflow, AutoLabels.VALID_NAMES)
+
+        then:
+        labels.keySet() == ['nextflow.io/runName', 'nextflow.io/resume', 'nextflow.io/runtimeVersion'] as Set
+    }
+
+    def 'should map only the included names'() {
+        given:
+        def workflow = Mock(WorkflowMetadata) {
+            getProjectName() >> 'nf-core/rnaseq'
+            getRunName() >> 'crazy_darwin'
+            getSessionId() >> UUID.randomUUID()
+            isResume() >> false
+            getRevision() >> '3.12.0'
+            getManifest() >> new Manifest([name: 'nf-core/rnaseq'])
+        }
+
+        expect:
+        AutoLabels.labelsFor(workflow, ['runName', 'revision'] as Set).keySet() == ['nextflow.io/runName', 'nextflow.io/revision'] as Set
+    }
+
+    def 'should map nothing for an empty include set or missing metadata'() {
+        given:
+        def workflow = Mock(WorkflowMetadata) { getProjectName() >> 'hello' }
+
+        expect:
+        AutoLabels.labelsFor(workflow, [] as Set) == [:]
+        AutoLabels.labelsFor(workflow, null) == [:]
+        AutoLabels.labelsFor(null, AutoLabels.VALID_NAMES) == [:]
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/platform/ResourceLabelPolicyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/platform/ResourceLabelPolicyTest.groovy
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.platform
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for the per-executor resource label policies
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class ResourceLabelPolicyTest extends Specification {
+
+    // -- identity
+
+    def 'should apply the labels verbatim'() {
+        given:
+        def labels = ['nextflow.io/runName': 'crazy_darwin', 'nextflow.io/repository': 'https://github.com/foo/bar']
+
+        expect:
+        ResourceLabelPolicy.IDENTITY.sanitize(labels) == labels
+        ResourceLabelPolicy.IDENTITY.sanitizeKey('nextflow.io/runName') == 'nextflow.io/runName'
+        ResourceLabelPolicy.IDENTITY.sanitizeValue('https://github.com/foo/bar') == 'https://github.com/foo/bar'
+    }
+
+    def 'should handle a null or empty map'() {
+        expect:
+        POLICY.sanitize(null) == [:]
+        POLICY.sanitize([:]) == [:]
+
+        where:
+        POLICY << [ResourceLabelPolicy.IDENTITY, ResourceLabelPolicy.AWS, ResourceLabelPolicy.GOOGLE, ResourceLabelPolicy.K8S, ResourceLabelPolicy.AZURE]
+    }
+
+    // -- aws
+
+    @Unroll
+    def 'should sanitize the aws key'() {
+        expect:
+        ResourceLabelPolicy.AWS.sanitizeKey(KEY) == EXPECTED
+
+        where:
+        KEY                             | EXPECTED
+        'nextflow.io/runName'           | 'nextflow.io/runName'
+        'seqera.io/platform/workflowId' | 'seqera.io/platform/workflowId'
+        'cost centre'                   | 'cost centre'
+        'a+b-c=d.e_f:g/h@i'             | 'a+b-c=d.e_f:g/h@i'
+        'foo#bar'                       | 'foo_bar'
+        'foo(bar)'                      | 'foo_bar_'
+        ''                              | ''
+        null                            | ''
+    }
+
+    def 'should sanitize the aws value'() {
+        expect:
+        ResourceLabelPolicy.AWS.sanitizeValue('https://github.com/foo/bar') == 'https://github.com/foo/bar'
+        ResourceLabelPolicy.AWS.sanitizeValue('some#value') == 'some_value'
+    }
+
+    def 'should truncate the aws key and value without a trailing blank'() {
+        given:
+        def key = 'a' * 127 + ' ' + 'b' * 10
+        def value = 'x' * 255 + ' ' + 'y' * 10
+
+        when:
+        def k = ResourceLabelPolicy.AWS.sanitizeKey(key)
+        def v = ResourceLabelPolicy.AWS.sanitizeValue(value)
+
+        then:
+        k == 'a' * 127
+        v == 'x' * 255
+    }
+
+    def 'should keep an empty aws value'() {
+        expect:
+        ResourceLabelPolicy.AWS.sanitize(['nextflow.io/revision': '']) == ['nextflow.io/revision': '']
+    }
+
+    // -- google
+
+    @Unroll
+    def 'should sanitize the google key'() {
+        expect:
+        ResourceLabelPolicy.GOOGLE.sanitizeKey(KEY) == EXPECTED
+
+        where:
+        KEY                             | EXPECTED
+        'nextflow.io/runName'           | 'nextflow_io_runname'
+        'seqera.io/platform/workflowId' | 'seqera_io_platform_workflowid'
+        'foo-bar_baz'                   | 'foo-bar_baz'
+        '1foo'                          | 'foo'
+        '123'                           | ''
+        '-_.'                           | ''
+        ''                              | ''
+        null                            | ''
+    }
+
+    @Unroll
+    def 'should sanitize the google value'() {
+        expect:
+        ResourceLabelPolicy.GOOGLE.sanitizeValue(VALUE) == EXPECTED
+
+        where:
+        VALUE                                   | EXPECTED
+        'crazy_darwin'                          | 'crazy_darwin'
+        'https://github.com/foo/bar'            | 'https___github_com_foo_bar'
+        'nf-core/rnaseq'                        | 'nf-core_rnaseq'
+        '3.12.0'                                | '3_12_0'
+        ''                                      | ''
+        null                                    | ''
+    }
+
+    def 'should truncate the google key and value'() {
+        expect:
+        ResourceLabelPolicy.GOOGLE.sanitizeKey('k' * 70) == 'k' * 63
+        ResourceLabelPolicy.GOOGLE.sanitizeValue('v' * 70) == 'v' * 63
+    }
+
+    def 'should drop the google entries with no key or no value'() {
+        expect:
+        ResourceLabelPolicy.GOOGLE.sanitize([
+            'nextflow.io/runName': 'crazy_darwin',
+            '123': 'dropped-no-key',
+            'nextflow.io/revision': '' ]) == ['nextflow_io_runname': 'crazy_darwin']
+    }
+
+    // -- kubernetes
+
+    @Unroll
+    def 'should sanitize the k8s key'() {
+        expect:
+        ResourceLabelPolicy.K8S.sanitizeKey(KEY) == EXPECTED
+
+        where:
+        KEY                             | EXPECTED
+        'nextflow.io/runName'           | 'nextflow.io/runName'
+        'nextflow.io/resume'            | 'nextflow.io/resume'
+        'seqera.io/platform/workflowId' | 'seqera.io/platform_workflowId'
+        'runName'                       | 'runName'
+        'NEXTFLOW.IO/runName'           | 'nextflow.io/runName'
+        'foo bar'                       | 'foo_bar'
+        'nextflow.io/-runName-'         | 'nextflow.io/runName'
+        'nextflow.io/'                  | ''
+        ''                              | ''
+        null                            | ''
+    }
+
+    @Unroll
+    def 'should sanitize the k8s value'() {
+        expect:
+        ResourceLabelPolicy.K8S.sanitizeValue(VALUE) == EXPECTED
+
+        where:
+        VALUE                                       | EXPECTED
+        'crazy_darwin'                              | 'crazy_darwin'
+        'https://github.com/foo/bar'                | 'github.com_foo_bar'
+        'git@github.com:foo/bar.git'                | 'git_github.com_foo_bar.git'
+        'ssh://git@github.com/foo/bar'              | 'git_github.com_foo_bar'
+        '/leading/and/trailing/'                    | 'leading_and_trailing'
+        ''                                          | ''
+        null                                        | ''
+    }
+
+    def 'should truncate the k8s value leaving an alphanumeric trailing char'() {
+        expect:
+        ResourceLabelPolicy.K8S.sanitizeValue('a' * 62 + '-' + 'b' * 10) == 'a' * 62
+        ResourceLabelPolicy.K8S.sanitizeValue('a' * 70) == 'a' * 63
+        ResourceLabelPolicy.K8S.sanitizeKey('nextflow.io/' + 'k' * 70) == 'nextflow.io/' + 'k' * 63
+    }
+
+    def 'should drop the k8s entries with no key or no value'() {
+        expect:
+        ResourceLabelPolicy.K8S.sanitize([
+            'nextflow.io/runName': 'crazy_darwin',
+            '///': 'dropped-no-key',
+            'nextflow.io/repository': '' ]) == ['nextflow.io/runName': 'crazy_darwin']
+    }
+
+    // -- azure
+
+    @Unroll
+    def 'should sanitize the azure key'() {
+        expect:
+        ResourceLabelPolicy.AZURE.sanitizeKey(KEY) == EXPECTED
+
+        where:
+        KEY                             | EXPECTED
+        'nextflow.io/runName'           | 'nextflow.io/runName'
+        'seqera.io/platform/workflowId' | 'seqera.io/platform/workflowId'
+        'microsoft.foo'                 | 'foo'
+        'Microsoft_Bar'                 | 'Bar'
+        'microsoft'                     | ''
+        ''                              | ''
+        null                            | ''
+    }
+
+    def 'should keep the azure values as they are'() {
+        expect:
+        ResourceLabelPolicy.AZURE.sanitize(['nextflow.io/repository': 'https://github.com/foo/bar', 'microsoft': 'dropped', 'nextflow.io/revision': ''])
+                == ['nextflow.io/repository': 'https://github.com/foo/bar', 'nextflow.io/revision': '']
+    }
+
+    // -- all
+
+    def 'should keep the order of the source map'() {
+        given:
+        def labels = ['nextflow.io/projectName': 'nf-core/rnaseq', 'nextflow.io/runName': 'crazy_darwin', 'nextflow.io/resume': 'false']
+
+        expect:
+        POLICY.sanitize(labels).values() as List == ['nf-core/rnaseq', 'crazy_darwin', 'false'].collect { POLICY.sanitizeValue(it) }
+
+        where:
+        POLICY << [ResourceLabelPolicy.IDENTITY, ResourceLabelPolicy.AWS, ResourceLabelPolicy.GOOGLE, ResourceLabelPolicy.K8S, ResourceLabelPolicy.AZURE]
+    }
+
+    def 'should have a name'() {
+        expect:
+        ResourceLabelPolicy.IDENTITY.name == 'identity'
+        ResourceLabelPolicy.AWS.name == 'aws'
+        ResourceLabelPolicy.GOOGLE.name == 'google'
+        ResourceLabelPolicy.K8S.name == 'k8s'
+        ResourceLabelPolicy.AZURE.name == 'azure'
+    }
+
+}

--- a/modules/nextflow/src/test/groovy/nextflow/platform/ResourceLabelPolicyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/platform/ResourceLabelPolicyTest.groovy
@@ -237,4 +237,20 @@ class ResourceLabelPolicyTest extends Specification {
         ResourceLabelPolicy.AZURE.name == 'azure'
     }
 
+    // -- locale independence
+
+    def 'should lowercase labels independently of the default locale'() {
+        given: 'a default locale whose lowercasing of I yields a dotless ı, not the ASCII i (Turkish)'
+        def previous = Locale.getDefault()
+        Locale.setDefault(Locale.forLanguageTag('tr-TR'))
+
+        expect: 'the google and k8s policies still fold I to the ASCII i'
+        ResourceLabelPolicy.GOOGLE.sanitizeKey('seqera.io/platform/workflowId') == 'seqera_io_platform_workflowid'
+        ResourceLabelPolicy.GOOGLE.sanitizeValue('WorkflowId') == 'workflowid'
+        ResourceLabelPolicy.K8S.sanitizeKey('NEXTFLOW.IO/runName') == 'nextflow.io/runName'
+
+        cleanup:
+        Locale.setDefault(previous)
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskArrayCollectorTest.groovy
@@ -22,6 +22,7 @@ import com.google.common.hash.HashCode
 import nextflow.Session
 import nextflow.executor.Executor
 import nextflow.executor.TaskArrayExecutor
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.script.BaseScript
 import nextflow.script.BodyDef
 import nextflow.script.ProcessConfig
@@ -134,6 +135,50 @@ class TaskArrayCollectorTest extends Specification {
         taskArray.getArraySize() == 3
         taskArray.getContainerConfig().getEnvWhitelist() == [ 'ARRAY_JOB_INDEX' ]
         taskArray.isContainerEnabled() == false
+    }
+
+    def 'should create task array with the auto resource labels' () {
+        given:
+        def exec = Mock(DummyExecutor) {
+            getWorkDir() >> TestHelper.createInMemTempDir()
+            getArrayIndexName() >> 'ARRAY_JOB_INDEX'
+        }
+        def config = Spy(ProcessConfig, constructorArgs: [Mock(BaseScript), 'PROC']) {
+            createTaskConfig() >> Mock(TaskConfig)
+            get('resourceLabels') >> ['My.Label': 'Foo/Bar']
+        }
+        def proc = Mock(TaskProcessor) {
+            getConfig() >> config
+            getExecutor() >> exec
+            getName() >> 'PROC'
+            getSession() >> Mock(Session) { getAutoResourceLabels() >> ['nextflow.io/runName': 'crazy_frog'] }
+            isSingleton() >> false
+            getTaskBody() >> { new BodyDef(null, 'source') }
+        }
+        def collector = Spy(new TaskArrayCollector(proc, exec, 5))
+        and:
+        def task = Mock(TaskRun) {
+            index >> 1
+            getHash() >> HashCode.fromString('0123456789abcdef')
+            getWorkDir() >> Paths.get('/work/foo')
+        }
+        def handler = Mock(TaskHandler) {
+            getTask() >> task
+        }
+
+        when:
+        def taskArray = collector.createTaskArray([task])
+        then:
+        1 * handler.withArrayChild(true) >> handler
+        1 * exec.createTaskHandler(task) >> handler
+        1 * handler.prepareLauncher()
+        1 * collector.createArrayTaskScript([handler]) >> 'the-task-array-script'
+        and:
+        // the array job carries the auto labels, merged as they are for a plain task
+        taskArray.config.getResourceLabels() == ['nextflow.io/runName': 'crazy_frog', 'My.Label': 'Foo/Bar']
+        and:
+        // and the executor policy applies to the auto entries only
+        taskArray.config.getResourceLabels(ResourceLabelPolicy.GOOGLE) == ['nextflow_io_runname': 'crazy_frog', 'My.Label': 'Foo/Bar']
     }
 
     def 'should get array ref' () {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Paths
 
 import nextflow.exception.FailedGuardException
 import nextflow.exception.ProcessUnrecoverableException
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.script.BaseScript
 import nextflow.script.ProcessConfig
 import nextflow.script.TaskClosure
@@ -725,6 +726,111 @@ class TaskConfigTest extends Specification {
 //        config.validateShell(['bash', ' -eu '])
 //        then:
 //        thrown(IllegalArgumentException)
+    }
+
+    def 'should return the declared resource labels when no auto labels are given' () {
+        given:
+        def config = new TaskConfig(resourceLabels: [team: 'genomics'])
+
+        when:
+        def labels = config.getResourceLabels()
+        then:
+        labels == [team: 'genomics']
+        and:
+        // the declared map is returned as-is
+        labels.is(config.get('resourceLabels'))
+
+        when:
+        config.setAutoResourceLabels(null)
+        then:
+        config.getResourceLabels() == [team: 'genomics']
+        config.getResourceLabels(ResourceLabelPolicy.GOOGLE) == [team: 'genomics']
+    }
+
+    def 'should merge the auto resource labels under the declared ones' () {
+        given:
+        def config = new TaskConfig(resourceLabels: ['nextflow.io/runName': 'custom', team: 'genomics'])
+        config.setAutoResourceLabels([
+            'nextflow.io/runName': 'crazy_darwin',
+            'nextflow.io/projectName': 'nf-core/rnaseq' ])
+
+        when:
+        def labels = config.getResourceLabels()
+        then:
+        // the declared label wins on the key collision
+        labels == [
+            'nextflow.io/projectName': 'nf-core/rnaseq',
+            'nextflow.io/runName': 'custom',
+            team: 'genomics' ]
+        and:
+        // the auto labels come first, then the declared ones
+        labels.keySet() as List == ['nextflow.io/runName', 'nextflow.io/projectName', 'team']
+        and:
+        config.getResourceLabelsAsString() == 'nextflow.io/runName=custom,nextflow.io/projectName=nf-core/rnaseq,team=genomics'
+    }
+
+    def 'should return the auto resource labels when no label is declared' () {
+        given:
+        def config = new TaskConfig()
+        config.setAutoResourceLabels(['nextflow.io/runName': 'crazy_darwin'])
+
+        expect:
+        config.getResourceLabels() == ['nextflow.io/runName': 'crazy_darwin']
+    }
+
+    def 'should sanitize the auto resource labels only' () {
+        given:
+        def config = new TaskConfig(resourceLabels: ['My.Team/Name': 'Genomics Team'])
+        config.setAutoResourceLabels([
+            'nextflow.io/runName': 'crazy_darwin',
+            'nextflow.io/repository': 'https://github.com/foo/bar' ])
+
+        when:
+        def labels = config.getResourceLabels(ResourceLabelPolicy.GOOGLE)
+        then:
+        labels == [
+            'nextflow_io_runname': 'crazy_darwin',
+            'nextflow_io_repository': 'https___github_com_foo_bar',
+            'My.Team/Name': 'Genomics Team' ]
+
+        when:
+        labels = config.getResourceLabels(ResourceLabelPolicy.K8S)
+        then:
+        labels == [
+            'nextflow.io/runName': 'crazy_darwin',
+            'nextflow.io/repository': 'github.com_foo_bar',
+            'My.Team/Name': 'Genomics Team' ]
+
+        when:
+        // the un-sanitized labels are what the trace records observe
+        labels = config.getResourceLabels()
+        then:
+        labels == [
+            'nextflow.io/runName': 'crazy_darwin',
+            'nextflow.io/repository': 'https://github.com/foo/bar',
+            'My.Team/Name': 'Genomics Team' ]
+    }
+
+    def 'should decide the collision on the sanitized auto key' () {
+        given:
+        def config = new TaskConfig(resourceLabels: ['nextflow_io_runname': 'custom'])
+        config.setAutoResourceLabels(['nextflow.io/runName': 'crazy_darwin'])
+
+        expect:
+        // the declared key only collides once the auto key is mangled by the policy
+        config.getResourceLabels(ResourceLabelPolicy.GOOGLE) == ['nextflow_io_runname': 'custom']
+        config.getResourceLabels(ResourceLabelPolicy.K8S) == ['nextflow.io/runName': 'crazy_darwin', 'nextflow_io_runname': 'custom']
+    }
+
+    def 'should carry over the auto resource labels on clone' () {
+        given:
+        def config = new TaskConfig(resourceLabels: [team: 'genomics'])
+        config.setAutoResourceLabels(['nextflow.io/runName': 'crazy_darwin'])
+
+        when:
+        def copy = config.clone()
+        then:
+        copy.getResourceLabels() == ['nextflow.io/runName': 'crazy_darwin', team: 'genomics']
     }
 
     def 'should get arch and container platform' () {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskConfigTest.groovy
@@ -763,10 +763,11 @@ class TaskConfigTest extends Specification {
             'nextflow.io/runName': 'custom',
             team: 'genomics' ]
         and:
-        // the auto labels come first, then the declared ones
-        labels.keySet() as List == ['nextflow.io/runName', 'nextflow.io/projectName', 'team']
+        // the auto labels come first, then the declared ones -- an overridden auto entry is
+        // dropped, therefore it takes the position of the declared label overriding it
+        labels.keySet() as List == ['nextflow.io/projectName', 'nextflow.io/runName', 'team']
         and:
-        config.getResourceLabelsAsString() == 'nextflow.io/runName=custom,nextflow.io/projectName=nf-core/rnaseq,team=genomics'
+        config.getResourceLabelsAsString() == 'nextflow.io/projectName=nf-core/rnaseq,nextflow.io/runName=custom,team=genomics'
     }
 
     def 'should return the auto resource labels when no label is declared' () {
@@ -809,6 +810,20 @@ class TaskConfigTest extends Specification {
             'nextflow.io/runName': 'crazy_darwin',
             'nextflow.io/repository': 'https://github.com/foo/bar',
             'My.Team/Name': 'Genomics Team' ]
+    }
+
+    def 'should override the auto label declared with the canonical key' () {
+        given:
+        def config = new TaskConfig(resourceLabels: ['nextflow.io/runName': 'custom', 'seqera.io/platform/workflowId': 'mine'])
+        config.setAutoResourceLabels(['nextflow.io/runName': 'crazy_darwin', 'seqera.io/platform/workflowId': '1a2b3c'])
+
+        expect:
+        // the auto entry is dropped before the normalisation, therefore the policy cannot
+        // turn the collision into two distinct keys
+        config.getResourceLabels(ResourceLabelPolicy.GOOGLE) == ['nextflow.io/runName': 'custom', 'seqera.io/platform/workflowId': 'mine']
+        config.getResourceLabels(ResourceLabelPolicy.K8S) == ['nextflow.io/runName': 'custom', 'seqera.io/platform/workflowId': 'mine']
+        config.getResourceLabels(ResourceLabelPolicy.AWS) == ['nextflow.io/runName': 'custom', 'seqera.io/platform/workflowId': 'mine']
+        config.getResourceLabels() == ['nextflow.io/runName': 'custom', 'seqera.io/platform/workflowId': 'mine']
     }
 
     def 'should decide the collision on the sanitized auto key' () {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskProcessorTest.groovy
@@ -436,10 +436,11 @@ class TaskProcessorTest extends Specification {
 
     def 'should create a task preview' () {
         given:
-        def config = new ProcessConfig([cpus: 10, memory: '100 GB'])
+        def config = new ProcessConfig([cpus: 10, memory: '100 GB', resourceLabels: [team: 'genomics']])
         def EXEC = Mock(Executor) { getName()>>'exec-name'}
         def BODY = Mock(BodyDef) { getType()>>ScriptType.SCRIPTLET }
-        def processor = new TaskProcessor(config: config, name: 'proc-name', executor: EXEC, taskBody: BODY)
+        def SESS = Mock(Session) { getAutoResourceLabels() >> ['nextflow.io/runName': 'crazy_darwin'] }
+        def processor = new TaskProcessor(config: config, name: 'proc-name', executor: EXEC, taskBody: BODY, session: SESS)
 
         when:
         def result = processor.createTaskPreview()
@@ -448,6 +449,41 @@ class TaskProcessorTest extends Specification {
         result.config.executor == 'exec-name'
         result.config.getCpus() == 10
         result.config.getMemory() == MemoryUnit.of('100 GB')
+        and:
+        // the auto resource labels are merged under the declared ones
+        result.config.getResourceLabels() == ['nextflow.io/runName': 'crazy_darwin', team: 'genomics']
+    }
+
+    def 'should create a task run with the auto resource labels' () {
+        given:
+        def config = new ProcessConfig([resourceLabels: [team: 'genomics', 'nextflow.io/runName': 'custom']])
+        def EXEC = Mock(Executor) { getName()>>'exec-name'}
+        def BODY = Mock(BodyDef) { getType()>>ScriptType.SCRIPTLET }
+        def SESS = Mock(Session) { getAutoResourceLabels() >> ['nextflow.io/runName': 'crazy_darwin', 'nextflow.io/sessionId': '1a2b3c'] }
+        def processor = new TaskProcessor(config: config, name: 'proc-name', executor: EXEC, taskBody: BODY, session: SESS)
+
+        when:
+        def task = processor.createTaskRun(new TaskStartParams(TaskId.of(1), 1))
+        then:
+        // the auto labels reach the task config, and the declared label still wins
+        task.config.getResourceLabels() == [
+                'nextflow.io/sessionId': '1a2b3c',
+                'nextflow.io/runName': 'custom',
+                team: 'genomics' ]
+    }
+
+    def 'should create a task run with no auto resource labels when the feature is off' () {
+        given:
+        def config = new ProcessConfig([resourceLabels: [team: 'genomics']])
+        def EXEC = Mock(Executor) { getName()>>'exec-name'}
+        def BODY = Mock(BodyDef) { getType()>>ScriptType.SCRIPTLET }
+        def SESS = Mock(Session) { getAutoResourceLabels() >> [:] }
+        def processor = new TaskProcessor(config: config, name: 'proc-name', executor: EXEC, taskBody: BODY, session: SESS)
+
+        when:
+        def task = processor.createTaskRun(new TaskStartParams(TaskId.of(1), 1))
+        then:
+        task.config.getResourceLabels() == [team: 'genomics']
     }
 
     @Unroll

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -39,6 +39,7 @@ import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.BashWrapperBuilder
 import nextflow.fusion.FusionAwareTask
 import nextflow.fusion.FusionConfig
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.processor.BatchContext
 import nextflow.processor.BatchHandler
 import nextflow.processor.TaskArrayRun
@@ -830,7 +831,10 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
          * create the request object
          */
         final opts = getAwsOptions()
-        final labels = task.config.getResourceLabels()
+        // the labels are applied as Batch job tags, therefore the auto-derived ones are normalised
+        // to the tag syntax while the user-declared ones are passed through untouched. Note that
+        // Batch allows at most 50 tags per job, which is not enforced here
+        final labels = task.config.getResourceLabels(ResourceLabelPolicy.AWS)
         final builder = SubmitJobRequest.builder()
         builder.jobName(getJobName(task))
         builder.jobQueue(getJobQueue(task))

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -1134,6 +1134,38 @@ class AwsBatchTaskHandlerTest extends Specification {
         req.propagateTags() == true
     }
 
+    def 'should create an aws submit request with auto resource labels'() {
+        given:
+        def VAR_FOO = KeyValuePair.builder().name('FOO').value('1').build()
+        def config = new TaskConfig(memory: '8GB', cpus: 4, resourceLabels: ['my!label': 'a,b#c'])
+        config.setAutoResourceLabels([
+                'nextflow.io/runName': 'crazy#frog',
+                'seqera.io/platform/workflowId': '4a#bcd' ])
+        def task = Mock(TaskRun)
+        task.getName() >> 'batch-task'
+        task.getConfig() >> config
+
+        def handler = Spy(AwsBatchTaskHandler)
+
+        when:
+        def req = handler.newSubmitRequest(task)
+        then:
+        1 * handler.getSubmitCommand() >> ['sh', '-c', 'hello']
+        1 * handler.maxSpotAttempts() >> 0
+        1 * handler.getAwsOptions() >> { new AwsOptions(awsConfig: new AwsConfig(batch: [cliPath: '/bin/aws'])) }
+        1 * handler.getJobQueue(task) >> 'queue1'
+        1 * handler.getJobDefinition(task) >> 'job-def:1'
+        1 * handler.getEnvironmentVars() >> [VAR_FOO]
+
+        and:
+        // the auto labels are normalised to the Batch tag syntax, the declared one is untouched
+        req.tags() == [
+                'nextflow.io/runName': 'crazy_frog',
+                'seqera.io/platform/workflowId': '4a_bcd',
+                'my!label': 'a,b#c' ]
+        req.propagateTags() == true
+    }
+
     def 'get fusion submit command' () {
         given:
         def remoteWorkDir = S3PathFactory.parse('s3://my-bucket/work/dir')

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy
@@ -93,6 +93,7 @@ import nextflow.cloud.types.CloudMachineInfo
 import nextflow.cloud.types.PriceModel
 import nextflow.fusion.FusionHelper
 import nextflow.fusion.FusionScriptLauncher
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.processor.TaskRun
 import nextflow.util.CacheHelper
 import nextflow.util.MemoryUnit
@@ -752,7 +753,10 @@ class AzBatchService implements Closeable {
             throw new IllegalArgumentException(msg)
         }
 
-        final metadata = task.config.getResourceLabels()
+        // normalise the auto-derived labels for the Azure Batch metadata syntax; the labels
+        // declared by the process are applied verbatim. Note: the pool id is derived from this
+        // map, therefore a label changing at each run implies a new auto-pool at each run
+        final metadata = task.config.getResourceLabels(ResourceLabelPolicy.AZURE)
         final key = CacheHelper.hasher([vmType.name, opts, metadata]).hash().toString()
         final poolId = "nf-pool-$key-$vmType.name"
         return new AzVmPoolSpec(poolId: poolId, vmType: vmType, opts: opts, metadata: metadata)

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzBatchServiceTest.groovy
@@ -511,7 +511,7 @@ class AzBatchServiceTest extends Specification {
                 getMemory() >> MEM
                 getCpus() >> CPUS
                 getMachineType() >> TYPE
-                getResourceLabels() >> [foo: 'bar']
+                getResourceLabels(_) >> [foo: 'bar']
             }
         }
 
@@ -523,6 +523,67 @@ class AzBatchServiceTest extends Specification {
         spec.poolId == 'nf-pool-42f3635f3fb8b71160900efa959f7809-Standard_X1'
         spec.metadata == [foo: 'bar']
 
+    }
+
+    def 'should sanitise the auto resource labels in the autopool metadata' () {
+        given:
+        def LOC = 'europe'
+        def CFG = new AzConfig([batch: [location: LOC]])
+        def CPUS = 2
+        def MEM = MemoryUnit.of('1 GB')
+        def TYPE = 'Standard_X1'
+        def VM = new AzVmType(name: TYPE, numberOfCores: CPUS)
+        and:
+        def exec = createExecutor(CFG)
+        AzBatchService svc = Spy(AzBatchService, constructorArgs: [exec])
+        and:
+        def CONFIG = new TaskConfig(cpus: CPUS, memory: MEM, machineType: TYPE, resourceLabels: ['microsoft.dept': 'the/user value'])
+        CONFIG.setAutoResourceLabels(['nextflow.io/runName': 'crazy_curie', 'microsoft.io/workflowId': '12345'])
+        and:
+        def TASK = Mock(TaskRun) { getConfig() >> CONFIG }
+
+        when:
+        def spec = svc.specFromAutoPool(TASK)
+        then:
+        1 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
+        and:
+        // the auto labels are normalised for Azure Batch i.e. the reserved `microsoft` name
+        // prefix is stripped, while the label declared by the process is applied verbatim
+        spec.metadata == ['nextflow.io/runName': 'crazy_curie', 'io/workflowId': '12345', 'microsoft.dept': 'the/user value']
+        and:
+        spec.metadata.keySet() as List == ['nextflow.io/runName', 'io/workflowId', 'microsoft.dept']
+    }
+
+    def 'should derive the autopool id from the sanitised labels' () {
+        given:
+        def LOC = 'europe'
+        def CFG = new AzConfig([batch: [location: LOC]])
+        def CPUS = 2
+        def MEM = MemoryUnit.of('1 GB')
+        def TYPE = 'Standard_X1'
+        def VM = new AzVmType(name: TYPE, numberOfCores: CPUS)
+        and:
+        def exec = createExecutor(CFG)
+        AzBatchService svc = Spy(AzBatchService, constructorArgs: [exec])
+        and:
+        def AUTO = new TaskConfig(cpus: CPUS, memory: MEM, machineType: TYPE)
+        AUTO.setAutoResourceLabels(['microsoft.io/dept': 'bio'])
+        and:
+        def DECLARED = new TaskConfig(cpus: CPUS, memory: MEM, machineType: TYPE, resourceLabels: ['io/dept': 'bio'])
+        and:
+        def TASK1 = Mock(TaskRun) { getConfig() >> AUTO }
+        def TASK2 = Mock(TaskRun) { getConfig() >> DECLARED }
+
+        when:
+        def spec1 = svc.specFromAutoPool(TASK1)
+        def spec2 = svc.specFromAutoPool(TASK2)
+        then:
+        2 * svc.guessBestVm(LOC, CPUS, MEM, null, TYPE) >> VM
+        and:
+        // the pool id is hashed from the sanitised map, therefore it only depends on the
+        // labels as they are applied to the pool
+        spec1.metadata == ['io/dept': 'bio']
+        spec1.poolId == spec2.poolId
     }
 
     def 'should set jobs to automatically terminate by default' () {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -49,6 +49,7 @@ import nextflow.executor.res.DiskResource
 import nextflow.fusion.FusionAwareTask
 import nextflow.fusion.FusionConfig
 import nextflow.fusion.FusionScriptLauncher
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.processor.TaskArrayRun
 import nextflow.processor.TaskConfig
 import nextflow.processor.TaskHandler
@@ -535,7 +536,8 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                     .setEmail(batchConfig.serviceAccountEmail)
             )
 
-        allocationPolicy.putAllLabels(task.config.getResourceLabels())
+        // the labels derived from the workflow metadata are normalised as required by the Google Batch API
+        allocationPolicy.putAllLabels(task.config.getResourceLabels(ResourceLabelPolicy.GOOGLE))
 
         if( batchConfig.networkTags )
             allocationPolicy.addAllTags(batchConfig.networkTags)
@@ -592,7 +594,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             .addTaskGroups(buildTaskGroup(taskSpec, task))
             .setAllocationPolicy(allocationResult.policy)
             .setLogsPolicy(createLogsPolicy())
-            .putAllLabels(task.config.getResourceLabels())
+            .putAllLabels(task.config.getResourceLabels(ResourceLabelPolicy.GOOGLE))
             .build()
     }
 

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -76,7 +76,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getContainer() >> CONTAINER_IMAGE
             getConfig() >> Mock(TaskConfig) {
                 getCpus() >> 2
-                getResourceLabels() >> [:]
+                getResourceLabels(_) >> [:]
             }
         }
         and:
@@ -179,7 +179,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
                 getMachineType() >> MACHINE_TYPE
                 getMemory() >> MEM
                 getTime() >> TIMEOUT
-                getResourceLabels() >> [foo: 'bar']
+                getResourceLabels(_) >> [foo: 'bar']
             }
         }
         and:
@@ -262,6 +262,52 @@ class GoogleBatchTaskHandlerTest extends Specification {
         req.getTaskGroups(0).getTaskSpec().getComputeResource().getBootDiskMib() == 100 * 1024
     }
 
+    def 'should create submit request with auto resource labels' () {
+        given:
+        def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')
+        def CONTAINER_IMAGE = 'debian:latest'
+        def exec = Mock(GoogleBatchExecutor) {
+            getBatchConfig() >> Mock(BatchConfig)
+        }
+        and:
+        // the label declared by the process is illegal for the Google Batch API, still it must be applied verbatim
+        def config = new TaskConfig(cpus: 2, resourceLabels: ['My.Label': 'Foo/Bar'])
+        config.setAutoResourceLabels([
+            'nextflow.io/runName': 'crazy_darwin',
+            'nextflow.io/repository': 'https://github.com/foo/bar',
+            'seqera.io/platform/workflowId': '4kZ8Xy' ])
+        and:
+        def bean = new TaskBean(workDir: WORK_DIR, inputFiles: [:])
+        def task = Mock(TaskRun) {
+            toTaskBean() >> bean
+            getHashLog() >> 'abcd1234'
+            getWorkDir() >> WORK_DIR
+            getContainer() >> CONTAINER_IMAGE
+            getConfig() >> config
+        }
+        and:
+        def launcher = new GoogleBatchLauncherSpecMock('bash .command.run')
+        and:
+        def handler = Spy(new GoogleBatchTaskHandler(task, exec))
+
+        when:
+        def req = handler.newSubmitRequest(task, launcher)
+        then:
+        handler.fusionEnabled() >> false
+        handler.findBestMachineType(_, false) >> null
+
+        and:
+        def expected = [
+            nextflow_io_runname: 'crazy_darwin',
+            nextflow_io_repository: 'https___github_com_foo_bar',
+            seqera_io_platform_workflowid: '4kz8xy',
+            'My.Label': 'Foo/Bar' ]
+        and:
+        // the allocation policy and the job carry the very same labels
+        req.getAllocationPolicy().getLabelsMap() == expected
+        req.getLabelsMap() == expected
+    }
+
     def 'should use custom job name'() {
         given:
         def WORK_DIR = CloudStorageFileSystem.forBucket('foo').getPath('/scratch')
@@ -322,7 +368,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getConfig() >> Mock(TaskConfig) {
                 getCpus() >> 2
                 getMachineType() >> "template://${INSTANCE_TEMPLATE}"
-                getResourceLabels() >> [:]
+                getResourceLabels(_) >> [:]
             }
         }
         and:
@@ -449,7 +495,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getContainer() >> CONTAINER_IMAGE
             getConfig() >> Mock(TaskConfig) {
                 getCpus() >> 2
-                getResourceLabels() >> [:]
+                getResourceLabels(_) >> [:]
             }
         }
         and:
@@ -508,7 +554,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getContainer() >> CONTAINER_IMAGE
             getConfig() >> Mock(TaskConfig) {
                 getCpus() >> 2
-                getResourceLabels() >> [:]
+                getResourceLabels(_) >> [:]
                 getMachineType() >> "n1-*,n2-*"
             }
         }
@@ -1006,7 +1052,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getContainer() >> CONTAINER_IMAGE
             getConfig() >> Mock(TaskConfig) {
                 getCpus() >> 8
-                getResourceLabels() >> [:]
+                getResourceLabels(_) >> [:]
             }
         }
         and:
@@ -1045,7 +1091,7 @@ class GoogleBatchTaskHandlerTest extends Specification {
             getContainer() >> CONTAINER_IMAGE
             getConfig() >> Mock(TaskConfig) {
                 getCpus() >> 8
-                getResourceLabels() >> [:]
+                getResourceLabels(_) >> [:]
             }
         }
         and:

--- a/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
+++ b/plugins/nf-k8s/src/main/nextflow/k8s/K8sTaskHandler.groovy
@@ -39,6 +39,7 @@ import nextflow.k8s.model.PodEnv
 import nextflow.k8s.model.PodOptions
 import nextflow.k8s.model.PodSpecBuilder
 import nextflow.k8s.model.ResourceType
+import nextflow.platform.ResourceLabelPolicy
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskRun
 import nextflow.processor.TaskStatus
@@ -295,7 +296,9 @@ class K8sTaskHandler extends TaskHandler implements FusionAwareTask {
         if( labels ) {
             result.putAll(labels)
         }
-        final resLabels = task.config.getResourceLabels()
+        // the auto-derived labels are normalised to comply with the pod label syntax,
+        // while the ones declared by the process are applied verbatim
+        final resLabels = task.config.getResourceLabels(ResourceLabelPolicy.K8S)
         if( resLabels )
             result.putAll(resLabels)
         result.'nextflow.io/app' = 'nextflow'

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -734,7 +734,7 @@ class K8sTaskHandlerTest extends Specification {
         task.getName() >> 'hello-world-1'
         task.getProcessor() >> proc
         task.getConfig() >> Mock(TaskConfig) {
-            getResourceLabels() >> [mylabel: 'myvalue']
+            getResourceLabels(_) >> [mylabel: 'myvalue']
         }
         proc.getName() >> 'hello-proc'
         exec.getSession() >> sess
@@ -788,6 +788,94 @@ class K8sTaskHandlerTest extends Specification {
         labels.'nextflow.io/taskName' ==  'hello-world-1'
         labels.'nextflow.io/sessionId' instanceof String
         labels.'nextflow.io/sessionId' == "uuid-${uuid.toString()}".toString()
+    }
+
+    def 'should normalise the auto resource labels only' () {
+        given:
+        def uuid = UUID.randomUUID()
+        def task = Mock(TaskRun)
+        def exec = Mock(K8sExecutor)
+        def proc = Mock(TaskProcessor)
+        def sess = Mock(Session)
+        def handler = Spy(new K8sTaskHandler(executor: exec))
+        and:
+        def config = new TaskConfig(resourceLabels: ['user.io/My Label': 'https://example.com/thing'])
+        config.setAutoResourceLabels([
+                'nextflow.io/repository': 'https://github.com/foo/bar',
+                'seqera.io/platform/workflowId': '1a2b3c',
+                'nextflow.io/revision': '' ])
+
+        when:
+        def labels = handler.getLabels(task)
+        then:
+        handler.getRunName() >> 'pedantic-joe'
+        task.getName() >> 'hello-world-1'
+        task.getProcessor() >> proc
+        task.getConfig() >> config
+        proc.getName() >> 'hello-proc'
+        exec.getSession() >> sess
+        sess.getUniqueId() >> uuid
+        exec.getK8sConfig() >> [:]
+        and:
+        // the auto labels are normalised to comply with the pod label syntax
+        labels.'nextflow.io/repository' == 'github.com_foo_bar'
+        labels.'seqera.io/platform_workflowId' == '1a2b3c'
+        and:
+        // an auto label sanitising to an empty value cannot be applied
+        !labels.containsKey('nextflow.io/revision')
+        and:
+        // the label declared by the process is applied verbatim
+        labels.'user.io/My Label' == 'https://example.com/thing'
+    }
+
+    def 'should submit a pod request with the sanitised auto resource labels' () {
+        given:
+        def WORK_DIR = Paths.get('/some/work/dir')
+        def uuid = UUID.randomUUID()
+        def task = Mock(TaskRun)
+        def exec = Mock(K8sExecutor)
+        def proc = Mock(TaskProcessor)
+        def sess = Mock(Session)
+        def client = Mock(K8sClient)
+        def builder = Mock(K8sWrapperBuilder)
+        def handler = Spy(new K8sTaskHandler(builder: builder, executor: exec))
+        handler.getClient() >> client
+        and:
+        def config = new TaskConfig(resourceLabels: [mylabel: 'myvalue'])
+        config.setAutoResourceLabels([
+                'nextflow.io/repository': 'https://github.com/foo/bar',
+                'seqera.io/platform/workflowId': '1a2b3c' ])
+
+        when:
+        def result = handler.newSubmitRequest(task)
+        then:
+        _ * handler.fusionEnabled() >> false
+        1 * handler.fixOwnership() >> false
+        1 * handler.entrypointOverride() >> false
+        1 * handler.cpuLimitsEnabled() >> false
+        1 * handler.getPodOptions() >> new PodOptions()
+        1 * handler.getSyntheticPodName(task) >> 'nf-123'
+        1 * handler.getAnnotations() >> [:]
+        1 * handler.getContainerMounts() >> []
+        1 * client.getConfig() >> new ClientConfig()
+        _ * handler.getRunName() >> 'pedantic-joe'
+        _ * task.getContainer() >> 'debian:latest'
+        _ * task.getWorkDir() >> WORK_DIR
+        _ * task.getConfig() >> config
+        _ * task.getName() >> 'hello-world-1'
+        _ * task.getProcessor() >> proc
+        _ * proc.getName() >> 'hello-proc'
+        _ * exec.getSession() >> sess
+        _ * exec.getK8sConfig() >> [:]
+        _ * sess.getUniqueId() >> uuid
+        and:
+        // the repository URL is submitted as a legal pod label value, and the two-slash
+        // Platform key as a legal pod label key
+        result.metadata.labels.'nextflow.io/repository' == 'github.com_foo_bar'
+        result.metadata.labels.'seqera.io/platform_workflowId' == '1a2b3c'
+        and:
+        // the label declared by the process is submitted byte-identical
+        result.metadata.labels.mylabel == 'myvalue'
     }
 
     def 'should delete pod if complete' () {

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -828,6 +828,38 @@ class K8sTaskHandlerTest extends Specification {
         labels.'user.io/My Label' == 'https://example.com/thing'
     }
 
+    def 'should keep the executor pod labels on a collision with the resource labels' () {
+        given:
+        def uuid = UUID.randomUUID()
+        def task = Mock(TaskRun)
+        def exec = Mock(K8sExecutor)
+        def proc = Mock(TaskProcessor)
+        def sess = Mock(Session)
+        def handler = Spy(new K8sTaskHandler(executor: exec))
+        and:
+        def config = new TaskConfig(resourceLabels: ['nextflow.io/runName': 'mine'])
+        config.setAutoResourceLabels([
+                'nextflow.io/runName': 'crazy_darwin',
+                'nextflow.io/sessionId': uuid.toString() ])
+
+        when:
+        def labels = handler.getLabels(task)
+        then:
+        handler.getRunName() >> 'pedantic-joe'
+        task.getName() >> 'hello-world-1'
+        task.getProcessor() >> proc
+        task.getConfig() >> config
+        proc.getName() >> 'hello-proc'
+        exec.getSession() >> sess
+        sess.getUniqueId() >> uuid
+        exec.getK8sConfig() >> [:]
+        and:
+        // the pod labels managed by the executor are applied last, therefore they win over
+        // both the auto-derived and the declared resource labels using the same key
+        labels.'nextflow.io/runName' == 'pedantic-joe'
+        labels.'nextflow.io/sessionId' == "uuid-${uuid.toString()}".toString()
+    }
+
     def 'should submit a pod request with the sanitised auto resource labels' () {
         given:
         def WORK_DIR = Paths.get('/some/work/dir')

--- a/plugins/nf-seqera/src/main/io/seqera/config/ExecutorOpts.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/config/ExecutorOpts.groovy
@@ -19,6 +19,7 @@ package io.seqera.config
 import groovy.transform.CompileStatic
 import nextflow.config.spec.ConfigOption
 import nextflow.config.spec.ConfigScope
+import nextflow.platform.AutoLabels
 import nextflow.script.dsl.Description
 import nextflow.util.Duration
 
@@ -32,12 +33,6 @@ import nextflow.util.Duration
 """)
 @CompileStatic
 class ExecutorOpts implements ConfigScope {
-
-    static final Set<String> VALID_AUTO_LABELS = Collections.unmodifiableSet(new LinkedHashSet<>([
-        'projectName', 'userName', 'runName', 'sessionId', 'resume',
-        'revision', 'commitId', 'repository', 'manifestName',
-        'runtimeVersion', 'workflowId', 'workspaceId', 'computeEnvId'
-    ]))
 
     final RetryOpts retryPolicy
 
@@ -91,10 +86,15 @@ class ExecutorOpts implements ConfigScope {
     """)
     final MachineRequirementOpts machineRequirement
 
+    @Deprecated
     @ConfigOption
     @Description("""
+        DEPRECATED: use `tower.autoLabels` instead. This option is honoured for backward
+        compatibility and takes precedence over `tower.autoLabels` when specified, including
+        when set to `false`.
+
         Automatically attach workflow metadata labels (with the `nextflow.io/` and
-        `seqera.io/platform/` prefixes) to the session. Accepts:
+        `seqera.io/platform/` prefixes) to the compute resources. Accepts:
           - `true`: include all available metadata labels
           - `false` (default): disable
           - a list or comma-separated string of short names: e.g.
@@ -170,7 +170,9 @@ class ExecutorOpts implements ConfigScope {
             : Duration.of('5 sec')
         // machine requirement settings
         this.machineRequirement = new MachineRequirementOpts(opts.machineRequirement as Map ?: Map.of())
-        this.autoLabels = parseAutoLabels(opts.get('autoLabels'))
+        // note the labels are resolved session-wide by `Session#getAutoResourceLabels` -- parsing
+        // them here still validates the setting and rejects an unknown name at config load time
+        this.autoLabels = AutoLabels.parse(opts.get('autoLabels'), 'seqera.executor.autoLabels')
         // prediction model
         this.predictionModel = opts.predictionModel as String ?: null
         // scheduling requirements (e.g. per-user vCPU cap)
@@ -223,24 +225,6 @@ class ExecutorOpts implements ConfigScope {
 
     Set<String> getAutoLabels() {
         return autoLabels
-    }
-
-    protected static Set<String> parseAutoLabels(Object value) {
-        if( value == null || value == false )
-            return Collections.<String>emptySet()
-        if( value == true )
-            return VALID_AUTO_LABELS
-        List<String> raw
-        if( value instanceof CharSequence )
-            raw = value.toString().tokenize(',').collect { String s -> s.trim() }.findAll { String s -> s }
-        else if( value instanceof List )
-            raw = ((List) value).collect { it?.toString()?.trim() }.findAll { String s -> s } as List<String>
-        else
-            throw new IllegalArgumentException("Invalid 'seqera.executor.autoLabels' value '${value}' - expected true, false, a list, or a comma-separated string")
-        final invalid = raw.findAll { String s -> !(s in VALID_AUTO_LABELS) }
-        if( invalid )
-            throw new IllegalArgumentException("Invalid 'seqera.executor.autoLabels' name(s) ${invalid} - valid names are: ${VALID_AUTO_LABELS.join(', ')}")
-        return Collections.unmodifiableSet(new LinkedHashSet<>(raw))
     }
 
     String getPredictionModel() {

--- a/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
@@ -19,73 +19,20 @@ package io.seqera.executor
 import com.google.common.hash.Hashing
 
 import groovy.transform.CompileStatic
-import nextflow.NextflowMeta
-import nextflow.script.WorkflowMetadata
 
 /**
  * Helper class to manage run labels.
  *
- * Builds the labels map from workflow metadata ({@code nextflow.io/*}),
- * scheduler metadata ({@code seqera:sched:*}), and user-configured labels.
+ * Builds the labels map from the resource labels attached to the run -- the auto-derived
+ * workflow metadata labels, see {@link nextflow.platform.AutoLabels}, and the config-level
+ * {@code process.resourceLabels} -- and the scheduler metadata ({@code seqera:sched:*}).
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @CompileStatic
 class Labels {
 
-    static final Set<String> ALL_AUTO_LABELS = Collections.unmodifiableSet(new LinkedHashSet<>([
-        'projectName', 'userName', 'runName', 'sessionId', 'resume',
-        'revision', 'commitId', 'repository', 'manifestName',
-        'runtimeVersion', 'workflowId', 'workspaceId', 'computeEnvId'
-    ]))
-
     private final Map<String,String> entries = new LinkedHashMap<>(20)
-
-    /**
-     * Add all {@code nextflow.io/*} and {@code seqera.io/platform/*} labels
-     * derived from workflow metadata.
-     */
-    Labels withWorkflowMetadata(WorkflowMetadata workflow) {
-        return withWorkflowMetadata(workflow, ALL_AUTO_LABELS)
-    }
-
-    /**
-     * Add workflow metadata labels filtered by the {@code include} set of
-     * short names (e.g. {@code 'runName'}). Unknown names are ignored; the
-     * caller is expected to validate membership upstream.
-     */
-    Labels withWorkflowMetadata(WorkflowMetadata workflow, Set<String> include) {
-        if( !include ) return this
-        if( include.contains('projectName') && workflow.projectName )
-            entries.put('nextflow.io/projectName', workflow.projectName)
-        // the Platform user that submitted the run, falling back to the OS user running the launcher
-        final userName = workflow.platform?.user?.userName ?: workflow.userName
-        if( include.contains('userName') && userName )
-            entries.put('nextflow.io/userName', userName)
-        if( include.contains('runName') && workflow.runName )
-            entries.put('nextflow.io/runName', workflow.runName)
-        if( include.contains('sessionId') && workflow.sessionId )
-            entries.put('nextflow.io/sessionId', workflow.sessionId.toString())
-        if( include.contains('resume') )
-            entries.put('nextflow.io/resume', String.valueOf(workflow.resume))
-        if( include.contains('revision') && workflow.revision )
-            entries.put('nextflow.io/revision', workflow.revision)
-        if( include.contains('commitId') && workflow.commitId )
-            entries.put('nextflow.io/commitId', workflow.commitId)
-        if( include.contains('repository') && workflow.repository )
-            entries.put('nextflow.io/repository', workflow.repository)
-        if( include.contains('manifestName') && workflow.manifest?.name )
-            entries.put('nextflow.io/manifestName', workflow.manifest.name)
-        if( include.contains('runtimeVersion') && NextflowMeta.instance.version )
-            entries.put('nextflow.io/runtimeVersion', NextflowMeta.instance.version.toString())
-        if( include.contains('workflowId') && workflow.platform?.workflowId )
-            entries.put('seqera.io/platform/workflowId', workflow.platform.workflowId)
-        if( include.contains('workspaceId') && workflow.platform?.workspace?.id )
-            entries.put('seqera.io/platform/workspaceId', workflow.platform.workspace.id)
-        if( include.contains('computeEnvId') && workflow.platform?.computeEnv?.id )
-            entries.put('seqera.io/platform/computeEnvId', workflow.platform.computeEnv.id)
-        return this
-    }
 
     /**
      * Add {@code seqera:sched:*} scheduler labels
@@ -103,8 +50,10 @@ class Labels {
     }
 
     /**
-     * Add config-level {@code process.resourceLabels}. Values are coerced to
-     * string via {@link String#valueOf} to satisfy the scheduler API typing.
+     * Add resource labels, either auto-derived from the workflow metadata or declared as
+     * config-level {@code process.resourceLabels}. Values are coerced to string via
+     * {@link String#valueOf} to satisfy the scheduler API typing. Labels added last win
+     * on a key collision.
      */
     Labels withProcessResourceLabels(Map<String,?> map) {
         if( !map ) return this

--- a/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
@@ -30,26 +30,15 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class Labels {
 
-    private final Map<String,String> entries = new LinkedHashMap<>(20)
-
     /**
-     * Add resource labels, either auto-derived from the workflow metadata or declared as
-     * config-level {@code process.resourceLabels}. Values are coerced to string via
-     * {@link String#valueOf} to satisfy the scheduler API typing. Labels added last win
-     * on a key collision.
+     * Merge the two label maps, coercing keys and values to string via {@link #toStringMap}.
+     * These are the labels auto-derived from the workflow metadata ({@code base}), overlaid by
+     * the config-level {@code process.resourceLabels} ({@code overlay}) which win on a key collision.
      */
-    Labels withProcessResourceLabels(Map<String,?> map) {
-        if( !map ) return this
-        for( Map.Entry<String,?> entry : map.entrySet() )
-            entries.put(entry.key.toString(), String.valueOf(entry.value))
-        return this
-    }
-
-    /**
-     * @return all labels as an unmodifiable map
-     */
-    Map<String,String> getEntries() {
-        return Collections.unmodifiableMap(entries)
+    static Map<String,String> merge(Map<String,?> base, Map<String,?> overlay) {
+        final result = new LinkedHashMap<String,String>(toStringMap(base))
+        result.putAll(toStringMap(overlay))
+        return result
     }
 
     /**

--- a/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/Labels.groovy
@@ -16,8 +16,6 @@
 
 package io.seqera.executor
 
-import com.google.common.hash.Hashing
-
 import groovy.transform.CompileStatic
 
 /**
@@ -25,7 +23,7 @@ import groovy.transform.CompileStatic
  *
  * Builds the labels map from the resource labels attached to the run -- the auto-derived
  * workflow metadata labels, see {@link nextflow.platform.AutoLabels}, and the config-level
- * {@code process.resourceLabels} -- and the scheduler metadata ({@code seqera:sched:*}).
+ * {@code process.resourceLabels}.
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
@@ -33,21 +31,6 @@ import groovy.transform.CompileStatic
 class Labels {
 
     private final Map<String,String> entries = new LinkedHashMap<>(20)
-
-    /**
-     * Add {@code seqera:sched:*} scheduler labels
-     */
-    Labels withSchedRunId(String runId) {
-        if( runId )
-            entries.put('seqera:sched:runId', runId)
-        return this
-    }
-
-    Labels withSchedClusterId(String clusterId) {
-        if( clusterId )
-            entries.put('seqera:sched:clusterId', clusterId)
-        return this
-    }
 
     /**
      * Add resource labels, either auto-derived from the workflow metadata or declared as
@@ -67,19 +50,6 @@ class Labels {
      */
     Map<String,String> getEntries() {
         return Collections.unmodifiableMap(entries)
-    }
-
-    /**
-     * Compute a run identifier as SipHash of sessionId + runName
-     */
-    protected static String runId(String sessionId, String runName) {
-        return Hashing
-                .sipHash24()
-                .newHasher()
-                .putUnencodedChars(sessionId)
-                .putUnencodedChars(runName)
-                .hash()
-                .toString()
     }
 
     /**

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
@@ -67,6 +67,11 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
 
     private volatile String workflowId
 
+    /**
+     * The complete set of resource labels attached to the run -- the labels derived from the
+     * workflow metadata plus the config-level {@code process.resourceLabels}. See
+     * {@link #computeRunResourceLabels()}.
+     */
     private volatile Map<String,String> runResourceLabels = Collections.<String,String>emptyMap()
 
     private SeqeraBatchSubmitter batchSubmitter
@@ -146,10 +151,6 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
         final computeEnvId = PlatformHelper.getComputeEnvId(towerConfig, SysEnv.get()) ?: seqeraConfig.computeEnvId
 
         computeRunResourceLabels()
-        final labels = new Labels()
-        if( seqeraConfig.autoLabels )
-            labels.withWorkflowMetadata(session.workflowMetadata, seqeraConfig.autoLabels)
-        labels.withProcessResourceLabels(runResourceLabels)
         final predictionModel = seqeraConfig.predictionModel ? PredictionModel.fromValue(seqeraConfig.predictionModel) : null
         final pipeline = new PipelineSpec()
                 .workflowId(workflowId)
@@ -162,7 +163,7 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
                 .providerConfig(seqeraConfig.providerConfig)
                 .name(session.runName)
                 .machineRequirement(SchemaMapperUtil.toMachineRequirement(seqeraConfig.machineRequirement))
-                .labels(labels.entries)
+                .labels(runResourceLabels)
                 .workspaceId(workspaceId)
                 .pipeline(pipeline)
                 .predictionModel(predictionModel)
@@ -261,16 +262,37 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
         return Collections.unmodifiableMap(runResourceLabels)
     }
 
+    /**
+     * Compute the run-level resource labels: the labels derived from the workflow metadata --
+     * see {@link nextflow.Session#getAutoResourceLabels()} -- overlaid by the config-level
+     * {@code process.resourceLabels}, which win on a key collision.
+     *
+     * This is the baseline {@link SeqeraTaskHandler} deltas the task labels against, therefore
+     * it must hold *every* label the runtime merges into a task config: the auto labels are
+     * injected into each {@link nextflow.processor.TaskConfig}, so a config-only baseline would
+     * re-send all of them with every single task.
+     */
     @PackageScope
     void computeRunResourceLabels() {
+        final labels = new Labels()
+                .withProcessResourceLabels(session.getAutoResourceLabels())
+                .withProcessResourceLabels(configResourceLabels())
+        this.runResourceLabels = labels.entries
+    }
+
+    /**
+     * @return
+     *      The config-level {@code process.resourceLabels}, coerced to strings. A dynamic
+     *      (closure) value is skipped because it can only be resolved per-task
+     */
+    protected Map<String,String> configResourceLabels() {
         final processMap = session.config.process as Map
         final value = processMap?.get('resourceLabels')
         if( value instanceof Closure ) {
             log.debug "Skipping run-level process.resourceLabels: dynamic (closure) values are only resolved per-task"
-            this.runResourceLabels = Collections.<String,String>emptyMap()
-            return
+            return Collections.<String,String>emptyMap()
         }
-        this.runResourceLabels = Labels.toStringMap(value)
+        return Labels.toStringMap(value)
     }
 
     SeqeraBatchSubmitter getBatchSubmitter() {

--- a/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
+++ b/plugins/nf-seqera/src/main/io/seqera/executor/SeqeraExecutor.groovy
@@ -274,10 +274,7 @@ class SeqeraExecutor extends Executor implements ExtensionPoint {
      */
     @PackageScope
     void computeRunResourceLabels() {
-        final labels = new Labels()
-                .withProcessResourceLabels(session.getAutoResourceLabels())
-                .withProcessResourceLabels(configResourceLabels())
-        this.runResourceLabels = labels.entries
+        this.runResourceLabels = Labels.merge(session.getAutoResourceLabels(), configResourceLabels())
     }
 
     /**

--- a/plugins/nf-seqera/src/test/io/seqera/config/ExecutorOptsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/config/ExecutorOptsTest.groovy
@@ -16,6 +16,7 @@
 
 package io.seqera.config
 
+import nextflow.platform.AutoLabels
 import nextflow.util.Duration
 import spock.lang.Specification
 
@@ -188,7 +189,7 @@ class ExecutorOptsTest extends Specification {
         config.machineRequirement.provisioning == 'spot'
     }
 
-    def 'should enable all auto labels when set to true' () {
+    def 'should parse the auto labels with the runtime helper' () {
         when:
         def config = new ExecutorOpts([
             endpoint: 'https://sched.example.com',
@@ -196,95 +197,7 @@ class ExecutorOptsTest extends Specification {
         ])
 
         then:
-        config.autoLabels == ExecutorOpts.VALID_AUTO_LABELS
-    }
-
-    def 'should disable auto labels when set to false' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: false
-        ])
-
-        then:
-        config.autoLabels.isEmpty()
-    }
-
-    def 'should accept auto labels as a list of short names' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: ['runName', 'projectName']
-        ])
-
-        then:
-        config.autoLabels == ['runName', 'projectName'] as Set
-    }
-
-    def 'should accept workspaceId and computeEnvId in auto labels' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: ['workspaceId', 'computeEnvId']
-        ])
-
-        then:
-        config.autoLabels == ['workspaceId', 'computeEnvId'] as Set
-    }
-
-    def 'should trim whitespace in auto labels list entries' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: [' runName', 'projectName ']
-        ])
-
-        then:
-        config.autoLabels == ['runName', 'projectName'] as Set
-    }
-
-    def 'should accept auto labels as a comma-separated string' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: 'runName,projectName,workflowId'
-        ])
-
-        then:
-        config.autoLabels == ['runName', 'projectName', 'workflowId'] as Set
-    }
-
-    def 'should tolerate whitespace around comma-separated auto labels' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: 'runName, projectName ,workflowId'
-        ])
-
-        then:
-        config.autoLabels == ['runName', 'projectName', 'workflowId'] as Set
-    }
-
-    def 'should treat empty auto labels list as disabled' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: []
-        ])
-
-        then:
-        config.autoLabels.isEmpty()
-    }
-
-    def 'should treat empty auto labels string as disabled' () {
-        when:
-        def config = new ExecutorOpts([
-            endpoint: 'https://sched.example.com',
-            autoLabels: ''
-        ])
-
-        then:
-        config.autoLabels.isEmpty()
+        config.autoLabels == AutoLabels.VALID_NAMES
     }
 
     def 'should reject unknown auto labels name' () {

--- a/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
@@ -16,10 +16,6 @@
 
 package io.seqera.executor
 
-import nextflow.NextflowMeta
-import nextflow.config.Manifest
-import nextflow.script.PlatformMetadata
-import nextflow.script.WorkflowMetadata
 import spock.lang.Specification
 
 /**
@@ -28,60 +24,6 @@ import spock.lang.Specification
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class LabelsTest extends Specification {
-
-    def 'should create labels with all workflow metadata'() {
-        given:
-        def sessionId = UUID.randomUUID()
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'nf-core/rnaseq'
-            getUserName() >> 'pditommaso'
-            getRunName() >> 'crazy_darwin'
-            getSessionId() >> sessionId
-            isResume() >> true
-            getRevision() >> '3.12.0'
-            getCommitId() >> 'abc1234'
-            getRepository() >> 'https://github.com/nf-core/rnaseq'
-            getManifest() >> new Manifest([name: 'nf-core/rnaseq'])
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow)
-
-        then:
-        labels.entries['nextflow.io/projectName'] == 'nf-core/rnaseq'
-        labels.entries['nextflow.io/userName'] == 'pditommaso'
-        labels.entries['nextflow.io/runName'] == 'crazy_darwin'
-        labels.entries['nextflow.io/sessionId'] == sessionId.toString()
-        labels.entries['nextflow.io/resume'] == 'true'
-        labels.entries['nextflow.io/revision'] == '3.12.0'
-        labels.entries['nextflow.io/commitId'] == 'abc1234'
-        labels.entries['nextflow.io/repository'] == 'https://github.com/nf-core/rnaseq'
-        labels.entries['nextflow.io/manifestName'] == 'nf-core/rnaseq'
-        labels.entries['nextflow.io/runtimeVersion'] == NextflowMeta.instance.version.toString()
-    }
-
-    def 'should prefer the platform user name over the OS user name'() {
-        given:
-        def platform = new PlatformMetadata()
-        if( platformUser )
-            platform.user = new PlatformMetadata.User(id: '1', userName: platformUser)
-        def workflow = Mock(WorkflowMetadata) {
-            getUserName() >> 'ec2-user'
-            getPlatform() >> platform
-        }
-
-        when:
-        def labels = new Labels().withWorkflowMetadata(workflow, ['userName'] as Set)
-
-        then:
-        labels.entries['nextflow.io/userName'] == expected
-
-        where:
-        platformUser    | expected
-        'jane.doe'      | 'jane.doe'
-        null            | 'ec2-user'
-    }
 
     def 'should compute stable runId from sessionId and runName'() {
         given:
@@ -92,36 +34,6 @@ class LabelsTest extends Specification {
         Labels.runId(sid, runName) == Labels.runId(sid, runName)
         Labels.runId(sid, runName) != Labels.runId(sid, 'other_name')
         Labels.runId(sid, runName) != Labels.runId(UUID.randomUUID().toString(), runName)
-    }
-
-    def 'should omit null workflow metadata from labels'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'hello'
-            getUserName() >> 'user1'
-            getRunName() >> 'happy_turing'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getRevision() >> null
-            getCommitId() >> null
-            getRepository() >> null
-            getManifest() >> new Manifest([:])
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow)
-
-        then:
-        labels.entries.containsKey('nextflow.io/projectName')
-        labels.entries.containsKey('nextflow.io/userName')
-        labels.entries.containsKey('nextflow.io/runName')
-        labels.entries.containsKey('nextflow.io/sessionId')
-        labels.entries['nextflow.io/resume'] == 'false'
-        !labels.entries.containsKey('nextflow.io/revision')
-        !labels.entries.containsKey('nextflow.io/commitId')
-        !labels.entries.containsKey('nextflow.io/repository')
-        !labels.entries.containsKey('nextflow.io/manifestName')
     }
 
     def 'should add scheduler labels'() {
@@ -146,121 +58,6 @@ class LabelsTest extends Specification {
         !labels.entries.containsKey('seqera:sched:clusterId')
     }
 
-    def 'should include platform workspaceId and computeEnvId when available'() {
-        given:
-        def platform = new PlatformMetadata('wf-abc123')
-        platform.workspace = new PlatformMetadata.Workspace(workspaceId: '1234')
-        platform.computeEnv = new PlatformMetadata.ComputeEnv(id: 'ce-abc')
-        def workflow = Mock(WorkflowMetadata) {
-            getRunName() >> 'happy_turing'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getManifest() >> new Manifest([:])
-            getPlatform() >> platform
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow, ['workspaceId', 'computeEnvId'] as Set)
-
-        then:
-        labels.entries.keySet() == ['seqera.io/platform/workspaceId', 'seqera.io/platform/computeEnvId'] as Set
-        labels.entries['seqera.io/platform/workspaceId'] == '1234'
-        labels.entries['seqera.io/platform/computeEnvId'] == 'ce-abc'
-    }
-
-    def 'should include platform workflowId when available'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'hello'
-            getUserName() >> 'user1'
-            getRunName() >> 'happy_turing'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getManifest() >> new Manifest([:])
-            getPlatform() >> new PlatformMetadata('wf-abc123')
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow)
-
-        then:
-        labels.entries['seqera.io/platform/workflowId'] == 'wf-abc123'
-    }
-
-    def 'should omit platform workflowId when not set'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'hello'
-            getUserName() >> 'user1'
-            getRunName() >> 'happy_turing'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getManifest() >> new Manifest([:])
-            getPlatform() >> new PlatformMetadata()
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow)
-
-        then:
-        !labels.entries.containsKey('seqera.io/platform/workflowId')
-    }
-
-    def 'should emit only included workflow metadata labels'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'nf-core/rnaseq'
-            getRunName() >> 'crazy_darwin'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getRevision() >> '3.12.0'
-            getManifest() >> new Manifest([name: 'nf-core/rnaseq'])
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow, ['runName', 'revision'] as Set)
-
-        then:
-        labels.entries.keySet() == ['nextflow.io/runName', 'nextflow.io/revision'] as Set
-    }
-
-    def 'should emit only the workflowId label when filtered to workflowId'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'hello'
-            getRunName() >> 'happy_turing'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getManifest() >> new Manifest([:])
-            getPlatform() >> new PlatformMetadata('wf-abc123')
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow, ['workflowId'] as Set)
-
-        then:
-        labels.entries.keySet() == ['seqera.io/platform/workflowId'] as Set
-    }
-
-    def 'should emit nothing for an empty include set'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'hello'
-        }
-
-        when:
-        def labels = new Labels()
-                .withWorkflowMetadata(workflow, [] as Set)
-
-        then:
-        labels.entries.isEmpty()
-    }
-
     def 'should add process resource labels coercing values to string'() {
         when:
         def labels = new Labels()
@@ -282,19 +79,10 @@ class LabelsTest extends Specification {
         b.entries.isEmpty()
     }
 
-    def 'should let process resource labels override workflow metadata on key collision'() {
-        given:
-        def workflow = Mock(WorkflowMetadata) {
-            getProjectName() >> 'hello'
-            getRunName() >> 'happy_turing'
-            getSessionId() >> UUID.randomUUID()
-            isResume() >> false
-            getManifest() >> new Manifest([:])
-        }
-
+    def 'should let the resource labels added last win on key collision'() {
         when:
         def labels = new Labels()
-                .withWorkflowMetadata(workflow)
+                .withProcessResourceLabels(['nextflow.io/runName': 'happy_turing', 'nextflow.io/projectName': 'hello'])
                 .withProcessResourceLabels(['nextflow.io/runName': 'custom', team: 'a'])
 
         then:

--- a/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
@@ -25,37 +25,19 @@ import spock.lang.Specification
  */
 class LabelsTest extends Specification {
 
-    def 'should add process resource labels coercing values to string'() {
-        when:
-        def labels = new Labels()
-                .withProcessResourceLabels([team: 'genomics', priority: 7, retain: true])
-
-        then:
-        labels.entries['team'] == 'genomics'
-        labels.entries['priority'] == '7'
-        labels.entries['retain'] == 'true'
+    def 'should merge label maps coercing values with the overlay winning on collision'() {
+        expect:
+        Labels.merge(
+                ['nextflow.io/runName': 'happy_turing', 'nextflow.io/projectName': 'hello'],
+                ['nextflow.io/runName': 'custom', team: 7]
+        ) == ['nextflow.io/runName': 'custom', 'nextflow.io/projectName': 'hello', team: '7']
     }
 
-    def 'should ignore null or empty process resource labels'() {
-        when:
-        def a = new Labels().withProcessResourceLabels(null)
-        def b = new Labels().withProcessResourceLabels([:])
-
-        then:
-        a.entries.isEmpty()
-        b.entries.isEmpty()
-    }
-
-    def 'should let the resource labels added last win on key collision'() {
-        when:
-        def labels = new Labels()
-                .withProcessResourceLabels(['nextflow.io/runName': 'happy_turing', 'nextflow.io/projectName': 'hello'])
-                .withProcessResourceLabels(['nextflow.io/runName': 'custom', team: 'a'])
-
-        then:
-        labels.entries['nextflow.io/runName'] == 'custom'
-        labels.entries['team'] == 'a'
-        labels.entries['nextflow.io/projectName'] == 'hello'
+    def 'should treat a null or empty map as no labels when merging'() {
+        expect:
+        Labels.merge(null, null) == [:]
+        Labels.merge(['team': 'a'], null) == ['team': 'a']
+        Labels.merge(null, ['team': 'a']) == ['team': 'a']
     }
 
     def 'should coerce map values to strings'() {

--- a/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/LabelsTest.groovy
@@ -25,39 +25,6 @@ import spock.lang.Specification
  */
 class LabelsTest extends Specification {
 
-    def 'should compute stable runId from sessionId and runName'() {
-        given:
-        def sid = 'e2315a82-49b0-4langc3-a58a-0d7d52f7e3a1'
-        def runName = 'crazy_darwin'
-
-        expect:
-        Labels.runId(sid, runName) == Labels.runId(sid, runName)
-        Labels.runId(sid, runName) != Labels.runId(sid, 'other_name')
-        Labels.runId(sid, runName) != Labels.runId(UUID.randomUUID().toString(), runName)
-    }
-
-    def 'should add scheduler labels'() {
-        when:
-        def labels = new Labels()
-                .withSchedRunId('run-123')
-                .withSchedClusterId('cluster-456')
-
-        then:
-        labels.entries['seqera:sched:runId'] == 'run-123'
-        labels.entries['seqera:sched:clusterId'] == 'cluster-456'
-    }
-
-    def 'should skip null scheduler labels'() {
-        when:
-        def labels = new Labels()
-                .withSchedRunId(null)
-                .withSchedClusterId(null)
-
-        then:
-        !labels.entries.containsKey('seqera:sched:runId')
-        !labels.entries.containsKey('seqera:sched:clusterId')
-    }
-
     def 'should add process resource labels coercing values to string'() {
         when:
         def labels = new Labels()

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraExecutorTest.groovy
@@ -210,26 +210,44 @@ class SeqeraExecutorTest extends Specification {
         new SeqeraExecutor().isSecretNative()
     }
 
-    def 'should expose run resource labels coerced from config-level process.resourceLabels'() {
+    def 'should build the run baseline from the auto labels and the config-level process.resourceLabels'() {
         given:
         SysEnv.push([:])
         def executor = new SeqeraExecutor()
         executor.session = Mock(Session) {
+            getAutoResourceLabels() >> ['nextflow.io/runName': 'crazy_darwin']
             getConfig() >> [process: [resourceLabels: [team: 'a', priority: 7]]]
         }
 
         when:
         executor.computeRunResourceLabels()
 
-        then:
-        executor.runResourceLabels == [team: 'a', priority: '7']
+        then: 'the baseline is the complete label set, so the per-task delta can collapse to empty'
+        executor.runResourceLabels == ['nextflow.io/runName': 'crazy_darwin', team: 'a', priority: '7']
     }
 
-    def 'should yield empty run resource labels when process.resourceLabels is absent'() {
+    def 'should let the config-level process.resourceLabels win over an auto label'() {
         given:
         SysEnv.push([:])
         def executor = new SeqeraExecutor()
         executor.session = Mock(Session) {
+            getAutoResourceLabels() >> ['nextflow.io/runName': 'crazy_darwin']
+            getConfig() >> [process: [resourceLabels: ['nextflow.io/runName': 'custom']]]
+        }
+
+        when:
+        executor.computeRunResourceLabels()
+
+        then:
+        executor.runResourceLabels == ['nextflow.io/runName': 'custom']
+    }
+
+    def 'should yield an empty run baseline when neither auto nor config-level labels are given'() {
+        given:
+        SysEnv.push([:])
+        def executor = new SeqeraExecutor()
+        executor.session = Mock(Session) {
+            getAutoResourceLabels() >> [:]
             getConfig() >> [:]
         }
 
@@ -240,12 +258,13 @@ class SeqeraExecutorTest extends Specification {
         executor.runResourceLabels == [:]
     }
 
-    def 'should skip run resource labels when process.resourceLabels is a closure'() {
+    def 'should skip a dynamic process.resourceLabels while keeping the auto labels in the baseline'() {
         given:
         SysEnv.push([:])
         def executor = new SeqeraExecutor()
         def dynamic = { [team: 'a', priority: 7] }
         executor.session = Mock(Session) {
+            getAutoResourceLabels() >> ['nextflow.io/runName': 'crazy_darwin']
             getConfig() >> [process: [resourceLabels: dynamic]]
         }
 
@@ -254,7 +273,7 @@ class SeqeraExecutorTest extends Specification {
 
         then:
         noExceptionThrown()
-        executor.runResourceLabels == [:]
+        executor.runResourceLabels == ['nextflow.io/runName': 'crazy_darwin']
     }
 
     def 'createRun populates CreateRunRequest.labels with config-level resourceLabels merged with auto-labels'() {
@@ -267,33 +286,25 @@ class SeqeraExecutorTest extends Specification {
                 new CreateRunResponse().runId('run-1')
             }
         }
-        def platform = new nextflow.script.PlatformMetadata('wf-abc123')
-        platform.workspace = new nextflow.script.PlatformMetadata.Workspace(workspaceId: '1234')
-        platform.computeEnv = new nextflow.script.PlatformMetadata.ComputeEnv(id: 'ce-abc')
-        def workflowMeta = Mock(WorkflowMetadata) {
-            getProjectName() >> 'my-project'
-            getUserName() >> 'alice'
-            getRunName() >> 'test-run'
-            getSessionId() >> UUID.fromString('00000000-0000-0000-0000-000000000001')
-            getResume() >> false
-            getRevision() >> null
-            getCommitId() >> null
-            getRepository() >> null
-            getManifest() >> null
-            getPlatform() >> platform
-        }
+        def autoLabels = [
+            'nextflow.io/projectName': 'my-project',
+            'nextflow.io/runName': 'test-run',
+            'seqera.io/platform/workspaceId': '1234',
+            'seqera.io/platform/computeEnvId': 'ce-abc'
+        ]
         def sessionConfig = [
             process: [resourceLabels: [team: 'platform', priority: 3]],
-            seqera: [executor: [endpoint: 'https://sched.example.com', provider: 'aws', region: 'us-east-1', autoLabels: true]],
+            seqera: [executor: [endpoint: 'https://sched.example.com', provider: 'aws', region: 'us-east-1']],
             tower: [:]
         ]
         def session = Mock(Session) {
+            getAutoResourceLabels() >> autoLabels
             getConfig() >> sessionConfig
-            getWorkflowMetadata() >> workflowMeta
+            getWorkflowMetadata() >> Mock(WorkflowMetadata) { getPlatform() >> null }
             getWorkDir() >> java.nio.file.Paths.get('/work')
             getRunName() >> 'test-run'
         }
-        def seqeraOpts = new ExecutorOpts(endpoint: 'https://sched.example.com', provider: 'aws', region: 'us-east-1', autoLabels: true)
+        def seqeraOpts = new ExecutorOpts(endpoint: 'https://sched.example.com', provider: 'aws', region: 'us-east-1')
         def executor = new SeqeraExecutor()
         executor.session = session
         executor.@seqeraConfig = seqeraOpts
@@ -310,6 +321,42 @@ class SeqeraExecutorTest extends Specification {
         captured.getLabels()['nextflow.io/runName'] == 'test-run'
         captured.getLabels()['seqera.io/platform/workspaceId'] == '1234'
         captured.getLabels()['seqera.io/platform/computeEnvId'] == 'ce-abc'
+
+        cleanup:
+        executor.batchSubmitter?.shutdown()
+    }
+
+    def 'createRun honours the deprecated seqera.executor.autoLabels over tower.autoLabels'() {
+        given:
+        SysEnv.push([:])
+        CreateRunRequest captured = null
+        def mockClient = Mock(SchedClient) {
+            createRun(_) >> { args ->
+                captured = args[0] as CreateRunRequest
+                new CreateRunResponse().runId('run-1')
+            }
+        }
+        // a real session, so that the label set the executor sends is the one resolved by
+        // `Session#getAutoResourceLabels` out of the two config options
+        def session = new Session([
+            seqera: [executor: [endpoint: 'https://sched.example.com', autoLabels: 'projectName']],
+            tower: [autoLabels: 'runName']
+        ])
+        session.@workflowMetadata = Mock(WorkflowMetadata) {
+            getProjectName() >> 'my-project'
+            getRunName() >> 'test-run'
+        }
+        def executor = new SeqeraExecutor()
+        executor.session = session
+        executor.@seqeraConfig = new ExecutorOpts(endpoint: 'https://sched.example.com', autoLabels: 'projectName')
+        executor.@client = mockClient
+
+        when:
+        executor.createRun()
+
+        then:
+        captured != null
+        captured.getLabels() == ['nextflow.io/projectName': 'my-project']
 
         cleanup:
         executor.batchSubmitter?.shutdown()

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -1379,6 +1379,54 @@ class SeqeraTaskHandlerTest extends Specification {
         }
     }
 
+    def 'submit leaves Task.labels unset when the task declares no labels of its own'() {
+        given:
+        Task captured = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> captured = args[1] as Task }
+        }
+        def autoLabels = ['nextflow.io/runName': 'crazy_darwin', 'nextflow.io/resume': 'false']
+        // a real task config, so that the runtime merge of the auto labels is exercised
+        def taskConfig = new TaskConfig([cpus: 2, memory: '1 GB'])
+        taskConfig.setAutoResourceLabels(autoLabels)
+        def taskRun = Mock(TaskRun) {
+            getConfig() >> taskConfig
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getContainer() >> 'docker.io/library/alpine:3'
+            getContainerPlatform() >> 'linux/amd64'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromInt(1)
+            lazyName() >> 'sample_task'
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) {
+                getMachineRequirement() >> null
+                getTaskEnvironment() >> [:]
+            }
+            // the run baseline holds the very same auto labels -- see
+            // SeqeraExecutor#computeRunResourceLabels
+            getRunResourceLabels() >> autoLabels
+            ensureRunCreated() >> {}
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) {
+                fusionEnv() >> [:]
+            }
+            fusionSubmitCli() >> ['/bin/sh', '-c', 'true']
+        }
+
+        when:
+        handler.submit()
+
+        then: 'the auto labels are attached to the run, therefore not re-sent with every task'
+        captured != null
+        captured.getLabels() == null
+    }
+
     def 'submit leaves Task.labels unset when the task labels equal the run baseline'() {
         given:
         Task captured = null

--- a/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
+++ b/plugins/nf-seqera/src/test/io/seqera/executor/SeqeraTaskHandlerTest.groovy
@@ -1389,6 +1389,10 @@ class SeqeraTaskHandlerTest extends Specification {
         // a real task config, so that the runtime merge of the auto labels is exercised
         def taskConfig = new TaskConfig([cpus: 2, memory: '1 GB'])
         taskConfig.setAutoResourceLabels(autoLabels)
+        and:
+        // the merge must have happened, otherwise the empty delta below would prove nothing
+        assert taskConfig.getResourceLabels() == autoLabels
+        and:
         def taskRun = Mock(TaskRun) {
             getConfig() >> taskConfig
             getWorkDir() >> Paths.get('/work/ab/cd1234')
@@ -1425,6 +1429,52 @@ class SeqeraTaskHandlerTest extends Specification {
         then: 'the auto labels are attached to the run, therefore not re-sent with every task'
         captured != null
         captured.getLabels() == null
+    }
+
+    def 'submit sends the task labels missing from the run baseline'() {
+        given:
+        Task captured = null
+        def batchSubmitter = Mock(SeqeraBatchSubmitter) {
+            submit(_, _) >> { args -> captured = args[1] as Task }
+        }
+        // a real task config, so that the runtime merge of the auto labels is exercised
+        def taskConfig = new TaskConfig([cpus: 2, memory: '1 GB', resourceLabels: [team: 'genomics']])
+        taskConfig.setAutoResourceLabels(['nextflow.io/runName': 'crazy_darwin', 'nextflow.io/resume': 'false'])
+        def taskRun = Mock(TaskRun) {
+            getConfig() >> taskConfig
+            getWorkDir() >> Paths.get('/work/ab/cd1234')
+            getWorkDirStr() >> '/work/ab/cd1234'
+            getContainer() >> 'docker.io/library/alpine:3'
+            getContainerPlatform() >> 'linux/amd64'
+            getId() >> TaskId.of(1)
+            getHash() >> HashCode.fromInt(1)
+            lazyName() >> 'sample_task'
+        }
+        def executor = Mock(SeqeraExecutor) {
+            getClient() >> Mock(SchedClient)
+            getBatchSubmitter() >> batchSubmitter
+            getSeqeraConfig() >> Mock(ExecutorOpts) {
+                getMachineRequirement() >> null
+                getTaskEnvironment() >> [:]
+            }
+            // the run baseline only holds part of the labels carried by the task
+            getRunResourceLabels() >> ['nextflow.io/runName': 'crazy_darwin']
+            ensureRunCreated() >> {}
+        }
+        def handler = Spy(new SeqeraTaskHandler(taskRun, executor)) {
+            fusionEnabled() >> true
+            fusionLauncher() >> Mock(nextflow.fusion.FusionScriptLauncher) {
+                fusionEnv() >> [:]
+            }
+            fusionSubmitCli() >> ['/bin/sh', '-c', 'true']
+        }
+
+        when:
+        handler.submit()
+
+        then: 'only the delta against the run baseline is sent'
+        captured != null
+        captured.getLabels() == ['nextflow.io/resume': 'false', team: 'genomics']
     }
 
     def 'submit leaves Task.labels unset when the task labels equal the run baseline'() {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerConfig.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerConfig.groovy
@@ -46,6 +46,25 @@ class TowerConfig implements ConfigScope {
     """)
     final String accessToken
 
+    @ConfigOption(types=[Boolean, List, String])
+    @Description("""
+        Automatically derive resource labels from the workflow metadata (using the `nextflow.io/`
+        and `seqera.io/platform/` key prefixes) and attach them to the compute resources created
+        by the executor. Accepts:
+          - `true`: include all available metadata labels
+          - `false` (default): disable
+          - a list or comma-separated string of short names: e.g.
+            `['runName', 'projectName']` or `'runName,projectName'`
+
+        Valid names: `projectName`, `userName`, `runName`, `sessionId`, `resume`,
+        `revision`, `commitId`, `repository`, `manifestName`, `runtimeVersion`,
+        `workflowId`, `workspaceId`, `computeEnvId`.
+
+        The labels declared with the `resourceLabels` process directive take precedence
+        on key collision.
+    """)
+    final Object autoLabels
+
     @ConfigOption
     @Description("""
         The Compute Environment ID in Seqera Platform in which to launch the run (default: the primary environment in the workspace).
@@ -89,6 +108,9 @@ class TowerConfig implements ConfigScope {
 
     TowerConfig(Map opts, Map<String,String> env) {
         this.accessToken = PlatformHelper.getAccessToken(opts, env)
+        // keep the raw value: the runtime parses it with `AutoLabels.parse` and needs to
+        // tell apart the boolean, list and comma-separated string forms
+        this.autoLabels = opts.get('autoLabels')
         if( opts.computeEnvId )
             this.computeEnvId = opts.computeEnvId as String
         this.enabled = opts.enabled as boolean

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerConfigTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerConfigTest.groovy
@@ -16,8 +16,11 @@
 
 package io.seqera.tower.plugin
 
+import nextflow.config.spec.SpecNode
+import nextflow.platform.AutoLabels
 import nextflow.util.Duration
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Unit tests for TowerConfig
@@ -70,5 +73,46 @@ class TowerConfigTest extends Specification {
         then:
         config.httpConnectTimeout == Duration.of('5s')
         config.httpReadTimeout == Duration.of('2m')
+    }
+
+    @Unroll
+    def 'should keep the auto labels raw value for form: #VALUE'() {
+        when:
+        def config = new TowerConfig(OPTS, [:])
+
+        then:
+        // the value is carried over verbatim, because the runtime parses it with
+        // `AutoLabels.parse` and needs to tell the accepted forms apart
+        config.autoLabels == VALUE
+        and:
+        AutoLabels.parse(config.autoLabels, 'tower.autoLabels') == EXPECTED
+
+        where:
+        OPTS                                    | VALUE                        | EXPECTED
+        [:]                                     | null                         | [] as Set
+        [autoLabels: true]                      | true                         | AutoLabels.VALID_NAMES
+        [autoLabels: false]                     | false                        | [] as Set
+        [autoLabels: ['runName','projectName']] | ['runName','projectName']    | ['runName','projectName'] as Set
+        [autoLabels: 'runName,projectName']     | 'runName,projectName'        | ['runName','projectName'] as Set
+    }
+
+    def 'should expose the auto labels option in the config spec'() {
+        given:
+        def root = SpecNode.Scope.of(TowerConfig, '')
+
+        expect:
+        // the option must be part of the spec, otherwise `ConfigValidator` flags it
+        // as unrecognized and the config reference docs skip it
+        root.getOption(['autoLabels']) != null
+        and:
+        // all the accepted forms are declared
+        root.getOption(['autoLabels']).types().containsAll([Boolean, List, String])
+        and:
+        root.getOption(['autoLabels']).description().contains('`true`: include all available metadata labels')
+        root.getOption(['autoLabels']).description().contains('`false` (default): disable')
+        root.getOption(['autoLabels']).description().contains('a list or comma-separated string of short names')
+        and:
+        // every valid short name is documented
+        AutoLabels.VALID_NAMES.every { root.getOption(['autoLabels']).description().contains("`${it}`") }
     }
 }


### PR DESCRIPTION
## Summary

`seqera.executor.autoLabels` derives resource labels from the workflow metadata, but only the Seqera executor honours it. This promotes that mapping into the runtime so **every** executor supporting `resourceLabels` — AWS Batch, Azure Batch, Google Cloud Batch, Kubernetes, Seqera — attaches the same labels, driven by a new `tower.autoLabels` option.

Design: [`adr/20260821-auto-resource-labels.md`](adr/20260821-auto-resource-labels.md).

Off by default; nothing changes for a user who does not opt in.

```groovy
tower.autoLabels = true                                        // all 13 metadata labels
tower.autoLabels = ['projectName', 'runName', 'workspaceId']   // or a subset
```

## How it works

Every executor already reads labels through one accessor, `task.config.getResourceLabels()`, so a single merge point reaches all five.

- **`nextflow.platform.AutoLabels`** — the metadata-to-label mapping (`nextflow.io/*`, `seqera.io/platform/*`) and the option parsing, both lifted out of nf-seqera.
- **`nextflow.platform.ResourceLabelPolicy`** — per-backend key/value normalisation, with named `AWS`, `GOOGLE`, `K8S`, `AZURE` and `IDENTITY` policies. Label syntax is not portable: `nextflow.io/runName` is a legal AWS tag and Kubernetes label key but an illegal Google Cloud label key, and a Kubernetes label value rejects `https://github.com/foo/bar`.
- **`Session.getAutoResourceLabels()`** — one lazily computed, memoized set per session. Lazy is load-bearing: the Platform metadata is only populated at `notifyFlowCreate`.
- **`TaskConfig`** — a transient field (outside the LazyMap, no `Global.session`) plus two accessors: `getResourceLabels()` for trace and report consumers, and `getResourceLabels(policy)` for executors. **Declared labels always win and are never normalised.**
- **`TaskProcessor` / `TaskArrayCollector`** — inject the set at the three `TaskConfig` creation sites. An array job is submitted as a task in its own right, so it needs the labels too.

### nf-seqera convergence

nf-seqera stops owning the mapping and consumes the runtime one. `seqera.executor.autoLabels` still works, now deprecated, and wins over `tower.autoLabels` when present. Its run baseline becomes the **complete** set (auto plus config-level) rather than config-level only — otherwise the runtime merge would make `Labels.delta` re-send all 13 auto labels on every task.

## Review findings folded in

Three adversarial review passes ran over the implementation. The substantive catches:

- **The collision was decided on the post-sanitisation key**, so under a key-mangling policy a label declared with the canonical `nextflow.io/runName` failed to override the auto one and both were emitted — which the Google Cloud API rejects. It is now resolved before normalisation.
- Two documentation claims contradicted the landed code and were corrected: the Kubernetes key is *not* verbatim (`seqera.io/platform/workflowId` becomes `seqera.io/platform_workflowId`, because `PodSpecBuilder` throws on a two-slash key), and declared labels *are* sanitised on Kubernetes by the pre-existing pod-label sanitiser. The ADR was amended to match reality rather than the reverse.
- Three tests that could not fail were made non-vacuous — the `TaskProcessor` wiring had no coverage at all, and the nf-seqera delta test passed whether or not the merge happened.

## Caveats, documented rather than gated

- **Azure Batch**: resource labels are auto-pool metadata and the pool id is derived from them, so a per-run label such as `runName` or `sessionId` creates a fresh pool for every run, and the pools accumulate unless `azure.batch.deletePoolsOnCompletion` is set. A stable subset is recommended there.
- **Kubernetes**: the executor's own reserved `nextflow.io/*` pod labels are written after the resource labels and still win. Pre-existing precedence, left alone.

## Testing

683 tests, 0 failures: 329 in the runtime (`AutoLabelsTest`, `ResourceLabelPolicyTest`, `TaskConfigTest`, `TaskProcessorTest`, `TaskArrayCollectorTest`, `SessionTest`), 106 `AwsBatchTaskHandlerTest`, 109 `GoogleBatchTaskHandlerTest`, 108 `AzBatchServiceTest`, 31 `K8sTaskHandlerTest`, plus the full nf-seqera and nf-tower suites. `NXF_SMOKE=1 ./gradlew :nextflow:test` clean.

`resourceLabels` is absent from `TaskHasher`, so enabling this does not invalidate a resumed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
