### PR TITLE
Add configurable timeouts to SCM API requests

### DIFF
--- a/docs/git.mdx
+++ b/docs/git.mdx
@@ -73,13 +73,13 @@ httpClient {
 
 <AddedInVersion version="26.10" />
 
-The maximum time to wait for the connection to the Git hosting service API to be established, applied to a single attempt (default: `60 sec`). It must be greater than zero. Can also be set with the `NXF_GIT_CONNECT_TIMEOUT` environment variable.
+The maximum time to wait for the connection to the Git hosting service API to be established, applied to a single attempt (default: `60 sec`). It must be greater than zero. Can also be set with the `NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT` environment variable.
 
 ##### `httpClient.requestTimeout`
 
 <AddedInVersion version="26.10" />
 
-The maximum time to wait for a response from the Git hosting service API once the connection has been established, applied to a single attempt (default: `60 sec`). Set it to `0 sec` to wait indefinitely. Can also be set with the `NXF_GIT_REQUEST_TIMEOUT` environment variable.
+The maximum time to wait for a response from the Git hosting service API once the connection has been established, applied to a single attempt (default: `60 sec`). Set it to `0 sec` to wait indefinitely. Can also be set with the `NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT` environment variable.
 
 :::note
 These settings cannot be defined in `nextflow.config`. Nextflow resolves the pipeline repository before it parses the pipeline config, so the SCM config file and the environment variables are the only sources available at that point.

--- a/docs/git.mdx
+++ b/docs/git.mdx
@@ -58,6 +58,33 @@ SCM server name including the protocol prefix, e.g., `https://github.com`.
 
 SCM API `endpoint` URL, e.g., `https://api.github.com` (default: the same as `providers.<provider>.server`).
 
+### HTTP client settings
+
+The `httpClient` section configures the timeouts applied to the API requests Nextflow makes to the Git hosting service. These settings apply to every provider:
+
+```groovy
+httpClient {
+    connectTimeout = '10 sec'
+    requestTimeout = '45 sec'
+}
+```
+
+##### `httpClient.connectTimeout`
+
+<AddedInVersion version="26.10" />
+
+The maximum time to wait for the connection to the Git hosting service API to be established, applied to a single attempt (default: `60 sec`). It must be greater than zero. Can also be set with the `NXF_GIT_CONNECT_TIMEOUT` environment variable.
+
+##### `httpClient.requestTimeout`
+
+<AddedInVersion version="26.10" />
+
+The maximum time to wait for a response from the Git hosting service API once the connection has been established, applied to a single attempt (default: `60 sec`). Set it to `0 sec` to wait indefinitely. Can also be set with the `NXF_GIT_REQUEST_TIMEOUT` environment variable.
+
+:::note
+These settings cannot be defined in `nextflow.config`. Nextflow resolves the pipeline repository before it parses the pipeline config, so the SCM config file and the environment variables are the only sources available at that point.
+:::
+
 ## Git providers
 
 ### Bitbucket

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -182,13 +182,17 @@ When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fu
 
 <AddedInVersion version="26.10" />
 
-Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Connection attempts that time out are automatically retried, so a persistently unreachable host only fails after the connect timeout multiplied by the retry policy max attempts i.e. about 5 minutes with default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry.
+Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). It must be greater than zero.
 
-##### `NXF_GIT_READ_TIMEOUT`
+Connection attempts that time out are retried, because a connection that was never established proves the request did not reach the server. A persistently unreachable host therefore only fails after this timeout multiplied by the retry policy max attempts, i.e. about 5 minutes with the default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry. The retry behaviour itself is tuned with the `NXF_RETRY_POLICY_*` variables.
+
+##### `NXF_GIT_REQUEST_TIMEOUT`
 
 <AddedInVersion version="26.10" />
 
-Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`).
+Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Set it to `0s` to wait indefinitely.
+
+Unlike a connect timeout, a request that times out waiting for the response is not retried, since it did reach the server and may already have been acted on.
 
 ##### `NXF_HOME`
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -182,7 +182,7 @@ When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fu
 
 <AddedInVersion version="26.10" />
 
-Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`).
+Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Connection attempts that time out are automatically retried, so a persistently unreachable host only fails after the connect timeout multiplied by the retry policy max attempts i.e. about 5 minutes with default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry.
 
 ##### `NXF_GIT_READ_TIMEOUT`
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -178,6 +178,18 @@ For example, with `NXF_FILE_ROOT=/some/root/path`, the use of `file('hello')` wi
 
 When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fusion trace file (`.fusion/trace.json`) produced in the task work directory, replacing the metrics collected by the default bash command-trace wrapper. Requires Fusion to be enabled. GPU metrics from Fusion are always collected regardless of this setting (default: `false`).
 
+##### `NXF_GIT_CONNECT_TIMEOUT`
+
+<AddedInVersion version="26.10" />
+
+Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`).
+
+##### `NXF_GIT_READ_TIMEOUT`
+
+<AddedInVersion version="26.10" />
+
+Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`).
+
 ##### `NXF_HOME`
 
 Nextflow home directory (default: `$HOME/.nextflow`).

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -178,22 +178,6 @@ For example, with `NXF_FILE_ROOT=/some/root/path`, the use of `file('hello')` wi
 
 When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fusion trace file (`.fusion/trace.json`) produced in the task work directory, replacing the metrics collected by the default bash command-trace wrapper. Requires Fusion to be enabled. GPU metrics from Fusion are always collected regardless of this setting (default: `false`).
 
-##### `NXF_GIT_CONNECT_TIMEOUT`
-
-<AddedInVersion version="26.10" />
-
-Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). It must be greater than zero.
-
-Connection attempts that time out are retried, because a connection that was never established proves the request did not reach the server. A persistently unreachable host therefore only fails after this timeout multiplied by the retry policy max attempts, i.e. about 5 minutes with the default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry. The retry behaviour itself is tuned with the `NXF_RETRY_POLICY_*` variables.
-
-##### `NXF_GIT_REQUEST_TIMEOUT`
-
-<AddedInVersion version="26.10" />
-
-Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Set it to `0s` to wait indefinitely.
-
-Unlike a connect timeout, a request that times out waiting for the response is not retried, since it did reach the server and may already have been acted on.
-
 ##### `NXF_HOME`
 
 Nextflow home directory (default: `$HOME/.nextflow`).
@@ -303,6 +287,22 @@ Delay multiplier used for HTTP retryable operations (default: `2.0`).
 ##### `NXF_SCM_FILE`
 
 Defines the path location of the SCM config file .
+
+##### `NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT`
+
+<AddedInVersion version="26.10" />
+
+Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). It must be greater than zero.
+
+Connection attempts that time out are retried, because a connection that was never established proves the request did not reach the server. A persistently unreachable host therefore only fails after this timeout multiplied by the retry policy max attempts, i.e. about 5 minutes with the default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry. The retry behaviour itself is tuned with the `NXF_RETRY_POLICY_*` variables.
+
+##### `NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT`
+
+<AddedInVersion version="26.10" />
+
+Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Set it to `0s` to wait indefinitely.
+
+Unlike a connect timeout, a request that times out waiting for the response is not retried, since it did reach the server and may already have been acted on.
 
 ##### `NXF_SINGULARITY_CACHEDIR`
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -35,6 +35,7 @@ import nextflow.exception.AmbiguousPipelineNameException
 import nextflow.scm.HubOptions
 import nextflow.script.ScriptFile
 import nextflow.SysEnv
+import nextflow.util.HttpClientOpts
 import nextflow.util.IniFile
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.errors.RefNotFoundException
@@ -89,6 +90,11 @@ class AssetManager implements Closeable {
     private RepositoryStrategy strategy
 
     /**
+     * The http client settings declared in the SCM config file
+     */
+    private HttpClientOpts httpClientOpts
+
+    /**
      * Create a new asset manager object with default parameters
      */
     AssetManager() {
@@ -134,6 +140,7 @@ class AssetManager implements Closeable {
     AssetManager build( String pipelineName, Map config = null, HubOptions hubOpts = null, String revision = null, String mainScript = null ) {
 
         this.providerConfigs = ProviderConfig.createFromMap(config)
+        this.httpClientOpts = RepositoryProvider.httpClientOpts(config)
 
         this.project = resolveName(pipelineName)
         if( mainScript )
@@ -516,7 +523,9 @@ class AssetManager implements Closeable {
         if( !config )
             throw new AbortOperationException("Unknown repository configuration provider: $providerName")
 
-        return RepositoryFactory.newRepositoryProvider(config, project)
+        return RepositoryFactory
+            .newRepositoryProvider(config, project)
+            .setHttpClientOpts(httpClientOpts ?: RepositoryProvider.httpClientOpts(null))
     }
 
     AssetManager setLocalPath(File path) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -19,8 +19,10 @@ package nextflow.scm
 import static nextflow.util.StringUtils.*
 
 import java.net.http.HttpClient
+import java.net.http.HttpConnectTimeoutException
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
 import java.nio.channels.UnresolvedAddressException
 import java.time.Duration
 import java.util.concurrent.Executors
@@ -54,6 +56,16 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 @Slf4j
 @CompileStatic
 abstract class RepositoryProvider {
+
+    /**
+     * Default timeout to establish the connection with the SCM server
+     */
+    static final public Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(60)
+
+    /**
+     * Default timeout to receive the response from the SCM server
+     */
+    static final public Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60)
 
     @Canonical
     static class TagInfo {
@@ -223,10 +235,46 @@ abstract class RepositoryProvider {
         final builder = HttpRequest
             .newBuilder()
             .uri(new URI(api))
+            .timeout(readTimeout())
         final auth0 = getAuth()
         if( auth0 )
             builder.headers(auth0)
         return builder.GET().build()
+    }
+
+    /**
+     * The timeout to establish the connection with the SCM server. It can be overridden
+     * by the {@code NXF_GIT_CONNECT_TIMEOUT} environment variable specifying it as
+     * a duration string e.g. {@code 30s}
+     *
+     * @return The connect timeout as a {@link Duration} object
+     */
+    protected Duration connectTimeout() {
+        return timeout0('NXF_GIT_CONNECT_TIMEOUT', DEFAULT_CONNECT_TIMEOUT)
+    }
+
+    /**
+     * The timeout to receive the response once the connection with the SCM server is
+     * established. It can be overridden by the {@code NXF_GIT_READ_TIMEOUT} environment
+     * variable specifying it as a duration string e.g. {@code 30s}
+     *
+     * @return The read timeout as a {@link Duration} object
+     */
+    protected Duration readTimeout() {
+        return timeout0('NXF_GIT_READ_TIMEOUT', DEFAULT_READ_TIMEOUT)
+    }
+
+    static private Duration timeout0(String name, Duration defValue) {
+        final value = SysEnv.get(name)
+        if( !value )
+            return defValue
+        try {
+            return Duration.ofMillis( nextflow.util.Duration.of(value).toMillis() )
+        }
+        catch( Exception e ) {
+            log.warn "Invalid value for variable ${name}: '${value}' - using default: ${defValue.toSeconds()}s"
+            return defValue
+        }
     }
 
     /**
@@ -495,13 +543,21 @@ abstract class RepositoryProvider {
         if( httpClient==null )
             httpClient = newHttpClient()
 
-        return httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        }
+        catch( HttpConnectTimeoutException e ) {
+            throw new IOException("Unable to connect to '${request.uri()}' within ${connectTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
+        }
+        catch( HttpTimeoutException e ) {
+            throw new IOException("No response received from '${request.uri()}' within ${readTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_READ_TIMEOUT", e)
+        }
     }
 
     private HxClient newHttpClient() {
         final builder = HxClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
-            .connectTimeout(Duration.ofSeconds(60))
+            .connectTimeout(connectTimeout())
             .followRedirects(HttpClient.Redirect.NORMAL)
             // route through the forward proxy when configured
             .withProxyConfig(ProxyConfig.proxyConfig())

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -163,8 +163,24 @@ abstract class RepositoryProvider {
      */
     protected HttpClientOpts getHttpClientOpts() {
         if( httpClientOpts==null )
-            httpClientOpts = new HttpClientOpts(Collections.emptyMap(), HTTP_CLIENT_ENV_PREFIX, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)
+            httpClientOpts = httpClientOpts(null)
         return httpClientOpts
+    }
+
+    /**
+     * Build the HTTP client settings from the {@code httpClient} block of the SCM config file
+     * i.e. {@code ~/.nextflow/scm} or wherever {@code NXF_SCM_FILE} points.
+     * <p>
+     * That file is the one config source that is both already loaded when SCM resolution runs
+     * and shared with an embedder building the same map by hand - unlike {@code nextflow.config},
+     * which is not parsed until the project has been fetched.
+     *
+     * @param scmConfig The parsed SCM config file contents, or null when there is none
+     * @return The resulting {@link HttpClientOpts}; never null
+     */
+    static HttpClientOpts httpClientOpts(Map scmConfig) {
+        final opts = (Map) scmConfig?.get('httpClient') ?: Collections.emptyMap()
+        return new HttpClientOpts(opts, HTTP_CLIENT_ENV_PREFIX, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)
     }
 
     String getProject() {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -572,7 +572,11 @@ abstract class RepositoryProvider {
             throw new IOException("Unable to connect to '${request.uri()}' within ${getHttpClientOpts().connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
         }
         catch( HttpTimeoutException e ) {
-            throw new IOException("No response received from '${request.uri()}' within ${getHttpClientOpts().requestTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_REQUEST_TIMEOUT", e)
+            // report the bound actually applied to the request i.e. connect + request; it is
+            // null only when the request timeout is unbounded, in which case no timeout was
+            // set on the request and this branch is unreachable
+            final elapsed = getHttpClientOpts().httpRequestTimeout()
+            throw new IOException("No response received from '${request.uri()}'${elapsed ? " within ${elapsed.toSeconds()}s" : ''} - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_REQUEST_TIMEOUT", e)
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -24,7 +24,6 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.net.http.HttpTimeoutException
 import java.nio.channels.UnresolvedAddressException
-import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.function.Predicate
 
@@ -40,6 +39,8 @@ import nextflow.SysEnv
 import nextflow.exception.AbortOperationException
 import nextflow.exception.HttpResponseLengthExceedException
 import nextflow.exception.RateLimitExceededException
+import nextflow.util.Duration
+import nextflow.util.HttpClientOpts
 import nextflow.util.ProxyConfig
 import nextflow.util.RetryConfig
 import nextflow.util.Threads
@@ -60,12 +61,17 @@ abstract class RepositoryProvider {
     /**
      * Default timeout to establish the connection with the SCM server
      */
-    static final public Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(60)
+    static final public Duration DEFAULT_CONNECT_TIMEOUT = Duration.of('60s')
 
     /**
      * Default timeout to receive the response from the SCM server
      */
-    static final public Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60)
+    static final public Duration DEFAULT_REQUEST_TIMEOUT = Duration.of('60s')
+
+    /**
+     * The environment variable prefix used to resolve the HTTP client settings
+     */
+    static final private String HTTP_CLIENT_ENV_PREFIX = 'NXF_GIT_'
 
     @Canonical
     static class TagInfo {
@@ -103,6 +109,11 @@ abstract class RepositoryProvider {
     private RetryConfig retryConfig
 
     /**
+     * The timeout options to be used for http requests
+     */
+    private HttpClientOpts httpClientOpts
+
+    /**
      * The pipeline qualified name following the syntax {@code owner/repository}
      */
     protected String project
@@ -135,6 +146,25 @@ abstract class RepositoryProvider {
     RepositoryProvider setRetryConfig(RetryConfig retryConfig) {
         this.retryConfig = retryConfig
         return this
+    }
+
+    RepositoryProvider setHttpClientOpts(HttpClientOpts httpClientOpts) {
+        this.httpClientOpts = httpClientOpts
+        return this
+    }
+
+    /**
+     * The HTTP client timeout settings. When none has been set explicitly they are resolved
+     * from the {@code NXF_GIT_CONNECT_TIMEOUT} and {@code NXF_GIT_REQUEST_TIMEOUT} environment
+     * variables, falling back to the defaults - the environment being the only source available
+     * this early, since SCM resolution completes before any Nextflow config has been parsed.
+     *
+     * @return The {@link HttpClientOpts} for this provider; never null
+     */
+    protected HttpClientOpts getHttpClientOpts() {
+        if( httpClientOpts==null )
+            httpClientOpts = new HttpClientOpts(Collections.emptyMap(), HTTP_CLIENT_ENV_PREFIX, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)
+        return httpClientOpts
     }
 
     String getProject() {
@@ -235,46 +265,13 @@ abstract class RepositoryProvider {
         final builder = HttpRequest
             .newBuilder()
             .uri(new URI(api))
-            .timeout(readTimeout())
+        final timeout = getHttpClientOpts().httpRequestTimeout()
+        if( timeout != null )
+            builder.timeout(timeout)
         final auth0 = getAuth()
         if( auth0 )
             builder.headers(auth0)
         return builder.GET().build()
-    }
-
-    /**
-     * The timeout to establish the connection with the SCM server. It can be overridden
-     * by the {@code NXF_GIT_CONNECT_TIMEOUT} environment variable specifying it as
-     * a duration string e.g. {@code 30s}
-     *
-     * @return The connect timeout as a {@link Duration} object
-     */
-    protected Duration connectTimeout() {
-        return timeout0('NXF_GIT_CONNECT_TIMEOUT', DEFAULT_CONNECT_TIMEOUT)
-    }
-
-    /**
-     * The timeout to receive the response once the connection with the SCM server is
-     * established. It can be overridden by the {@code NXF_GIT_READ_TIMEOUT} environment
-     * variable specifying it as a duration string e.g. {@code 30s}
-     *
-     * @return The read timeout as a {@link Duration} object
-     */
-    protected Duration readTimeout() {
-        return timeout0('NXF_GIT_READ_TIMEOUT', DEFAULT_READ_TIMEOUT)
-    }
-
-    static private Duration timeout0(String name, Duration defValue) {
-        final value = SysEnv.get(name)
-        if( !value )
-            return defValue
-        try {
-            return Duration.ofMillis( nextflow.util.Duration.of(value).toMillis() )
-        }
-        catch( Exception e ) {
-            log.warn "Invalid value for variable ${name}: '${value}' - using default: ${defValue.toSeconds()}s"
-            return defValue
-        }
     }
 
     /**
@@ -556,17 +553,17 @@ abstract class RepositoryProvider {
         catch( HttpConnectTimeoutException e ) {
             // the underlying client retries connect timeouts - see isRetryable() -
             // therefore this is only reached once all attempts are exhausted
-            throw new IOException("Unable to connect to '${request.uri()}' within ${connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
+            throw new IOException("Unable to connect to '${request.uri()}' within ${getHttpClientOpts().connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
         }
         catch( HttpTimeoutException e ) {
-            throw new IOException("No response received from '${request.uri()}' within ${readTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_READ_TIMEOUT", e)
+            throw new IOException("No response received from '${request.uri()}' within ${getHttpClientOpts().requestTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_REQUEST_TIMEOUT", e)
         }
     }
 
     private HxClient newHttpClient() {
         final builder = HxClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
-            .connectTimeout(connectTimeout())
+            .connectTimeout(getHttpClientOpts().connectTimeout())
             .followRedirects(HttpClient.Redirect.NORMAL)
             // route through the forward proxy when configured
             .withProxyConfig(ProxyConfig.proxyConfig())

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -69,9 +69,10 @@ abstract class RepositoryProvider {
     static final public Duration DEFAULT_REQUEST_TIMEOUT = Duration.of('60s')
 
     /**
-     * The environment variable prefix used to resolve the HTTP client settings
+     * The environment variable prefix used to resolve the HTTP client settings,
+     * mirroring the {@code scm.httpClient} config path
      */
-    static final private String HTTP_CLIENT_ENV_PREFIX = 'NXF_GIT_'
+    static final private String HTTP_CLIENT_ENV_PREFIX = 'NXF_SCM_HTTPCLIENT_'
 
     @Canonical
     static class TagInfo {
@@ -155,9 +156,9 @@ abstract class RepositoryProvider {
 
     /**
      * The HTTP client timeout settings. When none has been set explicitly they are resolved
-     * from the {@code NXF_GIT_CONNECT_TIMEOUT} and {@code NXF_GIT_REQUEST_TIMEOUT} environment
-     * variables, falling back to the defaults - the environment being the only source available
-     * this early, since SCM resolution completes before any Nextflow config has been parsed.
+     * from the {@code NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT} and {@code NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT}
+     * environment variables, falling back to the defaults - the environment being the only source
+     * available this early, since SCM resolution completes before any Nextflow config has been parsed.
      *
      * @return The {@link HttpClientOpts} for this provider; never null
      */
@@ -173,14 +174,18 @@ abstract class RepositoryProvider {
      * <p>
      * That file is the one config source that is both already loaded when SCM resolution runs
      * and shared with an embedder building the same map by hand - unlike {@code nextflow.config},
-     * which is not parsed until the project has been fetched.
+     * which is not parsed until the project has been fetched. Each option resolves the same way
+     * {@link RetryConfig} resolves its own: the config map first, then the environment variable
+     * derived from {@link #HTTP_CLIENT_ENV_PREFIX} and the option name, then the default.
      *
      * @param scmConfig The parsed SCM config file contents, or null when there is none
      * @return The resulting {@link HttpClientOpts}; never null
      */
     static HttpClientOpts httpClientOpts(Map scmConfig) {
         final opts = (Map) scmConfig?.get('httpClient') ?: Collections.emptyMap()
-        return new HttpClientOpts(opts, HTTP_CLIENT_ENV_PREFIX, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)
+        final connectTimeout = RetryConfig.valueOf(opts, 'connectTimeout', HTTP_CLIENT_ENV_PREFIX, DEFAULT_CONNECT_TIMEOUT, Duration)
+        final requestTimeout = RetryConfig.valueOf(opts, 'requestTimeout', HTTP_CLIENT_ENV_PREFIX, DEFAULT_REQUEST_TIMEOUT, Duration)
+        return new HttpClientOpts(connectTimeout, requestTimeout)
     }
 
     String getProject() {
@@ -534,7 +539,7 @@ abstract class RepositoryProvider {
         // a connect timeout is always safe to retry because the TCP handshake
         // never completed, therefore no request data reached the server; the
         // check must target the connect subclass specifically - its parent
-        // HttpTimeoutException (read timeout) means the request reached the
+        // HttpTimeoutException (request timeout) means the request reached the
         // server and must remain fail-fast
         if( t instanceof HttpConnectTimeoutException )
             return true
@@ -569,14 +574,14 @@ abstract class RepositoryProvider {
         catch( HttpConnectTimeoutException e ) {
             // the underlying client retries connect timeouts - see isRetryable() -
             // therefore this is only reached once all attempts are exhausted
-            throw new IOException("Unable to connect to '${request.uri()}' within ${getHttpClientOpts().connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
+            throw new IOException("Unable to connect to '${request.uri()}' within ${getHttpClientOpts().connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT", e)
         }
         catch( HttpTimeoutException e ) {
             // report the bound actually applied to the request i.e. connect + request; it is
             // null only when the request timeout is unbounded, in which case no timeout was
             // set on the request and this branch is unreachable
             final elapsed = getHttpClientOpts().httpRequestTimeout()
-            throw new IOException("No response received from '${request.uri()}'${elapsed ? " within ${elapsed.toSeconds()}s" : ''} - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_REQUEST_TIMEOUT", e)
+            throw new IOException("No response received from '${request.uri()}'${elapsed ? " within ${elapsed.toSeconds()}s" : ''} - make sure the host is reachable or increase the timeout setting the variable NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT", e)
         }
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -518,6 +518,13 @@ abstract class RepositoryProvider {
     }
 
     protected boolean isRetryable(Throwable t) {
+        // a connect timeout is always safe to retry because the TCP handshake
+        // never completed, therefore no request data reached the server; the
+        // check must target the connect subclass specifically - its parent
+        // HttpTimeoutException (read timeout) means the request reached the
+        // server and must remain fail-fast
+        if( t instanceof HttpConnectTimeoutException )
+            return true
         // only retry SocketException and ignore generic IOException
         return t instanceof SocketException && !isCausedByUnresolvedAddressException(t)
     }
@@ -547,7 +554,9 @@ abstract class RepositoryProvider {
             return httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
         }
         catch( HttpConnectTimeoutException e ) {
-            throw new IOException("Unable to connect to '${request.uri()}' within ${connectTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
+            // the underlying client retries connect timeouts - see isRetryable() -
+            // therefore this is only reached once all attempts are exhausted
+            throw new IOException("Unable to connect to '${request.uri()}' within ${connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_CONNECT_TIMEOUT", e)
         }
         catch( HttpTimeoutException e ) {
             throw new IOException("No response received from '${request.uri()}' within ${readTimeout().toSeconds()}s - make sure the host is reachable or increase the timeout setting the variable NXF_GIT_READ_TIMEOUT", e)

--- a/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/AssetManagerTest.groovy
@@ -469,6 +469,20 @@ class AssetManagerTest extends Specification {
 
     }
 
+    def 'should pass the scm config http client opts to the provider' () {
+        given:
+        def config = [
+            httpClient: [connectTimeout: '30s', requestTimeout: '90s'],
+            providers: [github: [user: 'foo', password: 'bar']] ]
+
+        when:
+        def manager = new AssetManager().build('nextflow-io/hello', config)
+        def provider = manager.createHubProvider('github')
+        then:
+        provider.getHttpClientOpts().connectTimeout() == java.time.Duration.ofSeconds(30)
+        provider.getHttpClientOpts().requestTimeout() == java.time.Duration.ofSeconds(90)
+    }
+
     def testCreateProviderFor(){
 
         when:

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -320,6 +320,31 @@ class RepositoryProviderTest extends Specification {
         server.stop(0)
     }
 
+    def 'should build the http client opts from the scm config map' () {
+        given:
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s'])
+
+        when: 'the scm file carries an httpClient block'
+        def opts = RepositoryProvider.httpClientOpts([httpClient: [connectTimeout: '30s', requestTimeout: '90s']])
+        then: 'it wins over the env variable'
+        opts.connectTimeout() == Duration.ofSeconds(30)
+        opts.requestTimeout() == Duration.ofSeconds(90)
+
+        when: 'the scm file has no httpClient block'
+        opts = RepositoryProvider.httpClientOpts([providers: [github: [user: 'foo']]])
+        then: 'the env variable applies, then the default'
+        opts.connectTimeout() == Duration.ofSeconds(5)
+        opts.requestTimeout() == Duration.ofSeconds(60)
+
+        when: 'there is no scm config at all'
+        opts = RepositoryProvider.httpClientOpts(null)
+        then:
+        opts.connectTimeout() == Duration.ofSeconds(5)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
     private createMockResponseWithContentLength(long contentLength) {
         return new HttpResponse<byte[]>() {
             @Override

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -17,6 +17,7 @@
 package nextflow.scm
 
 import java.net.http.HttpClient
+import java.net.http.HttpConnectTimeoutException
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.net.http.HttpTimeoutException
@@ -138,6 +139,24 @@ class RepositoryProviderTest extends Specification {
         true        | new SocketException()
         false       | new SocketException(new UnresolvedAddressException())
         false       | new SocketTimeoutException()
+        true        | new HttpConnectTimeoutException('connect timed out')
+        false       | new HttpTimeoutException('request timed out')
+    }
+
+    def 'should retry connect timeouts via the http client retry condition' () {
+        given:
+        def provider = Spy(RepositoryProvider)
+
+        when:
+        def condition = provider.retryConfig0().getRetryCondition()
+        then:
+        // a connect timeout is retried, either direct or as the cause of another error
+        condition.test(new HttpConnectTimeoutException('connect timed out'))
+        condition.test(new IOException(new HttpConnectTimeoutException('connect timed out')))
+        // a read timeout is not retried
+        !condition.test(new HttpTimeoutException('request timed out'))
+        // an exception without a cause does not throw a NPE
+        !condition.test(new IOException('generic failure'))
     }
 
     def 'should not validate when max length is not configured via SysEnv' () {

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -19,9 +19,13 @@ package nextflow.scm
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
 import java.nio.channels.UnresolvedAddressException
+import java.time.Duration
 import javax.net.ssl.SSLSession
 
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
 import nextflow.SysEnv
 import nextflow.exception.HttpResponseLengthExceedException
 import nextflow.util.RetryConfig
@@ -179,6 +183,84 @@ class RepositoryProviderTest extends Specification {
 
         cleanup:
         SysEnv.pop()
+    }
+
+    def 'should use default http timeouts' () {
+        given:
+        SysEnv.push([:])
+        def provider = Spy(RepositoryProvider)
+
+        expect:
+        provider.connectTimeout() == RepositoryProvider.DEFAULT_CONNECT_TIMEOUT
+        provider.readTimeout() == RepositoryProvider.DEFAULT_READ_TIMEOUT
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should override http timeouts via env variables' () {
+        given:
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_READ_TIMEOUT: '250ms'])
+        def provider = Spy(RepositoryProvider)
+
+        expect:
+        provider.connectTimeout() == Duration.ofSeconds(5)
+        provider.readTimeout() == Duration.ofMillis(250)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should fallback to default timeouts when the value is invalid' () {
+        given:
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: 'foo', NXF_GIT_READ_TIMEOUT: 'bar'])
+        def provider = Spy(RepositoryProvider)
+
+        expect:
+        provider.connectTimeout() == RepositoryProvider.DEFAULT_CONNECT_TIMEOUT
+        provider.readTimeout() == RepositoryProvider.DEFAULT_READ_TIMEOUT
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should set the read timeout on the http request' () {
+        given:
+        SysEnv.push([NXF_GIT_READ_TIMEOUT: '250ms'])
+        def provider = Spy(RepositoryProvider)
+
+        when:
+        def request = provider.newRequest('http://foo.com/bar')
+        then:
+        request.timeout().get() == Duration.ofMillis(250)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should fail with a timeout error when the server does not reply' () {
+        given:
+        def server = HttpServer.create(new InetSocketAddress(0), 0)
+        server.createContext('/stall', { exchange ->
+            sleep 5_000
+            exchange.sendResponseHeaders(200, 0)
+            exchange.close()
+        } as HttpHandler)
+        server.start()
+        and:
+        SysEnv.push([NXF_GIT_READ_TIMEOUT: '500ms'])
+        def provider = Spy(RepositoryProvider)
+
+        when:
+        provider.invokeBytes("http://localhost:${server.address.port}/stall")
+        then:
+        def e = thrown(IOException)
+        e.message.startsWith("No response received from 'http://localhost:${server.address.port}/stall'")
+        e.cause instanceof HttpTimeoutException
+
+        cleanup:
+        SysEnv.pop()
+        server.stop(0)
     }
 
     private createMockResponseWithContentLength(long contentLength) {

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -140,8 +140,6 @@ class RepositoryProviderTest extends Specification {
         true        | new SocketException()
         false       | new SocketException(new UnresolvedAddressException())
         false       | new SocketTimeoutException()
-        true        | new HttpConnectTimeoutException('connect timed out')
-        false       | new HttpTimeoutException('request timed out')
     }
 
     def 'should retry connect timeouts via the http client retry condition' () {
@@ -205,42 +203,16 @@ class RepositoryProviderTest extends Specification {
         SysEnv.pop()
     }
 
-    def 'should use default http timeouts' () {
-        given:
-        SysEnv.push([:])
-        def provider = Spy(RepositoryProvider)
-
-        expect:
-        provider.httpClientOpts.connectTimeout() == Duration.ofSeconds(60)
-        provider.httpClientOpts.requestTimeout() == Duration.ofSeconds(60)
-
-        cleanup:
-        SysEnv.pop()
-    }
-
-    def 'should override http timeouts via env variables' () {
-        given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
-        def provider = Spy(RepositoryProvider)
-
-        expect:
-        provider.httpClientOpts.connectTimeout() == Duration.ofSeconds(5)
-        provider.httpClientOpts.requestTimeout() == Duration.ofMillis(250)
-
-        cleanup:
-        SysEnv.pop()
-    }
-
     def 'should fail when the timeout value is not a duration' () {
         given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: 'foo'])
+        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: 'foo'])
         def provider = Spy(RepositoryProvider)
 
         when:
         provider.getHttpClientOpts()
         then:
         def e = thrown(IllegalArgumentException)
-        e.message.contains('NXF_GIT_CONNECT_TIMEOUT')
+        e.message.contains('foo')
 
         cleanup:
         SysEnv.pop()
@@ -248,14 +220,12 @@ class RepositoryProviderTest extends Specification {
 
     def 'should prefer the http client opts set explicitly over the env variables' () {
         given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
+        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '5s', NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '250ms'])
         def provider = Spy(RepositoryProvider)
         and:
         provider.setHttpClientOpts(new HttpClientOpts(
-            [connectTimeout: '30s', requestTimeout: '90s'],
-            'NXF_GIT_',
-            RepositoryProvider.DEFAULT_CONNECT_TIMEOUT,
-            RepositoryProvider.DEFAULT_REQUEST_TIMEOUT))
+            nextflow.util.Duration.of('30s'),
+            nextflow.util.Duration.of('90s')))
 
         expect:
         provider.httpClientOpts.connectTimeout() == Duration.ofSeconds(30)
@@ -265,33 +235,25 @@ class RepositoryProviderTest extends Specification {
         SysEnv.pop()
     }
 
-    def 'should set the request timeout on the http request as connect plus request' () {
+    def 'should apply the request timeout to the http request as connect plus request' () {
         given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
+        SysEnv.push(env)
         def provider = Spy(RepositoryProvider)
 
         when:
         def request = provider.newRequest('http://foo.com/bar')
         then:
-        // HttpRequest.timeout() spans the connect phase too, so it carries the sum
-        request.timeout().get() == Duration.ofMillis(5_250)
+        // HttpRequest.timeout() spans the connect phase too, so it carries the sum;
+        // an unbounded request timeout applies none
+        request.timeout().orElse(null) == expected
 
         cleanup:
         SysEnv.pop()
-    }
 
-    def 'should not set a request timeout when the request timeout is unbounded' () {
-        given:
-        SysEnv.push([NXF_GIT_REQUEST_TIMEOUT: '0s'])
-        def provider = Spy(RepositoryProvider)
-
-        when:
-        def request = provider.newRequest('http://foo.com/bar')
-        then:
-        !request.timeout().isPresent()
-
-        cleanup:
-        SysEnv.pop()
+        where:
+        env                                                                                     | expected
+        [NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '5s', NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '250ms']  | Duration.ofMillis(5_250)
+        [NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '0s']                                               | null
     }
 
     def 'should fail with a timeout error when the server does not reply' () {
@@ -304,7 +266,7 @@ class RepositoryProviderTest extends Specification {
         } as HttpHandler)
         server.start()
         and:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '1s', NXF_GIT_REQUEST_TIMEOUT: '500ms'])
+        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '1s', NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '500ms'])
         def provider = Spy(RepositoryProvider)
 
         when:
@@ -312,7 +274,7 @@ class RepositoryProviderTest extends Specification {
         then:
         def e = thrown(IOException)
         e.message.startsWith("No response received from 'http://localhost:${server.address.port}/stall'")
-        e.message.contains('NXF_GIT_REQUEST_TIMEOUT')
+        e.message.contains('NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT')
         e.cause instanceof HttpTimeoutException
 
         cleanup:
@@ -322,7 +284,7 @@ class RepositoryProviderTest extends Specification {
 
     def 'should build the http client opts from the scm config map' () {
         given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s'])
+        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '5s'])
 
         when: 'the scm file carries an httpClient block'
         def opts = RepositoryProvider.httpClientOpts([httpClient: [connectTimeout: '30s', requestTimeout: '90s']])

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -29,6 +29,7 @@ import com.sun.net.httpserver.HttpHandler
 import com.sun.net.httpserver.HttpServer
 import nextflow.SysEnv
 import nextflow.exception.HttpResponseLengthExceedException
+import nextflow.util.HttpClientOpts
 import nextflow.util.RetryConfig
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -210,8 +211,8 @@ class RepositoryProviderTest extends Specification {
         def provider = Spy(RepositoryProvider)
 
         expect:
-        provider.connectTimeout() == RepositoryProvider.DEFAULT_CONNECT_TIMEOUT
-        provider.readTimeout() == RepositoryProvider.DEFAULT_READ_TIMEOUT
+        provider.httpClientOpts.connectTimeout() == Duration.ofSeconds(60)
+        provider.httpClientOpts.requestTimeout() == Duration.ofSeconds(60)
 
         cleanup:
         SysEnv.pop()
@@ -219,39 +220,75 @@ class RepositoryProviderTest extends Specification {
 
     def 'should override http timeouts via env variables' () {
         given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_READ_TIMEOUT: '250ms'])
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
         def provider = Spy(RepositoryProvider)
 
         expect:
-        provider.connectTimeout() == Duration.ofSeconds(5)
-        provider.readTimeout() == Duration.ofMillis(250)
+        provider.httpClientOpts.connectTimeout() == Duration.ofSeconds(5)
+        provider.httpClientOpts.requestTimeout() == Duration.ofMillis(250)
 
         cleanup:
         SysEnv.pop()
     }
 
-    def 'should fallback to default timeouts when the value is invalid' () {
+    def 'should fail when the timeout value is not a duration' () {
         given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: 'foo', NXF_GIT_READ_TIMEOUT: 'bar'])
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: 'foo'])
         def provider = Spy(RepositoryProvider)
 
-        expect:
-        provider.connectTimeout() == RepositoryProvider.DEFAULT_CONNECT_TIMEOUT
-        provider.readTimeout() == RepositoryProvider.DEFAULT_READ_TIMEOUT
+        when:
+        provider.getHttpClientOpts()
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('NXF_GIT_CONNECT_TIMEOUT')
 
         cleanup:
         SysEnv.pop()
     }
 
-    def 'should set the read timeout on the http request' () {
+    def 'should prefer the http client opts set explicitly over the env variables' () {
         given:
-        SysEnv.push([NXF_GIT_READ_TIMEOUT: '250ms'])
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
+        def provider = Spy(RepositoryProvider)
+        and:
+        provider.setHttpClientOpts(new HttpClientOpts(
+            [connectTimeout: '30s', requestTimeout: '90s'],
+            'NXF_GIT_',
+            RepositoryProvider.DEFAULT_CONNECT_TIMEOUT,
+            RepositoryProvider.DEFAULT_REQUEST_TIMEOUT))
+
+        expect:
+        provider.httpClientOpts.connectTimeout() == Duration.ofSeconds(30)
+        provider.httpClientOpts.requestTimeout() == Duration.ofSeconds(90)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should set the request timeout on the http request as connect plus request' () {
+        given:
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
         def provider = Spy(RepositoryProvider)
 
         when:
         def request = provider.newRequest('http://foo.com/bar')
         then:
-        request.timeout().get() == Duration.ofMillis(250)
+        // HttpRequest.timeout() spans the connect phase too, so it carries the sum
+        request.timeout().get() == Duration.ofMillis(5_250)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should not set a request timeout when the request timeout is unbounded' () {
+        given:
+        SysEnv.push([NXF_GIT_REQUEST_TIMEOUT: '0s'])
+        def provider = Spy(RepositoryProvider)
+
+        when:
+        def request = provider.newRequest('http://foo.com/bar')
+        then:
+        !request.timeout().isPresent()
 
         cleanup:
         SysEnv.pop()
@@ -267,7 +304,7 @@ class RepositoryProviderTest extends Specification {
         } as HttpHandler)
         server.start()
         and:
-        SysEnv.push([NXF_GIT_READ_TIMEOUT: '500ms'])
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '1s', NXF_GIT_REQUEST_TIMEOUT: '500ms'])
         def provider = Spy(RepositoryProvider)
 
         when:
@@ -275,6 +312,7 @@ class RepositoryProviderTest extends Specification {
         then:
         def e = thrown(IOException)
         e.message.startsWith("No response received from 'http://localhost:${server.address.port}/stall'")
+        e.message.contains('NXF_GIT_REQUEST_TIMEOUT')
         e.cause instanceof HttpTimeoutException
 
         cleanup:

--- a/modules/nf-commons/src/main/nextflow/util/HttpClientOpts.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/HttpClientOpts.groovy
@@ -16,14 +16,9 @@
 
 package nextflow.util
 
-import com.google.common.base.CaseFormat
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-import nextflow.SysEnv
-import nextflow.config.spec.ConfigOption
-import nextflow.config.spec.ConfigScope
-import nextflow.script.dsl.Description
 
 /**
  * Model the HTTP client timeout settings used to reach a remote service.
@@ -33,79 +28,37 @@ import nextflow.script.dsl.Description
  * Only the second one protects against a server that accepts the connection and then never
  * replies.
  * <p>
- * Values resolve the same way {@link RetryConfig} resolves its own: the config map first,
- * then the environment variable derived from {@code envPrefix} and the option name, then the
- * default. The env fallback matters because some clients — SCM repository access above all —
- * run before any Nextflow config has been parsed, so the config map is the only route that
- * exists for an embedder and the environment is the only route that exists for an operator.
+ * This is a plain value holder: it carries the two timeouts and derives the values the
+ * {@link java.net.http.HttpClient} API expects. Resolving them from a config map or the
+ * environment is left to the caller that owns the client — see e.g.
+ * {@code nextflow.scm.RepositoryProvider} — so that each client keeps its own option names,
+ * environment prefix and defaults, following the same resolution shape as {@link RetryConfig}.
  *
  * @author Rob Syme <rob.syme@gmail.com>
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @ToString(includeNames = true, includePackage = false)
 @EqualsAndHashCode
 @CompileStatic
-class HttpClientOpts implements ConfigScope {
+class HttpClientOpts {
 
-    @ConfigOption
-    @Description("""
-        The maximum time to wait for the connection to the remote service to be established,
-        applied to a single attempt. It bounds only reaching the service, never waiting for
-        its response — see `requestTimeout` for that. It must be greater than zero: unlike
-        `requestTimeout`, `0 sec` is not accepted as "unbounded".
-    """)
     final private Duration connectTimeout
-
-    @ConfigOption
-    @Description("""
-        The maximum time to wait for a response from the remote service once the connection
-        has been established, applied to a single attempt. Set to `0 sec` to wait
-        indefinitely.
-    """)
     final private Duration requestTimeout
 
     /**
-     * @param config    The config map holding the {@code connectTimeout} / {@code requestTimeout}
-     *                  entries, or an empty map to resolve from the environment
-     * @param envPrefix The prefix of the environment variables to fall back to e.g. {@code NXF_GIT_}
-     *                  yields {@code NXF_GIT_CONNECT_TIMEOUT} and {@code NXF_GIT_REQUEST_TIMEOUT}
-     * @param defConnectTimeout The connect timeout to use when neither source provides a value
-     * @param defRequestTimeout The request timeout to use when neither source provides a value
+     * @param connectTimeout The maximum time to wait for the connection to the remote service
+     *                  to be established, applied to a single attempt. It must be greater than
+     *                  zero: unlike {@code requestTimeout}, {@code 0} is not accepted as "unbounded".
+     * @param requestTimeout The maximum time to wait for a response once the connection has been
+     *                  established, applied to a single attempt. {@code 0} means wait indefinitely.
      */
-    HttpClientOpts(Map config, String envPrefix, Duration defConnectTimeout, Duration defRequestTimeout) {
-        connectTimeout = duration0(config, 'connectTimeout', envPrefix, defConnectTimeout)
-        requestTimeout = duration0(config, 'requestTimeout', envPrefix, defRequestTimeout)
+    HttpClientOpts(Duration connectTimeout, Duration requestTimeout) {
         // zero is not "unbounded" here — a connect phase that never gives up is not a bound
-        // worth expressing, and HttpClient.Builder rejects it. Catch it at the config edge so
-        // the message names the option rather than surfacing from the builder later on.
-        if( connectTimeout.toMillis() <= 0 )
+        // worth expressing, and HttpClient.Builder rejects it anyway
+        if( connectTimeout==null || connectTimeout.toMillis() <= 0 )
             throw new IllegalArgumentException("Config option 'connectTimeout' must be greater than zero - offending value: ${connectTimeout}")
-    }
-
-    /**
-     * Resolve one option, reporting the source that carried the offending value when it does
-     * not parse. {@link RetryConfig#valueOf} raises a bare "Not a valid duration value", which
-     * is of little use when the value came from an environment variable the user has to find.
-     */
-    private static Duration duration0(Map config, String name, String envPrefix, Duration defValue) {
-        try {
-            return RetryConfig.valueOf(config, name, envPrefix, defValue, Duration)
-        }
-        catch( IllegalArgumentException e ) {
-            final fromConfig = config?.get(name)
-            final source = fromConfig != null
-                ? "config option '${name}'"
-                : "variable ${envKey(envPrefix, name)}"
-            final value = fromConfig != null
-                ? fromConfig
-                : SysEnv.get(envKey(envPrefix, name))
-            throw new IllegalArgumentException("Invalid duration value for ${source}: '${value}'", e)
-        }
-    }
-
-    private static String envKey(String envPrefix, String name) {
-        if( !envPrefix.endsWith('_') )
-            envPrefix += '_'
-        return envPrefix.toUpperCase() + CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, name)
+        this.connectTimeout = connectTimeout
+        this.requestTimeout = requestTimeout
     }
 
     /**
@@ -123,7 +76,7 @@ class HttpClientOpts implements ConfigScope {
      * @return The timeout, or null to wait indefinitely
      */
     java.time.Duration requestTimeout() {
-        final long millis = requestTimeout.toMillis()
+        final long millis = requestTimeout != null ? requestTimeout.toMillis() : 0
         return millis > 0 ? java.time.Duration.ofMillis(millis) : null
     }
 

--- a/modules/nf-commons/src/main/nextflow/util/HttpClientOpts.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/HttpClientOpts.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.util
+
+import com.google.common.base.CaseFormat
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import nextflow.SysEnv
+import nextflow.config.spec.ConfigOption
+import nextflow.config.spec.ConfigScope
+import nextflow.script.dsl.Description
+
+/**
+ * Model the HTTP client timeout settings used to reach a remote service.
+ * <p>
+ * The two timeouts bound different phases: {@code connectTimeout} bounds establishing the
+ * connection, {@code requestTimeout} bounds waiting for the answer once it is established.
+ * Only the second one protects against a server that accepts the connection and then never
+ * replies.
+ * <p>
+ * Values resolve the same way {@link RetryConfig} resolves its own: the config map first,
+ * then the environment variable derived from {@code envPrefix} and the option name, then the
+ * default. The env fallback matters because some clients — SCM repository access above all —
+ * run before any Nextflow config has been parsed, so the config map is the only route that
+ * exists for an embedder and the environment is the only route that exists for an operator.
+ *
+ * @author Rob Syme <rob.syme@gmail.com>
+ */
+@ToString(includeNames = true, includePackage = false)
+@EqualsAndHashCode
+@CompileStatic
+class HttpClientOpts implements ConfigScope {
+
+    @ConfigOption
+    @Description("""
+        The maximum time to wait for the connection to the remote service to be established,
+        applied to a single attempt. It bounds only reaching the service, never waiting for
+        its response — see `requestTimeout` for that. It must be greater than zero: unlike
+        `requestTimeout`, `0 sec` is not accepted as "unbounded".
+    """)
+    final private Duration connectTimeout
+
+    @ConfigOption
+    @Description("""
+        The maximum time to wait for a response from the remote service once the connection
+        has been established, applied to a single attempt. Set to `0 sec` to wait
+        indefinitely.
+    """)
+    final private Duration requestTimeout
+
+    /**
+     * @param config    The config map holding the {@code connectTimeout} / {@code requestTimeout}
+     *                  entries, or an empty map to resolve from the environment
+     * @param envPrefix The prefix of the environment variables to fall back to e.g. {@code NXF_GIT_}
+     *                  yields {@code NXF_GIT_CONNECT_TIMEOUT} and {@code NXF_GIT_REQUEST_TIMEOUT}
+     * @param defConnectTimeout The connect timeout to use when neither source provides a value
+     * @param defRequestTimeout The request timeout to use when neither source provides a value
+     */
+    HttpClientOpts(Map config, String envPrefix, Duration defConnectTimeout, Duration defRequestTimeout) {
+        connectTimeout = duration0(config, 'connectTimeout', envPrefix, defConnectTimeout)
+        requestTimeout = duration0(config, 'requestTimeout', envPrefix, defRequestTimeout)
+        // zero is not "unbounded" here — a connect phase that never gives up is not a bound
+        // worth expressing, and HttpClient.Builder rejects it. Catch it at the config edge so
+        // the message names the option rather than surfacing from the builder later on.
+        if( connectTimeout.toMillis() <= 0 )
+            throw new IllegalArgumentException("Config option 'connectTimeout' must be greater than zero - offending value: ${connectTimeout}")
+    }
+
+    /**
+     * Resolve one option, reporting the source that carried the offending value when it does
+     * not parse. {@link RetryConfig#valueOf} raises a bare "Not a valid duration value", which
+     * is of little use when the value came from an environment variable the user has to find.
+     */
+    private static Duration duration0(Map config, String name, String envPrefix, Duration defValue) {
+        try {
+            return RetryConfig.valueOf(config, name, envPrefix, defValue, Duration)
+        }
+        catch( IllegalArgumentException e ) {
+            final fromConfig = config?.get(name)
+            final source = fromConfig != null
+                ? "config option '${name}'"
+                : "variable ${envKey(envPrefix, name)}"
+            final value = fromConfig != null
+                ? fromConfig
+                : SysEnv.get(envKey(envPrefix, name))
+            throw new IllegalArgumentException("Invalid duration value for ${source}: '${value}'", e)
+        }
+    }
+
+    private static String envKey(String envPrefix, String name) {
+        if( !envPrefix.endsWith('_') )
+            envPrefix += '_'
+        return envPrefix.toUpperCase() + CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, name)
+    }
+
+    /**
+     * The per-attempt connect timeout, in the form {@link java.net.http.HttpClient} expects.
+     *
+     * @return The timeout; never null, and guaranteed strictly positive
+     */
+    java.time.Duration connectTimeout() {
+        return java.time.Duration.ofMillis(connectTimeout.toMillis())
+    }
+
+    /**
+     * The per-attempt response timeout.
+     *
+     * @return The timeout, or null to wait indefinitely
+     */
+    java.time.Duration requestTimeout() {
+        final long millis = requestTimeout.toMillis()
+        return millis > 0 ? java.time.Duration.ofMillis(millis) : null
+    }
+
+    /**
+     * The value to pass to {@link java.net.http.HttpRequest.Builder#timeout}.
+     * <p>
+     * That timeout spans the connect phase as well as the response, so handing it the bare
+     * {@link #requestTimeout} would cap the connection attempt at a value that may be shorter
+     * than {@link #connectTimeout} — and a connect stall would then surface as
+     * {@code HttpTimeoutException} rather than {@code HttpConnectTimeoutException}, i.e. as
+     * the fail-fast case rather than the retryable one. Summing the two keeps each phase
+     * bounded by its own setting.
+     *
+     * @return The timeout, or null when the request timeout is unbounded
+     */
+    java.time.Duration httpRequestTimeout() {
+        final request = requestTimeout()
+        return request != null
+            ? connectTimeout().plus(request)
+            : null
+    }
+}

--- a/modules/nf-commons/src/main/nextflow/util/RetryConfig.groovy
+++ b/modules/nf-commons/src/main/nextflow/util/RetryConfig.groovy
@@ -124,7 +124,7 @@ class RetryConfig implements Retryable.Config {
         // try to get the value from the config map
         final cfg = config?.get(name)
         if( cfg != null ) {
-            return toType(cfg, type)
+            return toType0(cfg, type, "config option '$name'")
         }
         // try to fallback to the sys environment
         if( !prefix.endsWith('_') )
@@ -132,10 +132,28 @@ class RetryConfig implements Retryable.Config {
         final key = prefix.toUpperCase() + CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, name)
         final env = SysEnv.get(key)
         if( env != null ) {
-            return toType(env, type)
+            return toType0(env, type, "variable $key")
         }
         // return the default value
         return defValue
+    }
+
+    /**
+     * Convert the value, naming the source that carried it when it does not parse. The
+     * underlying error reports the offending value alone e.g. "Not a valid duration value:
+     * foo", which leaves the user hunting for which setting it came from.
+     *
+     * @param value  The raw value to convert
+     * @param type   The target type
+     * @param source A description of where the value came from, used in the error message
+     */
+    static private <T> T toType0(Object value, Class<T> type, String source) {
+        try {
+            return toType(value, type)
+        }
+        catch( IllegalArgumentException e ) {
+            throw new IllegalArgumentException("Invalid value for $source - ${e.message}", e)
+        }
     }
 
     @CompileDynamic

--- a/modules/nf-commons/src/test/nextflow/util/HttpClientOptsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/HttpClientOptsTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.util
+
+import nextflow.SysEnv
+import spock.lang.Specification
+
+/**
+ *
+ * @author Rob Syme <rob.syme@gmail.com>
+ */
+class HttpClientOptsTest extends Specification {
+
+    static final Duration CONNECT_DEF = Duration.of('60s')
+    static final Duration REQUEST_DEF = Duration.of('45s')
+
+    private HttpClientOpts opts(Map config=[:]) {
+        new HttpClientOpts(config, 'NXF_GIT_', CONNECT_DEF, REQUEST_DEF)
+    }
+
+    def 'should use the given defaults when nothing is configured' () {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        opts().connectTimeout() == java.time.Duration.ofSeconds(60)
+        opts().requestTimeout() == java.time.Duration.ofSeconds(45)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should take the value from the config map' () {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        opts([connectTimeout: '5s']).connectTimeout() == java.time.Duration.ofSeconds(5)
+        opts([requestTimeout: '250ms']).requestTimeout() == java.time.Duration.ofMillis(250)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should fall back to the env variable when the config map has no value' () {
+        given:
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
+
+        expect:
+        opts().connectTimeout() == java.time.Duration.ofSeconds(5)
+        opts().requestTimeout() == java.time.Duration.ofMillis(250)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should prefer the config map over the env variable' () {
+        given:
+        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s'])
+
+        expect:
+        opts([connectTimeout: '30s']).connectTimeout() == java.time.Duration.ofSeconds(30)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should treat a zero request timeout as unbounded' () {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        opts([requestTimeout: '0s']).requestTimeout() == null
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should reject a non-positive connect timeout' () {
+        given:
+        SysEnv.push([:])
+
+        when:
+        opts([connectTimeout: '0s'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('connectTimeout')
+        e.message.contains('greater than zero')
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should report the offending env variable when the value is not a duration' () {
+        given:
+        SysEnv.push([NXF_GIT_REQUEST_TIMEOUT: 'foo'])
+
+        when:
+        opts()
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('NXF_GIT_REQUEST_TIMEOUT')
+        e.message.contains('foo')
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should sum connect and request for the http request timeout' () {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        // HttpRequest.timeout() spans the connect phase as well as the response, so a
+        // request timeout shorter than the connect timeout would surface a connect stall
+        // as the non-retryable read-timeout exception
+        opts([connectTimeout: '10s', requestTimeout: '45s']).httpRequestTimeout() == java.time.Duration.ofSeconds(55)
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should have no http request timeout when the request timeout is unbounded' () {
+        given:
+        SysEnv.push([:])
+
+        expect:
+        opts([requestTimeout: '0s']).httpRequestTimeout() == null
+
+        cleanup:
+        SysEnv.pop()
+    }
+}

--- a/modules/nf-commons/src/test/nextflow/util/HttpClientOptsTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/HttpClientOptsTest.groovy
@@ -16,132 +16,49 @@
 
 package nextflow.util
 
-import nextflow.SysEnv
 import spock.lang.Specification
 
 /**
  *
  * @author Rob Syme <rob.syme@gmail.com>
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class HttpClientOptsTest extends Specification {
 
-    static final Duration CONNECT_DEF = Duration.of('60s')
-    static final Duration REQUEST_DEF = Duration.of('45s')
-
-    private HttpClientOpts opts(Map config=[:]) {
-        new HttpClientOpts(config, 'NXF_GIT_', CONNECT_DEF, REQUEST_DEF)
-    }
-
-    def 'should use the given defaults when nothing is configured' () {
+    def 'should expose the connect and request timeouts as java.time durations' () {
         given:
-        SysEnv.push([:])
+        def opts = new HttpClientOpts(Duration.of('10s'), Duration.of('250ms'))
 
         expect:
-        opts().connectTimeout() == java.time.Duration.ofSeconds(60)
-        opts().requestTimeout() == java.time.Duration.ofSeconds(45)
-
-        cleanup:
-        SysEnv.pop()
+        opts.connectTimeout() == java.time.Duration.ofSeconds(10)
+        opts.requestTimeout() == java.time.Duration.ofMillis(250)
     }
 
-    def 'should take the value from the config map' () {
-        given:
-        SysEnv.push([:])
-
+    def 'should treat a zero or missing request timeout as unbounded' () {
         expect:
-        opts([connectTimeout: '5s']).connectTimeout() == java.time.Duration.ofSeconds(5)
-        opts([requestTimeout: '250ms']).requestTimeout() == java.time.Duration.ofMillis(250)
-
-        cleanup:
-        SysEnv.pop()
-    }
-
-    def 'should fall back to the env variable when the config map has no value' () {
-        given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s', NXF_GIT_REQUEST_TIMEOUT: '250ms'])
-
-        expect:
-        opts().connectTimeout() == java.time.Duration.ofSeconds(5)
-        opts().requestTimeout() == java.time.Duration.ofMillis(250)
-
-        cleanup:
-        SysEnv.pop()
-    }
-
-    def 'should prefer the config map over the env variable' () {
-        given:
-        SysEnv.push([NXF_GIT_CONNECT_TIMEOUT: '5s'])
-
-        expect:
-        opts([connectTimeout: '30s']).connectTimeout() == java.time.Duration.ofSeconds(30)
-
-        cleanup:
-        SysEnv.pop()
-    }
-
-    def 'should treat a zero request timeout as unbounded' () {
-        given:
-        SysEnv.push([:])
-
-        expect:
-        opts([requestTimeout: '0s']).requestTimeout() == null
-
-        cleanup:
-        SysEnv.pop()
+        new HttpClientOpts(Duration.of('10s'), Duration.of('0s')).requestTimeout() == null
+        new HttpClientOpts(Duration.of('10s'), null).requestTimeout() == null
     }
 
     def 'should reject a non-positive connect timeout' () {
-        given:
-        SysEnv.push([:])
-
         when:
-        opts([connectTimeout: '0s'])
+        new HttpClientOpts(connect, Duration.of('30s'))
         then:
         def e = thrown(IllegalArgumentException)
         e.message.contains('connectTimeout')
         e.message.contains('greater than zero')
 
-        cleanup:
-        SysEnv.pop()
+        where:
+        connect << [Duration.of('0s'), null]
     }
 
-    def 'should report the offending env variable when the value is not a duration' () {
-        given:
-        SysEnv.push([NXF_GIT_REQUEST_TIMEOUT: 'foo'])
-
-        when:
-        opts()
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message.contains('NXF_GIT_REQUEST_TIMEOUT')
-        e.message.contains('foo')
-
-        cleanup:
-        SysEnv.pop()
-    }
-
-    def 'should sum connect and request for the http request timeout' () {
-        given:
-        SysEnv.push([:])
-
+    def 'should sum connect and request for the http request timeout, or none when unbounded' () {
         expect:
         // HttpRequest.timeout() spans the connect phase as well as the response, so a
         // request timeout shorter than the connect timeout would surface a connect stall
-        // as the non-retryable read-timeout exception
-        opts([connectTimeout: '10s', requestTimeout: '45s']).httpRequestTimeout() == java.time.Duration.ofSeconds(55)
-
-        cleanup:
-        SysEnv.pop()
-    }
-
-    def 'should have no http request timeout when the request timeout is unbounded' () {
-        given:
-        SysEnv.push([:])
-
-        expect:
-        opts([requestTimeout: '0s']).httpRequestTimeout() == null
-
-        cleanup:
-        SysEnv.pop()
+        // as the non-retryable request-timeout exception
+        new HttpClientOpts(Duration.of('10s'), Duration.of('45s')).httpRequestTimeout() == java.time.Duration.ofSeconds(55)
+        and: 'an unbounded request timeout applies none'
+        new HttpClientOpts(Duration.of('10s'), Duration.of('0s')).httpRequestTimeout() == null
     }
 }

--- a/modules/nf-commons/src/test/nextflow/util/RetryConfigTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/util/RetryConfigTest.groovy
@@ -130,4 +130,28 @@ class RetryConfigTest extends Specification {
         'one'       | 'foo_'    | 'bar'             | [FOO_BAR: 'one']
         'one'       | 'foo_'    | 'thisAndThat'     | [FOO_THIS_AND_THAT: 'one']
     }
+
+    def 'should name the environment variable that carried an invalid value' () {
+        given:
+        SysEnv.push([NXF_RETRY_POLICY_DELAY: 'foo'])
+
+        when:
+        RetryConfig.valueOf([:], 'delay', 'NXF_RETRY_POLICY_', Duration.of('1s'), Duration)
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('NXF_RETRY_POLICY_DELAY')
+        e.message.contains('foo')
+
+        cleanup:
+        SysEnv.pop()
+    }
+
+    def 'should name the config option that carried an invalid value' () {
+        when:
+        RetryConfig.valueOf([delay: 'foo'], 'delay', 'NXF_RETRY_POLICY_', Duration.of('1s'), Duration)
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("'delay'")
+        e.message.contains('foo')
+    }
 }


### PR DESCRIPTION
The HTTP client used by `nextflow.scm.RepositoryProvider` to call the Git hosting service API (GitHub, GitLab, etc.) hardcodes a 60-second connect timeout and sets no per-request timeout. An API call that connects and then receives no response waits indefinitely, and a dropped connection attempt costs a fixed 60 seconds with no retry. In server contexts that embed this code, a single stalled request is enough to produce multi-minute API latency.

### Configuration

Both timeouts move to `nextflow.util.HttpClientOpts` in nf-commons, which adopts the option names (`connectTimeout` / `requestTimeout`) and the zero-handling of `io.seqera.config.HttpClientOpts` in nf-seqera. It is a plain value holder; `RepositoryProvider.httpClientOpts()` resolves the values the way `RetryConfig` resolves its own, through the same `RetryConfig.valueOf` helper: the config map first, then the environment variable, then the default.

That resolution order is the one place this diverges from the review, and the reason is timing rather than preference. `CmdRun.run()` fetches the project at line 341 and does not construct a `ConfigBuilder` until line 367, so `nextflow.config` has not been parsed when SCM resolution runs. It cannot have been: you cannot read the config of a repository you have not fetched yet. `$HOME/.nextflow/config` goes through the same `ConfigBuilder`, so it is equally too late. An `scm.httpClient` scope in `nextflow.config` therefore could not configure the client that does the fetching, for the CLI or for anything embedding it.

Two sources are live at that point, and both are wired:

| Source | How |
| --- | --- |
| SCM config file | An `httpClient` block in `$HOME/.nextflow/scm`, or wherever `NXF_SCM_FILE` points. `AssetManager` hands it to each provider it creates. |
| Environment | `NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT` and `NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT`, derived from the option names so the variable mirrors the `scm.httpClient` config path. |

`setHttpClientOpts()` also lets an embedder supply the values directly. `AssetManager` calls it, so unlike `setRetryConfig()` it is not dead on arrival.

The `NXF_GIT_*` variables from earlier revisions of this PR are gone. Nothing here is released, so nothing is deprecated.

Resolution lives with the caller that owns the client rather than in the value holder, so each client keeps its own option names, environment prefix and defaults. That is what makes the class reusable without moving caller-specific `@Description` text into nf-commons.

### Review points adopted

The per-request timeout is now connect + request. `HttpRequest.timeout()` spans the connect phase, so passing the bare request timeout would cap the connection attempt at a value that may be shorter than `connectTimeout`, surfacing a connect stall as the non-retryable `HttpTimeoutException`.

`requestTimeout = 0s` means unbounded and omits the per-request timeout, rather than reaching `HttpRequest.Builder.timeout()` with `Duration.ZERO` and throwing on every request. `connectTimeout = 0s` is rejected at the config edge with a message naming the option.

Unparseable values now fail rather than warning and silently using the default, which is how `RetryConfig` already treats `NXF_RETRY_POLICY_*`. A typo'd timeout quietly becoming 60s is the failure this PR exists to prevent.

### Retry condition

`isRetryable` is unchanged, because `HxConfig.defaultRetryCondition()` cannot replace it as things stand:

* nf-commons pins `io.seqera:lib-httpx:2.4.0`, where that method does not exist and the default condition is `t instanceof IOException`, which retries read timeouts. `defaultRetryCondition(Throwable)` first appears in 2.6.0. nf-seqera is on 2.6.0; nf-wave, nf-tower and nf-google explicitly pin 2.4.0.
* At 2.6.0 it is still a broader policy than the one here. It retries any `IOException` other than a non-connect `HttpTimeoutException`, whereas the condition in this class retries only `SocketException` and explicitly not when caused by `UnresolvedAddressException`. Adopting the default would start retrying DNS failures five times with backoff, which is the latency this PR exists to remove.

Happy to bump the dependency and converge in a follow-up if the broader policy is wanted, but it seemed worth keeping out of this change.

### Tests

* `HttpClientOptsTest`: the timeouts exposed as `java.time` durations, zero-handling in both directions, and the connect + request sum.
* `RepositoryProviderTest`: an unparseable value failing, explicit opts winning over the environment, the summed timeout reaching `HttpRequest`, the static factory resolving an `httpClient` block over the environment over the defaults, and an end-to-end request timeout against a local stalled server.
* `AssetManagerTest`: the `httpClient` block from the SCM config file reaching the provider.
* `isRetryable` and the `HxConfig` retry-condition wiring, including cause traversal and null-cause safety.

Docs are marked `26.10`, so this needs to land before the 26.10 branch cut.

Includes #7565, which renamed the environment variables to mirror the config path, reduced `HttpClientOpts` to a value holder and moved resolution to the caller.

Complements #7401, #7402 and #7403, which reduce the volume of SCM API calls made during revision resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
