### PR TITLE
Add custom job names for AWS Batch

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/ExecutorConfig.groovy
@@ -63,7 +63,7 @@ class ExecutorConfig implements ConfigScope {
 
     @ConfigOption
     @Description('''
-        *Used only by grid executors and Google Batch.*
+        *Used only by grid executors, Google Batch, and AWS Batch.*
 
         Determines the name of jobs submitted to the underlying cluster executor:
         ```groovy

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -43,6 +43,7 @@ import nextflow.processor.BatchContext
 import nextflow.processor.BatchHandler
 import nextflow.processor.TaskArrayRun
 import nextflow.processor.TaskHandler
+import nextflow.processor.TaskProcessor
 import nextflow.processor.TaskRun
 import nextflow.processor.TaskStatus
 import nextflow.trace.TraceRecord
@@ -814,8 +815,36 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
     }
 
     protected String getJobName(TaskRun task) {
-        final result = prependWorkflowPrefix(task.name, environment)
-        return normalizeJobName(result)
+        final defaultName = normalizeJobName(prependWorkflowPrefix(task.name, environment))
+        final customName = customJobName(task)
+        if( !customName )
+            return defaultName
+
+        final result = normalizeJobName(customName)
+        if( !result || !(result[0] ==~ /[a-zA-Z0-9]/) )
+            return defaultName
+        return result
+    }
+
+    /**
+     * Resolve the `jobName` property defined in the Nextflow config file.
+     *
+     * @param task The underlying task to be executed
+     * @return The custom job name for the specified task, or {@code null} if it cannot be resolved
+     */
+    protected String customJobName(TaskRun task) {
+        try {
+            final custom = (Closure) executor.config.getExecConfigProp(executor.name, 'jobName', null)
+            if( !custom )
+                return null
+
+            final ctx = [(TaskProcessor.TASK_CONTEXT_PROPERTY_NAME): task.config]
+            return custom.cloneWith(ctx).call()?.toString()
+        }
+        catch( Exception e ) {
+            log.debug "Unable to resolve job custom name", e
+            return null
+        }
     }
 
     /**
@@ -1115,4 +1144,3 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         return -Math.floorDiv(-x,y);
     }
 }
-

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/batch/AwsBatchTaskHandlerTest.groovy
@@ -30,6 +30,7 @@ import nextflow.cloud.types.CloudMachineInfo
 import nextflow.cloud.types.PriceModel
 import nextflow.exception.ProcessUnrecoverableException
 import nextflow.executor.Executor
+import nextflow.executor.ExecutorConfig
 import nextflow.fusion.FusionScriptLauncher
 import nextflow.processor.Architecture
 import nextflow.processor.BatchContext
@@ -1283,11 +1284,60 @@ class AwsBatchTaskHandlerTest extends Specification {
         result == EXPECTED
 
         where:
-        ENV                             | NAME      | EXPECTED
-        [:]                             | 'foo'     | 'foo'
-        [TOWER_WORKFLOW_ID: '12345']    | 'foo'     | 'tw-12345-foo'
-        [TOWER_WORKFLOW_ID: '12345']    | 'foo'     | 'tw-12345-foo'
-        [TOWER_WORKFLOW_ID: '12345']    | 'foo(12)' | 'tw-12345-foo12'
+        ENV                          | NAME      | EXPECTED
+        [:]                          | 'foo'     | 'foo'
+        [TOWER_WORKFLOW_ID: '12345'] | 'foo'     | 'tw-12345-foo'
+        [TOWER_WORKFLOW_ID: '12345'] | 'foo'     | 'tw-12345-foo'
+        [TOWER_WORKFLOW_ID: '12345'] | 'foo(12)' | 'tw-12345-foo12'
+    }
+
+    def 'should get custom job name' () {
+        given:
+        def config = new ExecutorConfig(jobName: { "123-${task.name}" })
+        def executor = Mock(AwsBatchExecutor) {
+            getName() >> 'awsbatch'
+            getConfig() >> config
+        }
+        def handler = Spy(new AwsBatchTaskHandler(executor: executor))
+        def task = Mock(TaskRun) {
+            getName() >> 'fallback'
+            getConfig() >> new TaskConfig(name: 'hello world')
+        }
+
+        expect:
+        handler.getJobName(task) == '123-hello_world'
+    }
+
+    @Unroll
+    def 'should use default job name when custom job name cannot be resolved' () {
+        given:
+        def config = Mock(ExecutorConfig) {
+            getExecConfigProp('awsbatch', 'jobName', null) >> CUSTOM
+        }
+        def executor = Mock(AwsBatchExecutor) {
+            getName() >> 'awsbatch'
+            getConfig() >> config
+        }
+        def handler = Spy(new AwsBatchTaskHandler(executor: executor))
+        def task = Mock(TaskRun) {
+            getName() >> 'task (1)'
+            getConfig() >> Mock(TaskConfig)
+        }
+
+        expect:
+        handler.getJobName(task) == 'task_1'
+
+        where:
+        CUSTOM << [
+            null,
+            { null },
+            { '' },
+            { '***' },
+            { '   ' },
+            { '_custom' },
+            { '-custom' },
+            { throw new IllegalStateException('boom') }
+        ]
     }
 
     @Unroll


### PR DESCRIPTION
## Summary

AWS Batch currently generates job names from the task name and does not honor the `executor.jobName` configuration option. This makes it difficult to identify jobs from different users or workflow runs in a shared AWS Batch queue.

This PR adds support for the `executor.jobName` option in AWS Batch, following the existing behavior of grid executors and Google Batch.

```groovy
process {
    executor = 'awsbatch'
}

executor {
    jobName = { "custom-${task.name}" }
}
```

## Changes

- Resolve the `executor.jobName` closure through `executor.config`.
- Evaluate the closure with `task` bound to the task configuration, consistent with grid executors and Google Batch.
- Normalize custom names according to AWS Batch naming constraints and limit them to 128 characters.
- Fall back to the existing automatically generated job name when the closure:
  - is not configured;
  - returns `null` or an empty value;
  - throws an exception;
  - produces a normalized name that does not start with an alphanumeric character.
- Update the `executor.jobName` configuration description to include AWS Batch.

## Testing

- Added coverage for resolving and normalizing custom AWS Batch job names.
- Added fallback coverage for missing, null, empty, invalid, and failing job name closures.
- Verified that custom job names beginning with a number are accepted.
- `AwsBatchTaskHandlerTest`: 114 tests, 0 failures.
- Full `nf-amazon` test suite: 474 tests, 0 failures, 58 skipped.
- Validated custom job name submission with an AWS Batch workflow.

Closes #1232