### PR TITLE
Fix outputDir/workDir as implicit config variables

### DIFF
--- a/docs/config.mdx
+++ b/docs/config.mdx
@@ -102,6 +102,10 @@ The following constants are globally available in a Nextflow configuration file:
 
 The directory where the workflow was launched.
 
+##### `outputDir: Path`
+
+The directory where workflow outputs are published.
+
 ##### `projectDir: Path`
 
 The directory where the main script is located.

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -49,6 +49,8 @@ class ConfigBuilder {
 
     protected String workDir
 
+    protected String workDirDefault
+
     protected String profile = DEFAULT_PROFILE
 
     protected boolean validateProfile
@@ -107,6 +109,16 @@ class ConfigBuilder {
 
     ConfigBuilder setWorkDir(String value) {
         this.workDir = value
+        return this
+    }
+
+    /**
+     * A weaker `workDir` default (e.g. from `NXF_WORK`): visible to config-time
+     * interpolation like the hardcoded default, but -- unlike a `-work-dir` CLI
+     * flag -- must not override an explicit config assignment.
+     */
+    ConfigBuilder setWorkDirDefault(String value) {
+        this.workDirDefault = value
         return this
     }
 
@@ -229,6 +241,12 @@ class ConfigBuilder {
             if( workDir )
                 cliConfigVars.workDir = FileHelper.toCanonicalPath(workDir)
             binding.putAll(cliConfigVars)
+
+            // a weaker workDir default (e.g. NXF_WORK) still needs to be visible to config-time
+            // interpolation, but must not override an explicit config assignment the way the
+            // CLI flag above does
+            if( !workDir && workDirDefault )
+                binding.put('workDir', FileHelper.toCanonicalPath(workDirDefault))
 
             parser.setBinding(binding)
             if( cliConfigVars )

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy
@@ -25,6 +25,7 @@ import nextflow.NF
 import nextflow.SysEnv
 import nextflow.exception.AbortOperationException
 import nextflow.exception.ConfigParseException
+import nextflow.file.FileHelper
 import nextflow.secret.SecretsLoader
 import nextflow.secret.SecretsProvider
 /**
@@ -43,6 +44,10 @@ class ConfigBuilder {
     protected Path currentDir
 
     protected Map<String,?> cliParams
+
+    protected String outputDir
+
+    protected String workDir
 
     protected String profile = DEFAULT_PROFILE
 
@@ -92,6 +97,16 @@ class ConfigBuilder {
 
     ConfigBuilder setCliParams(Map<String,?> cliParams) {
         this.cliParams = cliParams
+        return this
+    }
+
+    ConfigBuilder setOutputDir(String value) {
+        this.outputDir = value
+        return this
+    }
+
+    ConfigBuilder setWorkDir(String value) {
+        this.workDir = value
         return this
     }
 
@@ -159,6 +174,7 @@ class ConfigBuilder {
         binding.put('projectDir', base)
         binding.put('launchDir', Path.of('.').toRealPath())
         binding.put('outputDir', Path.of('results').complete())
+        binding.put('workDir', Path.of('work').complete())
         binding.put('secrets', secretContext)
         return binding
     }
@@ -203,7 +219,20 @@ class ConfigBuilder {
             }
             binding.putAll(configVars())
 
+            // a CLI-supplied `-output-dir`/`-work-dir` takes precedence over the config's own
+            // default -- and over a same-named config assignment, via setCliConfigVars -- so
+            // that a config expression referencing `outputDir`/`workDir` sees the same value
+            // the session ultimately uses
+            final cliConfigVars = [:]
+            if( outputDir )
+                cliConfigVars.outputDir = FileHelper.toCanonicalPath(outputDir)
+            if( workDir )
+                cliConfigVars.workDir = FileHelper.toCanonicalPath(workDir)
+            binding.putAll(cliConfigVars)
+
             parser.setBinding(binding)
+            if( cliConfigVars )
+                parser.setCliConfigVars(cliConfigVars)
 
             // merge of the provided configuration files
             for( final entry : configEntries ) {

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy
@@ -73,6 +73,16 @@ interface ConfigParser {
     ConfigParser setProfiles(List<String> profiles)
 
     /**
+     * Define CLI-supplied values for implicit config variables (e.g. `outputDir`,
+     * `workDir`) that should take precedence over a same-named config assignment.
+     *
+     * @param vars
+     */
+    default ConfigParser setCliConfigVars(Map vars) {
+        return this
+    }
+
+    /**
      * Toggle whether to render compilation errors with ANSI colors.
      *
      * @param value

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -144,6 +144,11 @@ class ConfigDsl extends Script {
      * that if the param is referenced later in the config file,
      * the command line value is used.
      *
+     * A top-level assignment (e.g. `outputDir = ...`) also updates the script
+     * binding, so that a later reference to the same name -- in this file or
+     * in one it includes -- resolves to the assigned value instead of the
+     * binding's original (e.g. default) value.
+     *
      * @param names
      * @param value
      */
@@ -155,6 +160,8 @@ class ConfigDsl extends Script {
                 value = asDeclaredType(cliParams[name], value)
         }
         navigate(names.init()).put(names.last(), value)
+        if( names.size() == 1 )
+            getBinding().setVariable(names.first(), value)
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigDsl.groovy
@@ -56,6 +56,8 @@ class ConfigDsl extends Script {
 
     private Map cliParams
 
+    private Map cliConfigVars = [:]
+
     private List<String> profiles
 
     private Map target = [params: [:]]
@@ -91,6 +93,10 @@ class ConfigDsl extends Script {
 
     void setConfigParams(Map params) {
         (target.params as Map).putAll(params)
+    }
+
+    void setCliConfigVars(Map vars) {
+        this.cliConfigVars = vars
     }
 
     void setProfiles(List<String> profiles) {
@@ -147,7 +153,8 @@ class ConfigDsl extends Script {
      * A top-level assignment (e.g. `outputDir = ...`) also updates the script
      * binding, so that a later reference to the same name -- in this file or
      * in one it includes -- resolves to the assigned value instead of the
-     * binding's original (e.g. default) value.
+     * binding's original (e.g. default) value. A CLI-supplied value for that
+     * name takes precedence over the config's own assignment.
      *
      * @param names
      * @param value
@@ -159,6 +166,8 @@ class ConfigDsl extends Script {
             if( cliParams.containsKey(name) )
                 value = asDeclaredType(cliParams[name], value)
         }
+        if( names.size() == 1 && cliConfigVars.containsKey(names.first()) )
+            value = cliConfigVars[names.first()]
         navigate(names.init()).put(names.last(), value)
         if( names.size() == 1 )
             getBinding().setVariable(names.first(), value)
@@ -272,6 +281,7 @@ class ConfigDsl extends Script {
                 .setBinding(binding.getVariables())
                 .setParams(cliParams)
                 .setConfigParams(target.params as Map)
+                .setCliConfigVars(cliConfigVars)
                 .setProfiles(profiles)
         final config = parser.parse(configText, includePath)
         declaredProfiles.addAll(parser.getDeclaredProfiles())

--- a/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/parser/v2/ConfigParserV2.groovy
@@ -39,6 +39,8 @@ class ConfigParserV2 implements ConfigParser {
 
     private Map cliParams = [:]
 
+    private Map cliConfigVars = [:]
+
     private Map configParams = [:]
 
     private boolean ignoreIncludes = false
@@ -115,6 +117,12 @@ class ConfigParserV2 implements ConfigParser {
     }
 
     @Override
+    ConfigParserV2 setCliConfigVars(Map vars) {
+        this.cliConfigVars = vars
+        return this
+    }
+
+    @Override
     Set<String> getDeclaredProfiles() {
         return declaredProfiles
     }
@@ -148,6 +156,7 @@ class ConfigParserV2 implements ConfigParser {
             script.setStripSecrets(stripSecrets)
             script.setParams(cliParams)
             script.setConfigParams(configParams)
+            script.setCliConfigVars(cliConfigVars)
             script.setProfiles(appliedProfiles)
             script.run()
 

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -1039,4 +1039,91 @@ class ConfigBuilderTest extends Specification {
         SysEnv.pop()
     }
 
+    def 'should make a CLI-supplied outputDir available for config interpolation' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def cliOutputDir = folder.resolve('cli-output')
+        def text = '''
+        resolvedOutputDir = "$outputDir"
+        '''
+
+        when:
+        def cfg = new ConfigBuilder()
+                .setBaseDir(folder)
+                .setOutputDir(cliOutputDir.toString())
+                .build([text])
+        then:
+        cfg.resolvedOutputDir == cliOutputDir.toString()
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'should make a CLI-supplied workDir available for config interpolation' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def cliWorkDir = folder.resolve('cli-work')
+        def text = '''
+        resolvedWorkDir = "$workDir"
+        '''
+
+        when:
+        def cfg = new ConfigBuilder()
+                .setBaseDir(folder)
+                .setWorkDir(cliWorkDir.toString())
+                .build([text])
+        then:
+        cfg.resolvedWorkDir == cliWorkDir.toString()
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'should let a CLI-supplied outputDir override a config assignment' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def cliOutputDir = folder.resolve('cli-output')
+        def text = '''
+        outputDir = 'config-output'
+        resolvedOutputDir = "$outputDir"
+        '''
+
+        when:
+        def cfg = new ConfigBuilder()
+                .setBaseDir(folder)
+                .setOutputDir(cliOutputDir.toString())
+                .build([text])
+        then:
+        cfg.outputDir == cliOutputDir
+        cfg.resolvedOutputDir == cliOutputDir.toString()
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
+    def 'should propagate a CLI-supplied outputDir through an included config, overriding its own assignment' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def cliOutputDir = folder.resolve('cli-output')
+        def snippet = folder.resolve('included.config')
+        snippet.text = '''
+        outputDir = 'included-config-output'
+        resolvedOutputDir = "$outputDir"
+        '''
+        def text = """
+        includeConfig "$snippet"
+        """
+
+        when:
+        def cfg = new ConfigBuilder()
+                .setBaseDir(folder)
+                .setOutputDir(cliOutputDir.toString())
+                .build([text])
+        then:
+        cfg.resolvedOutputDir == cliOutputDir.toString()
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
 }

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigBuilderTest.groovy
@@ -1079,6 +1079,52 @@ class ConfigBuilderTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should use a weaker workDir default for config interpolation when no CLI flag is given' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def envWorkDir = folder.resolve('env-work')
+        SysEnv.push('NXF_WORK': envWorkDir.toString())
+        def text = '''
+        resolvedWorkDir = "$workDir"
+        '''
+
+        when:
+        def cfg = new ConfigBuilder()
+                .setBaseDir(folder)
+                .setWorkDirDefault(SysEnv.get('NXF_WORK'))
+                .build([text])
+        then:
+        cfg.resolvedWorkDir == envWorkDir.toString()
+
+        cleanup:
+        folder?.deleteDir()
+        SysEnv.pop()
+    }
+
+    def 'should let a config assignment override the weaker NXF_WORK default' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def envWorkDir = folder.resolve('env-work')
+        SysEnv.push('NXF_WORK': envWorkDir.toString())
+        def text = '''
+        workDir = 'config-work'
+        resolvedWorkDir = "$workDir"
+        '''
+
+        when:
+        def cfg = new ConfigBuilder()
+                .setBaseDir(folder)
+                .setWorkDirDefault(SysEnv.get('NXF_WORK'))
+                .build([text])
+        then:
+        cfg.workDir == 'config-work'
+        cfg.resolvedWorkDir == 'config-work'
+
+        cleanup:
+        folder?.deleteDir()
+        SysEnv.pop()
+    }
+
     def 'should let a CLI-supplied outputDir override a config assignment' () {
         given:
         def folder = Files.createTempDirectory('test')

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -889,13 +889,32 @@ class ConfigParserV2Test extends Specification {
             '''
 
         when:
-        // seed a pre-existing binding value, as ConfigBuilder does for outputDir, so this
-        // exercises the same "reassignment overrides an existing binding entry" scenario
-        def config = new ConfigParserV2().setBinding([workDir: 'default-work']).parse(CONFIG)
+        // defensive copy -- getConfigVars() is memoized, and setBinding() keeps the map
+        // it's given live, so parsing must not mutate the cached instance in place
+        def binding = new HashMap(ConfigBuilder.getConfigVars(Path.of('.').toRealPath(), [:]))
+        def config = new ConfigParserV2().setBinding(binding).parse(CONFIG)
 
         then:
         config.workDir == 'custom-work'
         config.report.file == 'custom-work/execution_report.html'
+    }
+
+    def 'should resolve outputDir/workDir to their pre-seeded defaults when never reassigned' () {
+        given:
+        def CONFIG = '''
+            report {
+                outputFile = "${outputDir}/execution_report.html"
+                workFile = "${workDir}/execution_report.html"
+            }
+            '''
+
+        when:
+        def binding = new HashMap(ConfigBuilder.getConfigVars(Path.of('.').toRealPath(), [:]))
+        def config = new ConfigParserV2().setBinding(binding).parse(CONFIG)
+
+        then:
+        config.report.outputFile == "${binding.outputDir}/execution_report.html"
+        config.report.workFile == "${binding.workDir}/execution_report.html"
     }
 
     static class ConfigFileHandler implements HttpHandler {

--- a/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/parser/v2/ConfigParserV2Test.groovy
@@ -859,6 +859,45 @@ class ConfigParserV2Test extends Specification {
         e.message.contains('offending scope: `docker`')
     }
 
+    def 'should reflect a reassigned outputDir in a later reference within the same file' () {
+        given:
+        def CONFIG = '''
+            outputDir = 'custom-out'
+            report {
+                file = "${outputDir}/execution_report.html"
+            }
+            '''
+
+        when:
+        // defensive copy -- getConfigVars() is memoized, and setBinding() keeps the map
+        // it's given live, so parsing must not mutate the cached instance in place
+        def binding = new HashMap(ConfigBuilder.getConfigVars(Path.of('.').toRealPath(), [:]))
+        def config = new ConfigParserV2().setBinding(binding).parse(CONFIG)
+
+        then:
+        config.outputDir == 'custom-out'
+        config.report.file == 'custom-out/execution_report.html'
+    }
+
+    def 'should reflect a reassigned workDir in a later reference within the same file' () {
+        given:
+        def CONFIG = '''
+            workDir = 'custom-work'
+            report {
+                file = "${workDir}/execution_report.html"
+            }
+            '''
+
+        when:
+        // seed a pre-existing binding value, as ConfigBuilder does for outputDir, so this
+        // exercises the same "reassignment overrides an existing binding entry" scenario
+        def config = new ConfigParserV2().setBinding([workDir: 'default-work']).parse(CONFIG)
+
+        then:
+        config.workDir == 'custom-work'
+        config.report.file == 'custom-work/execution_report.html'
+    }
+
     static class ConfigFileHandler implements HttpHandler {
 
         Path folder

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
@@ -94,6 +94,8 @@ class ConfigCmdAdapter {
     ConfigCmdAdapter setCmdRun(CmdRun cmdRun) {
         this.cmdRun = cmdRun
         builder.setProfile(cmdRun.profile)
+        builder.setOutputDir(cmdRun.outputDir)
+        builder.setWorkDir(cmdRun.workDir)
         return this
     }
 

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/config/ConfigCmdAdapter.groovy
@@ -96,6 +96,7 @@ class ConfigCmdAdapter {
         builder.setProfile(cmdRun.profile)
         builder.setOutputDir(cmdRun.outputDir)
         builder.setWorkDir(cmdRun.workDir)
+        builder.setWorkDirDefault(SysEnv.get('NXF_WORK'))
         return this
     }
 

--- a/modules/nf-lang/src/main/java/nextflow/config/dsl/ConfigDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/dsl/ConfigDsl.java
@@ -44,6 +44,12 @@ public interface ConfigDsl extends DslScope {
     """)
     Path getLaunchDir();
 
+    @Constant("outputDir")
+    @Description("""
+        The directory where workflow outputs are published.
+    """)
+    Path getOutputDir();
+
     @Constant("params")
     @Description("""
         Map of workflow parameters specified in the config file or as command line options.
@@ -61,6 +67,12 @@ public interface ConfigDsl extends DslScope {
         Map of pipeline secrets.
     """)
     Map<String,String> getSecrets();
+
+    @Constant("workDir")
+    @Description("""
+        The directory where task temporary files are stored.
+    """)
+    Path getWorkDir();
 
     // functions
 


### PR DESCRIPTION
## Summary

Make `outputDir` and `workDir` reliable implicit variables in Nextflow configuration files.

Users can configure these directories with a config assignment, a native command-line option, or for `workDir` the `NXF_WORK` environment variable. However, config expressions that referenced them could previously fail to compile, resolve to a stale/default value, or disagree with the directory ultimately used by the workflow.

This PR makes config-time interpolation reflect the effective directory value that Nextflow will use.

## User impact

The following configuration now works as expected:

```groovy
report {
    file = "${outputDir}/pipeline_info/execution_report.html"
}
```

When invoked with:

```bash
nextflow run main.nf -output-dir custom-results
```

the report path resolves to:

```text
custom-results/pipeline_info/execution_report.html
```

Similarly, `workDir` can be used in configuration expressions:

```groovy
some_config_file = "${workDir}/metadata/config.json"
```

(that's probably less useful, but I did it for consistency with `outputDir`).

The value is also propagated through included configuration files.

## What was wrong before

There were three separate problems in the v2 configuration parser:

1. `outputDir` and `workDir` were not declared as recognized implicit config variables, so valid references such as `${outputDir}` could fail during compilation.

2. Assigning a value did not update the parser binding used by later expressions:

   ```groovy
   outputDir = params.outdir

   report.file = "${outputDir}/report.html"
   ```

   The final configuration could contain the new `outputDir`, while `report.file` was evaluated using the previous default value.

3. Native command-line values were applied only after config parsing. As a result, `-output-dir` and `-work-dir` affected the final session but were not visible to expressions evaluated inside the config file.

`NXF_WORK` had an analogous visibility problem: it was applied as a fallback after parsing rather than being available to config expressions.

## Effective precedence

The parser now exposes the same effective values used by the session:

### `outputDir`

```text
default < config assignment < -output-dir
```

### `workDir`

```text
default < NXF_WORK < config assignment < -work-dir
```

For example, with:

```bash
NXF_WORK=/scratch/default nextflow run main.nf -work-dir /scratch/cli
```

the value visible during config evaluation is `/scratch/cli`.

Without `-work-dir`, `NXF_WORK` is visible during config evaluation, but an explicit config assignment still takes precedence:

```groovy
workDir = "${projectDir}/work"
config_path = "${workDir}/config.json"
```

## Implementation

- Declare `outputDir` and `workDir` as config DSL constants.
- Seed a default `workDir` value alongside the existing `outputDir` value.
- Update the script binding when top-level config variables are assigned.
- Pass native `-output-dir` and `-work-dir` values into the parser before config evaluation.
- Make `NXF_WORK` available during config evaluation as a weaker default than a config assignment.
- Propagate the effective values through `includeConfig`.

This change targets the default v2 configuration parser. The legacy v1 parser already reflects CLI and `NXF_WORK` overrides via a different mechanism, but same-file reassignment without a CLI flag remains unfixed there -- that's the original #5543 behavior, unchanged.

## Tests

Added regression coverage for:

- `outputDir` and `workDir` as implicit variables.
- Same-file reassignment.
- Default values.
- Native CLI values during interpolation.
- CLI precedence over config assignments.
- `NXF_WORK` precedence.
- Propagation through included configuration files.

Validated with:

```text
:nextflow:test
:nf-lang:test
:nf-cli-v1:test
```
