### PR TITLE
Instance flexibility for Google Batch

### DIFF
--- a/docs/google.mdx
+++ b/docs/google.mdx
@@ -134,6 +134,27 @@ process my_task {
 }
 ```
 
+<AddedInVersion version="26.10" />
+
+When the `google.batch.instanceFlexibility` config option is enabled and the `machineType` directive specifies two or more explicit machine types, i.e. without any `*` or `?` wildcard, Nextflow uses [instance flexibility](https://cloud.google.com/batch/docs/create-run-job-instance-flexibility), which allows Google Batch to launch the task with any of the given machine types, depending on the available capacity. This can improve the obtainability of the task VM, particularly when using spot instances.
+
+```groovy
+google.batch.instanceFlexibility = true
+```
+
+```nextflow
+process my_task {
+    cpus 8
+    memory '20 GB'
+    machineType 'n2-standard-8,n2d-standard-8,c3-standard-8'
+
+    script:
+    """
+    your_command --here
+    """
+}
+```
+
 <AddedInVersion version="24.04" />
 
 The `machineType` directive can also be an [Instance Template](https://cloud.google.com/compute/docs/instance-templates),

--- a/docs/reference/config/google.mdx
+++ b/docs/reference/config/google.mdx
@@ -74,6 +74,16 @@ For Google Batch, use [Batch-debian images](https://docs.cloud.google.com/batch/
 The default Container-Optimized OS (`batch-cos`) is not compatible with the Ops Agent.
 :::
 
+##### `google.batch.instanceFlexibility`
+
+<AddedInVersion version="26.10" />
+
+Enable [instance flexibility](https://cloud.google.com/batch/docs/create-run-job-instance-flexibility) (default: `false`). When enabled, a `machineType` directive that specifies two or more explicit machine types allows Google Batch to launch the task with any of them, depending on the available capacity.
+
+:::note
+Instance flexibility is a preview feature of Google Batch, therefore these jobs are submitted using the Batch `v1alpha` API.
+:::
+
 ##### `google.batch.logsPath`
 
 <AddedInVersion version="26.04" />

--- a/plugins/nf-google/build.gradle
+++ b/plugins/nf-google/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.14.1'
 
     api 'com.google.auth:google-auth-library-oauth2-http:1.39.1'
-    api 'com.google.cloud:google-cloud-batch:0.75.0'
+    api 'com.google.cloud:google-cloud-batch:0.96.0'
     api 'com.google.cloud:google-cloud-logging:3.23.5'
     api 'com.google.cloud:google-cloud-nio:0.128.5'
     api 'com.google.cloud:google-cloud-storage:2.58.0'

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -196,8 +196,10 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
          */
         final req = newSubmitRequest(task, spec0(launcher))
         log.trace "[GOOGLE BATCH] new job request > $req"
-        final resp = client.submitJob(jobId, req)
-        final uid = resp.getUid()
+        final selections = instanceSelections(task.config)
+        final uid = selections
+            ? client.submitJobWithInstanceFlexibility(jobId, req, selections)
+            : client.submitJob(jobId, req).getUid()
         updateStatus(jobId, '0', uid)
         log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` submitted > job=$jobId; uid=$uid; work-dir=${task.getWorkDirStr()}"
     }
@@ -401,8 +403,12 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
         else {
             final instancePolicy = AllocationPolicy.InstancePolicy.newBuilder()
 
+            // when two or more machine types are specified, let Batch choose one of them
+            // via the instance flexibility policy added at submit time
+            final selections = instanceSelections(task.config)
+
             if( fusionEnabled() && !disk ) {
-                final reqMachineType = task.config.getMachineType()
+                final reqMachineType = selections ? selections.first() : task.config.getMachineType()
                 disk = new DiskResource(
                     request: '375 GB',
                     type: reqMachineType ? chooseFusionDiskType(reqMachineType) : 'local-ssd'
@@ -410,7 +416,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
                 log.debug "[GOOGLE BATCH] Process `${task.lazyName()}` - adding local volume as fusion scratch: $disk"
             }
 
-            final machineType = findBestMachineType(task.config, disk?.type == 'local-ssd')
+            final machineType = selections
+                ? null
+                : findBestMachineType(task.config, disk?.type == 'local-ssd')
 
             if( machineType ) {
                 instancePolicy.setMachineType(machineType.type)
@@ -916,6 +924,26 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
 
     protected GoogleBatchMachineTypeSelector.MachineType bestMachineType0(int cpus, int memory, String location, boolean spot, boolean localSSD, List<String> families) {
         return GoogleBatchMachineTypeSelector.INSTANCE.bestMachineType(cpus, memory, location, spot, localSSD, families)
+    }
+
+    /**
+     * The list of machine types to be allowed by the job instance flexibility policy, that is
+     * when instance flexibility is enabled and the `machineType` directive specifies two or more
+     * explicit machine types e.g. `machineType 'n2-standard-4,c3-standard-4'`.
+     *
+     * Patterns containing `*` or `?` are not included because they are resolved to a single
+     * machine type by the machine type selector.
+     *
+     * @param config The task config
+     * @return The allowed machine types or an empty list when instance flexibility does not apply
+     */
+    protected List<String> instanceSelections(TaskConfig config) {
+        if( !batchConfig.instanceFlexibility )
+            return List.<String>of()
+        final machineType = config.getMachineType()
+        if( !machineType || !machineType.contains(',') || machineType.contains('*') || machineType.contains('?') )
+            return List.<String>of()
+        return machineType.tokenize(',').collect(it -> it.trim())
     }
 
     protected GoogleBatchMachineTypeSelector.MachineType findBestMachineType(TaskConfig config, boolean localSSD) {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -37,6 +37,12 @@ import com.google.cloud.batch.v1.Task
 import com.google.cloud.batch.v1.TaskGroupName
 import com.google.cloud.batch.v1.TaskName
 import com.google.cloud.batch.v1.TaskStatus
+import com.google.cloud.batch.v1alpha.AllocationPolicy as AlphaAllocationPolicy
+import com.google.cloud.batch.v1alpha.BatchServiceClient as AlphaBatchServiceClient
+import com.google.cloud.batch.v1alpha.BatchServiceSettings as AlphaBatchServiceSettings
+import com.google.cloud.batch.v1alpha.Job as AlphaJob
+import com.google.cloud.batch.v1alpha.LocationName as AlphaLocationName
+import com.google.protobuf.util.JsonFormat
 import dev.failsafe.Failsafe
 import dev.failsafe.RetryPolicy
 import dev.failsafe.event.EventListener
@@ -58,6 +64,7 @@ class BatchClient {
     protected String projectId
     protected String location
     protected BatchServiceClient batchServiceClient
+    private AlphaBatchServiceClient alphaServiceClient
     protected GoogleOpts config
     private Map<String, TaskStatusRecord> arrayTaskStatus = new ConcurrentHashMap<String, TaskStatusRecord>()
 
@@ -105,6 +112,59 @@ class BatchClient {
         return apply(()-> batchServiceClient.createJob(parent, job, jobId))
     }
 
+    /**
+     * Submit a job adding an instance flexibility policy for the specified machine types,
+     * so that Batch can choose any of them depending on the available capacity.
+     *
+     * Instance flexibility is only available in the Batch v1alpha API (preview), therefore
+     * the job is converted to the corresponding v1alpha message and submitted with a
+     * dedicated client. The resulting job is a regular Batch job and can be inspected
+     * with the v1 API as any other job.
+     *
+     * @param jobId The job unique id
+     * @param job The job to be submitted
+     * @param machineTypes The machine types allowed for this job
+     * @return The unique id of the submitted job
+     */
+    String submitJobWithInstanceFlexibility(String jobId, Job job, List<String> machineTypes) {
+        final parent = AlphaLocationName.of(projectId, location)
+        final alphaJob = toAlphaJob(job, machineTypes)
+        final result = apply(()-> alphaClient().createJob(parent, alphaJob, jobId))
+        return result.getUid()
+    }
+
+    /**
+     * Convert a v1 job to the corresponding v1alpha job, adding the instance flexibility
+     * policy for the specified machine types
+     *
+     * @param job The job to be converted
+     * @param machineTypes The machine types allowed for this job
+     * @return The v1alpha job
+     */
+    protected AlphaJob toAlphaJob(Job job, List<String> machineTypes) {
+        final builder = AlphaJob.newBuilder()
+        JsonFormat.parser().merge(JsonFormat.printer().print(job), builder)
+        builder.getAllocationPolicyBuilder().setInstanceFlexibilityPolicy(
+            AlphaAllocationPolicy.InstanceFlexibilityPolicy.newBuilder()
+                .putInstanceSelections('nextflow', AlphaAllocationPolicy.InstanceSelection.newBuilder()
+                    .addAllMachineTypes(machineTypes)
+                    .build())
+        )
+        return builder.build()
+    }
+
+    synchronized protected AlphaBatchServiceClient alphaClient() {
+        if( alphaServiceClient )
+            return alphaServiceClient
+        final provider = createCredentialsProvider(config)
+        final settings = AlphaBatchServiceSettings
+            .newBuilder()
+            .setHeaderProvider(FixedHeaderProvider.create('user-agent', 'Nextflow'))
+        if( provider )
+            settings.setCredentialsProvider(provider)
+        return alphaServiceClient = AlphaBatchServiceClient.create(settings.build())
+    }
+
     Job describeJob(String jobId) {
         final name = JobName.of(projectId, location, jobId)
         return apply(()-> batchServiceClient.getJob(name))
@@ -140,6 +200,7 @@ class BatchClient {
 
     void shutdown() {
         batchServiceClient.close()
+        alphaServiceClient?.close()
     }
 
     String getLocation() {

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchConfig.groovy
@@ -92,6 +92,12 @@ class BatchConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        Enable [instance flexibility](https://cloud.google.com/batch/docs/create-run-job-instance-flexibility), allowing Google Batch to choose any of the machine types specified by the `machineType` directive (default: `false`).
+    """)
+    final boolean instanceFlexibility
+
+    @ConfigOption
+    @Description("""
         The Google Cloud Storage path where job logs should be stored, e.g. `gs://my-logs-bucket/logs`.
     """)
     final String logsPath
@@ -154,6 +160,7 @@ class BatchConfig implements ConfigScope {
         gcsfuseOptions = opts.gcsfuseOptions as List<String> ?: DEFAULT_GCSFUSE_OPTS
         installGpuDrivers = opts.installGpuDrivers as boolean
         installOpsAgent = opts.installOpsAgent as boolean
+        instanceFlexibility = opts.instanceFlexibility as boolean
         logsPath = opts.logsPath
         maxSpotAttempts = opts.maxSpotAttempts != null ? opts.maxSpotAttempts as int : DEFAULT_MAX_SPOT_ATTEMPTS
         network = opts.network

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -561,6 +561,44 @@ class GoogleBatchTaskHandlerTest extends Specification {
         handler.getJobError() == null
     }
 
+    def 'should determine the instance selections' () {
+        given:
+        def handler = new GoogleBatchTaskHandler(batchConfig: new BatchConfig([instanceFlexibility: ENABLED]))
+        def config = Mock(TaskConfig) { getMachineType() >> MACHINE_TYPE }
+
+        expect:
+        handler.instanceSelections(config) == EXPECTED
+
+        where:
+        ENABLED | MACHINE_TYPE                   | EXPECTED
+        false   | 'n2-standard-4,c3-standard-4'  | []
+        true    | null                           | []
+        true    | 'n2-standard-4'                | []
+        true    | 'n2-*,c2-*'                    | []
+        true    | 'n?-standard-4,c3-standard-4'  | []
+        true    | 'template://my-template'       | []
+        true    | 'n2-standard-4,c3-standard-4'  | ['n2-standard-4','c3-standard-4']
+        true    | 'n2-standard-4, c3-standard-4' | ['n2-standard-4','c3-standard-4']
+    }
+
+    def 'should not set the machine type when using instance flexibility' () {
+        given:
+        def task = Mock(TaskRun) {
+            lazyName() >> 'foo (1)'
+            getConfig() >> Mock(TaskConfig) { getMachineType() >> 'n2-standard-4,c3-standard-4' }
+        }
+        def handler = Spy(new GoogleBatchTaskHandler(task: task, batchConfig: new BatchConfig([instanceFlexibility: true])))
+
+        when:
+        def result = handler.buildInstancePolicyOrTemplate(task, null)
+        then:
+        _ * handler.fusionEnabled() >> false
+        0 * handler.findBestMachineType(_,_) >> null
+        and:
+        !result.policy.getPolicy().getMachineType()
+        !handler.getMachineInfo()
+    }
+
     def 'should find best instance type' () {
         given:
         def workDir = Path.of('/work/dir')

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchClientTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchClientTest.groovy
@@ -15,6 +15,8 @@
  */
 package nextflow.cloud.google.batch.client
 
+import com.google.cloud.batch.v1.AllocationPolicy
+import com.google.cloud.batch.v1.Job
 import com.google.cloud.batch.v1.Task
 import com.google.cloud.batch.v1.TaskName
 import com.google.cloud.batch.v1.TaskStatus
@@ -63,6 +65,32 @@ class BatchClientTest extends Specification{
         client.getTaskInArrayStatus(job2, task2).state == TaskStatus.State.FAILED
         // no cached task
         client.getTaskInArrayStatus(job3, task3).state == TaskStatus.State.SUCCEEDED
+    }
+
+    def 'should convert a job adding the instance flexibility policy' () {
+        given:
+        def client = new BatchClient()
+        def job = Job.newBuilder()
+            .putLabels('foo','bar')
+            .setAllocationPolicy(AllocationPolicy.newBuilder()
+                .addInstances(AllocationPolicy.InstancePolicyOrTemplate.newBuilder()
+                    .setPolicy(AllocationPolicy.InstancePolicy.newBuilder()
+                        .setProvisioningModel(AllocationPolicy.ProvisioningModel.SPOT)))
+                .addTags('my-tag'))
+            .build()
+
+        when:
+        def result = client.toAlphaJob(job, ['n2-standard-4','c3-standard-4'])
+
+        then:
+        def selections = result.getAllocationPolicy().getInstanceFlexibilityPolicy().getInstanceSelectionsMap()
+        selections.size() == 1
+        selections.get('nextflow').getMachineTypesList() == ['n2-standard-4','c3-standard-4']
+        and:
+        // the other job settings are preserved
+        result.getLabelsMap() == [foo: 'bar']
+        result.getAllocationPolicy().getTagsList() == ['my-tag']
+        result.getAllocationPolicy().getInstances(0).getPolicy().getProvisioningModel().toString() == 'SPOT'
     }
 
     TaskStatusRecord makeTaskStatusRecord(TaskStatus.State state, long timestamp) {


### PR DESCRIPTION
Close #6686

This PR implements [instance flexibility](https://docs.cloud.google.com/batch/docs/create-run-job-instance-flexibility) for Google Batch, which makes it easier to request multiple instance types

Currently only available in the v1alpha -- marked as draft until the feature is available in v1.