### PR TITLE
Report a syntax error for an invalid output or emit assignment

### DIFF
--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -671,7 +671,7 @@ public class ScriptAstBuilder {
         Statement result;
         if( ctx.statement() != null ) {
             result = statement(ctx.statement());
-            if( !(result instanceof ExpressionStatement) ) {
+            if( !isEmitExpression(result) ) {
                 collectSyntaxError(new SyntaxException("Invalid output declaration in typed process -- must be a name, assignment, or expression", result));
                 return null;
             }
@@ -968,7 +968,7 @@ public class ScriptAstBuilder {
         Statement result;
         if( ctx.statement() != null ) {
             result = statement(ctx.statement());
-            if( !(result instanceof ExpressionStatement) ) {
+            if( !isEmitExpression(result) ) {
                 collectSyntaxError(new SyntaxException("Invalid workflow emit -- must be a name, assignment, or expression", result));
                 return null;
             }
@@ -992,7 +992,8 @@ public class ScriptAstBuilder {
     private boolean isEmitExpression(Statement stmt) {
         if( stmt instanceof ExpressionStatement es ) {
             var exp = es.getExpression();
-            return !(exp instanceof VariableExpression || exp instanceof AssignmentExpression);
+            return !(exp instanceof VariableExpression)
+                && !(exp instanceof BinaryExpression be && be.getOperation().isA(Types.ASSIGNMENT_OPERATOR));
         }
         return false;
     }

--- a/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
@@ -306,6 +306,63 @@ class ScriptAstBuilderTest extends Specification {
         errors[0].getOriginalMessage() == "Invalid workflow emit -- must be a name, assignment, or expression"
     }
 
+    def 'should report an error for an invalid output assignment' () {
+        when:
+        def errors = check(
+            '''\
+            nextflow.enable.types = true
+
+            process hello {
+                output:
+                target <<= 'world'
+
+                script:
+                ""
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 5
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == "Invalid output declaration in typed process -- must be a name, assignment, or expression"
+
+        when:
+        errors = check(
+            '''\
+            nextflow.enable.types = true
+
+            process hello {
+                output:
+                target.name = 'world'
+
+                script:
+                ""
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 5
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == "Invalid output declaration in typed process -- must be a name, assignment, or expression"
+
+        when:
+        errors = check(
+            '''\
+            workflow hello {
+                emit:
+                target <<= 'world'
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 3
+        errors[0].getStartColumn() == 5
+        errors[0].getOriginalMessage() == "Invalid workflow emit -- must be a name, assignment, or expression"
+    }
+
     def 'should report error for defining a typed process without preview flag' () {
         when:
         def errors = check(


### PR DESCRIPTION
Fix #7543

This PR hardens the syntax checking of typed process/workflow outputs. It did not catch invalid assignments such as `v <<= 'B'` and `x.y = 'B'`, so these fell through and produced cryptic compiler errors.