### PR TITLE
Update CI bucket to s3://nextflow-oss-ci [25.10.x backport]

### DIFF
--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/AwsS3NioTest.groovy
@@ -1034,7 +1034,7 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         def folder = Files.createTempDirectory('test')
         def target = folder.resolve('test-data.txt')
         and:
-        def source = s3path("s3://nf-kms-xyz/test-data.txt")
+        def source = s3path("s3://nextflow-ci-oss-kms/fixtures/test-data.txt")
 
         when:
         FileHelper.copyPath(source, target)
@@ -1047,12 +1047,12 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
 
     def 'should upload file to encrypted bucket' () {
         given:
-        def KEY = 'arn:aws:kms:eu-west-1:195996028523:key/e97ecf28-951e-4700-bf22-1bd416ec519f'
+        def KEY = 'arn:aws:kms:eu-west-1:807882257208:key/28c34bc1-d8da-4682-9b2e-3356aeb77cc9'
         and:
         def folder = Files.createTempDirectory('test')
         def source = folder.resolve('hello.txt'); source.text = 'Hello world'
         and:
-        def target = s3path("s3://nf-kms-xyz/test-${UUID.randomUUID()}.txt")
+        def target = s3path("s3://nextflow-ci-oss-kms/test-${UUID.randomUUID()}.txt")
         and: // assign some tags
         target.setTags([ONE: 'HELLO'])
 
@@ -1073,7 +1073,7 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
 
     def 'should upload directory to encrypted bucket' () {
         given:
-        def KEY = 'arn:aws:kms:eu-west-1:195996028523:key/e97ecf28-951e-4700-bf22-1bd416ec519f'
+        def KEY = 'arn:aws:kms:eu-west-1:807882257208:key/28c34bc1-d8da-4682-9b2e-3356aeb77cc9'
         and:
         def folder = Files.createTempDirectory('test')
         def source = folder.resolve('data'); source.mkdir()
@@ -1086,7 +1086,7 @@ class AwsS3NioTest extends Specification implements AwsS3BaseSpec {
         source.resolve('alpha/beta/file-5.txt').text = 'file 5'
 
         and:
-        def target = s3path("s3://nf-kms-xyz/test-${UUID.randomUUID()}")
+        def target = s3path("s3://nextflow-ci-oss-kms/test-${UUID.randomUUID()}")
         and: // assign some tags
         target.setTags([ONE: 'HELLO'])
 

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sConfigTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sConfigTest.groovy
@@ -393,13 +393,13 @@ class K8sConfigTest extends Specification {
     def 'should set env and sec context' () {
         given:
         def ctx = [
-                [env: 'FUSION_BUCKETS', value: 's3://nextflow-ci'],
+                [env: 'FUSION_BUCKETS', value: 's3://nextflow-ci-oss'],
                 [securityContext: [privileged: true]]]
 
         when:
         def cfg = new K8sConfig( pod: ctx )
         then:
-        cfg.getPodOptions().getEnvVars().first() == PodEnv.value('FUSION_BUCKETS', 's3://nextflow-ci')
+        cfg.getPodOptions().getEnvVars().first() == PodEnv.value('FUSION_BUCKETS', 's3://nextflow-ci-oss')
         cfg.getPodOptions().getSecurityContext().toSpec() == [privileged:true]
 
     }

--- a/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
+++ b/plugins/nf-k8s/src/test/nextflow/k8s/K8sTaskHandlerTest.groovy
@@ -863,11 +863,11 @@ class K8sTaskHandlerTest extends Specification {
         when:
         opts = handler.getPodOptions()
         then:
-        1 * k8sConfig.getPodOptions() >> new PodOptions([[env: 'FUSION_BUCKETS', value: 's3://nextflow-ci'], [privileged: true]])
+        1 * k8sConfig.getPodOptions() >> new PodOptions([[env: 'FUSION_BUCKETS', value: 's3://nextflow-ci-oss'], [privileged: true]])
         and:
         1 * handler.taskPodOptions() >> new PodOptions([:])
         and: 
-        opts == new PodOptions([[env: 'FUSION_BUCKETS', value: 's3://nextflow-ci'], [privileged: true]])
+        opts == new PodOptions([[env: 'FUSION_BUCKETS', value: 's3://nextflow-ci-oss'], [privileged: true]])
     }
 
     def 'should update startTimeMillis and completeTimeMillis with terminated state' () {

--- a/tests-v1/checks/cache-bak.nf/.checks
+++ b/tests-v1/checks/cache-bak.nf/.checks
@@ -21,7 +21,7 @@ $NXF_RUN -name test_1 | tee .stdout
 #
 # backup cache
 #
-NXF_WORK=s3://nextflow-ci/cache-test  \
+NXF_WORK=s3://nextflow-ci-oss/cache-test  \
   $NXF_CMD -log .nextflow-backup.log plugin nf-tower:cache-backup
 
 #
@@ -32,7 +32,7 @@ rm -rf .nextflow
 #
 # restore cache
 #
-NXF_WORK=s3://nextflow-ci/cache-test  \
+NXF_WORK=s3://nextflow-ci-oss/cache-test  \
   $NXF_CMD -log .nextflow-restore.log plugin nf-tower:cache-restore
 
 #

--- a/tests-v1/checks/cli-fs.nf/.checks
+++ b/tests-v1/checks/cli-fs.nf/.checks
@@ -11,10 +11,10 @@ NAME=test-cmd-$(basename `mktemp`).file
 head -c 1000000 </dev/urandom >myfile
 
 ## upload it
-$NXF_CMD -log cmd-fs-1.log fs cp myfile s3://nextflow-ci/$NAME
+$NXF_CMD -log cmd-fs-1.log fs cp myfile s3://nextflow-ci-oss/$NAME
 
 ## download it
-$NXF_CMD -log cmd-fs-2.log fs cp s3://nextflow-ci/$NAME $NAME
+$NXF_CMD -log cmd-fs-2.log fs cp s3://nextflow-ci-oss/$NAME $NAME
 
 ## check they are equals
 diff myfile $NAME || false

--- a/tests-v1/checks/fusion-symlink.nf/.checks
+++ b/tests-v1/checks/fusion-symlink.nf/.checks
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Skip test if AWS keys are missing
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo "Missing AWS credentials -- Skipping test"
   exit 0
 fi
 
-OUTDIR="s3://nextflow-ci/work/ci-test/fusion-symlink/$(uuidgen)"
+OUTDIR="s3://nextflow-ci-oss/work/ci-test/fusion-symlink/$(uuidgen)"
 
 #
 # normal run

--- a/tests-v1/checks/fusion-symlink.nf/.config
+++ b/tests-v1/checks/fusion-symlink.nf/.config
@@ -1,4 +1,4 @@
-workDir = 's3://nextflow-ci/work'
+workDir = 's3://nextflow-ci-oss/work'
 fusion.enabled = true
 fusion.exportStorageCredentials = true
 wave.enabled = true

--- a/tests-v1/checks/publish-s3-kms.nf/.checks
+++ b/tests-v1/checks/publish-s3-kms.nf/.checks
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-BUCKET="nf-kms-xyz"
+BUCKET="nextflow-ci-oss-kms"
 PREFIX="work/ci-test/publish-s3/$(uuidgen)"
 OUTDIR="s3://$BUCKET/$PREFIX"
 
 function check_kms_key() {
-  aws s3api head-object --bucket "$BUCKET" --key "$PREFIX/HELLO.tsv" | grep -c e5109f93-b42d-4c26-89ee-8b251029a41d
+  aws s3api head-object --bucket "$BUCKET" --key "$PREFIX/HELLO.tsv" | grep -c 28c34bc1-d8da-4682-9b2e-3356aeb77cc9
 }
 
 # Skip test if AWS keys are missing
@@ -27,4 +27,3 @@ $NXF_RUN -c .config --outdir "$OUTDIR" | tee .stdout
 $NXF_RUN -c .config --outdir "$OUTDIR"  -resume | tee .stdout
 [[ $(grep INFO .nextflow.log | grep -c 'Cached process') == 1 ]] || false
 [[ $(check_kms_key) == 1 ]] || false
-

--- a/tests-v1/checks/publish-s3-kms.nf/.config
+++ b/tests-v1/checks/publish-s3-kms.nf/.config
@@ -1,2 +1,2 @@
 aws.client.storageEncryption = 'aws:kms'
-aws.client.storageKmsKeyId = 'arn:aws:kms:eu-west-1:195996028523:key/e5109f93-b42d-4c26-89ee-8b251029a41d'
+aws.client.storageKmsKeyId = 'arn:aws:kms:eu-west-1:807882257208:alias/nextflow-ci-test'

--- a/tests-v1/checks/publish-s3.nf/.checks
+++ b/tests-v1/checks/publish-s3.nf/.checks
@@ -1,24 +1,22 @@
 function count_hello() {
   rm -rf hello
-  aws s3 cp --only-show-errors s3://nextflow-ci/work/ci-test/publish-s3/HELLO.tsv hello && < hello grep 'Hello, world' -c
+  aws s3 cp --only-show-errors s3://nextflow-ci-oss/work/ci-test/publish-s3/HELLO.tsv hello && < hello grep 'Hello, world' -c
 }
 
 # Skip test if AWS keys are missing
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo "Missing AWS credentials -- Skipping test"
   exit 0
 fi
 
 #
-# run normal mode 
+# run normal mode
 #
 $NXF_RUN | tee .stdout
 [[ `grep INFO .nextflow.log | grep -c 'Submitted process'` == 1 ]] || false
 
 #
-# run resume mode 
+# run resume mode
 #
 $NXF_RUN -resume | tee .stdout
 [[ `grep INFO .nextflow.log | grep -c 'Cached process'` == 1 ]] || false
-
-

--- a/tests-v1/checks/s3-report.nf/.checks
+++ b/tests-v1/checks/s3-report.nf/.checks
@@ -11,7 +11,6 @@ fi
 # run normal mode
 #
 $NXF_CMD -trace com.upplication.s3fs run nextflow-io/hello \
-  -with-trace s3://nextflow-ci/test/trace.txt \
-  -with-report s3://nextflow-ci/test/report.html \
+  -with-trace s3://nextflow-ci-oss/test/trace.txt \
+  -with-report s3://nextflow-ci-oss/test/report.html \
   | tee stdout
-

--- a/tests-v1/publish-s3.nf
+++ b/tests-v1/publish-s3.nf
@@ -1,6 +1,6 @@
 
 process my_process {
-    publishDir "s3://nextflow-ci/work/ci-test/publish-s3"
+    publishDir "s3://nextflow-ci-oss/work/ci-test/publish-s3"
 
     input:
     val(param)

--- a/tests/checks/cache-bak.nf/.checks
+++ b/tests/checks/cache-bak.nf/.checks
@@ -21,7 +21,7 @@ $NXF_RUN -name test_1 | tee .stdout
 #
 # backup cache
 #
-NXF_WORK=s3://nextflow-ci/cache-test  \
+NXF_WORK=s3://nextflow-ci-oss/cache-test  \
   $NXF_CMD -log .nextflow-backup.log plugin nf-tower:cache-backup
 
 #
@@ -32,7 +32,7 @@ rm -rf .nextflow
 #
 # restore cache
 #
-NXF_WORK=s3://nextflow-ci/cache-test  \
+NXF_WORK=s3://nextflow-ci-oss/cache-test  \
   $NXF_CMD -log .nextflow-restore.log plugin nf-tower:cache-restore
 
 #

--- a/tests/checks/cli-fs.nf/.checks
+++ b/tests/checks/cli-fs.nf/.checks
@@ -11,10 +11,10 @@ NAME=test-cmd-$(basename `mktemp`).file
 head -c 1000000 </dev/urandom >myfile
 
 ## upload it
-$NXF_CMD -log cmd-fs-1.log fs cp myfile s3://nextflow-ci/$NAME
+$NXF_CMD -log cmd-fs-1.log fs cp myfile s3://nextflow-ci-oss/$NAME
 
 ## download it
-$NXF_CMD -log cmd-fs-2.log fs cp s3://nextflow-ci/$NAME $NAME
+$NXF_CMD -log cmd-fs-2.log fs cp s3://nextflow-ci-oss/$NAME $NAME
 
 ## check they are equals
 diff myfile $NAME || false

--- a/tests/checks/fusion-symlink.nf/.checks
+++ b/tests/checks/fusion-symlink.nf/.checks
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Skip test if AWS keys are missing
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo "Missing AWS credentials -- Skipping test"
   exit 0
 fi
 
-OUTDIR="s3://nextflow-ci/work/ci-test/fusion-symlink/$(uuidgen)"
+OUTDIR="s3://nextflow-ci-oss/work/ci-test/fusion-symlink/$(uuidgen)"
 
 #
 # normal run

--- a/tests/checks/fusion-symlink.nf/.config
+++ b/tests/checks/fusion-symlink.nf/.config
@@ -1,4 +1,4 @@
-workDir = 's3://nextflow-ci/work'
+workDir = 's3://nextflow-ci-oss/work'
 fusion.enabled = true
 fusion.exportStorageCredentials = true
 wave.enabled = true

--- a/tests/checks/publish-s3-kms.nf/.checks
+++ b/tests/checks/publish-s3-kms.nf/.checks
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-BUCKET="nf-kms-xyz"
+BUCKET="nextflow-ci-oss-kms"
 PREFIX="work/ci-test/publish-s3/$(uuidgen)"
 OUTDIR="s3://$BUCKET/$PREFIX"
 
 function check_kms_key() {
-  aws s3api head-object --bucket "$BUCKET" --key "$PREFIX/HELLO.tsv" | grep -c e5109f93-b42d-4c26-89ee-8b251029a41d
+  aws s3api head-object --bucket "$BUCKET" --key "$PREFIX/HELLO.tsv" | grep -c 28c34bc1-d8da-4682-9b2e-3356aeb77cc9
 }
 
 # Skip test if AWS keys are missing
@@ -27,4 +27,3 @@ $NXF_RUN -c .config --outdir "$OUTDIR" | tee .stdout
 $NXF_RUN -c .config --outdir "$OUTDIR"  -resume | tee .stdout
 [[ $(grep INFO .nextflow.log | grep -c 'Cached process') == 1 ]] || false
 [[ $(check_kms_key) == 1 ]] || false
-

--- a/tests/checks/publish-s3-kms.nf/.config
+++ b/tests/checks/publish-s3-kms.nf/.config
@@ -1,2 +1,2 @@
 aws.client.storageEncryption = 'aws:kms'
-aws.client.storageKmsKeyId = 'arn:aws:kms:eu-west-1:195996028523:key/e5109f93-b42d-4c26-89ee-8b251029a41d'
+aws.client.storageKmsKeyId = 'arn:aws:kms:eu-west-1:807882257208:alias/nextflow-ci-test'

--- a/tests/checks/publish-s3.nf/.checks
+++ b/tests/checks/publish-s3.nf/.checks
@@ -1,24 +1,22 @@
 function count_hello() {
   rm -rf hello
-  aws s3 cp --only-show-errors s3://nextflow-ci/work/ci-test/publish-s3/HELLO.tsv hello && < hello grep 'Hello, world' -c
+  aws s3 cp --only-show-errors s3://nextflow-ci-oss/work/ci-test/publish-s3/HELLO.tsv hello && < hello grep 'Hello, world' -c
 }
 
 # Skip test if AWS keys are missing
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then 
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo "Missing AWS credentials -- Skipping test"
   exit 0
 fi
 
 #
-# run normal mode 
+# run normal mode
 #
 $NXF_RUN | tee .stdout
 [[ `grep INFO .nextflow.log | grep -c 'Submitted process'` == 1 ]] || false
 
 #
-# run resume mode 
+# run resume mode
 #
 $NXF_RUN -resume | tee .stdout
 [[ `grep INFO .nextflow.log | grep -c 'Cached process'` == 1 ]] || false
-
-

--- a/tests/checks/s3-report.nf/.checks
+++ b/tests/checks/s3-report.nf/.checks
@@ -11,7 +11,6 @@ fi
 # run normal mode
 #
 $NXF_CMD -trace com.upplication.s3fs run nextflow-io/hello \
-  -with-trace s3://nextflow-ci/test/trace.txt \
-  -with-report s3://nextflow-ci/test/report.html \
+  -with-trace s3://nextflow-ci-oss/test/trace.txt \
+  -with-report s3://nextflow-ci-oss/test/report.html \
   | tee stdout
-

--- a/tests/publish-s3.nf
+++ b/tests/publish-s3.nf
@@ -1,6 +1,6 @@
 
 process my_process {
-    publishDir "s3://nextflow-ci/work/ci-test/publish-s3"
+    publishDir "s3://nextflow-ci-oss/work/ci-test/publish-s3"
 
     input:
     val(param)

--- a/validation/awsbatch-unstage-fail.config
+++ b/validation/awsbatch-unstage-fail.config
@@ -3,10 +3,10 @@
  * published version will be downloaded instead of using local build
  */
 
-workDir = 's3://nextflow-ci/work'
+workDir = 's3://nextflow-ci-oss/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-ci'
 process.container = 'quay.io/nextflow/test-aws-unstage-fail:1.0'
 aws.region = 'eu-west-1'
-aws.batch.maxTransferAttempts = 3 
+aws.batch.maxTransferAttempts = 3
 aws.batch.delayBetweenAttempts = '5 sec'

--- a/validation/awsbatch.config
+++ b/validation/awsbatch.config
@@ -3,11 +3,11 @@
  * published version will be downloaded instead of using local build
  */
 
-workDir = 's3://nextflow-ci/work'
+workDir = 's3://nextflow-ci-oss/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-ci'
 process.container = 'quay.io/nextflow/rnaseq-nf:latest'
 aws.region = 'eu-west-1'
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
-aws.batch.maxTransferAttempts = 3 
+aws.batch.maxTransferAttempts = 3
 aws.batch.delayBetweenAttempts = '5 sec'

--- a/validation/awsbatch.sh
+++ b/validation/awsbatch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e 
+set -e
 
 get_abs_filename() {
   echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
@@ -43,17 +43,19 @@ $NXF_CMD run test-complexpaths.nf -resume -c awsbatch.config
 
 $NXF_CMD run test-subdirs.nf -c awsbatch.config
 
-NXF_CLOUDCACHE_PATH=s3://nextflow-ci/cache \
+NXF_CLOUDCACHE_PATH=s3://nextflow-ci-oss/cache \
 $NXF_CMD run nextflow-io/rnaseq-nf \
     -profile batch \
+    -w s3://nextflow-ci-oss/work \
     -with-report \
     -with-trace \
     -plugins nf-cloudcache
 [[ `grep -c 'Using Nextflow cache factory: nextflow.cache.CloudCacheFactory' .nextflow.log` == 1 ]] || false
 
-NXF_CLOUDCACHE_PATH=s3://nextflow-ci/cache \
+NXF_CLOUDCACHE_PATH=s3://nextflow-ci-oss/cache \
 $NXF_CMD run nextflow-io/rnaseq-nf \
     -profile batch \
+    -w s3://nextflow-ci-oss/work \
     -with-report \
     -with-trace \
     -plugins nf-cloudcache \
@@ -62,14 +64,15 @@ $NXF_CMD run nextflow-io/rnaseq-nf \
 [[ `grep -c 'Cached process > ' .nextflow.log` == 4 ]] || false
 
 ## run with fargate + wave
-NXF_CLOUDCACHE_PATH=s3://nextflow-ci/cache \
+NXF_CLOUDCACHE_PATH=s3://nextflow-ci-oss/cache \
 $NXF_CMD run nextflow-io/rnaseq-nf \
     -profile batch \
+    -w s3://nextflow-ci-oss/work \
     -plugins nf-cloudcache,nf-wave \
     -c awsfargate.config
 
 ## Test use of job array
-NXF_CLOUDCACHE_PATH=s3://nextflow-ci/cache \
+NXF_CLOUDCACHE_PATH=s3://nextflow-ci-oss/cache \
 $NXF_CMD run nextflow-io/hello \
     -process.array 10 \
     -plugins nf-cloudcache \

--- a/validation/awsfargate.config
+++ b/validation/awsfargate.config
@@ -3,12 +3,12 @@
  * published version will be downloaded instead of using local build
  */
 
-workDir = 's3://nextflow-ci/work'
+workDir = 's3://nextflow-ci-oss/work'
 process.executor = 'awsbatch'
 process.queue = 'nextflow-fg'
 process.container = 'quay.io/nextflow/rnaseq-nf:latest'
 aws.region = 'eu-west-1'
 aws.batch.platformType = 'fargate'
-aws.batch.jobRole = 'arn:aws:iam::195996028523:role/nf-batchjobrole'
-aws.batch.executionRole = 'arn:aws:iam::195996028523:role/nf-batchexecutionrole'
+aws.batch.jobRole = 'arn:aws:iam::807882257208:role/nf-batchjobrole'
+aws.batch.executionRole = 'arn:aws:iam::807882257208:role/nf-batchexecutionrole'
 wave.enabled = true

--- a/validation/wave-tests/example6/run-aws.sh
+++ b/validation/wave-tests/example6/run-aws.sh
@@ -1,7 +1,7 @@
 $NXF_CMD run \
     rnaseq-nf \
     -profile batch,s3-data \
+    -w s3://nextflow-ci-oss/work \
     -with-wave \
     -with-fusion \
     -process.scratch false
-

--- a/validation/wave-tests/example6/run.sh
+++ b/validation/wave-tests/example6/run.sh
@@ -1,5 +1,4 @@
 $NXF_CMD run \
     rnaseq-nf \
     -with-wave \
-    -w s3://nextflow-ci/wave
-
+    -w s3://nextflow-ci-oss/wave


### PR DESCRIPTION
Backport of #7440 to `STABLE-25.10.x`.

## Why

CI on this branch is currently **red for a reason unrelated to any code change**: the three KMS encrypted-bucket specs in `AwsS3NioTest` are hardcoded to `s3://nf-kms-xyz` in AWS account, which the current CI credentials can no longer reach. All three fail with a bare `S3Exception`:

```
AwsS3NioTest > should download file from encrypted bucket FAILED
AwsS3NioTest > should upload file to encrypted bucket FAILED
AwsS3NioTest > should upload directory to encrypted bucket FAILED
```

#7440 migrated the CI fixtures to `s3://nextflow-ci-oss` / `s3://nextflow-ci-oss-kms` (new KMS key) on `master`, but was never backported. This branch's last green CI run was 2026-07-22, before that migration — hence the drift.

This blocks any PR targeting `STABLE-25.10.x`, e.g. #7544.

## Backport notes

Cherry-pick of 55a6932e1862e6dbedd010dbd6ff8ee4a0ef2f3a. One conflict, in `K8sTaskHandlerTest.groovy`: this branch had `s3://nextflow-ci` where master had already moved on, and the surrounding line differs by trailing whitespace. Resolved by applying only the bucket rename and keeping this branch's existing formatting, so the diff there is exactly two lines. Note the mock stub and its matching assertion must both be renamed or the spec fails.

Everything else applied cleanly.

## Verification

- `:plugins:nf-k8s:test` — 237 tests, 0 skipped, 0 failures
- `:plugins:nf-amazon:test` — 419 tests, 0 failures (52 skipped = credential-gated real-bucket specs)
- No `nf-kms-xyz` references remain anywhere on the branch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
