### PR TITLE
Add directory option to resolve report paths against outputDir

### DIFF
--- a/docs/reference/config/dag.mdx
+++ b/docs/reference/config/dag.mdx
@@ -23,6 +23,12 @@ Controls the maximum depth at which to render sub-workflows (default: no limit).
 
 Controls the direction of the DAG, can be `'LR'` (left-to-right) or `'TB'` (top-to-bottom) (default: `'TB'`).
 
+##### `dag.directory`
+
+<AddedInVersion version="26.10" />
+
+The directory where the DAG file should be saved. Must be a relative path, which is resolved against the workflow output directory (`outputDir`). Cannot be used when `dag.file` is an absolute path. By default, it is not used and `dag.file` is resolved against the launch directory.
+
 ##### `dag.enabled`
 
 When `true` enables the generation of the DAG file (default: `false`).

--- a/docs/reference/config/report.mdx
+++ b/docs/reference/config/report.mdx
@@ -7,6 +7,12 @@ description: Reference for the report config scope, which controls the generatio
 
 The `report` scope controls the generation of the [execution report][execution-report].
 
+##### `report.directory`
+
+<AddedInVersion version="26.10" />
+
+The directory where the report file should be saved. Must be a relative path, which is resolved against the workflow output directory (`outputDir`). Cannot be used when `report.file` is an absolute path. By default, it is not used and `report.file` is resolved against the launch directory.
+
 ##### `report.enabled`
 
 Create the execution report on workflow completion (default: `false`).

--- a/docs/reference/config/timeline.mdx
+++ b/docs/reference/config/timeline.mdx
@@ -7,6 +7,12 @@ description: Reference for the timeline config scope, which controls the generat
 
 The `timeline` scope controls the generation of the [execution timeline][timeline-report].
 
+##### `timeline.directory`
+
+<AddedInVersion version="26.10" />
+
+The directory where the timeline file should be saved. Must be a relative path, which is resolved against the workflow output directory (`outputDir`). Cannot be used when `timeline.file` is an absolute path. By default, it is not used and `timeline.file` is resolved against the launch directory.
+
 ##### `timeline.enabled`
 
 Create the execution timeline on workflow completion (default: `false`).

--- a/docs/reference/config/trace.mdx
+++ b/docs/reference/config/trace.mdx
@@ -7,6 +7,12 @@ description: Reference for the trace config scope, which controls the generation
 
 The `trace` scope controls the generation of the [trace file][trace-report].
 
+##### `trace.directory`
+
+<AddedInVersion version="26.10" />
+
+The directory where the trace file should be saved. Must be a relative path, which is resolved against the workflow output directory (`outputDir`). Cannot be used when `trace.file` is an absolute path. By default, it is not used and `trace.file` is resolved against the launch directory.
+
 ##### `trace.enabled`
 
 Create the trace file on workflow completion (default: `false`).

--- a/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/DefaultObserverFactory.groovy
@@ -16,8 +16,12 @@
 
 package nextflow.trace
 
+import java.nio.file.Path
+
 import groovy.transform.CompileStatic
 import nextflow.Session
+import nextflow.exception.AbortOperationException
+import nextflow.file.FileHelper
 import nextflow.trace.config.DagConfig
 import nextflow.trace.config.ReportConfig
 import nextflow.trace.config.TimelineConfig
@@ -67,29 +71,55 @@ class DefaultObserverFactory implements TraceObserverFactoryV2 {
     protected void createReportObserver(Collection<TraceObserverV2> result) {
         final opts = session.config.report as Map ?: Collections.emptyMap()
         final config = new ReportConfig(opts)
-        if( config.enabled )
-            result << new ReportObserver(config)
+        if( config.enabled ) {
+            final path = resolve('report', config.directory, config.file)
+            result << new ReportObserver(config, path)
+        }
     }
 
     protected void createTimelineObserver(Collection<TraceObserverV2> result) {
         final opts = session.config.timeline as Map ?: Collections.emptyMap()
         final config = new TimelineConfig(opts)
-        if( config.enabled )
-            result << new TimelineObserver(config)
+        if( config.enabled ) {
+            final path = resolve('timeline', config.directory, config.file)
+            result << new TimelineObserver(config, path)
+        }
     }
 
     protected void createGraphObserver(Collection<TraceObserverV2> result) {
         final opts = session.config.dag as Map ?: Collections.emptyMap()
         final config = new DagConfig(opts)
-        if( config.enabled )
-            result << new GraphObserver(config)
+        if( config.enabled ) {
+            final path = resolve('dag', config.directory, config.file)
+            result << new GraphObserver(config, path)
+        }
     }
 
     protected void createTraceFileObserver(Collection<TraceObserverV2> result) {
         final opts = session.config.trace as Map ?: Collections.emptyMap()
         final config = new TraceConfig(opts)
-        if( config.enabled )
-            result << new TraceFileObserver(config)
+        if( config.enabled ) {
+            final path = resolve('trace', config.directory, config.file)
+            result << new TraceFileObserver(config, path)
+        }
+    }
+
+    /**
+     * Resolve the path of a report file. When `<scope>.directory` is given, the
+     * file is resolved against it, which in turn is resolved against the workflow
+     * output directory. Otherwise the file is resolved against the launch directory
+     * (the legacy behavior).
+     */
+    protected Path resolve(String scope, String directory, String file) {
+        final path = FileHelper.asPath(file)
+        if( !directory )
+            return path
+        if( path.isAbsolute() )
+            throw new AbortOperationException("Config option `${scope}.directory` cannot be used when `${scope}.file` is an absolute path -- offending value: ${file}")
+        final dir = FileHelper.asPath(directory)
+        if( dir.isAbsolute() )
+            throw new AbortOperationException("Config option `${scope}.directory` must be a relative path -- offending value: ${directory}")
+        return session.outputDir.resolve(directory).resolve(file).normalize()
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/GraphObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/GraphObserver.groovy
@@ -56,9 +56,9 @@ class GraphObserver implements TraceObserverV2 {
 
     String getName() { name }
 
-    GraphObserver(DagConfig config) {
+    GraphObserver(DagConfig config, Path file) {
         this.config = config
-        this.file = FileHelper.asPath(config.file)
+        this.file = file
         this.name = file.baseName
         this.format = file.getExtension().toLowerCase() ?: 'html'
     }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/ReportObserver.groovy
@@ -24,7 +24,6 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.exception.AbortOperationException
-import nextflow.file.FileHelper
 import nextflow.processor.TaskId
 import nextflow.script.WorkflowMetadata
 import nextflow.trace.config.ReportConfig
@@ -73,8 +72,8 @@ class ReportObserver implements TraceObserverV2 {
      */
     private boolean overwrite
 
-    ReportObserver(ReportConfig config) {
-        this.reportFile = FileHelper.asPath(config.file)
+    ReportObserver(ReportConfig config, Path reportFile) {
+        this.reportFile = reportFile
         this.maxTasks = config.maxTasks
         this.overwrite = config.overwrite
     }

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TimelineObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TimelineObserver.groovy
@@ -25,7 +25,6 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.exception.AbortOperationException
-import nextflow.file.FileHelper
 import nextflow.processor.TaskId
 import nextflow.trace.config.TimelineConfig
 import nextflow.trace.event.TaskEvent
@@ -61,8 +60,8 @@ class TimelineObserver implements TraceObserverV2 {
 
     private boolean overwrite
 
-    TimelineObserver(TimelineConfig config) {
-        this.reportFile = FileHelper.asPath(config.file)
+    TimelineObserver(TimelineConfig config, Path reportFile) {
+        this.reportFile = reportFile
         this.overwrite = config.overwrite
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/TraceFileObserver.groovy
@@ -25,7 +25,6 @@ import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import groovyx.gpars.agent.Agent
 import nextflow.Session
-import nextflow.file.FileHelper
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskId
 import nextflow.trace.config.TraceConfig
@@ -75,8 +74,8 @@ class TraceFileObserver implements TraceObserverV2 {
 
     private boolean useRawNumber
 
-    TraceFileObserver(TraceConfig config) {
-        tracePath = FileHelper.asPath(config.file)
+    TraceFileObserver(TraceConfig config, Path tracePath) {
+        this.tracePath = tracePath
         overwrite = config.overwrite
         separator = config.sep
         useRawNumbers(config.raw)

--- a/modules/nextflow/src/main/groovy/nextflow/trace/config/DagConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/config/DagConfig.groovy
@@ -53,6 +53,12 @@ class DagConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        The directory where the DAG file should be saved, relative to the workflow output directory.
+    """)
+    final String directory
+
+    @ConfigOption
+    @Description("""
         Graph file name (default: `'dag-<timestamp>.html'`).
     """)
     final String file
@@ -78,6 +84,7 @@ class DagConfig implements ConfigScope {
         enabled = opts.enabled as boolean
         depth = opts.depth != null ? opts.depth as int : -1
         direction = opts.direction ?: 'TB'
+        directory = opts.directory
         file = opts.file ?: defaultFileName()
         overwrite = opts.overwrite as boolean
         verbose = opts.verbose as boolean

--- a/modules/nextflow/src/main/groovy/nextflow/trace/config/ReportConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/config/ReportConfig.groovy
@@ -33,6 +33,12 @@ class ReportConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        The directory where the report file should be saved, relative to the workflow output directory.
+    """)
+    final String directory
+
+    @ConfigOption
+    @Description("""
         Create the execution report on workflow completion (default: `false`).
     """)
     final boolean enabled
@@ -58,6 +64,7 @@ class ReportConfig implements ConfigScope {
     ReportConfig() {}
 
     ReportConfig(Map opts) {
+        directory = opts.directory
         enabled = opts.enabled as boolean
         file = opts.file ?: defaultFileName()
         maxTasks = opts.maxTasks != null ? opts.maxTasks as int : DEF_MAX_TASKS

--- a/modules/nextflow/src/main/groovy/nextflow/trace/config/TimelineConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/config/TimelineConfig.groovy
@@ -31,6 +31,12 @@ class TimelineConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        The directory where the timeline file should be saved, relative to the workflow output directory.
+    """)
+    final String directory
+
+    @ConfigOption
+    @Description("""
         Create the timeline report on workflow completion file (default: `false`).
     """)
     final boolean enabled
@@ -51,6 +57,7 @@ class TimelineConfig implements ConfigScope {
     TimelineConfig() {}
 
     TimelineConfig(Map opts) {
+        directory = opts.directory
         enabled = opts.enabled as boolean
         file = opts.file ?: defaultFileName()
         overwrite = opts.overwrite as boolean

--- a/modules/nextflow/src/main/groovy/nextflow/trace/config/TraceConfig.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/trace/config/TraceConfig.groovy
@@ -48,6 +48,12 @@ class TraceConfig implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        The directory where the trace file should be saved, relative to the workflow output directory.
+    """)
+    final String directory
+
+    @ConfigOption
+    @Description("""
         Create the execution trace file on workflow completion (default: `false`).
     """)
     final boolean enabled
@@ -86,6 +92,7 @@ class TraceConfig implements ConfigScope {
     TraceConfig() {}
 
     TraceConfig(Map opts) {
+        directory = opts.directory
         enabled = opts.enabled as boolean
         fields = parseFields(opts.fields)
         file = opts.file ?: defaultFileName()

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -17,7 +17,7 @@
 package nextflow
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ThreadPoolExecutor
@@ -29,7 +29,6 @@ import nextflow.container.DockerConfig
 import nextflow.container.PodmanConfig
 import nextflow.container.SarusConfig
 import nextflow.exception.AbortOperationException
-import nextflow.file.FileHelper
 import nextflow.script.ScriptFile
 import nextflow.script.WorkflowMetadata
 import nextflow.trace.TraceFileObserver
@@ -64,9 +63,9 @@ class SessionTest extends Specification {
 
         when:
         session = new Session()
-        session.baseDir = Paths.get('some/folder')
+        session.baseDir = Path.of('some/folder')
         then:
-        session.baseDir == Paths.get('some/folder')
+        session.baseDir == Path.of('some/folder')
         session.binDir == null
 
         when:
@@ -102,7 +101,7 @@ class SessionTest extends Specification {
 
         when:
         session = new Session()
-        session.setBaseDir(Paths.get('/some/path'))
+        session.setBaseDir(Path.of('/some/path'))
         then:
         session.getLibDir() == []
 
@@ -139,6 +138,8 @@ class SessionTest extends Specification {
         def session
         def result
         def observer
+        and:
+        def outputDir = Path.of('/some/results')
 
         when:
         session = [:] as Session
@@ -154,7 +155,7 @@ class SessionTest extends Specification {
         observer = result[1] as TraceFileObserver
         then:
         result.size() == 2
-        observer.tracePath == FileHelper.asPath('name.txt')
+        observer.tracePath == Path.of('name.txt')
         observer.separator == '\t'
 
         when:
@@ -164,7 +165,7 @@ class SessionTest extends Specification {
         observer = result[1] as TraceFileObserver
         then:
         result.size() == 2
-        observer.tracePath == FileHelper.asPath('alpha.txt')
+        observer.tracePath == Path.of('alpha.txt')
         observer.separator == 'x'
         observer.fields == ['task_id','name','exit']
 
@@ -182,9 +183,43 @@ class SessionTest extends Specification {
         observer = result[1] as TraceFileObserver
         then:
         result.size() == 2
-        observer.tracePath == FileHelper.asPath('trace-20221001.txt')
+        observer.tracePath == Path.of('trace-20221001.txt')
         observer.separator == '\t'
         observer.fields == ['task_id','name','exit','vmem']
+
+        when: 'the trace directory is defined'
+        session = [:] as Session
+        session.config = [trace: [enabled: true, directory: 'pipeline_info', file: 'trace.txt']]
+        session.outputDir = outputDir
+        result = session.createObserversV2()
+        observer = result[1] as TraceFileObserver
+        then: 'the trace file is resolved against the output directory'
+        observer.tracePath == outputDir.resolve('pipeline_info/trace.txt')
+
+        when: 'the trace directory is the current directory'
+        session = [:] as Session
+        session.config = [trace: [enabled: true, directory: '.', file: 'trace.txt']]
+        session.outputDir = outputDir
+        result = session.createObserversV2()
+        observer = result[1] as TraceFileObserver
+        then: 'the trace file is placed in the output directory'
+        observer.tracePath == outputDir.resolve('trace.txt')
+
+        when: 'the trace directory is an absolute path'
+        session = [:] as Session
+        session.config = [trace: [enabled: true, directory: '/pipeline_info']]
+        session.outputDir = outputDir
+        session.createObserversV2()
+        then:
+        thrown(AbortOperationException)
+
+        when: 'the trace file is an absolute path'
+        session = [:] as Session
+        session.config = [trace: [enabled: true, directory: 'pipeline_info', file: '/other/trace.txt']]
+        session.outputDir = outputDir
+        session.createObserversV2()
+        then:
+        thrown(AbortOperationException)
 
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/trace/GraphObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/GraphObserverTest.groovy
@@ -39,7 +39,7 @@ class GraphObserverTest extends Specification {
     DAG test_dag
 
     def createObserver(Path file) {
-        new GraphObserver(new DagConfig(file: file.toString()))
+        new GraphObserver(new DagConfig(file: file.toString()), file)
     }
 
     def setup() {

--- a/modules/nextflow/src/test/groovy/nextflow/trace/ReportObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/ReportObserverTest.groovy
@@ -18,6 +18,7 @@ package nextflow.trace
 
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.nio.file.Path
 import java.time.OffsetDateTime
 
 import groovy.json.JsonSlurper
@@ -198,7 +199,7 @@ class ReportObserverTest extends Specification {
     def 'should render not tasks payload' () {
 
         given:
-        def observer = Spy(new ReportObserver(new ReportConfig([:])))
+        def observer = Spy(new ReportObserver(new ReportConfig([:]), Path.of('report.html')))
         def BIG = Mock(Map)
         BIG.size() >> ReportConfig.DEF_MAX_TASKS+1
 
@@ -211,7 +212,7 @@ class ReportObserverTest extends Specification {
 
     def 'should render tasks payload' () {
         given:
-        def observer = Spy(new ReportObserver(new ReportConfig([:])))
+        def observer = Spy(new ReportObserver(new ReportConfig([:]), Path.of('report.html')))
 
         def TASKID1 = TaskId.of(10)
         def TASKID2 = TaskId.of(20)

--- a/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/trace/TraceFileObserverTest.groovy
@@ -17,6 +17,7 @@
 package nextflow.trace
 
 import java.nio.file.Files
+import java.nio.file.Path
 
 import nextflow.Session
 import nextflow.executor.Executor
@@ -46,7 +47,7 @@ class TraceFileObserverTest extends Specification {
 
     def createObserver() {
         def config = new TraceConfig([:])
-        return new TraceFileObserver(config)
+        return new TraceFileObserver(config, Path.of(config.file))
     }
 
     def 'test set fields'() {
@@ -116,7 +117,7 @@ class TraceFileObserverTest extends Specification {
 
         // the observer class under test
         def config = new TraceConfig(file: file.toString())
-        def observer = new TraceFileObserver(config)
+        def observer = new TraceFileObserver(config, file)
 
         when:
         observer.onFlowCreate(null)
@@ -260,7 +261,7 @@ class TraceFileObserverTest extends Specification {
 
         // observer with overwrite=false (the default)
         def config = new TraceConfig(file: file.toString())
-        def observer = new TraceFileObserver(config)
+        def observer = new TraceFileObserver(config, file)
 
         when: 'onFlowCreate fails to create the file'
         observer.onFlowCreate(null)


### PR DESCRIPTION
This PR changes the behavior of relative report paths. Now they are resolved against the output directory when it is defined, otherwise they are resolved against the launch directory (existing behavior).

NOTE: the new behavior only applies when `outputDir` is **explicitly** set via config or CLI option. Otherwise it would effectively always apply because `outputDir` defaults to `results`.

