### PR TITLE
Fix false warning for executor selectors

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
@@ -128,12 +128,13 @@ class ConfigValidator {
     }
 
     /**
-     * Determine whether a scope name is a process selector.
+     * Determine whether a scope name is a selector, i.e. a process selector
+     * (`withLabel:`, `withName:`) or a per-executor selector (`$<executor>`).
      *
      * @param name
      */
     private boolean isSelector(String name) {
-        return name.startsWith('withLabel:') || name.startsWith('withName:')
+        return name.startsWith('withLabel:') || name.startsWith('withName:') || name.startsWith('$')
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/ConfigValidator.groovy
@@ -115,7 +115,7 @@ class ConfigValidator {
                 names.clear()
 
             if( value instanceof Map ) {
-                if( isSelector(key) )
+                if( isSelector(names) )
                     names.removeLast()
                 if( isMapOption(names) )
                     continue
@@ -128,13 +128,20 @@ class ConfigValidator {
     }
 
     /**
-     * Determine whether a scope name is a selector, i.e. a process selector
-     * (`withLabel:`, `withName:`) or a per-executor selector (`$<executor>`).
+     * Determine whether the last name in a scope path is a selector, i.e. a
+     * process selector (`withLabel:`, `withName:`) or a per-executor selector
+     * (`$<executor>`).
      *
-     * @param name
+     * @param names
      */
-    private boolean isSelector(String name) {
-        return name.startsWith('withLabel:') || name.startsWith('withName:') || name.startsWith('$')
+    private boolean isSelector(List<String> names) {
+        if( !names )
+            return false
+        final name = names.last()
+        if( name.startsWith('withLabel:') || name.startsWith('withName:') )
+            return true
+        // per-executor selector in the `executor` scope, e.g. `executor.$local`
+        return name.startsWith('$') && names.size() == 2 && names.first() == 'executor'
     }
 
     /**

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigValidatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigValidatorTest.groovy
@@ -55,6 +55,36 @@ class ConfigValidatorTest extends Specification {
         capture.toString().contains('Unrecognized config option \'executor.cpu\'')
     }
 
+    def 'should validate per-executor config options within a profile' () {
+        when:
+        new ConfigValidator().validate([
+            profiles: [
+                test: [
+                    executor: [
+                        '$local': [ cpus: 8 ]
+                    ]
+                ]
+            ]
+        ])
+        then:
+        !capture.toString().contains('Unrecognized config option')
+    }
+
+    def 'should not treat a $ selector outside the executor scope as a selector' () {
+        when:
+        new ConfigValidator().validate([
+            docker: [
+                '$foo': [ enabled: true ]
+            ],
+            process: [
+                '$bar': [ cpus: 2 ]
+            ]
+        ])
+        then:
+        capture.toString().contains('Unrecognized config option \'docker.$foo.enabled\'')
+        capture.toString().contains('Unrecognized config option \'process.$bar.cpus\'')
+    }
+
     def 'should warn about invalid config options' () {
         when:
         new ConfigValidator().validate([

--- a/modules/nextflow/src/test/groovy/nextflow/config/ConfigValidatorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ConfigValidatorTest.groovy
@@ -28,6 +28,33 @@ class ConfigValidatorTest extends Specification {
     @Rule
     OutputCapture capture = new OutputCapture()
 
+    def 'should validate per-executor config options' () {
+        when:
+        new ConfigValidator().validate([
+            executor: [
+                '$local': [
+                    cpus: 8,
+                    memory: '128 GB'
+                ]
+            ]
+        ])
+        then:
+        !capture.toString().contains('Unrecognized config option')
+    }
+
+    def 'should warn about invalid per-executor config options' () {
+        when:
+        new ConfigValidator().validate([
+            executor: [
+                '$local': [
+                    cpu: 8
+                ]
+            ]
+        ])
+        then:
+        capture.toString().contains('Unrecognized config option \'executor.cpu\'')
+    }
+
     def 'should warn about invalid config options' () {
         when:
         new ConfigValidator().validate([


### PR DESCRIPTION
Fix #7551

Treat a $-prefixed scope as a selector in ConfigValidator so that executor selectors such as `executor.$local.cpus` are accepted.