### PR TITLE
Fix cloning of typed process outputs to also clone topics

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessOutputsDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessOutputsDef.groovy
@@ -117,6 +117,9 @@ class ProcessOutputsDef implements Cloneable {
         result.params = new ArrayList<>(params.size())
         for( final param : params )
             result.params.add(param.clone())
+        result.topics = new ArrayList<>(topics.size())
+        for( final topic : topics )
+            result.topics.add(topic.clone())
         return result
     }
 

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessTopic.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/v2/ProcessTopic.groovy
@@ -26,7 +26,7 @@ import nextflow.script.params.OutParam
  * @author Ben Sherman <bentshermann@gmail.com>
  */
 @CompileStatic
-class ProcessTopic {
+class ProcessTopic implements Cloneable {
 
     /**
      * Lazy expression (e.g. closure) which defines the output value


### PR DESCRIPTION
Fix #7434

Typed process outputs (`ProcessOutputsDef`) contain both outputs and topic emissions. The class is cloneable in order to support process aliasing. However, `clone()` was only cloning outputs, not topic emissions. This caused the pipeline to hang when aliasing a process with topic emissions.

This PR fixes the clone. Confirmed locally that it fixes the reported issue.