### PR TITLE
Report an error for an aliased type include

### DIFF
--- a/docs/reference/syntax.mdx
+++ b/docs/reference/syntax.mdx
@@ -87,6 +87,10 @@ include { hello as sayHello } from './some/module'
 
 The include source should be a string literal. Each include clause should specify a name, and may also specify an *alias*. In the above example, `hello` is included under the alias `sayHello`.
 
+:::note
+[Enum](#enum-type) and [record](#record-type) types cannot be aliased. They must be included under their original name.
+:::
+
 Include clauses can be separated by semi-colons or newlines:
 
 ```nextflow
@@ -95,7 +99,7 @@ include { hello ; bye as goodbye } from './some/module'
 
 // newlines
 include {
-hello
+    hello
     bye as goodbye
 } from './some/module'
 ```

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -131,6 +131,10 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         for( var entry : node.entries ) {
             if( entry.getTarget() == null )
                 continue;
+            if( entry.getTarget() instanceof ClassNode && entry.alias != null ) {
+                vsc.addError("Included types cannot be aliased", entry);
+                continue;
+            }
             var name = entry.getNameOrAlias();
             var otherInclude = vsc.getInclude(name);
             if( otherInclude != null )

--- a/modules/nf-lang/src/test/groovy/nextflow/script/control/ResolveIncludeTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/control/ResolveIncludeTest.groovy
@@ -114,6 +114,32 @@ class ResolveIncludeTest extends Specification {
         deleteDir(root)
     }
 
+    def 'should report an error for an aliased type include' () {
+        given:
+        def root = tempDir()
+        def main = tempFile(root, 'main.nf',
+            '''\
+            include { Thing as Alias } from './types.nf'
+            ''')
+        def module = tempFile(root, 'types.nf',
+            '''\
+            record Thing {
+                id: String
+            }
+            ''')
+
+        when:
+        def errors = check(root, [main, module])
+        then:
+        errors.size() == 1
+        errors[0].getSourceLocator().endsWith('main.nf')
+        errors[0].getStartLine() == 1
+        errors[0].getOriginalMessage() == 'Included types cannot be aliased'
+
+        cleanup:
+        deleteDir(root)
+    }
+
     def 'should resolve an include' () {
         given:
         def root = tempDir()


### PR DESCRIPTION
Fix #7437

Aliases were silently ignored when including a record or enum type. The included type was appended to the compiler imports under its own name, so the alias never resolved while the original name stayed in scope.

This PR reports an error for included-type aliasing, since it is not needed. Aliasing was intended only to work around the fact that a process/workflow cannot be called more than once in the same workflow