### PR TITLE
Add azure.azcopy.opts config option

### DIFF
--- a/docs/reference/config/azure.mdx
+++ b/docs/reference/config/azure.mdx
@@ -27,6 +27,10 @@ The blob [access tier](https://learn.microsoft.com/en-us/azure/storage/blobs/acc
 
 The block size (in MB) used by `azcopy` to transfer files between Azure Blob Storage and compute nodes (default: `4`).
 
+##### `azure.azcopy.opts`
+
+Extra command line options appended to the `azcopy` upload and download commands e.g. `'--put-md5 --log-level ERROR'`.
+
 ##### `azure.batch.accountKey`
 
 The batch service account key. Defaults to environment variable `AZURE_BATCH_ACCOUNT_KEY`.

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzCopyOpts.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/config/AzCopyOpts.groovy
@@ -30,6 +30,7 @@ class AzCopyOpts implements ConfigScope {
 
     static public final String DEFAULT_BLOCK_SIZE = "4"
     static public final String DEFAULT_BLOB_TIER = "None"
+    static public final String DEFAULT_OPTS = ""
 
     @ConfigOption
     @Description("""
@@ -43,9 +44,16 @@ class AzCopyOpts implements ConfigScope {
     """)
     final String blobTier
 
+    @ConfigOption
+    @Description("""
+        Extra command line options appended to the `azcopy` upload and download commands e.g. `'--put-md5 --log-level ERROR'`.
+    """)
+    final String opts
+
     AzCopyOpts() {
         this.blockSize = DEFAULT_BLOCK_SIZE
         this.blobTier =  DEFAULT_BLOB_TIER
+        this.opts = DEFAULT_OPTS
     }
 
 
@@ -53,6 +61,7 @@ class AzCopyOpts implements ConfigScope {
         assert config!=null
         this.blockSize = config.blockSize ?: DEFAULT_BLOCK_SIZE
         this.blobTier = config.blobTier ?: DEFAULT_BLOB_TIER
+        this.opts = config.opts ?: DEFAULT_OPTS
     }
 
 }

--- a/plugins/nf-azure/src/main/nextflow/cloud/azure/file/AzBashLib.groovy
+++ b/plugins/nf-azure/src/main/nextflow/cloud/azure/file/AzBashLib.groovy
@@ -30,6 +30,7 @@ class AzBashLib extends BashFunLib<AzBashLib> {
 
     private String blockSize = AzCopyOpts.DEFAULT_BLOCK_SIZE
     private String blobTier = AzCopyOpts.DEFAULT_BLOB_TIER
+    private String opts = AzCopyOpts.DEFAULT_OPTS
 
 
     AzBashLib withBlockSize(String value) {
@@ -45,11 +46,18 @@ class AzBashLib extends BashFunLib<AzBashLib> {
     }
 
 
+    AzBashLib withOpts(String value) {
+        if( value )
+            this.opts = value
+        return this
+    }
+
     protected String setupAzCopyOpts() {
         """
         # custom env variables used for azcopy opts
         export AZCOPY_BLOCK_SIZE_MB=${blockSize}
         export AZCOPY_BLOCK_BLOB_TIER=${blobTier}
+        export AZCOPY_OPTS="${opts}"
         """.stripIndent(true)
     }
 
@@ -64,12 +72,12 @@ class AzBashLib extends BashFunLib<AzBashLib> {
 
             if [[ -d $name ]]; then
               if [[ "$base_name" == "$name" ]]; then
-                azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
               else
-                azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
               fi
             else
-              azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+              azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
             fi
         }
 
@@ -80,10 +88,10 @@ class AzBashLib extends BashFunLib<AzBashLib> {
             local ret
             mkdir -p "$basedir"
 
-            ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+            ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                 ## if fails check if it was trying to download a directory
                 mkdir -p $target
-                azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                     rm -rf $target
                     >&2 echo "Unable to download path: $source"
                     exit 1
@@ -106,6 +114,7 @@ class AzBashLib extends BashFunLib<AzBashLib> {
                 .withDelayBetweenAttempts(delayBetweenAttempts)
                 .withBlobTier(opts.blobTier)
                 .withBlockSize(opts.blockSize)
+                .withOpts(opts.opts)
                 .render()
     }
 

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/batch/AzFileCopyStrategyTest.groovy
@@ -173,6 +173,7 @@ class AzFileCopyStrategyTest extends Specification {
                 # custom env variables used for azcopy opts
                 export AZCOPY_BLOCK_SIZE_MB=4
                 export AZCOPY_BLOCK_BLOB_TIER=None
+                export AZCOPY_OPTS=""
 
                 nxf_az_upload() {
                     local name=$1
@@ -182,12 +183,12 @@ class AzFileCopyStrategyTest extends Specification {
 
                     if [[ -d $name ]]; then
                       if [[ "$base_name" == "$name" ]]; then
-                        azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                        azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                       else
-                        azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                        azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                       fi
                     else
-                      azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                      azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                     fi
                 }
 
@@ -198,10 +199,10 @@ class AzFileCopyStrategyTest extends Specification {
                     local ret
                     mkdir -p "$basedir"
 
-                    ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                    ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                         ## if fails check if it was trying to download a directory
                         mkdir -p $target
-                        azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                        azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                             rm -rf $target
                             >&2 echo "Unable to download path: $source"
                             exit 1
@@ -310,6 +311,7 @@ class AzFileCopyStrategyTest extends Specification {
                 # custom env variables used for azcopy opts
                 export AZCOPY_BLOCK_SIZE_MB=4
                 export AZCOPY_BLOCK_BLOB_TIER=None
+                export AZCOPY_OPTS=""
 
                 nxf_az_upload() {
                     local name=$1
@@ -319,12 +321,12 @@ class AzFileCopyStrategyTest extends Specification {
 
                     if [[ -d $name ]]; then
                       if [[ "$base_name" == "$name" ]]; then
-                        azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                        azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                       else
-                        azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                        azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                       fi
                     else
-                      azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                      azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                     fi
                 }
 
@@ -335,10 +337,10 @@ class AzFileCopyStrategyTest extends Specification {
                     local ret
                     mkdir -p "$basedir"
 
-                    ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                    ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                         ## if fails check if it was trying to download a directory
                         mkdir -p $target
-                        azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                        azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                             rm -rf $target
                             >&2 echo "Unable to download path: $source"
                             exit 1
@@ -471,6 +473,7 @@ class AzFileCopyStrategyTest extends Specification {
                     # custom env variables used for azcopy opts
                     export AZCOPY_BLOCK_SIZE_MB=4
                     export AZCOPY_BLOCK_BLOB_TIER=None
+                    export AZCOPY_OPTS=""
 
                     nxf_az_upload() {
                         local name=$1
@@ -480,12 +483,12 @@ class AzFileCopyStrategyTest extends Specification {
 
                         if [[ -d $name ]]; then
                           if [[ "$base_name" == "$name" ]]; then
-                            azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                            azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                           else
-                            azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                            azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                           fi
                         else
-                          azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                          azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                         fi
                     }
 
@@ -496,10 +499,10 @@ class AzFileCopyStrategyTest extends Specification {
                         local ret
                         mkdir -p "$basedir"
 
-                        ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                        ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                             ## if fails check if it was trying to download a directory
                             mkdir -p $target
-                            azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                            azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                                 rm -rf $target
                                 >&2 echo "Unable to download path: $source"
                                 exit 1

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzCopyOptsTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/config/AzCopyOptsTest.groovy
@@ -40,4 +40,10 @@ class AzCopyOptsTest extends Specification {
 
     }
 
+    def 'should get extra azcopy opts'() {
+        expect:
+        new AzCopyOpts([:]).opts == ''
+        new AzCopyOpts([opts: '--put-md5 --log-level ERROR']).opts == '--put-md5 --log-level ERROR'
+    }
+
 }

--- a/plugins/nf-azure/src/test/nextflow/cloud/azure/file/AzBashLibTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/cloud/azure/file/AzBashLibTest.groovy
@@ -32,6 +32,7 @@ class AzBashLibTest extends Specification {
             # custom env variables used for azcopy opts
             export AZCOPY_BLOCK_SIZE_MB=4
             export AZCOPY_BLOCK_BLOB_TIER=None
+            export AZCOPY_OPTS=""
 
             nxf_az_upload() {
                 local name=$1
@@ -41,12 +42,12 @@ class AzBashLibTest extends Specification {
 
                 if [[ -d $name ]]; then
                   if [[ "$base_name" == "$name" ]]; then
-                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   else
-                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   fi
                 else
-                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                 fi
             }
 
@@ -57,10 +58,10 @@ class AzBashLibTest extends Specification {
                 local ret
                 mkdir -p "$basedir"
 
-                ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                     ## if fails check if it was trying to download a directory
                     mkdir -p $target
-                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                         rm -rf $target
                         >&2 echo "Unable to download path: $source"
                         exit 1
@@ -134,6 +135,7 @@ class AzBashLibTest extends Specification {
             # custom env variables used for azcopy opts
             export AZCOPY_BLOCK_SIZE_MB=4
             export AZCOPY_BLOCK_BLOB_TIER=None
+            export AZCOPY_OPTS=""
 
             nxf_az_upload() {
                 local name=$1
@@ -143,12 +145,12 @@ class AzBashLibTest extends Specification {
 
                 if [[ -d $name ]]; then
                   if [[ "$base_name" == "$name" ]]; then
-                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   else
-                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   fi
                 else
-                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                 fi
             }
 
@@ -159,10 +161,10 @@ class AzBashLibTest extends Specification {
                 local ret
                 mkdir -p "$basedir"
 
-                ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                     ## if fails check if it was trying to download a directory
                     mkdir -p $target
-                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                         rm -rf $target
                         >&2 echo "Unable to download path: $source"
                         exit 1
@@ -236,6 +238,7 @@ class AzBashLibTest extends Specification {
             # custom env variables used for azcopy opts
             export AZCOPY_BLOCK_SIZE_MB=10
             export AZCOPY_BLOCK_BLOB_TIER=Hot
+            export AZCOPY_OPTS=""
 
             nxf_az_upload() {
                 local name=$1
@@ -245,12 +248,12 @@ class AzBashLibTest extends Specification {
 
                 if [[ -d $name ]]; then
                   if [[ "$base_name" == "$name" ]]; then
-                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   else
-                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   fi
                 else
-                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                 fi
             }
 
@@ -261,10 +264,10 @@ class AzBashLibTest extends Specification {
                 local ret
                 mkdir -p "$basedir"
 
-                ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                     ## if fails check if it was trying to download a directory
                     mkdir -p $target
-                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                         rm -rf $target
                         >&2 echo "Unable to download path: $source"
                         exit 1
@@ -272,5 +275,14 @@ class AzBashLibTest extends Specification {
                 }
             }
             '''.stripIndent()
+    }
+
+    def 'should add extra azcopy opts to the copy commands'() {
+        when:
+        def script = AzBashLib.script(new AzCopyOpts([opts: '--put-md5 --log-level ERROR']), 10, 20, Duration.of('30s'))
+        then:
+        script.contains('export AZCOPY_OPTS="--put-md5 --log-level ERROR"')
+        script.contains('azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS')
+        script.contains('ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1)')
     }
 }

--- a/plugins/nf-azure/src/test/nextflow/executor/BashWrapperBuilderWithAzTest.groovy
+++ b/plugins/nf-azure/src/test/nextflow/executor/BashWrapperBuilderWithAzTest.groovy
@@ -72,6 +72,7 @@ class BashWrapperBuilderWithAzTest extends Specification {
             # custom env variables used for azcopy opts
             export AZCOPY_BLOCK_SIZE_MB=4
             export AZCOPY_BLOCK_BLOB_TIER=None
+            export AZCOPY_OPTS=""
 
             nxf_az_upload() {
                 local name=$1
@@ -81,12 +82,12 @@ class BashWrapperBuilderWithAzTest extends Specification {
 
                 if [[ -d $name ]]; then
                   if [[ "$base_name" == "$name" ]]; then
-                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   else
-                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   fi
                 else
-                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                 fi
             }
 
@@ -97,10 +98,10 @@ class BashWrapperBuilderWithAzTest extends Specification {
                 local ret
                 mkdir -p "$basedir"
 
-                ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                     ## if fails check if it was trying to download a directory
                     mkdir -p $target
-                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                         rm -rf $target
                         >&2 echo "Unable to download path: $source"
                         exit 1
@@ -211,6 +212,7 @@ class BashWrapperBuilderWithAzTest extends Specification {
             # custom env variables used for azcopy opts
             export AZCOPY_BLOCK_SIZE_MB=4
             export AZCOPY_BLOCK_BLOB_TIER=None
+            export AZCOPY_OPTS=""
 
             nxf_az_upload() {
                 local name=$1
@@ -220,12 +222,12 @@ class BashWrapperBuilderWithAzTest extends Specification {
 
                 if [[ -d $name ]]; then
                   if [[ "$base_name" == "$name" ]]; then
-                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   else
-                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                    azcopy cp "$name" "$target/$dir_name?$AZ_SAS" --recursive --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                   fi
                 else
-                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB
+                  azcopy cp "$name" "$target/$name?$AZ_SAS" --block-blob-tier $AZCOPY_BLOCK_BLOB_TIER --block-size-mb $AZCOPY_BLOCK_SIZE_MB $AZCOPY_OPTS
                 fi
             }
 
@@ -236,10 +238,10 @@ class BashWrapperBuilderWithAzTest extends Specification {
                 local ret
                 mkdir -p "$basedir"
 
-                ret=$(azcopy cp "$source?$AZ_SAS" "$target" 2>&1) || {
+                ret=$(azcopy cp "$source?$AZ_SAS" "$target" $AZCOPY_OPTS 2>&1) || {
                     ## if fails check if it was trying to download a directory
                     mkdir -p $target
-                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive >/dev/null || {
+                    azcopy cp "$source/*?$AZ_SAS" "$target" --recursive $AZCOPY_OPTS >/dev/null || {
                         rm -rf $target
                         >&2 echo "Unable to download path: $source"
                         exit 1


### PR DESCRIPTION
## Why

`azcopy` exposes many transfer options, but Nextflow only surfaces `blockSize` and `blobTier`. Anything else (e.g. `--put-md5`, `--log-level`, `--cap-mbps`) is unreachable from a pipeline config.

## What

- Add `azure.azcopy.opts` config option, a string of extra command line options
- Export the value as `AZCOPY_OPTS` in the Azure bash helper prelude and append it to the `azcopy cp` upload and download commands
- Update docs and existing rendered-script test expectations
- Add tests for the new option and for the flags reaching the copy commands

The value is passed through unquoted at the call site so multiple flags word-split as expected. No validation is applied; invalid options fail at `azcopy`.