### PR TITLE
Align nf-agent test Groovy dependency to 4.0.33

### DIFF
--- a/plugins/nf-agent-pi/build.gradle
+++ b/plugins/nf-agent-pi/build.gradle
@@ -169,8 +169,8 @@ dependencies {
     api 'org.bouncycastle:bcpkix-jdk18on:1.84'
 
     testImplementation(testFixtures(project(':nextflow')))
-    testImplementation 'org.apache.groovy:groovy:4.0.31'
-    testImplementation 'org.apache.groovy:groovy-json:4.0.31'
+    testImplementation 'org.apache.groovy:groovy:4.0.33'
+    testImplementation 'org.apache.groovy:groovy-json:4.0.33'
 }
 
 // PiAgentPackagingTest asserts on the REAL artifacts - that the runtime is not vendored back into

--- a/plugins/nf-agent/build.gradle
+++ b/plugins/nf-agent/build.gradle
@@ -62,6 +62,6 @@ dependencies {
     api 'dev.langchain4j:langchain4j-skills:1.17.0-beta27'
 
     testImplementation(testFixtures(project(":nextflow")))
-    testImplementation "org.apache.groovy:groovy:4.0.31"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.31"
+    testImplementation "org.apache.groovy:groovy:4.0.33"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.33"
 }


### PR DESCRIPTION
## Summary

Bumps the pinned test Groovy dependency in the `nf-agent` and `nf-agent-pi` plugins from `4.0.31` to `4.0.33`, matching the Groovy version used by the root project (see `build.gradle`).

## Changes

- `plugins/nf-agent/build.gradle`: `groovy` and `groovy-nio` test dependencies `4.0.31` → `4.0.33`
- `plugins/nf-agent-pi/build.gradle`: `groovy` and `groovy-json` test dependencies `4.0.31` → `4.0.33`

Test-scope only; no runtime/behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)