### PR TITLE
Rename SCM HTTP client timeouts to the global NXF_HTTPCLIENT_* namespace

### DIFF
--- a/docs/git.mdx
+++ b/docs/git.mdx
@@ -73,13 +73,13 @@ httpClient {
 
 <AddedInVersion version="26.10" />
 
-The maximum time to wait for the connection to the Git hosting service API to be established, applied to a single attempt (default: `60 sec`). It must be greater than zero. Can also be set with the `NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT` environment variable.
+The maximum time to wait for the connection to the Git hosting service API to be established, applied to a single attempt (default: `60 sec`). It must be greater than zero. Can also be set with the `NXF_HTTPCLIENT_CONNECT_TIMEOUT` environment variable.
 
 ##### `httpClient.requestTimeout`
 
 <AddedInVersion version="26.10" />
 
-The maximum time to wait for a response from the Git hosting service API once the connection has been established, applied to a single attempt (default: `60 sec`). Set it to `0 sec` to wait indefinitely. Can also be set with the `NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT` environment variable.
+The maximum time to wait for a response from the Git hosting service API once the connection has been established, applied to a single attempt (default: `60 sec`). Set it to `0 sec` to wait indefinitely. Can also be set with the `NXF_HTTPCLIENT_REQUEST_TIMEOUT` environment variable.
 
 :::note
 These settings cannot be defined in `nextflow.config`. Nextflow resolves the pipeline repository before it parses the pipeline config, so the SCM config file and the environment variables are the only sources available at that point.

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -196,6 +196,8 @@ Connection attempts that time out are retried, because a connection that was nev
 
 Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Set it to `0s` to wait indefinitely.
 
+Unlike a connect timeout, a request that times out waiting for the response is not retried, since it did reach the server and may already have been acted on.
+
 ##### `NXF_JAVA_HOME`
 
 Defines the path location of the Java VM installation used to run Nextflow. This variable overrides the `JAVA_HOME` variable if defined.
@@ -301,8 +303,6 @@ Delay multiplier used for HTTP retryable operations (default: `2.0`).
 ##### `NXF_SCM_FILE`
 
 Defines the path location of the SCM config file .
-
-Unlike a connect timeout, a request that times out waiting for the response is not retried, since it did reach the server and may already have been acted on.
 
 ##### `NXF_SINGULARITY_CACHEDIR`
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -182,6 +182,20 @@ When set to `true`, collect task resource metrics (CPU, memory, I/O) from the Fu
 
 Nextflow home directory (default: `$HOME/.nextflow`).
 
+##### `NXF_HTTPCLIENT_CONNECT_TIMEOUT`
+
+<AddedInVersion version="26.10" />
+
+Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). It must be greater than zero.
+
+Connection attempts that time out are retried, because a connection that was never established proves the request did not reach the server. A persistently unreachable host therefore only fails after this timeout multiplied by the retry policy max attempts, i.e. about 5 minutes with the default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry. The retry behaviour itself is tuned with the `NXF_RETRY_POLICY_*` variables.
+
+##### `NXF_HTTPCLIENT_REQUEST_TIMEOUT`
+
+<AddedInVersion version="26.10" />
+
+Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Set it to `0s` to wait indefinitely.
+
 ##### `NXF_JAVA_HOME`
 
 Defines the path location of the Java VM installation used to run Nextflow. This variable overrides the `JAVA_HOME` variable if defined.
@@ -287,20 +301,6 @@ Delay multiplier used for HTTP retryable operations (default: `2.0`).
 ##### `NXF_SCM_FILE`
 
 Defines the path location of the SCM config file .
-
-##### `NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT`
-
-<AddedInVersion version="26.10" />
-
-Defines the timeout to establish the HTTP connection with the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). It must be greater than zero.
-
-Connection attempts that time out are retried, because a connection that was never established proves the request did not reach the server. A persistently unreachable host therefore only fails after this timeout multiplied by the retry policy max attempts, i.e. about 5 minutes with the default settings. Deployments that require bounded latency should set a lower value e.g. `5s`, which caps the worst case at about 30 seconds including the retry backoff, while a transient connection stall recovers in a few seconds on retry. The retry behaviour itself is tuned with the `NXF_RETRY_POLICY_*` variables.
-
-##### `NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT`
-
-<AddedInVersion version="26.10" />
-
-Defines the timeout to receive the response for a HTTP request made to the Git hosting service API e.g. GitHub, GitLab, etc. as a duration string e.g. `30s` (default: `60s`). Set it to `0s` to wait indefinitely.
 
 Unlike a connect timeout, a request that times out waiting for the response is not retried, since it did reach the server and may already have been acted on.
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/AssetManager.groovy
@@ -525,7 +525,7 @@ class AssetManager implements Closeable {
 
         return RepositoryFactory
             .newRepositoryProvider(config, project)
-            .setHttpClientOpts(httpClientOpts ?: RepositoryProvider.httpClientOpts(null))
+            .setHttpClientOpts(httpClientOpts ?: RepositoryProvider.httpClientOpts())
     }
 
     AssetManager setLocalPath(File path) {

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -69,8 +69,17 @@ abstract class RepositoryProvider {
     static final public Duration DEFAULT_REQUEST_TIMEOUT = Duration.of('60s')
 
     /**
-     * The environment variable prefix used to resolve the HTTP client settings,
-     * mirroring the {@code nextflow.httpClient} config path
+     * The environment variable prefix used to resolve the HTTP client settings.
+     * <p>
+     * It is deliberately client-agnostic rather than SCM-specific, for the same reason the
+     * retry policy of this very client resolves from the global {@code NXF_RETRY_POLICY_*}:
+     * {@link HttpClientOpts} lives in nf-commons so that other clients can take the same
+     * settings without repainting the variable names.
+     * <p>
+     * Note there is no matching {@code nextflow.config} scope, and cannot be - the config
+     * file is not parsed until the project has been fetched. The config-map half of the
+     * resolution reads the top-level {@code httpClient} block of the SCM config file
+     * instead; see {@link #httpClientOpts(Map)}.
      */
     static final private String HTTP_CLIENT_ENV_PREFIX = 'NXF_HTTPCLIENT_'
 

--- a/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/scm/RepositoryProvider.groovy
@@ -70,9 +70,9 @@ abstract class RepositoryProvider {
 
     /**
      * The environment variable prefix used to resolve the HTTP client settings,
-     * mirroring the {@code scm.httpClient} config path
+     * mirroring the {@code nextflow.httpClient} config path
      */
-    static final private String HTTP_CLIENT_ENV_PREFIX = 'NXF_SCM_HTTPCLIENT_'
+    static final private String HTTP_CLIENT_ENV_PREFIX = 'NXF_HTTPCLIENT_'
 
     @Canonical
     static class TagInfo {
@@ -156,7 +156,7 @@ abstract class RepositoryProvider {
 
     /**
      * The HTTP client timeout settings. When none has been set explicitly they are resolved
-     * from the {@code NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT} and {@code NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT}
+     * from the {@code NXF_HTTPCLIENT_CONNECT_TIMEOUT} and {@code NXF_HTTPCLIENT_REQUEST_TIMEOUT}
      * environment variables, falling back to the defaults - the environment being the only source
      * available this early, since SCM resolution completes before any Nextflow config has been parsed.
      *
@@ -164,7 +164,7 @@ abstract class RepositoryProvider {
      */
     protected HttpClientOpts getHttpClientOpts() {
         if( httpClientOpts==null )
-            httpClientOpts = httpClientOpts(null)
+            httpClientOpts = httpClientOpts()
         return httpClientOpts
     }
 
@@ -181,7 +181,7 @@ abstract class RepositoryProvider {
      * @param scmConfig The parsed SCM config file contents, or null when there is none
      * @return The resulting {@link HttpClientOpts}; never null
      */
-    static HttpClientOpts httpClientOpts(Map scmConfig) {
+    static HttpClientOpts httpClientOpts(Map scmConfig=null) {
         final opts = (Map) scmConfig?.get('httpClient') ?: Collections.emptyMap()
         final connectTimeout = RetryConfig.valueOf(opts, 'connectTimeout', HTTP_CLIENT_ENV_PREFIX, DEFAULT_CONNECT_TIMEOUT, Duration)
         final requestTimeout = RetryConfig.valueOf(opts, 'requestTimeout', HTTP_CLIENT_ENV_PREFIX, DEFAULT_REQUEST_TIMEOUT, Duration)
@@ -574,14 +574,14 @@ abstract class RepositoryProvider {
         catch( HttpConnectTimeoutException e ) {
             // the underlying client retries connect timeouts - see isRetryable() -
             // therefore this is only reached once all attempts are exhausted
-            throw new IOException("Unable to connect to '${request.uri()}' within ${getHttpClientOpts().connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT", e)
+            throw new IOException("Unable to connect to '${request.uri()}' within ${getHttpClientOpts().connectTimeout().toSeconds()}s (after ${retryConfig.maxAttempts} attempts) - make sure the host is reachable or increase the timeout setting the variable NXF_HTTPCLIENT_CONNECT_TIMEOUT", e)
         }
         catch( HttpTimeoutException e ) {
             // report the bound actually applied to the request i.e. connect + request; it is
             // null only when the request timeout is unbounded, in which case no timeout was
             // set on the request and this branch is unreachable
             final elapsed = getHttpClientOpts().httpRequestTimeout()
-            throw new IOException("No response received from '${request.uri()}'${elapsed ? " within ${elapsed.toSeconds()}s" : ''} - make sure the host is reachable or increase the timeout setting the variable NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT", e)
+            throw new IOException("No response received from '${request.uri()}'${elapsed ? " within ${elapsed.toSeconds()}s" : ''} - make sure the host is reachable or increase the timeout setting the variable NXF_HTTPCLIENT_REQUEST_TIMEOUT", e)
         }
     }
 

--- a/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/scm/RepositoryProviderTest.groovy
@@ -205,7 +205,7 @@ class RepositoryProviderTest extends Specification {
 
     def 'should fail when the timeout value is not a duration' () {
         given:
-        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: 'foo'])
+        SysEnv.push([NXF_HTTPCLIENT_CONNECT_TIMEOUT: 'foo'])
         def provider = Spy(RepositoryProvider)
 
         when:
@@ -220,7 +220,7 @@ class RepositoryProviderTest extends Specification {
 
     def 'should prefer the http client opts set explicitly over the env variables' () {
         given:
-        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '5s', NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '250ms'])
+        SysEnv.push([NXF_HTTPCLIENT_CONNECT_TIMEOUT: '5s', NXF_HTTPCLIENT_REQUEST_TIMEOUT: '250ms'])
         def provider = Spy(RepositoryProvider)
         and:
         provider.setHttpClientOpts(new HttpClientOpts(
@@ -252,8 +252,8 @@ class RepositoryProviderTest extends Specification {
 
         where:
         env                                                                                     | expected
-        [NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '5s', NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '250ms']  | Duration.ofMillis(5_250)
-        [NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '0s']                                               | null
+        [NXF_HTTPCLIENT_CONNECT_TIMEOUT: '5s', NXF_HTTPCLIENT_REQUEST_TIMEOUT: '250ms']  | Duration.ofMillis(5_250)
+        [NXF_HTTPCLIENT_REQUEST_TIMEOUT: '0s']                                               | null
     }
 
     def 'should fail with a timeout error when the server does not reply' () {
@@ -266,7 +266,7 @@ class RepositoryProviderTest extends Specification {
         } as HttpHandler)
         server.start()
         and:
-        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '1s', NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT: '500ms'])
+        SysEnv.push([NXF_HTTPCLIENT_CONNECT_TIMEOUT: '1s', NXF_HTTPCLIENT_REQUEST_TIMEOUT: '500ms'])
         def provider = Spy(RepositoryProvider)
 
         when:
@@ -274,7 +274,7 @@ class RepositoryProviderTest extends Specification {
         then:
         def e = thrown(IOException)
         e.message.startsWith("No response received from 'http://localhost:${server.address.port}/stall'")
-        e.message.contains('NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT')
+        e.message.contains('NXF_HTTPCLIENT_REQUEST_TIMEOUT')
         e.cause instanceof HttpTimeoutException
 
         cleanup:
@@ -284,7 +284,7 @@ class RepositoryProviderTest extends Specification {
 
     def 'should build the http client opts from the scm config map' () {
         given:
-        SysEnv.push([NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT: '5s'])
+        SysEnv.push([NXF_HTTPCLIENT_CONNECT_TIMEOUT: '5s'])
 
         when: 'the scm file carries an httpClient block'
         def opts = RepositoryProvider.httpClientOpts([httpClient: [connectTimeout: '30s', requestTimeout: '90s']])
@@ -299,7 +299,7 @@ class RepositoryProviderTest extends Specification {
         opts.requestTimeout() == Duration.ofSeconds(60)
 
         when: 'there is no scm config at all'
-        opts = RepositoryProvider.httpClientOpts(null)
+        opts = RepositoryProvider.httpClientOpts()
         then:
         opts.connectTimeout() == Duration.ofSeconds(5)
 


### PR DESCRIPTION
Stacked on #7536.

Implements **solution A** from [#7536 (comment)](https://github.com/nextflow-io/nextflow/pull/7536#issuecomment-5483595335) and the suggestion in [review comment r3897834068](https://github.com/nextflow-io/nextflow/pull/7536#discussion_r3897834068).

### Why

The SCM client's **retry** already uses the global `nextflow.retryPolicy` / `NXF_RETRY_POLICY_*`, but the **timeouts** were scoped as `NXF_SCM_HTTPCLIENT_*`, which is inconsistent and implies an `scm.httpClient` config path that doesn't really exist — the block is a top-level `httpClient` in the SCM file and can't live in `nextflow.config` anyway.

This lines the timeouts up with the global retry naming, and generalises to other clients later since the holder (`HttpClientOpts`) already lives in `nf-commons`:

| Before | After |
| --- | --- |
| `NXF_SCM_HTTPCLIENT_CONNECT_TIMEOUT` | `NXF_HTTPCLIENT_CONNECT_TIMEOUT` |
| `NXF_SCM_HTTPCLIENT_REQUEST_TIMEOUT` | `NXF_HTTPCLIENT_REQUEST_TIMEOUT` |
| `scm.httpClient.*` | `nextflow.httpClient.*` |

Only the environment prefix (`HTTP_CLIENT_ENV_PREFIX`), the doc references and the error/JavaDoc text change. Resolution order and the SCM-file `httpClient` block are untouched — the `httpClient` block in the SCM config file keeps its name and precedence.

### Optimisation

`RepositoryProvider.httpClientOpts(Map scmConfig)` gets a `null` default (`Map scmConfig=null`) so it can be invoked with no arguments, and the two call sites that passed `null` (`getHttpClientOpts()` and `AssetManager`) now use the empty form.

### Docs

- `docs/reference/env-vars.mdx`: the two vars renamed and moved to their new alphabetical position (after `NXF_HOME`).
- `docs/git.mdx`: env var references updated.

### Tests

`RepositoryProviderTest` updated to the new env var names; the "no scm config" case now exercises the no-arg `httpClientOpts()`. Full `:nextflow` SCM suite green (the one network-gated `@Requires(NXF_GITHUB_ACCESS_TOKEN)` download test is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude Code (Opus 4.8)
