### PR TITLE
Make exit() graceful, report error for return statement in workflow body

### DIFF
--- a/docs/reference/stdlib-namespaces/global.mdx
+++ b/docs/reference/stdlib-namespaces/global.mdx
@@ -58,9 +58,9 @@ Throw a script runtime error with an optional error message.
 
 ##### `exit( exitCode: int = 0, message: String = null )`
 
-<DeprecatedInVersion version="22.10">
-Use `error()` instead
-</DeprecatedInVersion>
+<ChangedInVersion version="26.10">
+The run now exits gracefully instead of exiting immediately.
+</ChangedInVersion>
 
 Stop the pipeline execution and return an exit code and optional error message.
 

--- a/docs/reference/stdlib-namespaces/global.mdx
+++ b/docs/reference/stdlib-namespaces/global.mdx
@@ -64,6 +64,10 @@ The run now exits gracefully instead of exiting immediately.
 
 Stop the pipeline execution and return an exit code and optional error message.
 
+:::note
+As a best practice, only call `exit()` from the workflow body. Use `error()` to fail the pipeline from a process or operator.
+:::
+
 ##### `file( filePattern: String, [options] ) -> Path | List<Path>`
 
 Get a file from a file name or glob pattern. Returns a collection of files if the glob pattern yields zero or multiple files.

--- a/docs/reference/syntax.mdx
+++ b/docs/reference/syntax.mdx
@@ -579,6 +579,8 @@ def sayHello(name) {
 }
 ```
 
+A return statement can only be used in a [function](#function) or [closure](#closure). It cannot be used in a [workflow](#workflow) body.
+
 ### throw
 
 A throw statement consists of the `throw` keyword followed by an expression that returns an error type:

--- a/modules/nextflow/src/main/groovy/nextflow/Nextflow.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Nextflow.groovy
@@ -24,6 +24,7 @@ import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 
 import groovyx.gpars.dataflow.DataflowReadChannel
+import nextflow.exception.ExitException
 import nextflow.exception.StopSplitIterationException
 import nextflow.exception.WorkflowScriptErrorException
 import nextflow.extension.GroupKey
@@ -219,20 +220,12 @@ class Nextflow {
      * @param exitCode The exit code to be returned
      * @param message The message that will be reported in the log file (optional)
      */
-    @Deprecated
     static void exit(int exitCode, String message = null) {
-        if( session.aborted ) {
-            log.debug "Ignoring exit because execution is already aborted -- message=$message"
-            return
-        }
-
-        if ( exitCode && message ) {
+        if( exitCode && message )
             log.error message
-        }
-        else if ( message ) {
+        else if( message )
             log.info message
-        }
-        System.exit(exitCode)
+        throw new ExitException(exitCode, message)
     }
 
     /**
@@ -240,7 +233,6 @@ class Nextflow {
      *
      * @param message The message that will be reported in the log file
      */
-    @Deprecated
     static void exit( String message ) {
         exit(0, message)
     }

--- a/modules/nextflow/src/main/groovy/nextflow/exception/ExitException.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/exception/ExitException.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.exception
+
+import groovy.transform.CompileStatic
+
+/**
+ * Exception thrown by the `exit()` function to stop the pipeline
+ * execution with the given exit code, without killing the JVM.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@CompileStatic
+class ExitException extends RuntimeException {
+
+    private final int exitCode
+
+    ExitException(int exitCode, String message=null) {
+        super(message)
+        this.exitCode = exitCode
+    }
+
+    int getExitCode() { exitCode }
+
+    @Override
+    synchronized Throwable fillInStackTrace() { this }
+
+}

--- a/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/ScriptRunner.groovy
@@ -28,6 +28,7 @@ import nextflow.Session
 import nextflow.container.inspect.ContainerInspectMode
 import nextflow.exception.AbortOperationException
 import nextflow.exception.AbortRunException
+import nextflow.exception.ExitException
 import nextflow.plugin.Plugins
 import nextflow.util.HistoryFile
 /**
@@ -134,6 +135,15 @@ class ScriptRunner {
             await()
             // shutdown session
             shutdown()
+        }
+        catch( ExitException e ) {
+            // the script requested to stop the execution via `exit()`
+            log.debug "Exit requested by the pipeline script -- exitCode=${e.exitCode}; message=${e.message ?: '-'}"
+            if( e.exitCode )
+                session.abort(e)
+            else
+                shutdown()
+            throw e
         }
         catch (Throwable e) {
             session.abort(e)

--- a/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/script/ScriptIncludesTest.groovy
@@ -553,7 +553,7 @@ class ScriptIncludesTest extends Dsl2Spec {
 
         workflow {
           def str = foo('dlrow')
-          return bar('Hello', str)
+          bar('Hello', str)
         }
         """
 

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -34,6 +34,7 @@ import nextflow.NF
 import nextflow.exception.AbortOperationException
 import nextflow.exception.AbortRunException
 import nextflow.exception.ConfigParseException
+import nextflow.exception.ExitException
 import nextflow.exception.ScriptCompilationException
 import nextflow.exception.ScriptRuntimeException
 import nextflow.secret.SecretsLoader
@@ -536,6 +537,12 @@ class Launcher {
             if( log.isTraceEnabled())
                 log.trace "Exit\n" + dumpThreads()
             return 0
+        }
+
+        catch( ExitException e ) {
+            // early termination requested by the pipeline script via `exit()`
+            // -- the message (if any) was already reported by `exit()`
+            return e.exitCode
         }
 
         catch( AbortRunException e ) {

--- a/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/control/VariableScopeVisitor.java
@@ -71,6 +71,7 @@ import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.CatchStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.ReturnStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
@@ -705,6 +706,13 @@ class VariableScopeVisitor extends ScriptVisitorSupport {
         var name = variable.getName();
         if( inOperatorCall && scope.isReferencedLocalVariable(name) && scope.getDeclaredVariable(name) == null )
             vsc.addWarning("Mutating an external variable in an operator closure can lead to a race condition", target.getName(), target);
+    }
+
+    @Override
+    public void visitReturnStatement(ReturnStatement node) {
+        if( currentDefinition instanceof WorkflowNode && currentClosure == null )
+            vsc.addError("Return statement cannot be used in a workflow body -- use `exit()` instead", node);
+        super.visitReturnStatement(node);
     }
 
     // expressions

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ScriptDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ScriptDsl.java
@@ -123,7 +123,6 @@ public interface ScriptDsl extends DslScope {
     """)
     void error(String message);
 
-    @Deprecated
     @Description("""
         Stop the pipeline execution and return an exit code and optional error message.
     """)

--- a/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/control/ScriptResolveTest.groovy
@@ -401,6 +401,48 @@ class ScriptResolveTest extends Specification {
         errors[0].getOriginalMessage() == 'Processes cannot be called from within a closure'
     }
 
+    def 'should report an error for a return statement in a workflow body' () {
+        when:
+        def errors = check(
+            '''\
+            workflow {
+                main:
+                if( params.help )
+                    return
+
+                publish:
+                nums = channel.of(1, 2, 3)
+            }
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 4
+        errors[0].getStartColumn() == 9
+        errors[0].getOriginalMessage() == 'Return statement cannot be used in a workflow body -- use `exit()` instead'
+    }
+
+    def 'should not report an error for a return statement in a closure' () {
+        when:
+        def errors = check(
+            '''\
+            workflow {
+                main:
+                nums = channel.of(1, 2, 3).map { v ->
+                    if( v == 2 )
+                        return 0
+                    return v
+                }
+
+                publish:
+                out = nums
+            }
+            '''
+        )
+        then:
+        errors.size() == 0
+    }
+
     def 'should report an error for an invalid workflow invocation' () {
         when:
         def errors = check(


### PR DESCRIPTION
Close #7537 

The `exit()` function is the only way to return early from a workflow without throwing an error:
- `error()` can only be used for errors, not for `exit 0`
- `return` is not safe in a workflow body because it breaks the `emit:` and `publish:` sections

However, `exit()` was deprecated because it exits immediately via `System.exit()`, bypassing the normal shutdown logic.

This PR makes two changes:
- make `exit()` graceful by throwing a special `ExitException`, which is handled by the runtime as "exit 0"
- report a syntax error for `return` in a workflow body (still allowed in closures)

Caveats:
- `return` is also disallowed in `onComplete:`/`onError:` even though it is technically safe to use there. This was done mainly for consistency, it would be confusing to disallow `return` only in `main:`
- `exit()` from a process body or operator closure always surfaces as a failure with exit-code 1, regardless of the requested exit code. I think this is a bad pattern anyway, so I discourage it in the docs