### PR TITLE
Deprecate storeDir and document alternative approach

### DIFF
--- a/docs/reference/process/directives/store-dir.mdx
+++ b/docs/reference/process/directives/store-dir.mdx
@@ -5,6 +5,10 @@ description: Reference for the `storeDir` process directive.
 
 # `storeDir`
 
+<DeprecatedInVersion version="26.10">
+Use [explicit workflow logic](#alternative-explicit-workflow-logic) instead.
+</DeprecatedInVersion>
+
 The `storeDir` directive stores task outputs in a permanent *store directory* instead of the work directory.
 
 On subsequent runs, each task is executed only if the declared output files do not exist in the store directory. When the files are present, the task is skipped and these files are used as the task outputs.
@@ -33,10 +37,31 @@ process make_blast_db {
 
 Caveats:
 
-- The `env`, `eval`, and `stdout` output qualifiers cannot be used with `storeDir` because they rely on helper files in the task directory. Use `path` outputs instead.
+- The `env`, `eval`, and `stdout` output qualifiers cannot be used with `storeDir` because they rely on helper files in the task directory.
 
-- If a process uses `storeDir` and all of its outputs are optional, the process is always skipped, even if the store directory is empty. Avoid this issue by specifying at least one required file output.
+- If a process uses `storeDir` and all of its outputs are optional, the process is always skipped, even if the store directory is empty.
 
 - The `storeDir` directive is not a replacement for publishing outputs. Use the [publishDir](./publish-dir) directive or [workflow outputs][workflow-output-def] instead.
+
+## Alternative: Explicit workflow logic
+
+Instead of `storeDir`, use explicit workflow logic to reuse an intermediate output if it is present and compute it otherwise:
+
+```nextflow
+params {
+    genome: Path
+    index: Path?
+}
+
+workflow {
+    index = params.index
+        ? channel.value(params.index)
+        : build_index(params.genome)
+
+    align(reads, index)
+}
+```
+
+This approach avoids the `storeDir` limitations described above and makes the caching behavior visible in the workflow logic.
 
 [workflow-output-def]: ../../../workflow#outputs

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -355,6 +355,7 @@ public interface ProcessDsl extends DslScope {
         """)
         void stageOutMode(String value);
 
+        @Deprecated
         @Description("""
             The `storeDir` directive allows you to use an external directory as a *permanent* cache for process outputs.
 


### PR DESCRIPTION
This PR deprecates the `storeDir` process directive and documents an alternative approach using explicit workflow logic.

The `storeDir` directive was introduced early in Nextflow's history to address a niche use case. However, over time it has proven difficult to integrate with new Nextflow features (e.g. `env` and `eval` outputs) and seems to be an anti-pattern.

It is only recently that an alternative approach became clear: use explicit workflow logic to reuse an intermediate output if present, or compute if absent.

Thanks to recent docs improvements, I think we can simply document this alternative approach on the `storeDir` page and safely deprecate it.

No runtime changes, just a documentation update and potential linter warnings.

See also: #5785 