### PR TITLE
Make eval output names stable across runs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/TaskHasher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/TaskHasher.groovy
@@ -76,10 +76,14 @@ class TaskHasher {
         }
 
         // add eval output commands
+        //
+        // note: the map is hashed as an unordered collection of entries, so the
+        // hash does not depend on the map iteration order, while still binding
+        // each eval output name to its command
         final outEvals = task.getOutputEvals()
         if( outEvals ) {
             keys.add("eval_outputs")
-            keys.add(computeEvalOutputCommands(outEvals))
+            keys.add(outEvals)
         }
 
         // add variables referenced in the task script but not declared as input/output
@@ -146,44 +150,6 @@ class TaskHasher {
         }
 
         return hash
-    }
-
-    /**
-     * Compute a deterministic string representation of eval output commands for cache hashing.
-     * This method creates a consistent hash key based on the semantic names and command values
-     * of eval outputs, ensuring cache invalidation when eval outputs change.
-     *
-     * @param outEvals Map of eval parameter names to their command strings
-     * @return A concatenated string of "name=command" pairs, sorted for deterministic hashing
-     */
-    protected static String computeEvalOutputCommands(Map<String, String> outEvals) {
-        // Assert precondition that outEvals should not be null or empty when this method is called
-        assert outEvals != null && !outEvals.isEmpty(), "Eval outputs should not be null or empty"
-
-        final result = new StringBuilder()
-
-        // Sort entries by key for deterministic ordering. This ensures that the same set of
-        // eval outputs always produces the same hash regardless of map iteration order,
-        // which is critical for cache consistency across different JVM runs.
-        // Without sorting, HashMap iteration order can vary between executions, leading to
-        // different cache keys for identical eval output configurations and causing
-        // unnecessary cache misses and task re-execution
-        final sortedEntries = outEvals.entrySet().sort { a, b -> a.key.compareTo(b.key) }
-
-        // Build content using for loop to concatenate "name=command" pairs.
-        // This creates a symmetric pattern with input parameter hashing where both
-        // the parameter name and its value contribute to the cache key
-        for( final entry : sortedEntries ) {
-            // Add newline separator between entries for readability in debug scenarios
-            if( result.length() > 0 ) {
-                result.append('\n')
-            }
-            // Format: "semantic_name=bash_command" - both name and command value are
-            // included because changing either should invalidate the task cache
-            result.append(entry.key).append('=').append(entry.value)
-        }
-
-        return result.toString()
     }
 
     /**

--- a/modules/nextflow/src/main/groovy/nextflow/script/params/CmdEvalParam.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/params/CmdEvalParam.groovy
@@ -16,8 +16,6 @@
 
 package nextflow.script.params
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import groovy.transform.InheritConstructors
 import groovy.transform.Memoized
 
@@ -29,18 +27,19 @@ import groovy.transform.Memoized
 @InheritConstructors
 class CmdEvalParam extends BaseOutParam implements OptionalParam {
 
-    private static AtomicInteger counter = new AtomicInteger()
-
     private Object target
 
-    private int count
-
-    {
-        count = counter.incrementAndGet()
-    }
-
+    /**
+     * The eval output name is derived from the parameter position in the process
+     * output block, so that it is stable across runs. Note: it must not depend on
+     * a global counter, otherwise adding or removing an `eval` output in one process
+     * would change the name -- and therefore the task hash -- of unrelated processes,
+     * invalidating their cache. See https://github.com/nextflow-io/nextflow/issues/7572
+     */
     String getName() {
-        return "nxf_out_eval_${count}"
+        return mapIndex >= 0
+            ? "nxf_out_eval_${index}_${mapIndex}"
+            : "nxf_out_eval_${index}"
     }
 
     BaseOutParam bind( def obj ) {

--- a/modules/nextflow/src/test/groovy/nextflow/processor/TaskHasherTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/TaskHasherTest.groovy
@@ -21,6 +21,7 @@ import java.nio.file.Path
 import nextflow.Session
 import nextflow.script.ProcessConfig
 import nextflow.script.bundle.ResourcesBundle
+import nextflow.util.CacheHelper
 import spock.lang.Specification
 /**
  *
@@ -162,23 +163,23 @@ class TaskHasherTest extends Specification {
         ]
     }
 
-    def 'should compute hash entries for eval outputs'() {
+    def 'should hash eval outputs independently of map order'() {
+        given:
+        // same entries, different insertion order and different map implementation
+        def evals1 = new LinkedHashMap(['nxf_out_eval_0': 'echo one', 'nxf_out_eval_1': 'echo two'])
+        def evals2 = new HashMap(['nxf_out_eval_1': 'echo two', 'nxf_out_eval_0': 'echo one'])
 
-        when:
-        def result1 = TaskHasher.computeEvalOutputCommands([
-            'nxf_out_eval_2': 'echo "value2"',
-            'nxf_out_eval_1': 'echo "value1"',
-            'nxf_out_eval_3': 'echo "value3"'
-        ])
+        expect:
+        CacheHelper.hasher(evals1).hash() == CacheHelper.hasher(evals2).hash()
+    }
 
-        def result2 = TaskHasher.computeEvalOutputCommands([
-            'nxf_out_eval_3': 'echo "value3"',
-            'nxf_out_eval_1': 'echo "value1"',
-            'nxf_out_eval_2': 'echo "value2"'
-        ])
+    def 'should hash eval outputs depending on the name-command binding'() {
+        given:
+        // same names and same commands, but paired the other way round
+        def evals1 = ['nxf_out_eval_0': 'echo one', 'nxf_out_eval_1': 'echo two']
+        def evals2 = ['nxf_out_eval_0': 'echo two', 'nxf_out_eval_1': 'echo one']
 
-        then:
-        result1 == result2
-        result1 == 'nxf_out_eval_1=echo "value1"\nnxf_out_eval_2=echo "value2"\nnxf_out_eval_3=echo "value3"'
+        expect:
+        CacheHelper.hasher(evals1).hash() != CacheHelper.hasher(evals2).hash()
     }
 }


### PR DESCRIPTION
Closes #7572

## Problem

The `eval` process output type generates an internal bookkeeping name, `nxf_out_eval_<N>`. That name is used in two places: as an input to the task hash (added by #6346), and as the key used to read the captured value back out of `.command.env`.

In the classic process DSL the name came from a session-wide static counter in `CmdEvalParam`, incremented once per `eval` param as process definitions were loaded:

```groovy
private static AtomicInteger counter = new AtomicInteger()
private int count
{ count = counter.incrementAndGet() }
```

So the ordinal depended on how many other `eval` outputs happened to be defined earlier in the session. Adding, removing or reordering an `eval`-using process shifted the name of every `eval`-using process defined *after* it, changing their task hashes and invalidating their cache. Inserting a single `include` for a new module is enough to do it.

Since nf-core modules use `eval` to capture tool versions, this affects most processes in a modern pipeline. The reporter hit it at scale: 458 MetaEuk tasks re-executed after an unrelated commit, with the rendered `.command.sh` byte-identical except `nxf_out_eval_25` → `nxf_out_eval_28`.

The typed (V2) process DSL is **not** affected — `ProcessToGroovyVisitorV2` builds a fresh `ProcessUnstageVisitor` per process, so its counter is already process-local.

## Changes

**1. `CmdEvalParam` — derive the name from the parameter position.**

`BaseParam` already carries `index` (declaration index within the process's own output list) and `mapIndex` (position within a `tuple(...)`, `-1` when top-level). Both are stable and process-local:

```groovy
String getName() {
    return mapIndex >= 0
        ? "nxf_out_eval_${index}_${mapIndex}"
        : "nxf_out_eval_${index}"
}
```

The name is now independent of other processes, while still encoding declaration order — which matters, because `eval` outputs bind to output channels positionally. The `mapIndex` guard keeps the generated bash variable a valid identifier.

Note this part is required regardless of how hashing works: because the name is the `.command.env` read-back key, an unstable name causes a cache miss even if it is removed from the hash entirely. In that case `collectOutEnvParam` throws `MissingValueException` on the cached work dir, `checkCachedOutput` swallows it into `return false`, and the task re-runs anyway — just after a wasted cache-DB hit, and with nothing in the log to explain it.

**2. `TaskHasher` — hash the eval map directly.**

`computeEvalOutputCommands` built a `name=command` string sorted by name, to guard against `HashMap` iteration order varying between runs. That is unnecessary: `HashBuilder` already dispatches `Map` to `hashUnorderedCollection`, which hashes each entry and *sums* the bytes. Addition is commutative, so the hash is deterministic regardless of iteration order — and each `Map.Entry` is hashed key-then-value, so the name-to-command binding is preserved and permuting two `eval` declarations still invalidates the cache.

43 lines become 5, and this matches how script global vars are already hashed a few lines below (`keys.add(vars.entrySet())`):

```groovy
final outEvals = task.getOutputEvals()
if( outEvals ) {
    keys.add("eval_outputs")
    keys.add(outEvals)
}
```

**3. Tests.** The case asserting the helper's exact output string is replaced by two asserting the properties that matter: the same entries in a `LinkedHashMap` and a `HashMap` hash equal, and swapping which command each name maps to changes the hash.

## Verification

Minimal repro — three trivial processes each with one `eval` output and an identical script body, in a module file. Run 1 includes `A` and `B`; run 2 adds one `include` line for `Z` ahead of it.

| scenario | before | after |
|---|---|---|
| insert an unrelated `eval` process, `-resume` | all 3 tasks re-run (`cached=0`) | `cached=2`, only the new `Z` runs |
| swap two `eval` declarations in one process, `-resume` | re-runs, correct values | re-runs, correct values |
| identical script, `-resume` | cached | cached |

The permutation row is the reason this does not simply drop the name from the hash, or hash the commands as an unordered bag of values: a bag discards the name-to-command binding, and with it the only signal that captures `eval` declaration order (`task.source` covers the `script:` block only, not the output block). Tested — with a bag, swapping two `eval` declarations reports the task as cached and silently emits the *previous* run's value assignment.

Also checked that names stay unique and values collect correctly for a process mixing top-level and tuple-nested eval outputs:

```
nxf_out_eval_0=echo one
nxf_out_eval_1_0=echo two
nxf_out_eval_1_1=echo three
nxf_out_eval_2=echo four
→ out0=one   out1=[two, three]   out2=four
```

`NXF_SMOKE=1 ./gradlew :nextflow:test` passes.

## Cache invalidation

⚠️ Both changes alter the hash for processes that use `eval` outputs, so those tasks re-execute once after upgrading. Worth a changelog note.

One thing left for a follow-up decision: while names remain in the hash, V1 and V2 do not agree on them for tuple-nested evals (V2 uses a flat per-process counter, this uses `index`/`mapIndex`), so migrating such a process to the typed DSL invalidates its cache for that reason alone. Closing that would mean either adopting V2's flat counter here too, or dropping names from the hash — both worth deciding deliberately rather than discovering later.
