### PR TITLE
Make ByteBufferInputStream resettable so an S3 upload can be retried

### DIFF
--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/ByteBufferInputStream.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/util/ByteBufferInputStream.java
@@ -35,8 +35,45 @@ public class ByteBufferInputStream extends InputStream {
 
     ByteBuffer buf;
 
+    /**
+     * Position to rewind to on {@link #reset()}: the mark when one was set, otherwise the position
+     * the stream started at.
+     */
+    private int mark;
+
     public ByteBufferInputStream(ByteBuffer buf) {
         this.buf = buf;
+        this.mark = buf.position();
+    }
+
+    /**
+     * Mark/reset IS supported: the content is a buffer already in memory, so rewinding is a position
+     * assignment. It matters because the AWS SDK asks a {@code RequestBody} for a fresh stream on
+     * every attempt: over a stream that reports {@code markSupported() == false} it builds a
+     * one-shot provider, and a RETRY then fails with "Content input stream does not support
+     * mark/reset, and was already read once" instead of re-sending. Both {@code S3OutputStream}
+     * upload paths pass this stream -- single-part {@code putObject} and multipart
+     * {@code uploadPart} -- so without mark/reset one transient 5xx on any driver-side S3 write
+     * aborted the operation instead of being retried.
+     */
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        this.mark = buf.position();
+    }
+
+    @Override
+    public synchronized void reset() {
+        buf.position(mark);
+    }
+
+    @Override
+    public int available() {
+        return buf.remaining();
     }
 
     public int read() throws IOException {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3UploadRetryTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/S3UploadRetryTest.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cloud.aws.nio
+
+import java.net.URI
+import java.nio.ByteBuffer
+
+import nextflow.cloud.aws.nio.util.ByteBufferInputStream
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.http.AbortableInputStream
+import software.amazon.awssdk.http.ExecutableHttpRequest
+import software.amazon.awssdk.http.HttpExecuteRequest
+import software.amazon.awssdk.http.HttpExecuteResponse
+import software.amazon.awssdk.http.SdkHttpClient
+import software.amazon.awssdk.http.SdkHttpResponse
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import spock.lang.Specification
+
+/**
+ * A single-part {@code S3OutputStream} upload sends its buffer as
+ * {@code RequestBody.fromInputStream(new ByteBufferInputStream(buf), len)}. The SDK asks that body
+ * for a fresh stream on EVERY attempt, so the upload is only retryable if the stream can be re-read.
+ *
+ * This drives a real {@link S3Client} over a stubbed transport that fails the first attempt with
+ * 503, which is the shape of the transient error the SDK is meant to absorb.
+ */
+class S3UploadRetryTest extends Specification {
+
+    /** Transport stub: reads the request body like a real send, fails attempt 1 with 503. */
+    static class FlakyTransport implements SdkHttpClient {
+        int attempts = 0
+        List<Integer> bytesSeen = []
+
+        @Override
+        ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+            return new ExecutableHttpRequest() {
+                @Override
+                HttpExecuteResponse call() {
+                    attempts++
+                    // consume the body, as sending it would
+                    final provider = request.contentStreamProvider()
+                    bytesSeen << (provider.present ? provider.get().newStream().bytes.length : 0)
+                    final status = attempts == 1 ? 503 : 200
+                    return HttpExecuteResponse.builder()
+                            .response(SdkHttpResponse.builder().statusCode(status).build())
+                            .responseBody(AbortableInputStream.create(new ByteArrayInputStream(new byte[0])))
+                            .build()
+                }
+
+                @Override
+                void abort() { }
+            }
+        }
+
+        @Override
+        void close() { }
+    }
+
+    def 'a single-part upload survives a transient 503 -- the body is re-read on the retry'() {
+        given:
+        def payload = ('x' * 128).bytes
+        def transport = new FlakyTransport()
+        def s3 = S3Client.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create('key', 'secret')))
+                .endpointOverride(URI.create('https://s3.local'))
+                .httpClient(transport)
+                .build()
+        and: 'the body S3OutputStream builds for a single-part putObject'
+        def body = RequestBody.fromInputStream(
+                new ByteBufferInputStream(ByteBuffer.wrap(payload)), payload.length)
+
+        when:
+        s3.putObject(PutObjectRequest.builder().bucket('bucket').key('key').build(), body)
+
+        then: 'the SDK retried, and the retry re-sent as many bytes as the first attempt'
+        transport.attempts == 2
+        transport.bytesSeen[1] == transport.bytesSeen[0]
+        and: 'each attempt carried the whole payload (plus the SDK aws-chunked framing)'
+        transport.bytesSeen[0] >= payload.length
+
+        cleanup:
+        s3?.close()
+    }
+}

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/ByteBufferInputStreamTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/nio/util/ByteBufferInputStreamTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cloud.aws.nio.util
+
+import java.nio.ByteBuffer
+
+import software.amazon.awssdk.core.sync.RequestBody
+import spock.lang.Specification
+
+class ByteBufferInputStreamTest extends Specification {
+
+    def 'should read the buffer content'() {
+        given:
+        def stream = new ByteBufferInputStream(ByteBuffer.wrap('hello'.bytes))
+        expect:
+        stream.bytes == 'hello'.bytes
+    }
+
+    /**
+     * The SDK asks a {@code RequestBody} for a fresh stream on every attempt, so a body that can be
+     * read only once cannot be RETRIED: the second attempt fails with IllegalStateException instead
+     * of re-sending.
+     */
+    def 'a request body built from the buffer can be re-read, so the SDK can retry'() {
+        given:
+        def payload = 'index-bytes-for-the-cache'.bytes
+        def body = RequestBody.fromInputStream(new ByteBufferInputStream(ByteBuffer.wrap(payload)), payload.length)
+
+        when: 'the SDK asks for the stream twice, as it does when the first attempt failed'
+        def first = body.contentStreamProvider().newStream().bytes
+        def second = body.contentStreamProvider().newStream().bytes
+
+        then: 'both attempts see the whole payload'
+        first == payload
+        second == payload
+    }
+
+    def 'a partially consumed stream rewinds to the mark'() {
+        given: 'the shape of a failed attempt -- some bytes went out before the error'
+        def payload = '0123456789'.bytes
+        def stream = new ByteBufferInputStream(ByteBuffer.wrap(payload))
+
+        expect:
+        stream.markSupported()
+
+        when:
+        stream.mark(payload.length)
+        def partial = new byte[4]
+        stream.read(partial, 0, 4)
+        stream.reset()
+
+        then: 'the retry re-sends the whole body, not the tail'
+        partial == '0123'.bytes
+        stream.bytes == payload
+    }
+
+    def 'reset without an explicit mark rewinds to the start'() {
+        given: 'the SDK may reset a provider it never marked'
+        def stream = new ByteBufferInputStream(ByteBuffer.wrap('abc'.bytes))
+
+        when:
+        stream.read()
+        stream.reset()
+
+        then:
+        stream.bytes == 'abc'.bytes
+    }
+
+    def 'available reports the unread remainder'() {
+        given:
+        def stream = new ByteBufferInputStream(ByteBuffer.wrap('abcde'.bytes))
+        expect:
+        stream.available() == 5
+        when:
+        stream.read()
+        then:
+        stream.available() == 4
+    }
+}


### PR DESCRIPTION
## Summary

`ByteBufferInputStream` does not override `markSupported()`, so it reports `false`, and
`RequestBody.fromInputStream(stream, length)` therefore wraps it in a **one-shot** content provider.

The AWS SDK asks a request body for a fresh stream on *every* attempt, so any second read fails with:

```
java.lang.IllegalStateException: Content input stream does not support mark/reset, and was already read once.
	at software.amazon.awssdk.http.ContentStreamProvider$3.newStream(ContentStreamProvider.java:137)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage$ClosingStreamProvider.newStream(StreamManagingStage.java:75)
	at software.amazon.awssdk.http.auth.aws.internal.signer.AwsChunkedV4PayloadSigner.sign(AwsChunkedV4PayloadSigner.java:91)
	…
	at nextflow.cloud.aws.nio.S3OutputStream.putObject(S3OutputStream.java:630)
	at nextflow.cloud.aws.nio.S3OutputStream.close(S3OutputStream.java:384)
```

instead of re-sending the body.

Both `S3OutputStream` upload paths pass this stream:

- single-part `putObject` — `S3OutputStream.java:585`
- multipart `uploadPart` — `S3OutputStream.java:468`

So a transient error on **any** driver-side S3 write — a file written through the NIO output stream, a
`publishDir` copy, foreign-file staging, a cloud cache index — aborts the operation instead of being
retried, which is precisely what the SDK's retry policy exists to prevent.

## Why it looks intermittent

It needs a retryable error to occur, so it shows up under load and disappears when the same step is
run in isolation. I hit it as an occasional abort *after* a workflow had completed successfully:
`Session.destroy` → the cache store's `close()` → `S3OutputStream.close()` → single-part `putObject`,
**1.56 s** into a PUT of a ~34-byte object. That duration is a round trip plus a retry backoff, not a
signing error — and an earlier run in the same session had written the same kind of object without
trouble, which rules out anything deterministic.

Worth noting that the SDK's default `requestChecksumCalculation` puts these PUTs on the aws-chunked
signing path (a 128-byte payload goes out as 170 bytes of framing + CRC32 trailer), which is why the
signer appears in the stack. The chunked signer makes the body fragile; the retry is what makes the
failure occasional.

## Fix

The content is a `ByteBuffer` already in memory, so rewinding is a position assignment. `mark`/`reset`
are now supported and `available()` reports the unread remainder. `reset()` without a prior `mark()`
rewinds to the position the stream started at, since the SDK may reset a provider it never marked.

No copy is introduced. A transient 5xx now costs a re-send of the already-buffered part rather than
failing the operation.

## Tests

Both fail on current `master` and pass with the fix:

- **`S3UploadRetryTest`** — drives a real `S3Client` over a stubbed `SdkHttpClient` that answers the
  first attempt with `503`, then asserts the retry re-sent as many bytes as the first attempt. On
  unmodified `master` it fails with the exact exception and signer stack above, no network or
  credentials required.
- **`ByteBufferInputStreamTest`** — pins the mark/reset semantics: re-reading a `RequestBody`,
  rewinding after a partial read, `reset()` with no prior `mark()`, and `available()`.

`./gradlew :plugins:nf-amazon:test` → 471 tests, 0 failures.

Opened as a draft for review of the approach: making the stream resettable fixes every caller, but the
alternative would be to change the two `S3OutputStream` call sites to a re-readable `RequestBody`
(`fromBytes` / `fromContentProvider`) and leave the stream class alone.
