### PR TITLE
Add `manifest.diagram` config option

### DIFF
--- a/docs/reference/config/manifest.mdx
+++ b/docs/reference/config/manifest.mdx
@@ -61,7 +61,7 @@ Free text describing the workflow project.
 
 ##### `manifest.diagram`
 
-<AddedInVersion version="26.08" />
+<AddedInVersion version="26.10" />
 
 Project workflow diagram location (Relative path or URL).
 

--- a/docs/reference/config/manifest.mdx
+++ b/docs/reference/config/manifest.mdx
@@ -59,6 +59,12 @@ Git repository default branch (default: `master`).
 
 Free text describing the workflow project.
 
+##### `manifest.diagram`
+
+<AddedInVersion version="26.08" />
+
+Project workflow diagram location (Relative path or URL).
+
 ##### `manifest.docsUrl`
 
 Project documentation URL.

--- a/modules/nextflow/src/main/groovy/nextflow/config/Manifest.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/config/Manifest.groovy
@@ -67,6 +67,12 @@ class Manifest implements ConfigScope {
 
     @ConfigOption
     @Description("""
+        Project workflow diagram location (Relative path or URL).
+    """)
+    final String diagram
+
+    @ConfigOption
+    @Description("""
         Project documentation URL.
     """)
     final String docsUrl
@@ -147,6 +153,7 @@ class Manifest implements ConfigScope {
         contributors = parseContributors(opts.contributors)
         defaultBranch = opts.defaultBranch as String
         description = opts.description as String
+        diagram = opts.diagram as String
         docsUrl = opts.docsUrl as String
         doi = opts.doi as String
         gitmodules = opts.gitmodules
@@ -193,6 +200,7 @@ class Manifest implements ConfigScope {
             doi: doi,
             docsUrl: docsUrl,
             icon: icon,
+            diagram: diagram,
             organization: organization,
             license: license,
         ]

--- a/modules/nextflow/src/test/groovy/nextflow/config/ManifestTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/config/ManifestTest.groovy
@@ -50,6 +50,7 @@ class ManifestTest extends Specification {
             name: 'foo',
             organization: 'My Organization',
             icon: 'icon.png',
+            diagram: 'docs/images/diagram.svg',
             docsUrl: 'https://docs.io',
             license: 'Apache v2'
         ]
@@ -71,6 +72,7 @@ class ManifestTest extends Specification {
         manifest.name == 'foo'
         manifest.organization == 'My Organization'
         manifest.icon == 'icon.png'
+        manifest.diagram == 'docs/images/diagram.svg'
         manifest.docsUrl == 'https://docs.io'
         manifest.license == 'Apache v2'
 
@@ -94,6 +96,7 @@ class ManifestTest extends Specification {
         manifest.docsUrl == null
         manifest.organization == null
         manifest.icon == null
+        manifest.diagram == null
         manifest.license == null
 
     }

--- a/modules/nf-lang/src/main/java/nextflow/script/namespaces/ManifestNamespace.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/namespaces/ManifestNamespace.java
@@ -48,6 +48,12 @@ public interface ManifestNamespace extends Namespace {
     """)
     String getDescription();
 
+    @Constant("diagram")
+    @Description("""
+        Project workflow diagram location (Relative path or URL).
+    """)
+    String getDiagram();
+
     @Constant("docsUrl")
     @Description("""
         Project documentation URL.


### PR DESCRIPTION
Adds a `manifest.diagram` config option declaring the location of a pipeline's workflow diagram, as a relative path or URL. Mirrors `manifest.icon`: a flat string, no validation, no resolution, no rendering.

### Why

Many pipelines ship a hand-drawn workflow diagram, and where one exists it is often the quickest way to convey what the pipeline does. Today it is only discoverable by parsing the README and guessing which image is the workflow figure rather than the logo or a badge. Across nf-core these assets are diverse in style, format and naming, with no pattern that matches them all (`nf-core-rnaseq_metro_map_grey.svg`, `sarek_subway.svg`, `taxprofiler_tube.svg`, `mag_metromap_light.svg`), and some pipelines ship several figures with nothing marking which is canonical.

Declaring it in the manifest lets anything already reading pipeline metadata show the author's intended overview without guessing.

Follows the flat-field precedent of #4034, resolved in #5314 by adding `docsUrl`, `icon`, `license` and `organization`. Complements #5023, which was closed because these diagrams are hand-made rather than generatable from the DAG.

One field rather than a light/dark pair, since an SVG can serve both themes.

### Changes

- `Manifest.groovy`: new `@ConfigOption`, constructor assignment, `toMap()` entry
- `ManifestNamespace.java`: exposed as `workflow.manifest.diagram`
- `ManifestTest.groovy`: extended the existing populated and empty manifest cases
- `docs/reference/config/manifest.mdx`: documented with `<AddedInVersion version="26.08" />`
