### PR TITLE
docs: clarify lineage behavior with resume and publishDir

### DIFF
--- a/docs/tutorials/data-lineage.mdx
+++ b/docs/tutorials/data-lineage.mdx
@@ -249,9 +249,14 @@ The previous example traced a workflow output to its producing task. Conversely,
 $ nextflow lineage view lid://eff8846883b46c5a76f11e7e4480a6c8#output
 [
   {
+    "type": "val",
+    "name": "id",
+    "value": "ggal_gut"
+  },
+  {
     "type": "path",
-    "name": "pair_id",
-    "value": "lid://eff8846883b46c5a76f11e7e4480a6c8/ggal_gut"
+    "name": null,
+    "value": "lid://eff8846883b46c5a76f11e7e4480a6c8/quant_ggal_gut"
   }
 ]
 ```
@@ -341,6 +346,37 @@ lid://c47bf9183c56715c9bca1a67a4acdc68
 :::tip
 The `view` subcommand outputs JSON, so you can use JSON processing tools such as [jq](https://jqlang.org/) to further query and transform results. The `find` subcommand prints one LID per line, which pipes directly into `xargs`.
 :::
+
+## Use lineage with resume
+
+Resumed runs are recorded as distinct runs that share a session ID.
+
+Every run writes a new `WorkflowRun` record with its own LID, including resumed runs, so `nextflow lineage list` shows one row per run:
+
+```console
+$ nextflow lineage list
+TIMESTAMP               RUN NAME                SESSION ID                              LINEAGE ID
+2025-05-09 13:28:30 CDT peaceful_blackwell      065bdc6b-89b4-42ee-92c1-2a5af37f2c50    lid://16b31030474f2e96c55f4940bca3ab64
+2025-05-09 14:02:11 CDT wise_euler              065bdc6b-89b4-42ee-92c1-2a5af37f2c50    lid://65044872aad36f97e42336b9ba0dee57
+```
+
+Both rows have the same session ID because `-resume` reuses the session ID of the initial run. The session ID is recorded in the `sessionId` field of the `WorkflowRun` record, as well as every `TaskRun` record, which makes it the key for querying an entire resume chain.
+
+A cached task is not re-executed, so it does not produce a new `TaskRun` record. Its LID is the task hash, so the record written by the run that originally executed the task is still the record for that task. The `workflowRun` field of a `TaskRun` therefore points to the run that actually executed it, not necessarily the resumed run.
+
+This distinction matters when querying. Finding tasks by `workflowRun` returns only the tasks that the given run executed:
+
+```console
+$ nextflow lineage find type=TaskRun workflowRun=lid://65044872aad36f97e42336b9ba0dee57
+```
+
+Finding tasks by `sessionId` returns every task across the initial run and all of its resumes:
+
+```console
+$ nextflow lineage find type=TaskRun sessionId=065bdc6b-89b4-42ee-92c1-2a5af37f2c50
+```
+
+Workflow outputs behave differently from task runs. Nextflow publishes the outputs of cached tasks on every run, so each run gets its own `FileOutput` records under its own LID, and the `source` field of each one points back to the task output that produced it. A resumed run's output directory is fully described by its own `WorkflowRun` LID, whether or not its tasks were cached.
 
 ## Compare task runs
 
@@ -435,10 +471,6 @@ Nextflow types are represented in workflow outputs as follows:
 | `Map`        | object                      | `Map`, `Record` |
 | `Path`       | string with `lid://` prefix | `Path` |
 
-:::note
-Files published via `publishDir` are also recorded in lineage, as long as they are published inside the run's output directory (`outputDir`, which defaults to `results`). The `WorkflowOutput` record does not capture these outputs, so they can only be retrieved by direct lookup (see [Workflow outputs](#workflow-outputs)).
-:::
-
 ### Output labels
 
 When labels are assigned to a workflow output with the `label` directive, they appear in the `labels` field of each corresponding `FileOutput` record:
@@ -459,6 +491,40 @@ $ nextflow lineage view lid://9410d13abeec617640b5fe9735ba12fc/multiqc_report.ht
 Labels can be used to filter files when querying lineage records with the `nextflow lineage find` command.
 
 See [Labels][workflow-output-labels] for details on assigning labels to workflow outputs.
+
+## Use lineage with publishDir
+
+Lineage does not require the `output` block. It is possible to produce lineage with the `publishDir` directive, but it requires a few extra steps.
+
+### Set output directory
+
+A published file is recorded in lineage only if it lands inside the run's output directory (`outputDir`), which defaults to `results`. Nextflow resolves a `publishDir` path against the launch directory, not against `outputDir`, so the two settings are not guaranteed to match.
+
+Set `outputDir` to a directory that contains every `publishDir` target:
+
+```groovy
+outputDir = params.outdir
+```
+
+### Find workflow outputs by publish path
+
+A run without an `output` block produces no `WorkflowOutput` record, so `lid://<WORKFLOW_RUN_HASH>#output` returns nothing. Look up published files by their path relative to the output directory instead, as shown in [Workflow outputs](#workflow-outputs):
+
+```console
+$ nextflow lineage view lid://16b31030474f2e96c55f4940bca3ab64/multiqc_report.html
+```
+
+### Recover output metadata
+
+The `output` block can publish metadata alongside files, while `publishDir` only publishes files. However, this metadata can be retrieved by tracing a published file back to the producing task and reading that task's outputs.
+
+Start with the published file. Follow its `source` to the task run, then view the task output, as shown in [Task runs](#task-runs) and [Task outputs](#task-outputs):
+
+```console
+$ nextflow lineage view lid://<TASK_RUN_HASH>#output
+```
+
+The `TaskOutput` record holds every declared output, not just files, so any metadata emitted as a `val` output is recorded there.
 
 ## Use lineage in a Nextflow script
 

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinObserver.groovy
@@ -106,19 +106,19 @@ class LinObserver implements TraceObserverV2 {
     private Map<String,String> outputsStoreDirLid = new HashMap<String,String>(10)
     private PathNormalizer normalizer
 
-    LinObserver(Session session, LinStore store){
+    LinObserver(Session session, LinStore store) {
         this.session = session
         this.store = store
     }
 
     @TestOnly
-    String getExecutionHash(){ executionHash }
+    String getExecutionHash() { executionHash }
 
     @TestOnly
-    String setExecutionHash(String hash){ this.executionHash = hash }
+    String setExecutionHash(String hash) { this.executionHash = hash }
 
     @TestOnly
-    String setNormalizer(PathNormalizer normalizer){  this.normalizer = normalizer }
+    String setNormalizer(PathNormalizer normalizer) {  this.normalizer = normalizer }
 
     @Override
     void onFlowBegin() {
@@ -134,8 +134,8 @@ class LinObserver implements TraceObserverV2 {
     }
 
     @Override
-    void onFlowComplete(){
-        if(workflowOutput?.output ){
+    void onFlowComplete() {
+        if(workflowOutput?.output ) {
             workflowOutput.createdAt = OffsetDateTime.now()
             final key = executionHash + '#output'
             this.store.save(key, workflowOutput)
@@ -186,7 +186,7 @@ class LinObserver implements TraceObserverV2 {
         return executionHash
     }
 
-    protected static List<Parameter> getNormalizedParams(Map<String, Object> params, PathNormalizer normalizer){
+    protected static List<Parameter> getNormalizedParams(Map<String, Object> params, PathNormalizer normalizer) {
         final normalizedParams = new LinkedList<Parameter>()
         for( Map.Entry<String,Object> entry : params ) {
             final key = entry.key
@@ -208,7 +208,7 @@ class LinObserver implements TraceObserverV2 {
         storeTaskResults(task, normalizer)
     }
 
-    protected String storeTaskResults(TaskRun task, PathNormalizer normalizer){
+    protected String storeTaskResults(TaskRun task, PathNormalizer normalizer) {
         final outputParams = getNormalizedTaskOutputs(task, normalizer)
         final value = new TaskOutput( asUriString(task.hash.toString()), asUriString(executionHash), OffsetDateTime.now(), outputParams )
         final key = task.hash.toString() + '#output'
@@ -216,7 +216,7 @@ class LinObserver implements TraceObserverV2 {
         return key
     }
 
-    private List<Parameter> getNormalizedTaskOutputs(TaskRun task, PathNormalizer normalizer){
+    private List<Parameter> getNormalizedTaskOutputs(TaskRun task, PathNormalizer normalizer) {
         final outputs = task.getOutputs()
         final outputParams = new LinkedList<Parameter>()
         for( Map.Entry<OutParam,Object> entry : outputs ) {
@@ -406,7 +406,7 @@ class LinObserver implements TraceObserverV2 {
         return executionHash + SEPARATOR + rel
     }
 
-    protected String getTaskRelative(TaskRun task, Path path){
+    protected String getTaskRelative(TaskRun task, Path path) {
         if (path.isAbsolute()) {
             final rel = getTaskRelative0(task, path)
             if (rel)
@@ -421,7 +421,7 @@ class LinObserver implements TraceObserverV2 {
         return path.normalize().toString()
     }
 
-    private String getTaskRelative0(TaskRun task, Path path){
+    private String getTaskRelative0(TaskRun task, Path path) {
         final workDirAbsolute = task.workDir.toAbsolutePath()
         if (path.startsWith(workDirAbsolute)) {
             return workDirAbsolute.relativize(path).toString()
@@ -462,15 +462,15 @@ class LinObserver implements TraceObserverV2 {
                 event.labels)
             store.save(key, value)
         }
-        catch (OutputRelativePathException ignored ){
-            log.warn1("Lineage for workflow output is not supported by publishDir directive")
+        catch (OutputRelativePathException ignored) {
+            log.warn1("Lineage was not recorded for published file '${event.target.toUriString()}' because it is outside the output directory")
         }
         catch (Throwable e) {
             log.warn("Unexpected error storing published file '${event.target.toUriString()}' for workflow '${executionHash}'", e)
         }
     }
 
-    String getSourceReference(Path source){
+    String getSourceReference(Path source) {
         final hash = FileHelper.getTaskHashFromPath(source, session.workDir)
         if (hash) {
             final target = FileHelper.getWorkFolder(session.workDir, hash).relativize(source).toString()
@@ -512,12 +512,12 @@ class LinObserver implements TraceObserverV2 {
         return param.class.simpleName
     }
 
-    private Object convertPathsToLidReferences(Object value){
+    private Object convertPathsToLidReferences(Object value) {
         if( value instanceof Path ) {
             try {
                 final key = getWorkflowOutputKey(value)
                 return asUriString(key)
-            } catch (Throwable e){
+            } catch (Throwable e) {
                 //Workflow output key not found
                 return value
             }
@@ -572,7 +572,7 @@ class LinObserver implements TraceObserverV2 {
         return managedInputs
     }
 
-    private List<Object> manageFileInParam(List<FileHolder> files, PathNormalizer normalizer){
+    private List<Object> manageFileInParam(List<FileHolder> files, PathNormalizer normalizer) {
         final paths = new LinkedList<Object>();
         for( FileHolder it : files ) {
             final path = it.sourcePath ?: it.storePath


### PR DESCRIPTION
This PR adds more prose to the data lineage tutorial based on further discussion with @luisas and @FriederikeHanssen

- Document how lineage records are produced on resumed runs
- Replace `publishDir` note with a dedicated section
- Change error message in LinObserver to remove confusion about publishDir