### PR TITLE
Fix lineage checksum computed in standard mode regardless of label

### DIFF
--- a/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/Checksum.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/Checksum.groovy
@@ -38,10 +38,12 @@ class Checksum {
     }
 
     static Checksum ofNextflow(String value) {
-        new Checksum(CacheHelper.hasher(value).hash().toString(), 'nextflow', CacheHelper.HashMode.DEFAULT().toString().toLowerCase())
+        final mode = CacheHelper.HashMode.DEFAULT()
+        new Checksum(CacheHelper.hasher(value, mode).hash().toString(), 'nextflow', mode.toString().toLowerCase())
     }
 
     static Checksum ofNextflow(Path path) {
-        new Checksum(CacheHelper.hasher(path).hash().toString(), 'nextflow', CacheHelper.HashMode.DEFAULT().toString().toLowerCase())
+        final mode = CacheHelper.HashMode.DEFAULT()
+        new Checksum(CacheHelper.hasher(path, mode).hash().toString(), 'nextflow', mode.toString().toLowerCase())
     }
 }

--- a/modules/nf-lineage/src/test/nextflow/lineage/model/ChecksumTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/model/ChecksumTest.groovy
@@ -16,9 +16,13 @@
 
 package nextflow.lineage.model
 
+import java.nio.file.Files
+import java.nio.file.Path
+
 import nextflow.lineage.model.v1beta1.Checksum
 import nextflow.util.CacheHelper
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  *
@@ -54,5 +58,41 @@ class ChecksumTest extends Specification {
         checksum1.algorithm == 'nextflow'
         checksum1.value == CacheHelper.hasher('1234567890abcdef').hash().toString()
         checksum1.mode == 'standard'
+    }
+
+    @Unroll
+    def 'should compute ofNextflow checksum with the mode it reports - #mode'() {
+        given: 'a file and NXF_CACHE_MODE set to the given mode'
+        Path path = Files.createTempFile('checksum', '.txt')
+        path.text = 'Hello world'
+        setDefaultHashMode(mode)
+
+        when:
+        def checksum = Checksum.ofNextflow(path)
+
+        then: 'the reported mode is the configured one'
+        checksum.algorithm == 'nextflow'
+        checksum.mode == mode.toString().toLowerCase()
+
+        and: 'the value is the hash for that mode, not for the standard mode'
+        checksum.value == CacheHelper.hasher(path, mode).hash().toString()
+
+        cleanup:
+        setDefaultHashMode(null)
+        Files.deleteIfExists(path)
+
+        where:
+        mode << CacheHelper.HashMode.values()
+    }
+
+    /**
+     * Override the hash mode default, which {@link CacheHelper.HashMode} reads from
+     * NXF_CACHE_MODE in a static initialiser and therefore cannot be changed by
+     * setting the environment variable from a test.
+     */
+    private static void setDefaultHashMode(CacheHelper.HashMode mode) {
+        final field = CacheHelper.HashMode.class.getDeclaredField('defaultValue')
+        field.setAccessible(true)
+        field.set(null, mode)
     }
 }


### PR DESCRIPTION
Closes #7579

`Checksum.ofNextflow` read the hash mode from two places that disagreed. The value came from the single-argument `CacheHelper.hasher()`, which hard-codes `HashMode.STANDARD`, while the `mode` label came from `HashMode.DEFAULT()`, which reads `NXF_CACHE_MODE`.

So with `lineage.enabled` and `NXF_CACHE_MODE` set to anything other than `STANDARD`, every checksum written to the lineage store was labelled `deep`, `sha256` or `lenient` but computed in standard mode. `LinPath.validateChecksum` recomputes using the label, so `nextflow lineage check` reported a mismatch on every `FileOutput` record — including records the same Nextflow version had just written.

The mode genuinely changes the hash for a path: `HashBuilder.hashFile` reads file content for `DEEP`/`SHA256`, and `hashFileMetadata` omits `lastModifiedTime` for `LENIENT`.

## Fix

Read the mode once and use it for both the computation and the label, so the two cannot drift apart again. The `String` overload is included for consistency even though `HashBuilder` ignores the mode for non-path values.

## Verification

Before, on the reporter's pipeline — one value, four labels, and only standard mode validates:

```
NXF_CACHE_MODE   recorded mode   recorded value                     lineage check
STANDARD         standard        5921f2d79b596d74bcdad4d23ac0a763   succeed
DEEP             deep            5921f2d79b596d74bcdad4d23ac0a763   does not match
SHA256           sha256          5921f2d79b596d74bcdad4d23ac0a763   does not match
LENIENT          lenient         5921f2d79b596d74bcdad4d23ac0a763   does not match
```

After — a distinct value per mode, all validating:

```
standard 64e40398b426cb5c8817e44e60b13108   succeed
deep     0d475d021ace0481a6e2e8ca635be3b0   succeed
sha256   ef99e33ba7a10c6040db96183b4ea0ae   succeed
lenient  c472344bc0d54291cf734302e43291ba   succeed
```

The new `ChecksumTest` case asserts, for every `HashMode`, that the value matches the hash for the mode the checksum reports. It fails for `DEEP`, `LENIENT` and `SHA256` without the fix and passes with it. It sets the default mode by reflection because `HashMode` caches `NXF_CACHE_MODE` in a static initialiser, so a test cannot change it through the environment — happy to swap that for a proper seam if you'd prefer one.

## Note for reviewers

This does not repair stores already on disk: records written by earlier versions keep a standard-mode value under a non-standard label, so `lineage check` will still fail on them.
