### PR TITLE
Compute lineage checksums in the mode they report

### DIFF
--- a/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/Checksum.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/Checksum.groovy
@@ -42,6 +42,10 @@ class Checksum {
     }
 
     static Checksum ofNextflow(Path path) {
-        new Checksum(CacheHelper.hasher(path).hash().toString(), 'nextflow', CacheHelper.HashMode.DEFAULT().toString().toLowerCase())
+        ofNextflow(path, CacheHelper.HashMode.DEFAULT())
+    }
+
+    static Checksum ofNextflow(Path path, CacheHelper.HashMode mode) {
+        new Checksum(CacheHelper.hasher(path, mode).hash().toString(), 'nextflow', mode.toString().toLowerCase())
     }
 }

--- a/modules/nf-lineage/src/test/nextflow/lineage/model/ChecksumTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/model/ChecksumTest.groovy
@@ -16,6 +16,8 @@
 
 package nextflow.lineage.model
 
+import java.nio.file.Files
+
 import nextflow.lineage.model.v1beta1.Checksum
 import nextflow.util.CacheHelper
 import spock.lang.Specification
@@ -54,5 +56,43 @@ class ChecksumTest extends Specification {
         checksum1.algorithm == 'nextflow'
         checksum1.value == CacheHelper.hasher('1234567890abcdef').hash().toString()
         checksum1.mode == 'standard'
+    }
+
+    def 'should hash a path in the mode it reports'() {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def file = folder.resolve('foo.txt'); file.text = 'Hello world'
+
+        when:
+        def checksum = Checksum.ofNextflow(file, MODE)
+
+        then:
+        checksum.algorithm == 'nextflow'
+        checksum.mode == EXPECTED
+        checksum.value == CacheHelper.hasher(file, MODE).hash().toString()
+
+        cleanup:
+        folder?.deleteDir()
+
+        where:
+        MODE                          | EXPECTED
+        CacheHelper.HashMode.STANDARD | 'standard'
+        CacheHelper.HashMode.LENIENT  | 'lenient'
+        CacheHelper.HashMode.DEEP     | 'deep'
+        CacheHelper.HashMode.SHA256   | 'sha256'
+    }
+
+    def 'should give identical files the same deep checksum'() {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def one = folder.resolve('one.txt'); one.text = 'Hello world'
+        def two = folder.resolve('two.txt'); two.text = 'Hello world'
+
+        expect:
+        Checksum.ofNextflow(one, CacheHelper.HashMode.DEEP).value ==
+            Checksum.ofNextflow(two, CacheHelper.HashMode.DEEP).value
+
+        cleanup:
+        folder?.deleteDir()
     }
 }


### PR DESCRIPTION
Closes #7579

## Problem

`Checksum.ofNextflow(Path)` takes its value and its `mode` label from two different places:

```groovy
static Checksum ofNextflow(Path path) {
    new Checksum(CacheHelper.hasher(path).hash().toString(), 'nextflow',
                 CacheHelper.HashMode.DEFAULT().toString().toLowerCase())
}
```

`CacheHelper.hasher(path)` is the single-argument overload, which hard-codes `HashMode.STANDARD`. `HashMode.DEFAULT()` reads `NXF_CACHE_MODE`. With that variable set to `deep`, `sha256` or `lenient`, every checksum written to the store carries a standard-mode value under a non-standard label.

`LinPath.validateChecksum` recomputes using the label, so `nextflow lineage check` fails on every `FileOutput` record in such a store, and resolving a `lid://` path in a workflow logs the same mismatch per file. `FileOutput` records and the `DataPath` records for external inputs and bin entries are all affected.

## Changes

**1. `Checksum` — read the mode once and use it for both.**

```groovy
static Checksum ofNextflow(Path path) {
    ofNextflow(path, CacheHelper.HashMode.DEFAULT())
}

static Checksum ofNextflow(Path path, CacheHelper.HashMode mode) {
    new Checksum(CacheHelper.hasher(path, mode).hash().toString(), 'nextflow',
                 mode.toString().toLowerCase())
}
```

With `NXF_CACHE_MODE` unset, `DEFAULT()` returns `STANDARD` and recorded values are unchanged. Only stores written under a non-standard mode differ.

The overload exists so the behaviour is testable. `HashMode.DEFAULT()` reads the environment in a static initialiser, so a test cannot vary it. It also mirrors the existing `Checksum.of(value, algorithm, mode)`.

`ofNextflow(String)` is left alone, since hashing a string does not consult the mode.

**2. `ChecksumTest` — cover all four modes.**

One test runs per mode and asserts the recorded value is reproducible from the recorded label. A second asserts two files with identical content share a deep checksum, which is the property a content mode promises.

## Note on semantics

This assumes a lineage checksum should honour the configured mode. If these checksums are meant to record cache identity rather than file content, the alternative fix is to hard-code the label to `standard` and leave the values alone. Happy to switch if that is the preferred reading.
