### PR TITLE
Add codespell CI check and fix existing typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@ skip = .git,*.pdf,*.svg,timeline-expected.html,*.fq,*.min.js,ScriptDslTest.groov
 # some cases where we need to catch using regex
 ignore-regex = \bhel\*|fo\\
 # some variables, names, etc to ignore
-ignore-words-list = splitted,ois,tre,marge,smoot,afile,bams,bais,pre-pending,re-use
+ignore-words-list = splitted,ois,tre,marge,smoot,afile,bams,bais,pre-pending,re-use,te,afterall,unparseable,errorprone,statics

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -28,8 +28,12 @@ jobs:
         with:
           only_warn: 1
 
-      # Committable suggestions. No-ops on fork PRs (read-only token)
-      - run: pipx run codespell --write-changes
+      # Committable suggestions. No-ops on fork PRs (read-only token).
+      # codespell exits non-zero for typos it will not auto-fix (multiple
+      # candidates), so ignore it -- reviewdog must still see the fixes it made
+      - run: pipx run codespell --write-changes || true
+      # Fork PRs get a read-only token, so posting suggestions 403s -- never fail on it
       - uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
+        continue-on-error: true
         with:
           tool_name: codespell

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,35 @@
+name: Codespell
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  codespell:
+    name: Check spelling
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Inline annotations on every PR, including forks. Uses .codespellrc
+      - uses: codespell-project/actions-codespell@e3258cca84ce02b0bb36a3d41f2c18f719a0cc1a # v2.4.3
+        with:
+          only_warn: 1
+
+      # Committable suggestions. No-ops on fork PRs (read-only token)
+      - run: pipx run codespell --write-changes
+      - uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
+        with:
+          tool_name: codespell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,7 +454,7 @@
 ## [Version 25.11.0-edge](https://github.com/nextflow-io/nextflow/releases/tag/v25.11.0-edge) - 28 Nov 2025
 
 - Add Google Batch LogsPolicy PATH option for logging to GCS (#6431) [5b61afe0]
-- Add default value to Apptainer pull timeout config paramter (#6534) [f4548bd1]
+- Add default value to Apptainer pull timeout config parameter (#6534) [f4548bd1]
 - Add test case for printing config with nested includes (#2498) [0876d557]
 - Allow pre-existing write-protected plugins directory to be used (#6594) [33943b5b]
 - Change log level from warn1 to debug1 for K8s Job Pod Warnings (#6523) [74d1b786]
@@ -486,7 +486,7 @@
 - Optimize exit code handling by relying on scheduler status for successful executions (#6484) [454a2ae8]
 - Remove unnecessary runtime checks with strict syntax (#6539) [9e296b85]
 - Remove unused BatchHelper class (#6547) [1c543c05]
-- Remove wiremock-groovy dependency and update tests using this dependecy (#6611) [6f4cf1ac]
+- Remove wiremock-groovy dependency and update tests using this dependency (#6611) [6f4cf1ac]
 - Update bundled Docker runtime to 19.03.15 (#6565) [6c081376]
 - Update migration timeline for plugin registry (#6543) [ecfb62df]
 - Update trace table columns in Reports page (#6483) [064ef346]
@@ -604,7 +604,7 @@
 - Fix GString equality checks with String (#6330) [01e18883]
 - Fix GitHub Actions commit message parsing to use only first line [5bc91622]
 - Fix NPE when contributors omit contribution field in manifest (#6383) [dd2154ca]
-- Fix Platorm refresh token handling [ba78ef74]
+- Fix Platform refresh token handling [ba78ef74]
 - Fix duplicate page and redirects in docs (#6386) [efba138f]
 - Fix false warning for map config options (#6359) [872d124c]
 - Fix groupTuple operator to handle GString vs String keys consistently (#6400) [206cc015]
@@ -760,7 +760,7 @@
 - Fix bug in generated Groovy code (#6082) [f0620656]
 - Fix default imports in included configs (#6096) [8f790615]
 - Fix variable checking in v2 config parser (#6097) [c3e9367b]
-- Force overwritting to trace file (#6105) [b9dace93]
+- Force overwriting to trace file (#6105) [b9dace93]
 - Improve documentation of splitCsv operator (#6131) [f09ae8d7]
 - Make RepositoryProvider readBytes public (#6138) [9221b112]
 - Remove Az Fusion environment variable (#6143) [6c595eac]
@@ -780,7 +780,7 @@
 ## [Version 25.04.3](https://github.com/nextflow-io/nextflow/releases/tag/v25.04.3) - 2 Jun 2025
 
 - Add Platform info to Fusion license (#6142) [375db65a]
-- Force overwritting to trace file (#6105) [59e9d88d]
+- Force overwriting to trace file (#6105) [59e9d88d]
 - Bump nf-tower@1.11.3 [f7509bce]
 
 ## [Version 25.04.2](https://github.com/nextflow-io/nextflow/releases/tag/v25.04.2) - 13 May 2025
@@ -1044,7 +1044,7 @@
 - Fix CLI params normalization (#5661) [e2e prod] [b5d43adc]
 - Fix Execution may hang reading trace file (#5683) [17d7a083]
 - Fix Google Batch hang when internal error during scheduling (#5567) [18f7de13]
-- Fix GroovyCompiler source and target compability [6dd92e3a]
+- Fix GroovyCompiler source and target compatibility [6dd92e3a]
 - Fix Only close the cache db if it is not null (#5631) [93860828]
 - Fix Azure repos when clone URL is used (#5667) [dc6cc414]
 - Fix shell directive with trace command in wrapper script (#4292) [8342889e]

--- a/adr/20251017-typed-processes.md
+++ b/adr/20251017-typed-processes.md
@@ -202,7 +202,7 @@ Outputs can be arbitrary expressions, rather that being restricted to specific q
 
 ### Nullable outputs
 
-By default, the `file()` and `files()` function raise an error if the given file is missing. These functions can be called with `optionel: true` to allow missing files. This way, it is possible to declare a tuple output that contains nullable values:
+By default, the `file()` and `files()` function raise an error if the given file is missing. These functions can be called with `optional: true` to allow missing files. This way, it is possible to declare a tuple output that contains nullable values:
 
 ```groovy
 process MAYBE {

--- a/adr/20260306-record-types.md
+++ b/adr/20260306-record-types.md
@@ -339,7 +339,7 @@ process FASTQC {
 }
 ```
 
-This approach is syntactically more concise, and it re-uses the typed output syntax that was introduced in Nextflow 25.10.
+This approach is syntactically more concise, and it reuses the typed output syntax that was introduced in Nextflow 25.10.
 
 However, with this approach, the same syntax can have different meanings depending on the surrounding context (e.g. presence/absence of the `nextflow.enable.types` feature flag), which can be confusing for both users and agents.
 

--- a/docs/developer/config-scopes.mdx
+++ b/docs/developer/config-scopes.mdx
@@ -14,7 +14,7 @@ Scope classes are used to generate a configuration spec, which is in turn used f
 
 - Generating reference documentation (in progress)
 
-Scope classes are also used by the runtime itself as type-safe domain objects. This way, the construciton of domain objects from the configuration map is isolated from the rest of the runtime.
+Scope classes are also used by the runtime itself as type-safe domain objects. This way, the construction of domain objects from the configuration map is isolated from the rest of the runtime.
 
 ## Definition
 

--- a/docs/migrations/dsl1.mdx
+++ b/docs/migrations/dsl1.mdx
@@ -103,7 +103,7 @@ Similarly, in DSL2, process outputs can be consumed by multiple consumers automa
 
 In DSL1, the entire Nextflow pipeline must be defined in a single file. For example, `main.nf`. This restriction becomes cumbersome as a pipeline grows and hinders the sharing and reuse of pipeline components.
 
-DSL2 introduces the ability for scripts to *include* other scripts. While splitting a pipeline into multiple scripts is not mandatory in DSL2, it is useful for organizing a large pipeline and re-using modules created by others. See [Modules][module-page] for more information.
+DSL2 introduces the ability for scripts to *include* other scripts. While splitting a pipeline into multiple scripts is not mandatory in DSL2, it is useful for organizing a large pipeline and reusing modules created by others. See [Modules][module-page] for more information.
 
 :::note
 DSL2 scripts cannot exceed 64 KB in size. Split large DSL1 scripts into multiple smaller scripts to avoid this limit.

--- a/docs/modules/modules.mdx
+++ b/docs/modules/modules.mdx
@@ -7,7 +7,7 @@ description: Reuse Nextflow definitions across pipelines using local and registr
 
 Nextflow scripts can include **definitions** (workflows, processes, and functions) from other scripts.
 A **module** is a self-contained process definition and corresponding [spec file][dev-modules-structure].
-Modules can be re-used within a pipeline and can be shared across projects.
+Modules can be reused within a pipeline and can be shared across projects.
 By packaging process definitions as modules, you avoid duplicating code and benefit from community improvements.
 
 There are two ways to use modules in Nextflow:

--- a/docs/reference/operator.mdx
+++ b/docs/reference/operator.mdx
@@ -752,7 +752,7 @@ An optional [closure][script-closure] can be used to control how two items are m
 
 The `merge` operator may return a channel or value depending on the inputs:
 
-- If the first argument is a channel, the `merge` operator returns a channel merging as many values as are available for all inputs. Dataflow values are re-used for each merged value.
+- If the first argument is a channel, the `merge` operator returns a channel merging as many values as are available for all inputs. Dataflow values are reused for each merged value.
 
 - If the first argument is a dataflow value, the `merge` operator returns a dataflow value, merging the first value from each input, regardless of whether there are channel inputs with additional values.
 

--- a/docs/reference/process/directives/cache.mdx
+++ b/docs/reference/process/directives/cache.mdx
@@ -9,7 +9,7 @@ The `cache` directive controls whether and how task executions are cached.
 
 ## Usage
 
-By default, cached task executions are re-used when the pipeline is launched with the [resume][getstarted-resume] option. Use the `cache` directive to disable caching for a specific process:
+By default, cached task executions are reused when the pipeline is launched with the [resume][getstarted-resume] option. Use the `cache` directive to disable caching for a specific process:
 
 ```nextflow
 process hello {

--- a/docs/strict-syntax.mdx
+++ b/docs/strict-syntax.mdx
@@ -706,7 +706,7 @@ There are two ways to preserve Groovy code:
 
 Any Groovy code can be moved into the `lib` directory, which supports the full Groovy language. This approach is useful for temporarily preserving some Groovy code until it can be updated later and incorporated into a Nextflow script. See [The `lib` directory][lib-directory] for more information.
 
-For Groovy code that is complicated or if it depends on third-party libraries, it may be better to create a plugin. Plugins can define custom functions that can be included by Nextflow scripts like a script definition. Furthermore, plugins can be easily re-used across different pipelines. See [Developing plugins][plugins-dev-page] for more information on how to develop plugins.
+For Groovy code that is complicated or if it depends on third-party libraries, it may be better to create a plugin. Plugins can define custom functions that can be included by Nextflow scripts like a script definition. Furthermore, plugins can be easily reused across different pipelines. See [Developing plugins][plugins-dev-page] for more information on how to develop plugins.
 
 [config-syntax]: ./config#syntax
 [dsl1-page]: ./migrations/dsl1

--- a/examples/agents/01_structured-output/README.md
+++ b/examples/agents/01_structured-output/README.md
@@ -39,7 +39,7 @@ every agent task runs in. It is safe to run locally as a first test of the
    - `key_points: List<String>` — a bullet-list of the main takeaways
 
    These four types (`String`, `Float`, `Boolean`, `List<String>`) cover the
-   full set of scalar and collection types the v1 JSON-schema deriver supports.
+   full set of scalar and collection types the v1 JSON-schema derivation supports.
 
 3. **The `analyst` agent** is declared with:
    - `model 'openai/gpt-5-mini'` — the LLM to call.

--- a/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/extension/PublishOp.groovy
@@ -83,7 +83,7 @@ class PublishOp {
 
     /**
      * Perform an action. If an exception is raised, bind the
-     * excpetion to the target and don't perform any more actions.
+     * exception to the target and don't perform any more actions.
      *
      * @param action
      */

--- a/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/file/FilePorter.groovy
@@ -415,7 +415,7 @@ class FilePorter {
     static private boolean checkPathIntegrity(Path source, Path target) {
         try {
             // the file must have the same size. this is needed
-            // to prevent re-using broken files left by a previous interrupted download
+            // to prevent reusing broken files left by a previous interrupted download
             final attrs = Files.readAttributes(source, BasicFileAttributes)
             final same = attrs.isDirectory()
                     ? checkDirIntegrity0(source, target)

--- a/modules/nextflow/src/main/groovy/nextflow/script/DataflowTypeHelper.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/DataflowTypeHelper.groovy
@@ -34,7 +34,7 @@ import org.codehaus.groovy.runtime.InvokerHelper
  * - Legacy workflows use v1 dataflow types: DataflowBroadcast, DataflowVariable
  *
  * While a given script must be either typed or legacy, typed workflows
- * can be composed with legacy workflows and vise versa. In order to support
+ * can be composed with legacy workflows and vice versa. In order to support
  * this, the calling workflow must be able to convert between v1 and v2 dataflow
  * types based on whether the callee is typed or legacy.
  *

--- a/modules/nextflow/src/test/groovy/nextflow/agent/AgentConfigSelectorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/agent/AgentConfigSelectorTest.groovy
@@ -344,7 +344,7 @@ class AgentConfigSelectorTest extends Dsl2Spec {
         then:
         newAgent().buildAgentTask(['hello']).config.container == 'mine:1'
 
-        when: 'a `withLabel:` selector declares one -- the default must not pre-empt the ladder'
+        when: 'a `withLabel:` selector declares one -- the default must not preempt the ladder'
         bareSession([docker: [enabled: true], agent: ['withLabel:reasoning': [container: 'mine:2']]])
         then:
         newAgent([model: 'openai/gpt-4o', label: ['reasoning']]).buildAgentTask(['hello']).config.container == 'mine:2'

--- a/modules/nextflow/src/test/groovy/nextflow/agent/AgentConfigTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/agent/AgentConfigTest.groovy
@@ -642,7 +642,7 @@ class AgentConfigTest extends Specification {
         [OPENAI_BASE_URL: 'http://oai/v1']                                   | [apiProvider: 'anthropic'] | 'openai/gpt-4o'             || null
         [ANTHROPIC_BASE_URL: 'http://ant/v1']                                | [apiProvider: 'anthropic'] | 'openai/gpt-4o'             || 'http://ant/v1'
         and: 'no invented conventions: these variables are read by nobody'
-        [MISTRAL_BASE_URL: 'http://mis/v1']                                  | [:]                        | 'mistral/mistral-large'     || null
+        [MISTRAL_BASE_URL: 'http://mistral/v1']                              | [:]                        | 'mistral/mistral-large'     || null
         [OPENROUTER_BASE_URL: 'http://or/v1']                                | [:]                        | 'openrouter/x'              || null
         [GOOGLE_BASE_URL: 'http://goo/v1']                                   | [:]                        | 'google/gemini-2.0-flash'   || null
         and: 'nothing set means "use the provider default"'

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/cli/CmdPlugin.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/cli/CmdPlugin.groovy
@@ -258,7 +258,7 @@ class CmdPlugin extends CmdBase implements UsageAware {
             gitCmd.call()
         }
         catch (Exception e) {
-            throw new AbortOperationException("Unable to clone pluging template repository - cause: ${e.message}")
+            throw new AbortOperationException("Unable to clone plugin template repository - cause: ${e.message}")
         }
     }
 

--- a/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginsFacade.groovy
@@ -238,7 +238,7 @@ class PluginsFacade implements PluginStateListener {
             return new DevPluginManager(root)
         }
         if( embedded ) {
-            // use the custom plugin manager to by-pass the creation of a local plugin repository
+            // use the custom plugin manager to bypass the creation of a local plugin repository
             return new EmbeddedPluginManager(root)
         }
         return new LocalPluginManager(root)

--- a/modules/nf-lang/src/main/java/nextflow/config/control/StripSecretsVisitor.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/control/StripSecretsVisitor.java
@@ -89,7 +89,7 @@ public class StripSecretsVisitor extends ClassCodeExpressionTransformer {
 
     /**
      * Replace any reference to a secret with a string literal
-     * in order to not dislose the secret value when printin the config.
+     * in order to not disclose the secret value when printing the config.
      *
      * @param node
      */

--- a/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/dsl/ProcessDsl.java
@@ -99,7 +99,7 @@ public interface ProcessDsl extends DslScope {
         void beforeScript(String value);
 
         @Description("""
-            The `cache` directive allows you to store the process results to a local cache. When the cache is enabled *and* the pipeline is launched with the `-resume` option, any task executions that are already cached will be re-used.
+            The `cache` directive allows you to store the process results to a local cache. When the cache is enabled *and* the pipeline is launched with the `-resume` option, any task executions that are already cached will be reused.
 
             [Read more](https://docs.seqera.io/nextflow/reference/process#cache)
         """)

--- a/modules/nf-lang/src/main/java/nextflow/script/types/TaskConfig.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/types/TaskConfig.java
@@ -130,7 +130,7 @@ public interface TaskConfig {
 
     @Constant("cache")
     @Description("""
-        The `cache` directive allows you to store the process results to a local cache. When the cache is enabled *and* the pipeline is launched with the `-resume` option, any task executions that are already cached will be re-used.
+        The `cache` directive allows you to store the process results to a local cache. When the cache is enabled *and* the pipeline is launched with the `-resume` option, any task executions that are already cached will be reused.
 
         [Read more](https://docs.seqera.io/nextflow/reference/process#cache)
     """)

--- a/modules/nf-lineage/src/main/nextflow/lineage/LinUtils.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/LinUtils.groovy
@@ -213,7 +213,7 @@ class LinUtils {
             log.trace("No property found for $key")
             return null
         }
-        // Return a single record if only ine results is found.
+        // Return a single record if only one result is found.
         return results.size() == 1 ? results[0] : results
     }
 
@@ -233,7 +233,7 @@ class LinUtils {
     /**
      * Helper function to convert from String ISO 8601 to FileTime.
      *
-     * @param date ISO formated time
+     * @param date ISO formatted time
      * @return Converted FileTime or null if date is not available (null or 'N/A')
      */
     static FileTime toFileTime(OffsetDateTime date) {

--- a/modules/nf-lineage/src/main/nextflow/lineage/fs/LinPath.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/fs/LinPath.groovy
@@ -266,7 +266,7 @@ class LinPath implements Path, LogicalDataPath {
      * Get a metadata sub-object as LinMetadataPath.
      * If the requested sub-object is the workflow or task outputs, retrieves the outputs from the outputs description.
      *
-     * @param fs LinFilesystem for the te.
+     * @param fs LinFileSystem associated to the LinPath
      * @param key Parent metadata key.
      * @param object Parent object.
      * @param children Array of string in indicating the properties to navigate to get the sub-object.

--- a/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/Checksum.groovy
+++ b/modules/nf-lineage/src/main/nextflow/lineage/model/v1beta1/Checksum.groovy
@@ -22,7 +22,7 @@ import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import nextflow.util.CacheHelper
 /**
- * Models a checksum including the value as well as the algortihm and mode used to compute it.
+ * Models a checksum including the value as well as the algorithm and mode used to compute it.
  *
  * @author Jorge Ejarque <jorge.ejarque@seqera.io
  */

--- a/modules/nf-lineage/src/test/nextflow/lineage/fs/LinPathTest.groovy
+++ b/modules/nf-lineage/src/test/nextflow/lineage/fs/LinPathTest.groovy
@@ -530,7 +530,7 @@ class LinPathTest extends Specification {
         then:
         thrown(IllegalArgumentException)
 
-        when: 'getting name with larger index tha namecount'
+        when: 'getting name with larger index than namecount'
         new LinPath(fs, "1234").getName(2)
         then:
         thrown(IllegalArgumentException)
@@ -540,7 +540,7 @@ class LinPathTest extends Specification {
         then:
         thrown(IllegalArgumentException)
 
-        when: 'getting subpath with larger index tha namecount'
+        when: 'getting subpath with larger index than namecount'
         new LinPath(fs, "1234").subpath(0,2)
         then:
         thrown(IllegalArgumentException)

--- a/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/ng/ChunkBufferFactory.java
+++ b/plugins/nf-amazon/src/main/nextflow/cloud/aws/nio/ng/ChunkBufferFactory.java
@@ -58,10 +58,10 @@ public class ChunkBufferFactory {
 
         // add logistic delay to slow down the allocation of new buffer
         // when the request approach or exceed the max capacity
-        final int indx = count.getAndIncrement();
+        final int index = count.getAndIncrement();
         if( log.isTraceEnabled() )
-            log.trace("Creating a new buffer index={}; capacity={}", indx, capacity);
-        return new ChunkBuffer(this, chunkSize, indx);
+            log.trace("Creating a new buffer index={}; capacity={}", index, capacity);
+        return new ChunkBuffer(this, chunkSize, index);
     }
 
     void giveBack(ChunkBuffer buffer) {

--- a/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsS3ConfigTest.groovy
+++ b/plugins/nf-amazon/src/test/nextflow/cloud/aws/config/AwsS3ConfigTest.groovy
@@ -169,7 +169,7 @@ class AwsS3ConfigTest extends Specification {
         false       | [:]
         false       | [endpoint: 'https://s3.us-east-2.amazonaws.com']
         true        | [endpoint: 'https://foo.com']
-        // consider AWS china as custom ednpoint
+        // consider AWS china as custom endpoint
         // see https://github.com/nextflow-io/nextflow/issues/5836
         true        | [endpoint: 'https://xxxx.s3.cn-north-1.vpce.amazonaws.com.cn']
     }

--- a/tests-v1/checks/task-vars.nf/.checks
+++ b/tests-v1/checks/task-vars.nf/.checks
@@ -14,9 +14,9 @@ $NXF_RUN | tee stdout
 < stdout grep 'memory: 1 GB'
 < stdout grep 'proc: printVars'
 < stdout grep 'exec: local'
-< stdout grep 'indx: 1'
-< stdout grep 'indx: 2'
-< stdout grep 'indx: 3'
+< stdout grep 'index: 1'
+< stdout grep 'index: 2'
+< stdout grep 'index: 3'
 
 
 #
@@ -33,6 +33,6 @@ $NXF_RUN -resume | tee stdout
 < stdout grep 'memory: 1 GB'
 < stdout grep 'proc: printVars'
 < stdout grep 'exec: local'
-< stdout grep 'indx: 1'
-< stdout grep 'indx: 2'
-< stdout grep 'indx: 3'
+< stdout grep 'index: 1'
+< stdout grep 'index: 2'
+< stdout grep 'index: 3'

--- a/tests-v1/task-vars.nf
+++ b/tests-v1/task-vars.nf
@@ -30,7 +30,7 @@ process printVars {
     each x
 
     """
-    echo indx: ${task.index}
+    echo index: ${task.index}
     echo proc: ${task.process}
     echo exec: ${task.executor}
     echo cpus: ${task.cpus}

--- a/tests/checks/task-vars.nf/.checks
+++ b/tests/checks/task-vars.nf/.checks
@@ -14,9 +14,9 @@ $NXF_RUN | tee stdout
 < stdout grep 'memory: 1 GB'
 < stdout grep 'proc: printVars'
 < stdout grep 'exec: local'
-< stdout grep 'indx: 1'
-< stdout grep 'indx: 2'
-< stdout grep 'indx: 3'
+< stdout grep 'index: 1'
+< stdout grep 'index: 2'
+< stdout grep 'index: 3'
 
 
 #
@@ -33,6 +33,6 @@ $NXF_RUN -resume | tee stdout
 < stdout grep 'memory: 1 GB'
 < stdout grep 'proc: printVars'
 < stdout grep 'exec: local'
-< stdout grep 'indx: 1'
-< stdout grep 'indx: 2'
-< stdout grep 'indx: 3'
+< stdout grep 'index: 1'
+< stdout grep 'index: 2'
+< stdout grep 'index: 3'

--- a/tests/task-vars.nf
+++ b/tests/task-vars.nf
@@ -31,7 +31,7 @@ process printVars {
 
     script:
     """
-    echo indx: ${task.index}
+    echo index: ${task.index}
     echo proc: ${task.process}
     echo exec: ${task.executor}
     echo cpus: ${task.cpus}

--- a/tests/unstage-controls-storedir.nf
+++ b/tests/unstage-controls-storedir.nf
@@ -1,4 +1,4 @@
-// Test to validate unstage controls copy error is not printed whe using storeDir. https://github.com/nextflow-io/nextflow/issues/6311
+// Test to validate unstage controls copy error is not printed when using storeDir. https://github.com/nextflow-io/nextflow/issues/6311
 
 workflow {
   test()


### PR DESCRIPTION
Adds a codespell check to CI and clears the typos already in the codebase. Codespell used to run but was removed in Jan 2025, presumably because it was annoying.

Note that this doesn't ever fail CI, it does two things:

1. Adds annotations to PRs warning about what it thinks are spelling errors (shown on Files Changed and Check summary). Old annotations disappear when the check re-runs.
2. For PRs from branches (not forks) where codespell can auto-fix in an unambiguous manner, the action adds a comment with the fix in a `suggestion` code block, so that folks can easily apply the fix with a couple of clicks from the GitHub PR review interface.

I've done it this way to try to avoid it ever blocking a PR (ie. don't be annoying). But hopefully can still surface and make it trivial to fix typos.

Inspired by https://github.com/nextflow-io/nextflow/pull/7593

<details>
<summary>Details</summary>

## Background

Codespell was added in #4324 back in October 2023, config and workflow together. The workflow was removed in 6617f52a3 (Jan 2025), but `.codespellrc` was left behind — so the config has been sitting there for a year with nothing reading it. This restores the check and brings the config up to date.

## The workflow

Runs on pull requests. Two steps:

The [codespell action](https://github.com/codespell-project/actions-codespell) registers a problem matcher, so every hit shows up as an inline annotation on the Files Changed tab. It runs with `only_warn: 1` and does not fail the build.

`codespell --write-changes` then rewrites the unambiguous hits in the runner's workspace, and [reviewdog/action-suggester](https://github.com/reviewdog/action-suggester) turns the resulting diff into committable review suggestions, filtered to lines the PR actually touched. Nothing is committed; the action stashes the changes away afterwards. This step no-ops on pull requests from forks, where GitHub issues a read-only token — those PRs still get the annotations.

Hidden paths are skipped, which is codespell's default, so `.github/` and `.claude/` are not checked. The focus is user-facing text: docs, log messages, comments.

## Config changes

Five false positives added to `ignore-words-list`:

| Word | Why |
|---|---|
| `te` | `TupleExpression te` pattern variable, 10 occurrences across nf-lang |
| `afterall` | `afterAll()` method name |
| `unparseable` | valid variant spelling, used throughout |
| `errorprone` | `com.google.errorprone` import |
| `statics` | "Pure statics that read no agent state" |

## Fixes

43 findings across docs, javadoc, comments, log and exception messages, and 6 CHANGELOG entries. Mostly ordinary misspellings — `paramter`, `dependecy`, `algortihm`, `excpetion`, `construciton`, `vise versa`.

Two need explaining:

`tests/task-vars.nf` echoes `indx: ${task.index}`, and `tests/checks/task-vars.nf/.checks` greps stdout for `indx: 1`. Fixing only the `.nf` file would break the integration test, so both sides move together. Same in `tests-v1/`. Worth flagging as a general hazard with `--write-changes`: codespell skips dotfiles, so it will happily half-rename a string that a hidden file asserts on.

`AgentConfigTest` used `http://mis/v1` as a Mistral endpoint. That is not a typo — it matches the abbreviation pattern of every neighbour in the same data table (`oai`, `ant`, `or`, `goo`, `nxf`). Spelled out to `mistral` so codespell stops flagging it, rather than adding another ignore entry.

Also fixed `dislose` → `disclose` in `StripSecretsVisitor`, which codespell does not catch — its dictionary is not exhaustive.

## Verification

`codespell` reports zero findings on the tree. `nf-lang`, `nf-lineage`, `nf-cli-v1` and `nf-amazon` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
