### PR TITLE
Resolve a missing config secret to null

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/secret/SecretsLoader.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/secret/SecretsLoader.groovy
@@ -68,7 +68,17 @@ class SecretsLoader {
             def getProperty(String name) {
                 if( !provider )
                     throw new AbortOperationException("Unable to resolve secrets.$name - no secret provider is available")
-                provider.getSecret(name)?.value
+                try {
+                    return provider.getSecret(name)?.value
+                }
+                catch( MissingSecretException e ) {
+                    // the provider explicitly reported the secret does not exist. resolve it
+                    // to `null` so that expressions such as `secrets.FOO ?: 'default'` can be
+                    // used to make a secret optional. any other error (missing permissions,
+                    // connectivity, etc) is a genuine failure and must not be swallowed here
+                    log.debug "Secret '$name' is not available - cause: ${e.message}"
+                    return null
+                }
             }
         }
     }

--- a/modules/nextflow/src/main/groovy/nextflow/secret/SecretsProvider.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/secret/SecretsProvider.groovy
@@ -37,6 +37,13 @@ interface SecretsProvider extends ExtensionPoint, Closeable {
     /**
      * Retrieve a {@code Secret} by the name from the secret provider
      *
+     * A secret that does not exist is not an error condition. Implementations must either
+     * return {@code null} or throw a {@link MissingSecretException}, so that expressions
+     * such as {@code secrets.FOO ?: 'default'} can be used to make a secret optional.
+     *
+     * Any other exception is taken to mean the lookup itself failed, e.g. missing
+     * permissions or connectivity issues, and is propagated to the caller.
+     *
      * @param name The secret name
      * @return The {@code Secret} instance with the given name or {@code null} otherwise
      */

--- a/modules/nextflow/src/test/groovy/nextflow/secret/SecretsLoaderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/secret/SecretsLoaderTest.groovy
@@ -91,6 +91,33 @@ class SecretsLoaderTest extends Specification {
         SysEnv.pop()
     }
 
+    def 'should resolve a missing secret to null' () {
+        given:
+        def provider = Mock(SecretsProvider)
+
+        when:
+        def result = SecretsLoader.secretContext(provider).FOO
+        then:
+        1 * provider.getSecret('FOO') >> { throw new MissingSecretException("Unknown secret 'FOO'") }
+        and:
+        result == null
+    }
+
+    def 'should propagate provider errors other than a missing secret' () {
+        given:
+        def provider = Mock(SecretsProvider)
+
+        when:
+        SecretsLoader.secretContext(provider).FOO
+        then:
+        1 * provider.getSecret('FOO') >> { throw new AbortOperationException('Permission denied') }
+        and:
+        def e = thrown(AbortOperationException)
+        e.message == 'Permission denied'
+        and:
+        !(e instanceof MissingSecretException)
+    }
+
     def 'should note create secret context' () {
         given:
         SysEnv.push(NXF_ENABLE_SECRETS: "false")


### PR DESCRIPTION
## Problem

`SecretsProvider.getSecret()` is documented to return the secret *"or `null` otherwise"*, and `SecretsLoader.makeSecretsContext()` depends on that:

```groovy
provider.getSecret(name)?.value
```

The secrets docs recommend relying on this to make a secret optional:

```groovy
includeConfig secrets.MY_SECRET
    ? "https://example.com/extra.config?secret=${secrets.MY_SECRET}"
    : '/dev/null'
```

`LocalSecretsProvider` honours the contract — a lookup miss is a plain `Map.get()` returning `null`. Providers backed by a cloud secret manager can't do that as directly, because the vendor client raises a not-found error instead of returning an empty result. When one of those propagates, it escapes `getProperty()` and aborts config parsing before the run starts:

```
ERROR ~ Unable to parse config file: '.../nextflow.config'

  io.grpc.StatusRuntimeException: NOT_FOUND: Secret [projects/<id>/secrets/<name>] not found or has no versions.
  ...
  at nextflow.secret.SecretsLoader$1.getProperty(SecretsLoader.groovy:71)
```

The result is that a config which works fine against the local secrets store fails as soon as the same pipeline runs somewhere a cloud-backed provider is active, even though the config was written the way the docs recommend.

## Change

`MissingSecretException` has been in `nextflow.secret` since the secrets feature was merged in 2021, but nothing has ever thrown or caught it. This wires it up as the contract for this case:

- `makeSecretsContext()` catches `MissingSecretException` and resolves the secret to `null`, so `secrets.FOO ?: 'default'` behaves the same on every provider.
- Every other exception still propagates. A `PERMISSION_DENIED`, an expired credential or a network timeout stays a hard error rather than silently falling back to a default value — which would be the failure mode of a blanket `catch( Exception )` here.
- `SecretsProvider.getSecret()` javadoc now spells out the two acceptable ways to report a missing secret, so provider implementations have something concrete to target.

A provider that already returns `null` needs no change.

## Tests

Two specs added to `SecretsLoaderTest`:

- a provider throwing `MissingSecretException` resolves to `null`
- a provider throwing any other `AbortOperationException` propagates unchanged

Both fail without the change. The existing spec covering `NXF_ENABLE_SECRETS=false` (where `NullProvider` throws a plain `AbortOperationException`) still passes, confirming the catch is narrow.

```
nextflow.secret.SecretsLoaderTest: tests=10 failures=0 errors=0 skipped=0
```