### PR TITLE
Fix local executor resource accounting race

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/LocalPollingMonitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/LocalPollingMonitor.groovy
@@ -41,6 +41,11 @@ class LocalPollingMonitor extends TaskPollingMonitor {
     static private OperatingSystemMXBean OS = { (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean() }()
 
     /**
+     * Guards resource accounting shared by the submitter and polling threads.
+     */
+    private final Object resourceLock = new Object()
+
+    /**
      * Number of `free` CPUs available to execute pending tasks
      */
     private int availCpus
@@ -200,10 +205,17 @@ class LocalPollingMonitor extends TaskPollingMonitor {
         if( acceleratorTracker.name() != null && taskAccelerators > acceleratorTracker.total() )
             throw new ProcessUnrecoverableException("Process requirement exceeds available accelerators -- req: $taskAccelerators; avail: ${acceleratorTracker.total()}")
 
+        final int availableCpus
+        final long availableMemory
+        synchronized(resourceLock) {
+            availableCpus = availCpus
+            availableMemory = availMemory
+        }
+
         final accelOk = acceleratorTracker.name() == null || taskAccelerators <= acceleratorTracker.available()
-        final result = super.canSubmit(handler) && taskCpus <= availCpus && taskMemory <= availMemory && accelOk
+        final result = super.canSubmit(handler) && taskCpus <= availableCpus && taskMemory <= availableMemory && accelOk
         if( !result && log.isTraceEnabled( ) ) {
-            log.trace "Task `${handler.task.name}` cannot be scheduled -- taskCpus: $taskCpus <= availCpus: $availCpus && taskMemory: ${new MemoryUnit(taskMemory)} <= availMemory: ${new MemoryUnit(availMemory)} && taskAccelerators: $taskAccelerators <= availAccelerators: ${acceleratorTracker.name() != null ? acceleratorTracker.available() : 'n/a'}"
+            log.trace "Task `${handler.task.name}` cannot be scheduled -- taskCpus: $taskCpus <= availCpus: $availableCpus && taskMemory: ${new MemoryUnit(taskMemory)} <= availMemory: ${new MemoryUnit(availableMemory)} && taskAccelerators: $taskAccelerators <= availAccelerators: ${acceleratorTracker.name() != null ? acceleratorTracker.available() : 'n/a'}"
         }
         return result
     }
@@ -231,8 +243,13 @@ class LocalPollingMonitor extends TaskPollingMonitor {
             throw e
         }
 
-        availCpus -= cpus(handler)
-        availMemory -= mem(handler)
+        // Evaluate task configuration outside the lock so other tasks can complete.
+        final taskCpus = cpus(handler)
+        final taskMemory = mem(handler)
+        synchronized(resourceLock) {
+            availCpus -= taskCpus
+            availMemory -= taskMemory
+        }
     }
 
     /**
@@ -249,8 +266,12 @@ class LocalPollingMonitor extends TaskPollingMonitor {
     protected boolean remove(TaskHandler handler) {
         final result = super.remove(handler)
         if( result ) {
-            availCpus += cpus(handler)
-            availMemory += mem(handler)
+            final taskCpus = cpus(handler)
+            final taskMemory = mem(handler)
+            synchronized(resourceLock) {
+                availCpus += taskCpus
+                availMemory += taskMemory
+            }
             if( handler instanceof LocalTaskHandler )
                 acceleratorTracker.release(handler.acceleratorIds ?: Collections.<String>emptyList())
         }

--- a/modules/nextflow/src/test/groovy/nextflow/processor/LocalPollingMonitorTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/processor/LocalPollingMonitorTest.groovy
@@ -17,6 +17,9 @@
 package nextflow.processor
 
 import java.lang.management.ManagementFactory
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 import com.sun.management.OperatingSystemMXBean
 import nextflow.Session
@@ -30,6 +33,74 @@ import spock.lang.Specification
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 class LocalPollingMonitorTest extends Specification {
+
+    def 'should retain #resource accounting when #operation is paused'() {
+        given:
+        def memory = MemoryUnit.of('26GB')
+        def monitor = new LocalPollingMonitor(cpus: 8, memory: memory.toBytes(),
+                capacity: 8, session: Stub(Session), name: 'local', pollInterval: 100)
+        def testThread = Thread.currentThread()
+        def entered = new CountDownLatch(1)
+        def released = new CountDownLatch(1)
+        def pause = { String name ->
+            if( name == resource && Thread.currentThread() != testThread ) {
+                entered.countDown()
+                assert released.await(10, TimeUnit.SECONDS)
+            }
+        }
+        def config = Stub(TaskConfig) {
+            getCpus() >> { pause('cpus'); 1 }
+            getMemory() >> { pause('memory'); MemoryUnit.of('1GB') }
+        }
+        def first = Stub(TaskHandler) {
+            getTask() >> new TaskRun(config: config)
+        }
+        def second = Stub(TaskHandler) {
+            getTask() >> new TaskRun(config: config)
+        }
+        def fullPool = Stub(TaskHandler) {
+            getTask() >> new TaskRun(config: new TaskConfig(cpus: 8, memory: memory))
+            canForkProcess() >> true
+            isReady() >> true
+        }
+        def executor = Executors.newSingleThreadExecutor()
+
+        when:
+        monitor.submit(first)
+        // Pause one thread's resource evaluation while the other updates the counters.
+        def paused = executor.submit({
+            if( operation == 'submission' )
+                monitor.submit(second)
+            else
+                assert monitor.remove(first)
+        } as Runnable)
+        assert entered.await(10, TimeUnit.SECONDS)
+        if( operation == 'submission' )
+            assert monitor.remove(first)
+        else
+            monitor.submit(second)
+        released.countDown()
+        paused.get(10, TimeUnit.SECONDS)
+        assert monitor.remove(second)
+
+        then:
+        monitor.runningQueue.empty
+        monitor.availCpus == 8
+        monitor.availMemory == memory.toBytes()
+        monitor.canSubmit(fullPool)
+
+        cleanup:
+        released.countDown()
+        executor.shutdownNow()
+        assert executor.awaitTermination(10, TimeUnit.SECONDS)
+
+        where:
+        resource | operation
+        'cpus'   | 'submission'
+        'memory' | 'submission'
+        'cpus'   | 'completion'
+        'memory' | 'completion'
+    }
 
     def 'should allocated and free resources' () {
 


### PR DESCRIPTION
Concurrent task submission and completion can lose updates to the local executor’s available CPU and memory counters. An undercount can leave pending tasks blocked indefinitely, even after all running tasks have completed.

Protect resource updates and availability snapshots with a shared lock, keeping task resource evaluation outside the critical section.

Add a deterministic regression covering CPU and memory accounting in both overlap directions. All four cases fail before the fix; all 12 `LocalPollingMonitorTest` tests pass afterward.

Related prior discussion in #5850 raised a [race concern around CPU/memory accounting order](https://github.com/nextflow-io/nextflow/pull/5850#discussion_r2169708477) and noted that moving resource deductions before submission could [leak resources when submission fails](https://github.com/nextflow-io/nextflow/pull/5850#discussion_r3389605421). This fix preserves the submission order while synchronizing resource accounting.
