### PR TITLE
Fix independently-verified findings from a security audit [26.04.x backport]

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazoncorretto:21-al2023
-RUN yum install -y procps-ng shadow-utils which
+RUN yum install -y procps-ng shadow-utils which util-linux
 
 ENV NXF_HOME=/.nextflow
 ARG TARGETPLATFORM=linux/amd64

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -25,8 +25,8 @@
 # with such ID and adds it to the `docker` group, then assigns the docker
 # socket file ownership to that user.
 #
-# Finally it switches the `nextflow` user using the `su` command and
-# executes the original target command line.
+# Finally it switches to the `nextflow` user and executes the original
+# target command line.
 #
 # authors:
 #  Paolo Di Tommaso
@@ -35,9 +35,6 @@
 
 # enable debugging
 [[ "$NXF_DEBUG_ENTRY" ]] && set -x
-
-# wrap cli args with single quote to avoid wildcard expansion
-cli=''; for x in "$@"; do cli+="'$x' "; done
 
 # the NXF_USRMAP hold the user ID in the host environment
 if [[ "$NXF_USRMAP" ]]; then
@@ -50,13 +47,10 @@ useradd -u "$NXF_USRMAP" -G docker -s /bin/bash nextflow
 chown nextflow /var/run/docker.sock
 chown -R nextflow /.nextflow
 
-# finally run the target command with `nextflow` user
-su nextflow << EOF
-[[ "$NXF_DEBUG_ENTRY" ]] && set -x
-exec bash -c "$cli"
-EOF
+# run the target command as `nextflow`, passing argv through (no shell)
+exec runuser -u nextflow -- "$@"
 
 # otherwise just execute the command
 else
-exec bash -c "$cli"
+exec "$@"
 fi

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true

--- a/modules/nextflow/src/main/groovy/nextflow/util/RemoteSession.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/util/RemoteSession.groovy
@@ -149,6 +149,8 @@ class RemoteSession implements Serializable, Closeable {
         while( (entry=zip.getNextEntry()) != null ) {
 
             def file = target.resolve(entry.getName());
+            if( !file.normalize().startsWith(target.normalize()) )
+                throw new IllegalArgumentException("Unsafe zip entry path: ${entry.getName()}")
             if(entry.isDirectory()) {
                 continue
             }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerXAuth.groovy
@@ -25,6 +25,7 @@ import java.util.regex.Pattern
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.file.http.XAuthProvider
+import nextflow.util.StringUtils
 
 /**
  * Implements Tower authentication strategy for resources accessed
@@ -83,16 +84,18 @@ class TowerXAuth implements XAuthProvider {
                 .build()
 
         final resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString())
-        log.debug "Refresh cookie response: [${resp.statusCode()}] ${resp.body()}"
-        if( resp.statusCode() != 200 )
+        if( resp.statusCode() != 200 ) {
+            log.debug "Refresh cookie response: [${resp.statusCode()}] ${resp.body()}"
             return false
+        }
+        log.debug "Refresh cookie response: [${resp.statusCode()}]"
 
         final authCookie = getCookie('JWT')
         final refreshCookie = getCookie('JWT_REFRESH_TOKEN')
 
         // set the new bearer token in the current client session
         if( authCookie?.value ) {
-            log.trace "Updating http client bearer token=$authCookie.value"
+            log.trace "Updating http client bearer token=${StringUtils.redact(authCookie.value)}"
             accessToken = authCookie.value
         }
         else {
@@ -101,7 +104,7 @@ class TowerXAuth implements XAuthProvider {
 
         // set the new refresh token
         if( refreshCookie?.value ) {
-            log.trace "Updating http client refresh token=$refreshCookie.value"
+            log.trace "Updating http client refresh token=${StringUtils.redact(refreshCookie.value)}"
             refreshToken = refreshCookie.value
         }
         else {


### PR DESCRIPTION
Backports #7503 to `STABLE-26.04.x`. This is the #7503 item of the reported security set; the dependency half of that set is #7598. Unlike the dependency backport, this one is **actual code** — it is not a version bump, and it needed manual conflict resolution in three files.

## What it fixes

- **Shell injection in `docker/entry.sh`.** The script built its command line by hand-wrapping each argument in single quotes and handed the resulting string to `bash -c`. An argument containing a single quote closes that quoting and the rest is parsed as shell, so anything able to pass arbitrary Nextflow CLI args through the container entrypoint could execute commands. Now `exec runuser -u nextflow -- "$@"`, so argv is passed through without a third shell parse.
- **JWTs written to logs in `TowerXAuth`.** Raw bearer and refresh tokens were logged at `debug`/`trace`. Those levels get turned on during routine troubleshooting and the resulting logs get shared around. Tokens are now passed through `StringUtils.redact`, and the refresh response body is logged on non-200 only — so failure diagnostics survive without printing a valid token on success.
- **Zip Slip in `RemoteSession`.** Zip entry names were resolved straight against the target directory with no containment check, so a crafted `../../` entry could write outside it. Now rejected with `IllegalArgumentException`. No production caller reaches this today, but the method is reachable.
- **Unverified Gradle wrapper download.** No `distributionSha256Sum`, so a tampered or MITM'd `services.gradle.org` response would have been used as-is.

## Deviations from the master commit

All three are forced by differences on this branch, and all three are places where copying `master` verbatim would have been wrong:

1. **Gradle checksum is for 9.3.1, not 9.6.1.** This branch uses `gradle-9.3.1-bin.zip`; `master` is on 9.6.1. Pasting master's `distributionSha256Sum` would have made every Gradle invocation on this branch fail the integrity check. The pinned value is the checksum of the 9.3.1 archive, verified by downloading it and computing `sha256sum` locally:
   ```
   b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
   ```
   This matches the `.sha256` published alongside the distribution. Worth a second pair of eyes, since a wrong value here breaks the build for everyone on the branch.
2. **Dockerfile stays on `amazoncorretto:21-al2023`.** This branch targets Java 21; `master` has moved to 25. Only the `util-linux` install is taken from the upstream diff — it is what provides `runuser`.
3. **Only the `StringUtils` import is added to `TowerXAuth`.** The upstream diff also adds `ProxyConfig`, which belongs to a master-only refactor that isn't on this branch.

## Verification

Run against this branch locally, Java 21:

- `bash -n docker/entry.sh` — syntax OK.
- **Gradle checksum verified end-to-end**: with a scratch `GRADLE_USER_HOME`, the wrapper re-downloaded the distribution and validated it against the pinned sum, reaching `Gradle 9.3.1` successfully. A wrong checksum fails loudly here, so this is a real check rather than an assumption.
- `:nextflow:compileGroovy` and `:plugins:nf-tower:compileGroovy` — **BUILD SUCCESSFUL**.
- `:nextflow:test --tests nextflow.util.RemoteSessionTest` — **BUILD SUCCESSFUL**.
- `:plugins:nf-tower:test` — **BUILD SUCCESSFUL**.

Not covered by the above: nothing exercises the `runuser` path outside a built container image, so the entrypoint change wants a manual `docker run` check against the 26.04.x image before this is taken off draft. There is also no regression test for the Zip Slip rejection — upstream didn't add one either, and it may be worth adding here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
