### PR TITLE
Retry request timeouts in the Tower and Wave HTTP clients

### DIFF
--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/TowerClient.groovy
@@ -18,6 +18,8 @@ package io.seqera.tower.plugin
 
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
+import java.net.http.HttpTimeoutException
+import java.util.function.Predicate
 import java.util.regex.Matcher
 
 import groovy.json.JsonGenerator
@@ -27,6 +29,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.TupleConstructor
 import groovy.util.logging.Slf4j
 import io.seqera.http.HxClient
+import io.seqera.http.HxConfig
 import io.seqera.tower.plugin.exception.ForbiddenException
 import io.seqera.tower.plugin.exception.NotFoundException
 import io.seqera.tower.plugin.exception.UnauthorizedException
@@ -221,14 +224,30 @@ class TowerClient {
         return result
     }
 
+    /**
+     * Retry-on-exception rule for the Seqera Platform client. Retries the httpx default network
+     * conditions, plus a request timeout raised after the request was sent - which the httpx
+     * default deliberately excludes (see {@link HxConfig#defaultRetryCondition}). The trace calls
+     * are idempotent telemetry, so a stalled request is safe to re-send; otherwise a single
+     * transient timeout aborts the whole run.
+     */
+    protected static boolean retryCondition(Throwable t) {
+        return HxConfig.defaultRetryCondition(t) || t instanceof HttpTimeoutException
+    }
+
     protected void initHttpClient() {
         final builder = HxClient.newBuilder()
-        // auth settings
+        // retry backoff + condition (config() replaces the config builder, so seed it before auth)
+        builder.config(
+            HxConfig.newBuilder()
+                .retryConfig(this.retryPolicy)
+                .retryCondition({ Object t -> retryCondition((Throwable) t) } as Predicate)
+                .build() )
+        // auth settings (applied on top of the seeded config)
         setupClientAuth(builder, getAccessToken())
-        // retry + proxy settings (proxy applies to the main client and the token-refresh client)
+        // proxy + client settings (proxy applies to the main client and the token-refresh client)
         this.httpClient = builder
             .withProxyConfig(ProxyConfig.proxyConfig())
-            .retryConfig(this.retryPolicy)
             .followRedirects(HttpClient.Redirect.NORMAL)
             .version(HttpClient.Version.HTTP_1_1)
             .connectTimeout(java.time.Duration.ofMillis(connectTimeout.millis))

--- a/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
+++ b/plugins/nf-tower/src/test/io/seqera/tower/plugin/TowerClientTest.groovy
@@ -16,7 +16,9 @@
 
 package io.seqera.tower.plugin
 
+import java.net.http.HttpConnectTimeoutException
 import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
 import java.time.Instant
 
 import com.github.tomakehurst.wiremock.WireMockServer
@@ -34,6 +36,19 @@ class TowerClientTest extends Specification {
     protected boolean aroundNow(value) {
         def now = Instant.now().toEpochMilli()
         value > now-1_000 && value <= now
+    }
+
+    def 'should retry request timeouts' () {
+        // The trace calls are idempotent telemetry, so - unlike the httpx default, which
+        // excludes a request timeout raised after the request was sent - a stalled request
+        // is safe to re-send and must be retried rather than aborting the run.
+        expect:
+        TowerClient.retryCondition(new HttpTimeoutException('request timeout'))
+        TowerClient.retryCondition(new HttpConnectTimeoutException('connect timeout'))
+        TowerClient.retryCondition(new SocketTimeoutException('socket timeout'))
+        TowerClient.retryCondition(new IOException('connection reset'))
+        and:
+        !TowerClient.retryCondition(new RuntimeException('not an I/O error'))
     }
 
     def 'should parse response' () {

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/WaveClient.groovy
@@ -21,6 +21,7 @@ import static nextflow.util.SysHelper.*
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
@@ -30,6 +31,7 @@ import java.time.ZoneId
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.function.Predicate
 
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
@@ -43,6 +45,7 @@ import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import io.seqera.http.HxClient
+import io.seqera.http.HxConfig
 import io.seqera.util.trace.TraceUtils
 import io.seqera.wave.api.BuildStatusResponse
 import io.seqera.wave.api.ContainerStatus
@@ -168,6 +171,11 @@ class WaveClient {
      */
     protected HxClient.Builder newHttpClientBuilder() {
         final builder = HxClient.newBuilder()
+                // seed the retry condition first: config() replaces the config builder (and its
+                // proxy/auth), so it must precede withProxyConfig() and the auth settings below
+                .config( HxConfig.newBuilder()
+                        .retryCondition({ Object t -> retryCondition((Throwable) t) } as Predicate)
+                        .build() )
                 .version(HttpClient.Version.HTTP_1_1)
                 .followRedirects(HttpClient.Redirect.NEVER)
                 .connectTimeout(config.httpOpts().connectTimeout())
@@ -194,6 +202,16 @@ class WaveClient {
         return newHttpClientBuilder()
                 .retryConfig(config.retryOpts())
                 .build()
+    }
+
+    /**
+     * Retry-on-exception rule for the Wave/Tower HTTP clients. Retries the httpx default network
+     * conditions, plus a request timeout raised after the request was sent - which the httpx
+     * default deliberately excludes (see {@link HxConfig#defaultRetryCondition}) - so a single
+     * transient stall does not fail an otherwise recoverable request.
+     */
+    protected static boolean retryCondition(Throwable t) {
+        return HxConfig.defaultRetryCondition(t) || t instanceof HttpTimeoutException
     }
 
     WaveConfig config() { return config }

--- a/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
+++ b/plugins/nf-wave/src/test/io/seqera/wave/plugin/WaveClientTest.groovy
@@ -65,6 +65,18 @@ import test.OutputCapture
 @Slf4j
 class WaveClientTest extends Specification {
 
+    def 'should retry request timeouts' () {
+        // Retry a request timeout raised after the request was sent - which the httpx default
+        // excludes - so a single transient stall on the Wave/Tower API does not fail the request.
+        expect:
+        WaveClient.retryCondition(new java.net.http.HttpTimeoutException('request timeout'))
+        WaveClient.retryCondition(new java.net.http.HttpConnectTimeoutException('connect timeout'))
+        WaveClient.retryCondition(new SocketTimeoutException('socket timeout'))
+        WaveClient.retryCondition(new IOException('connection reset'))
+        and:
+        !WaveClient.retryCondition(new RuntimeException('not an I/O error'))
+    }
+
     @CompileStatic
     private static List<Path> untar(final InputStream is, final Path outputDir)  {
 


### PR DESCRIPTION
### Problem

Since **lib-httpx 2.5.0** the default retry condition (`HxConfig.defaultRetryCondition`) no longer retries a *request* timeout raised after the request was sent (a bare `HttpTimeoutException`) — only a *connect* timeout stays retryable. Neither `TowerClient` nor `WaveClient` sets a custom condition, so both silently inherited that behaviour when their lib-httpx dependency was bumped.

For Tower this is fatal: `traceProgress` throws `AbortRunException` on any error, so a single ~60s stall on the telemetry endpoint aborts an otherwise-healthy run and kills its running tasks. Observed in a `google-batch` validation run:

```
ERROR TowerObserver - Aborting session due to Seqera Platform telemetry exception - Unexpected HTTP response
- endpoint    : https://api.cloud.seqera.io/trace/<id>/progress
- status code : 0
- response msg: Unable to connect to Seqera Platform API
```

(one attempt, zero retries, the same API reachable seconds earlier).

### Change

Give both clients a custom retry condition that keeps the httpx default network conditions **and** additionally retries `HttpTimeoutException` — the trace/API calls are idempotent, so a stalled request is safe to re-send:

```groovy
protected static boolean retryCondition(Throwable t) {
    return HxConfig.defaultRetryCondition(t) || t instanceof HttpTimeoutException
}
```

The condition is seeded onto the shared `HxConfig` via `config()`, which had to move ahead of the auth/proxy builder calls because `config()` replaces the config builder. Scope is limited to the Tower and Wave clients; the lib-httpx default is unchanged for other consumers.

### Tests

- `TowerClientTest`: added `should retry request timeouts` (32 pass).
- `WaveClientTest`: added `should retry request timeouts` (84 pass).

### Notes / follow-ups (not in this PR)

- Retry only recovers from *transient* stalls; a persistent outage still aborts, just later (up to `maxAttempts × timeout`), because `traceProgress` remains fatal. Making progress telemetry best-effort (like `updateWorkflow`) is a separate change.
- The condition also retries timeouts on POSTs (`traceCreate`), the small duplicate-submit risk lib-httpx's default deliberately avoids; a method-aware `shouldRetryOnException(request, …)` override would avoid that but needs a client subclass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
