### PR TITLE
Run afterScript from the exit trap so early failures are covered

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-run.txt
@@ -106,14 +106,22 @@ nxf_fs_fcp() {
 on_exit() {
     ## This is invoked via `trap on_exit EXIT` at the end of nxf_main, therefore
     ## $? here is the exit status of the very last command run by nxf_main, i.e.
-    ## nxf_unstage_controls (or {{after_script}}, if the task defines one).
+    ## nxf_unstage_controls.
     ## It's kept as a last-resort fallback ONLY: nxf_main_ret and nxf_unstage_ret
     ## below already capture the two "expected" failure points (the task command
     ## and the output unstaging step), so last_err only wins when the failure
-    ## happened somewhere else, e.g. in nxf_unstage_controls, in the after script,
-    ## or the trap fired directly because of `set -e`/`set -u` without either
-    ## variable being set.
+    ## happened somewhere else, e.g. in nxf_unstage_controls, or the trap fired
+    ## directly because of `set -e`/`set -u` without either variable being set.
     local last_err=$?
+    ## The 'afterScript' directive runs here rather than at the end of nxf_main so
+    ## that it is executed however the task terminated, including when nxf_main was
+    ## aborted early by `set -e`/`set -u` (a failing beforeScript, module load, conda
+    ## activation or input staging) and never reached its last statement. Fast failure
+    ## is disabled for it so a failing after script cannot prevent the exit status from
+    ## being published below; its own exit status is discarded and does not mask the
+    ## task result.
+    set +e
+    {{after_script}}
     ## Exit status precedence (first non-zero wins):
     ##   1) nxf_main_ret    - exit status of the user task script, set by
     ##                        `wait $pid || nxf_main_ret=$?` once nxf_launch completes.
@@ -182,8 +190,7 @@ nxf_unstage() {
     ## even if the task or the outputs unstaging above failed, so the logs
     ## needed to diagnose the failure are always copied back. Its own exit
     ## status is intentionally NOT captured into nxf_unstage_ret: it becomes
-    ## the generic `last_err` fallback in on_exit instead (see there), unless
-    ## an after script runs later, whose exit status then takes its place.
+    ## the generic `last_err` fallback in on_exit instead (see there).
     nxf_unstage_controls
 }
 
@@ -214,7 +221,6 @@ nxf_main() {
     pid=$!
     wait $pid || nxf_main_ret=$?
     {{unstage_cmd}}
-    {{after_script}}
 }
 
 $NXF_ENTRY

--- a/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/BashWrapperBuilderTest.groovy
@@ -1271,6 +1271,24 @@ class BashWrapperBuilderTest extends Specification {
         binding.containsKey('after_script')
     }
 
+    def 'should run the after script from the exit trap' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+
+        when:
+        def wrapper = newBashWrapperBuilder(workDir: folder, afterScript: 'cleanup_that').buildNew0()
+
+        then:
+        // the after script must run from `on_exit`, not from the tail of `nxf_main`:
+        // `nxf_main` bails out to the exit trap under `set -e` when the task fails
+        // before the command is launched e.g. a failing beforeScript or input staging
+        wrapper.contains('on_exit')
+        wrapper.tokenize('\n').findIndexOf { it.contains('cleanup_that') } < wrapper.tokenize('\n').findIndexOf { it.contains('nxf_main() {') }
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'should get output env capture snippet' () {
         given:
         def builder = new BashWrapperBuilder(Mock(TaskBean))

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper-with-trace.txt
@@ -278,6 +278,7 @@ nxf_fs_fcp() {
 
 on_exit() {
     local last_err=$?
+    set +e
     local exit_status=${nxf_main_ret:=0}
     [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
     [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}

--- a/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
+++ b/modules/nextflow/src/test/resources/nextflow/executor/test-bash-wrapper.txt
@@ -86,6 +86,7 @@ nxf_fs_fcp() {
 
 on_exit() {
     local last_err=$?
+    set +e
     local exit_status=${nxf_main_ret:=0}
     [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
     [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}


### PR DESCRIPTION
Closes #6077.

## Problem

`afterScript` is skipped when a task fails *before* the task command is launched — a failing `beforeScript`, module load, conda/spack activation, or input staging. A failing task *command* was never affected, which is why this shows up only on the early-failure paths and made the original report look like "afterScript never runs on error".

In `command-run.txt` the wrapper runs under `set -e`, and `{{after_script}}` was the last statement of `nxf_main`:

```bash
nxf_main() {
    trap on_exit EXIT
    ...
    {{before_script}}      # still under set -e
    {{module_load}}
    {{conda_activate}}
    {{stage_cmd}}          # still under set -e

    set +e
    ( ... nxf_launch ... ) &
    wait $pid || nxf_main_ret=$?
    {{unstage_cmd}}
    {{after_script}}       # never reached if we bailed out above
}
```

`set +e` only covers the task command. Anything failing earlier aborts to the `EXIT` trap and never reaches the after script.

## Change

Move `{{after_script}}` into `on_exit`, so it runs however the task terminated rather than only when `nxf_main` reaches its last line. It sits after `last_err` is captured and before `{{sync_cmd}}` / `{{exit_file}}` / `{{cleanup_cmd}}`, so the success path is unchanged: the after script still runs in the (possibly scratch) task directory, before `.exitcode` is published and before scratch is cleaned up.

One deliberate behaviour change: `set +e` around it means a failing after script can no longer prevent `.exitcode` from being written. Its exit status is now discarded instead of feeding the `last_err` fallback. Stale comments in `on_exit` and `nxf_unstage` describing the old ordering were updated.

## Verification

Built with `make compile` and run via `./launch.sh`:

- `beforeScript 'exit 7'` + `afterScript` — after script now runs. Previously skipped.
- Failing task command, and successful task — after script still runs in both. No regression.
- `scratch true` — after script still executes inside the scratch directory before cleanup.
- `./gradlew :nextflow:test --tests 'nextflow.executor.*' --tests 'nextflow.processor.*'` passes.

Adds a regression test asserting the after script renders inside `on_exit` rather than in `nxf_main`; it fails against the unpatched template. The two `BashWrapperBuilderTest` golden files each gain one `set +e` line (`##` comments are stripped from the rendered wrapper).

## Worth a second opinion

The template is shared by every executor, so the cloud backends (AWS Batch, Google Batch, Kubernetes) — where the wrapper is invoked differently — are worth a look, as is the decision to swallow the after-script exit status.
