### PR TITLE
Propagate machine info to array-child tasks in Google Batch executor

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -208,6 +208,9 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             for( int i=0; i<task.children.size(); i++ ) {
                 final handler = task.children[i] as GoogleBatchTaskHandler
                 final arrayTaskId = executor.getArrayTaskId(jobId, i)
+                // propagate the machine info resolved for the array job to each child task,
+                // otherwise every array-child trace record reports a null machine type/cost
+                handler.@machineInfo = this.machineInfo
                 handler.updateStatus(jobId, arrayTaskId, uid)
             }
         }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchTaskHandlerTest.groovy
@@ -44,6 +44,7 @@ import nextflow.executor.Executor
 import nextflow.executor.ExecutorConfig
 import nextflow.executor.res.AcceleratorResource
 import nextflow.executor.res.DiskResource
+import nextflow.processor.TaskArrayRun
 import nextflow.processor.TaskBean
 import nextflow.processor.TaskConfig
 import nextflow.processor.TaskProcessor
@@ -1197,6 +1198,28 @@ class GoogleBatchTaskHandlerTest extends Specification {
         result.getContainer().getOptions() == '--foo'
         result.getContainer().getVolumesList() == ['/mnt:/mnt:rw']
         result.getEnvironment().getVariablesMap() == [VAR1: 'value1']
+    }
+
+    def 'should propagate machine info to array child tasks on update status' () {
+        given:
+        def child0 = Spy(GoogleBatchTaskHandler)
+        def child1 = Spy(GoogleBatchTaskHandler)
+        def arrayTask = new TaskArrayRun(children: [child0, child1])
+        def exec = Mock(GoogleBatchExecutor) {
+            getArrayTaskId('job-1', 0) >> '0.0'
+            getArrayTaskId('job-1', 1) >> '0.1'
+        }
+        def handler = Spy(GoogleBatchTaskHandler)
+        handler.task = arrayTask
+        handler.@executor = exec
+        handler.@machineInfo = new CloudMachineInfo(type: 'n2-standard-4', zone: 'europe-west2', priceModel: PriceModel.spot)
+
+        when:
+        handler.updateStatus('job-1', '0', 'uid-1')
+
+        then:
+        child0.@machineInfo == handler.@machineInfo
+        child1.@machineInfo == handler.@machineInfo
     }
 
     def 'should resolve zone from status events: #DESCRIPTION' () {


### PR DESCRIPTION
## Summary

Fixes null `machineType`/cost reporting for array-batched tasks on the Google Batch executor.

When a process uses the `array` directive, `submit()` is only ever invoked on the array-parent task handler, which resolves and stores the job's `CloudMachineInfo` (machine type, zone, price model) as an instance field. `updateStatus()` then cascades `jobId`/`taskId`/`uid` down to each array-child handler, but never copies `machineInfo` — so every child's trace record reports a null machine type, and any downstream consumer that prices a task from its machine type (e.g. Seqera Platform) cannot compute a cost for it.

This is safe because Google Batch enforces a uniform `InstancePolicy` (machine type, CPU, memory, disk) across every element of one array job — array-eligible processes already require identical resource directives — so copying the parent's resolved `CloudMachineInfo` to every child reflects what actually ran, not an approximation.

## Changes

- `GoogleBatchTaskHandler.groovy` — copy `machineInfo` to each child handler in `updateStatus()`'s array branch, alongside the existing `jobId`/`taskId`/`uid` propagation. Uses the `.@` direct field operator since `machineInfo` is a private field and plain property assignment on another instance resolves to a (nonexistent) setter.
- `GoogleBatchTaskHandlerTest.groovy` — new test asserting every array-child handler ends up with the same `machineInfo` as the parent after `updateStatus()`.

## Test plan

- [x] New test: `should propagate machine info to array child tasks on update status`
- [x] Full `nf-google` test suite passes (`./gradlew :plugins:nf-google:test`)