### PR TITLE
docs: clarify how to use cloudcache manually

### DIFF
--- a/docs/cache-and-resume.mdx
+++ b/docs/cache-and-resume.mdx
@@ -53,9 +53,28 @@ The default cache store uses the `.nextflow/cache` directory, relative to the la
 
 Due to the limitations of LevelDB, the database for a given session ID can only be accessed by one reader/writer at a time. This means, for example, that you cannot use `nextflow log` to query the task metadata for a pipeline run while it is still running.
 
-The cloud cache is an alternative cache store that uses cloud storage instead of the local cache directory. You can use it by setting the `NXF_CLOUDCACHE_PATH` environment variable to the desired cache path (e.g. `s3://my-bucket/cache`) and providing the necessary credentials.
+The cloud cache is an alternative cache store that uses cloud storage instead of the local cache directory. It is particularly useful when running Nextflow in a cloud VM, where the default cache would be lost once the run completes and the VM is terminated. Because it is backed by cloud storage, it supports multiple readers and writers.
 
-The cloud cache is particularly useful when launching Nextflow from within the cloud, where the default cache would be lost once the pipeline completes and the VM instance is terminated. Furthermore, because it is backed by cloud storage, it can support multiple readers and writers.
+The cloud cache is automatically used by Seqera Platform. To use the cloud cache manually:
+
+1. Set `NXF_CLOUDCACHE_PATH` to the desired cache path (e.g. `s3://my-bucket/cache`).
+2. Set `NXF_IGNORE_RESUME_HISTORY` to `true` to disable the history file.
+3. Always specify the session ID when resuming with `-resume`.
+4. Always specify a run name with `-name`.
+
+For example:
+
+```bash
+# configure cloud cache
+export NXF_CLOUDCACHE_PATH=s3://my-bucket/cache
+export NXF_IGNORE_RESUME_HISTORY=true
+
+# initial run
+nextflow run <pipeline> -name my-run-1
+
+# resumed run (use session ID from initial run)
+nextflow run <pipeline> -name my-run-2 -resume <session-id>
+```
 
 ## Work directory
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -70,6 +70,8 @@ Defines the directory where downloaded pipeline repositories are stored (default
 
 Defines the base cache directory when using the default cache store (default: `"$launchDir/.nextflow"`).
 
+This must be a local directory. To store the task cache in object storage, use [`NXF_CLOUDCACHE_PATH`](#nxf_cloudcache_path).
+
 ##### `NXF_CHARLIECLOUD_CACHEDIR`
 
 Directory where remote Charliecloud images are stored. When using a computing cluster it must be a shared folder accessible from all compute nodes.
@@ -78,7 +80,7 @@ Directory where remote Charliecloud images are stored. When using a computing cl
 
 <AddedInVersion version="23.10" />
 
-Defines the base cache path when using the cloud cache store.
+Defines the base cache path when using the cloud cache store. See [Cache stores][cache-stores] for more information.
 
 ##### `NXF_CLOUD_DRIVER`
 
@@ -197,6 +199,12 @@ Nextflow retries connection attempts that time out, because the request never re
 Maximum time to wait for a response from the Git hosting service API after the connection is established, for a single attempt (default: `60s`). Set to `0s` to wait indefinitely.
 
 Nextflow does not retry requests that time out waiting for a response, because the request reached the server and the server may already have processed it.
+
+##### `NXF_IGNORE_RESUME_HISTORY`
+
+Disables the history file (`.nextflow/history`) used to track previous runs (default: `false`).
+
+When the history file is disabled, `nextflow run` requires an explicit run name (`-name`), and `-resume` requires an explicit session ID. See [Cache stores][cache-stores] for more information.
 
 ##### `NXF_JAVA_HOME`
 
@@ -503,6 +511,7 @@ Forces the terminal width of ANSI-formatted log output. Overrides automatic term
 
 [agent-page]: ../agent
 [agent-provider]: ../agent#the-api-provider
+[cache-stores]: ../cache-and-resume#cache-stores
 [process-conda]: ./process/directives/conda
 [process-publishdir]: ./process/directives/publish-dir
 [process-spack]: ./process/directives/spack


### PR DESCRIPTION
Follow-up to #6424

This PR clarifies how to use the cloudcache without Seqera Platform. Intentionally brief as it is borderline internal behavior, but has some valid use cases.

Also clarifies that `NXF_CACHE_DIR` only supports local paths.