### PR TITLE
Report invalid escape sequences at the exact position

### DIFF
--- a/modules/nf-lang/src/main/antlr/ConfigLexer.g4
+++ b/modules/nf-lang/src/main/antlr/ConfigLexer.g4
@@ -577,6 +577,7 @@ EscapeSequence
     |   UnicodeEscape
     |   DollarEscape
     |   LineEscape
+    |   InvalidEscape
     ;
 
 fragment
@@ -606,6 +607,11 @@ DollarEscape
 fragment
 LineEscape
     :   Backslash LineTerminator
+    ;
+
+fragment
+InvalidEscape
+    :   Backslash .
     ;
 
 fragment

--- a/modules/nf-lang/src/main/antlr/ScriptLexer.g4
+++ b/modules/nf-lang/src/main/antlr/ScriptLexer.g4
@@ -610,6 +610,7 @@ EscapeSequence
     |   UnicodeEscape
     |   DollarEscape
     |   LineEscape
+    |   InvalidEscape
     ;
 
 fragment
@@ -639,6 +640,11 @@ DollarEscape
 fragment
 LineEscape
     :   Backslash LineTerminator
+    ;
+
+fragment
+InvalidEscape
+    :   Backslash .
     ;
 
 fragment

--- a/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/config/parser/ConfigAstBuilder.java
@@ -94,6 +94,7 @@ import org.codehaus.groovy.syntax.SyntaxException;
 import org.codehaus.groovy.syntax.Types;
 
 import static nextflow.config.parser.ConfigParser.*;
+import static nextflow.script.parser.EscapeUtils.checkEscapes;
 import static nextflow.script.parser.PositionConfigureUtils.ast;
 import static nextflow.script.parser.PositionConfigureUtils.tokenPosition;
 import static org.codehaus.groovy.ast.expr.VariableExpression.THIS_EXPRESSION;
@@ -888,6 +889,7 @@ public class ConfigAstBuilder {
 
     private ConstantExpression string(ParserRuleContext ctx) {
         var text = ctx.getText();
+        checkEscapes(text, ctx).forEach(this::collectSyntaxError);
         var result = constX(stringLiteral(text));
         result.putNodeMetaData(ASTNodeMarker.VERBATIM_TEXT, text);
         return result;
@@ -990,6 +992,7 @@ public class ConfigAstBuilder {
 
     private ConstantExpression gstringText(ParserRuleContext ctx, String beginQuotation) {
         var text = ctx.getText();
+        checkEscapes(text, ctx).forEach(this::collectSyntaxError);
         var quotedText = new StringBuilder(text)
             .insert(0, beginQuotation)
             .append(beginQuotation)

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/EscapeUtils.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/EscapeUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.script.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.codehaus.groovy.syntax.SyntaxException;
+
+/**
+ * Utilities for validating escape sequences in string literals.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class EscapeUtils {
+
+    private static final String ESCAPABLE_CHARS = "btnfrs\"'\\$\r\n";
+
+    private static final String SLASH_STR = "/";
+
+    /**
+     * Get the list of errors for each invalid escape sequence in a
+     * string literal.
+     *
+     * The lexer accepts invalid escapes (see `InvalidEscape` in the grammar)
+     * so that the error can be reported here at the exact position, instead
+     * of causing the enclosing string to fail and be reported at the start
+     * of the string.
+     *
+     * @param text
+     * @param ctx
+     */
+    public static List<SyntaxException> checkEscapes(String text, ParserRuleContext ctx) {
+        if( text.indexOf('\\') == -1 || text.startsWith(SLASH_STR) )
+            return Collections.emptyList();
+        var errors = new ArrayList<SyntaxException>();
+        var line = ctx.getStart().getLine();
+        var column = ctx.getStart().getCharPositionInLine() + 1;
+        for( int i = 0; i < text.length(); i++ ) {
+            var c = text.charAt(i);
+            if( c == '\n' ) {
+                line++;
+                column = 1;
+            }
+            else if( c == '\\' && i + 1 < text.length() ) {
+                var next = text.charAt(i + 1);
+                if( !isEscapable(text, i + 1) )
+                    errors.add(new SyntaxException("Invalid escape sequence: '\\" + next + "'", line, column, line, column + 2));
+                i++;
+                if( next == '\n' || next == '\r' ) {
+                    line++;
+                    column = 1;
+                }
+                else {
+                    column += 2;
+                }
+            }
+            else {
+                column++;
+            }
+        }
+        return errors;
+    }
+
+    private static boolean isEscapable(String text, int i) {
+        var c = text.charAt(i);
+        if( c == 'u' )
+            return isUnicodeEscape(text, i + 1);
+        return ESCAPABLE_CHARS.indexOf(c) != -1 || ('0' <= c && c <= '7');
+    }
+
+    /**
+     * Determine whether a unicode escape is followed by four hex digits.
+     * Groovy allows one or more `u`s after the backslash.
+     */
+    private static boolean isUnicodeEscape(String text, int i) {
+        while( i < text.length() && text.charAt(i) == 'u' )
+            i++;
+        if( i + 4 > text.length() )
+            return false;
+        for( int j = i; j < i + 4; j++ ) {
+            if( Character.digit(text.charAt(j), 16) == -1 )
+                return false;
+        }
+        return true;
+    }
+
+}

--- a/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
+++ b/modules/nf-lang/src/main/java/nextflow/script/parser/ScriptAstBuilder.java
@@ -113,6 +113,7 @@ import org.codehaus.groovy.syntax.SyntaxException;
 import org.codehaus.groovy.syntax.Types;
 
 import static nextflow.script.ast.ASTUtils.*;
+import static nextflow.script.parser.EscapeUtils.checkEscapes;
 import static nextflow.script.parser.PositionConfigureUtils.ast;
 import static nextflow.script.parser.PositionConfigureUtils.tokenPosition;
 import static nextflow.script.parser.ScriptParser.*;
@@ -1654,6 +1655,7 @@ public class ScriptAstBuilder {
 
     private ConstantExpression string(ParserRuleContext ctx) {
         var text = ctx.getText();
+        checkEscapes(text, ctx).forEach(this::collectSyntaxError);
         var result = constX(stringLiteral(text));
         result.putNodeMetaData(ASTNodeMarker.VERBATIM_TEXT, text);
         return result;
@@ -1756,6 +1758,7 @@ public class ScriptAstBuilder {
 
     private ConstantExpression gstringText(ParserRuleContext ctx, String beginQuotation) {
         var text = ctx.getText();
+        checkEscapes(text, ctx).forEach(this::collectSyntaxError);
         var quotedText = new StringBuilder(text)
             .insert(0, beginQuotation)
             .append(beginQuotation)

--- a/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
+++ b/modules/nf-lang/src/test/groovy/nextflow/script/parser/ScriptAstBuilderTest.groovy
@@ -610,7 +610,7 @@ class ScriptAstBuilderTest extends Specification {
         errors[0].getOriginalMessage() == "Unexpected character: '\$'"
 
         when:
-        // invalid escape sequence in a gstring (the `\\` matches no rule)
+        // invalid escape sequence in a gstring
         errors = check(
             '''\
             "abc \\q def"
@@ -620,7 +620,58 @@ class ScriptAstBuilderTest extends Specification {
         errors.size() == 1
         errors[0].getStartLine() == 1
         errors[0].getStartColumn() == 6
-        errors[0].getOriginalMessage() == "Unexpected character: '\\'"
+        errors[0].getOriginalMessage() == "Invalid escape sequence: '\\q'"
+    }
+
+    def 'should report an invalid escape sequence at the exact position' () {
+        when:
+        // an invalid escape should not be reported at the start of the string
+        def errors = check(
+            '''\
+            x = \'\'\'
+                gsub(/\\./, "0")
+            \'\'\'
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 2
+        errors[0].getStartColumn() == 11
+        errors[0].getOriginalMessage() == "Invalid escape sequence: '\\.'"
+
+        when:
+        errors = check(
+            '''\
+            x = \'a\\.b\'
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getStartLine() == 1
+        errors[0].getStartColumn() == 7
+        errors[0].getOriginalMessage() == "Invalid escape sequence: '\\.'"
+
+        when:
+        // a unicode escape must be followed by four hex digits
+        errors = check(
+            '''\
+            x = \'\\uZZZZ\'
+            '''
+        )
+        then:
+        errors.size() == 1
+        errors[0].getOriginalMessage() == "Invalid escape sequence: '\\u'"
+
+        when:
+        // valid escapes and slashy strings should not be flagged
+        errors = check(
+            '''\
+            x = \'a\\n\\t\\\\\\u00e9\\101b\'
+            y = /a\\.b/
+            '''
+        )
+        then:
+        errors.size() == 0
     }
 
     def 'should allow escaped and interpolated gstring characters' () {


### PR DESCRIPTION
Closes nextflow-io/language-server#152

## Problem

An invalid escape sequence such as `\.` causes the enclosing string literal to match no lexer rule. The lexer falls back to the unexpected-character rule, which consumes the opening quote, so the error is reported at the start of the string instead of at the escape — and lexing is aborted for the rest of the file.

The script from the issue has two invalid escapes (`\ ` on line 7 and `\.` on line 9), but only reported one error, in the wrong place:

```
repro.nf:7:38: Unexpected character: '''
│   7 |     ch_rename_ids_awk = channel.of('''\
╰     |                                    ^
```

Groovy has the same behavior, so it wasn't obvious from the error where to look. See [GROOVY-12171](https://issues.apache.org/jira/browse/GROOVY-12171) for the same bug with `$` instead of `\`, fixed upstream in 6.0.0-beta-1.

## Solution

Add an `InvalidEscape` alternative to the grammar so the string is tokenized, then report the error from the AST builder, where the exact offset is known. Both errors are now reported at the escape itself:

```
repro.nf:7:39: Invalid escape sequence: '\ '
│   7 |     ch_rename_ids_awk = channel.of('''\
╰     |                                       ^^
repro.nf:9:19: Invalid escape sequence: '\.'
│   9 |             gsub(/\./, "0")
╰     |                   ^^
```

The check is shared by the script and config parsers via `EscapeUtils`. Slashy strings are skipped, since a backslash is literal there.

An action on the fragment rule is not an option — ANTLR does not execute actions in fragment rules.