### PR TITLE
Fix env config scope not applied with Google Batch

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchFusionAdapter.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchFusionAdapter.groovy
@@ -60,7 +60,7 @@ class GoogleBatchFusionAdapter implements GoogleBatchLauncherSpec {
     }
 
     @Override
-    Map<String, String> getEnvironment() {
+    Map<String, String> getBatchEnvironment() {
         return launcher.fusionEnv()
     }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchLauncherSpec.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchLauncherSpec.groovy
@@ -46,7 +46,7 @@ interface GoogleBatchLauncherSpec {
         return ['/bin/bash','-o','pipefail','-c', runCommand() ]
     }
 
-    default Map<String,String> getEnvironment() {
+    default Map<String,String> getBatchEnvironment() {
         return Map.of()
     }
 }

--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/GoogleBatchTaskHandler.groovy
@@ -328,7 +328,7 @@ class GoogleBatchTaskHandler extends TaskHandler implements FusionAwareTask {
             container.setOptions(containerOptions)
 
         final env = Environment.newBuilder()
-            .putAllVariables(launcher.getEnvironment())
+            .putAllVariables(launcher.getBatchEnvironment())
             .build()
 
         return Runnable.newBuilder()

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchLauncherSpecMock.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchLauncherSpecMock.groovy
@@ -46,7 +46,7 @@ class GoogleBatchLauncherSpecMock implements GoogleBatchLauncherSpec {
         return runCommand
     }
 
-    Map<String,String> getEnvironment() {
+    Map<String,String> getBatchEnvironment() {
         return environment
     }
 }

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/GoogleBatchScriptLauncherTest.groovy
@@ -21,6 +21,7 @@ import java.nio.file.Paths
 import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem
 import nextflow.cloud.google.GoogleOpts
 import nextflow.cloud.google.batch.client.BatchConfig
+import nextflow.processor.TaskBean
 import nextflow.processor.TaskRun
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -98,6 +99,25 @@ class GoogleBatchScriptLauncherTest extends Specification{
         launcher.targetScriptFile() == workDir.resolve(TaskRun.CMD_SCRIPT)
         launcher.targetWrapperFile() == workDir.resolve(TaskRun.CMD_RUN)
         launcher.targetStageFile() == workDir.resolve(TaskRun.CMD_STAGE)
+    }
+
+    def 'should export the config env in the task wrapper' () {
+        given:
+        def workDir = CloudStorageFileSystem.forBucket('my-bucket').getPath('/work/dir')
+        def bean = new TaskBean(
+                name: 'foo',
+                workDir: workDir,
+                targetDir: workDir,
+                script: 'echo hello',
+                containerImage: 'ubuntu:latest',
+                containerEnabled: true,
+                containerNative: true,
+                environment: [MY_ENV_VAR: 'my_value'] )
+
+        when:
+        def launcher = new GoogleBatchScriptLauncher(bean, null)
+        then:
+        launcher.makeBinding().task_env == 'export MY_ENV_VAR="my_value"\n'
     }
 
 }


### PR DESCRIPTION
Variables declared in the `env { }` config scope were never exported into the task environment on Google Batch, so a process reading them failed on `google-batch` while working with every other executor. The `export` lines are simply absent from `.command.run` — nothing is rendered between `set -u` and `nxf_stage`.

### Cause

An accidental method collision between two unrelated meanings of "environment".

`BashWrapperBuilder` reaches the task environment through `@Delegate private TaskBean bean`, which generates a `getEnvironment()` on the builder, and renders the wrapper from it:

```groovy
final env = copyStrategy.getEnvScript(environment, runWithContainer)
```

`GoogleBatchScriptLauncher extends BashWrapperBuilder implements GoogleBatchLauncherSpec`, and that interface declares its own `getEnvironment()` — the env vars to attach to the Batch `Runnable`, which only the Fusion adapter needs:

```groovy
default Map<String,String> getEnvironment() {
    return Map.of()
}
```

Because the class already inherits a `getEnvironment()` from the interface, Groovy's `@Delegate` transform skips generating the delegating method, and the interface's empty default wins. Reflection confirms it: the declaring class of `getEnvironment()` is `GoogleBatchScriptLauncher`, not `BashWrapperBuilder`.

One shadowed getter caused both halves of the symptom — the empty map fed `{{task_env}}` in `.command.run`, and `GoogleBatchTaskHandler` called the same getter for the Batch `Runnable` environment.

Fusion runs were unaffected, since `GoogleBatchFusionAdapter` wraps a separate `FusionScriptLauncher` that does not implement the interface. That matches the reports on the issue, which all had `fusion.enabled = false`.

### Fix

Rename the launcher spec method to `getBatchEnvironment()` so the two meanings stop colliding, restoring the `@Delegate` behaviour for the Google Batch launcher. Config env vars are now exported in `.command.run`, exactly as AWS Batch and Azure Batch do, and the Batch `Runnable` environment is unchanged.

An alternative — overriding `getEnvironment()` in `GoogleBatchScriptLauncher` to return the task env — fixes the symptom with a smaller diff, but leaves the name collision in place and would additionally push every config env var into the Batch API request.

### Testing

Added a regression test asserting the config env reaches the wrapper binding. It fails on `master` and passes with this change; the full `nf-google` suite passes.

Closes #5623