### PR TITLE
fix(google-batch): recover the job when the createJob response is lost

### DIFF
--- a/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
+++ b/plugins/nf-google/src/main/nextflow/cloud/google/batch/client/BatchClient.groovy
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeoutException
 import dev.failsafe.function.CheckedPredicate
 
 import com.google.api.gax.core.CredentialsProvider
+import com.google.api.gax.rpc.AlreadyExistsException
 import com.google.api.gax.rpc.DeadlineExceededException
 import com.google.api.gax.rpc.FixedHeaderProvider
 import com.google.api.gax.rpc.NotFoundException
@@ -102,7 +103,21 @@ class BatchClient {
 
     Job submitJob(String jobId, Job job) {
         final parent = LocationName.of(projectId, location)
-        return apply(()-> batchServiceClient.createJob(parent, job, jobId))
+        return apply(()-> {
+            try {
+                return batchServiceClient.createJob(parent, job, jobId)
+            }
+            catch( AlreadyExistsException e ) {
+                // the create request is retried when the response is lost e.g. due to a 502 error
+                // or a client-side deadline, therefore an ALREADY_EXISTS error means a previous
+                // attempt did create the job -- fetch it instead of failing the submission.
+                // note: this is nested within the retry policy on purpose, so that a NOT_FOUND
+                // from the lookup retries the create instead of aborting the task
+                // see https://github.com/nextflow-io/nextflow/issues/6916
+                log.debug "[GOOGLE BATCH] Job $jobId already exists - retrieving the job created by a previous submit attempt"
+                return batchServiceClient.getJob(JobName.of(projectId, location, jobId))
+            }
+        })
     }
 
     Job describeJob(String jobId) {

--- a/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchClientSubmitJobTest.groovy
+++ b/plugins/nf-google/src/test/nextflow/cloud/google/batch/client/BatchClientSubmitJobTest.groovy
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2013-2026, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.cloud.google.batch.client
+
+import java.util.concurrent.TimeUnit
+
+import com.google.api.gax.core.NoCredentialsProvider
+import com.google.api.gax.grpc.GrpcTransportChannel
+import com.google.api.gax.rpc.AlreadyExistsException
+import com.google.api.gax.rpc.FixedTransportChannelProvider
+import com.google.api.gax.rpc.NotFoundException
+import com.google.cloud.batch.v1.BatchServiceClient
+import com.google.cloud.batch.v1.BatchServiceSettings
+import com.google.cloud.batch.v1.CreateJobRequest
+import com.google.cloud.batch.v1.GetJobRequest
+import com.google.cloud.batch.v1.Job
+import com.google.cloud.batch.v1.JobName
+import io.grpc.CallOptions
+import io.grpc.ClientCall
+import io.grpc.ManagedChannel
+import io.grpc.Metadata
+import io.grpc.MethodDescriptor
+import io.grpc.Status
+import nextflow.cloud.google.GoogleOpts
+import spock.lang.Specification
+
+/**
+ * Checks that a `createJob` request whose response is lost does not abort the task submission.
+ *
+ * `BatchServiceClient.createJob` and `getJob` are final and cannot be stubbed, so the real
+ * client is driven against a fake channel that answers calls with a scripted sequence of
+ * results. This exercises the actual API client and the failsafe retry policy around it.
+ *
+ * see https://github.com/nextflow-io/nextflow/issues/6916
+ */
+class BatchClientSubmitJobTest extends Specification {
+
+    static final String PROJECT = 'proj-1'
+    static final String LOCATION = 'europe-west1'
+    static final String JOB_ID = 'nf-06071afa-1773255240303'
+    static final String JOB_NAME = JobName.of(PROJECT, LOCATION, JOB_ID).toString()
+
+    /**
+     * A fake Batch endpoint replaying a scripted sequence of results per RPC. Each queued entry
+     * is either a {@link Status} to fail the call with, or a {@link Job} to return.
+     */
+    static class FakeBatchChannel extends ManagedChannel {
+
+        final List<String> calls = Collections.synchronizedList(new ArrayList<String>())
+        final Queue<Object> createResults = new LinkedList<>()
+        final Queue<Object> getResults = new LinkedList<>()
+
+        @Override
+        String authority() { 'batch.googleapis.test' }
+
+        @Override
+        ClientCall newCall(MethodDescriptor method, CallOptions options) {
+            return new ClientCall() {
+                private ClientCall.Listener listener
+                private Object result
+
+                @Override
+                void start(ClientCall.Listener responseListener, Metadata headers) {
+                    this.listener = responseListener
+                }
+
+                @Override
+                void request(int numMessages) { }
+
+                @Override
+                void cancel(String message, Throwable cause) { }
+
+                @Override
+                void sendMessage(Object message) {
+                    // record the call and pick the next scripted result for this RPC
+                    if( message instanceof CreateJobRequest ) {
+                        calls << "createJob:${message.getJobId()}".toString()
+                        result = createResults.poll()
+                    }
+                    else if( message instanceof GetJobRequest ) {
+                        calls << "getJob:${message.getName()}".toString()
+                        result = getResults.poll()
+                    }
+                    else {
+                        throw new IllegalStateException("Unexpected request: ${message?.getClass()}")
+                    }
+                    if( result == null )
+                        throw new IllegalStateException("No scripted result left for ${method.getFullMethodName()}")
+                }
+
+                @Override
+                void halfClose() {
+                    if( result instanceof Status ) {
+                        listener.onClose(result as Status, new Metadata())
+                    }
+                    else {
+                        listener.onMessage(result)
+                        listener.onClose(Status.OK, new Metadata())
+                    }
+                }
+            }
+        }
+
+        @Override ManagedChannel shutdown() { return this }
+        @Override ManagedChannel shutdownNow() { return this }
+        @Override boolean isShutdown() { return false }
+        @Override boolean isTerminated() { return false }
+        @Override boolean awaitTermination(long timeout, TimeUnit unit) { return true }
+    }
+
+    FakeBatchChannel fake
+    BatchServiceClient service
+
+    def setup() {
+        fake = new FakeBatchChannel()
+        final settings = BatchServiceSettings.newBuilder()
+            .setTransportChannelProvider(FixedTransportChannelProvider.create(GrpcTransportChannel.create(fake)))
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build()
+        service = BatchServiceClient.create(settings)
+    }
+
+    def cleanup() {
+        service?.close()
+    }
+
+    BatchClient newClient() {
+        new BatchClient(
+            projectId: PROJECT,
+            location: LOCATION,
+            batchServiceClient: service,
+            config: new GoogleOpts([batch: [retryPolicy: [delay: '1ms', maxDelay: '10ms']]]) )
+    }
+
+    static Job aJob(String uid) {
+        Job.newBuilder().setName(JOB_NAME).setUid(uid).build()
+    }
+
+    def 'should submit a job' () {
+        given:
+        fake.createResults << aJob('job-uid-0')
+
+        when:
+        def result = newClient().submitJob(JOB_ID, Job.newBuilder().build())
+
+        then:
+        result.getUid() == 'job-uid-0'
+        and:
+        fake.calls == ["createJob:$JOB_ID"]
+    }
+
+    def 'should adopt the job created by a request whose response was lost' () {
+        given: 'the create reaches Batch but its response is lost, so the retry finds the job it created'
+        fake.createResults << Status.UNAVAILABLE.withDescription('502:Bad Gateway')
+        fake.createResults << Status.ALREADY_EXISTS.withDescription("Resource '$JOB_NAME' already exists")
+        fake.getResults << aJob('job-uid-1')
+
+        when:
+        def result = newClient().submitJob(JOB_ID, Job.newBuilder().build())
+
+        then: 'the submission returns the pre-existing job instead of aborting the task'
+        result.getUid() == 'job-uid-1'
+        and:
+        fake.calls == ["createJob:$JOB_ID", "createJob:$JOB_ID", "getJob:$JOB_NAME"]
+    }
+
+    def 'should recover the same way from a client-side deadline' () {
+        given:
+        fake.createResults << Status.DEADLINE_EXCEEDED.withDescription('deadline exceeded after 59.999709386s')
+        fake.createResults << Status.ALREADY_EXISTS.withDescription("Resource '$JOB_NAME' already exists")
+        fake.getResults << aJob('job-uid-3')
+
+        when:
+        def result = newClient().submitJob(JOB_ID, Job.newBuilder().build())
+
+        then:
+        result.getUid() == 'job-uid-3'
+    }
+
+    def 'should retry the create when the job cannot be read back' () {
+        given: 'ALREADY_EXISTS is reported but the job is not there'
+        fake.createResults << Status.UNAVAILABLE.withDescription('502:Bad Gateway')
+        fake.createResults << Status.ALREADY_EXISTS.withDescription("Resource '$JOB_NAME' already exists")
+        fake.getResults << Status.NOT_FOUND.withDescription("Resource '$JOB_NAME' was not found")
+        and: 'the next create attempt succeeds'
+        fake.createResults << aJob('job-uid-2')
+
+        when:
+        def result = newClient().submitJob(JOB_ID, Job.newBuilder().build())
+
+        then: 'the lookup failure retries the create instead of aborting the task'
+        result.getUid() == 'job-uid-2'
+        and:
+        fake.calls == ["createJob:$JOB_ID", "createJob:$JOB_ID", "getJob:$JOB_NAME", "createJob:$JOB_ID"]
+    }
+
+    def 'should give up when the job can neither be read back nor recreated' () {
+        given: 'every create is reported ALREADY_EXISTS and every lookup NOT_FOUND'
+        5.times {
+            fake.createResults << Status.ALREADY_EXISTS.withDescription("Resource '$JOB_NAME' already exists")
+            fake.getResults << Status.NOT_FOUND.withDescription("Resource '$JOB_NAME' was not found")
+        }
+
+        when:
+        newClient().submitJob(JOB_ID, Job.newBuilder().build())
+
+        then: 'the retry policy is bounded and the error surfaces'
+        thrown(NotFoundException)
+        and:
+        fake.calls.count { it.startsWith('createJob') } == 5
+    }
+
+    def 'should surface ALREADY_EXISTS from a generic API call' () {
+        given: 'the recovery is specific to submitJob -- other calls keep the plain behaviour'
+        fake.getResults << Status.ALREADY_EXISTS.withDescription('unexpected')
+
+        when:
+        newClient().describeJob(JOB_ID)
+
+        then:
+        thrown(AlreadyExistsException)
+    }
+}


### PR DESCRIPTION
Closes #6916

## Problem

A run on `google-batch` aborts with an `ALREADY_EXISTS` error naming a job that Nextflow itself just generated:

```
Caused by:
  ALREADY_EXISTS: Resource "projects/.../jobs/nf-06071afa-1773255240303" already exists
```

Nothing external created that job — Nextflow collided with its own earlier create request.

`BatchClient.apply()` wraps every Batch API call in a failsafe retry policy that retries `UnavailableException`, `DeadlineExceededException`, `IOException` and `TimeoutException`. Every one of those is ambiguous: the request may have been applied server-side before the response was lost. `createJob` is not idempotent under such a retry, so the second attempt is rejected with `ALREADY_EXISTS`, which is not in the retry predicate and propagates out of `submitJob()` → `GoogleBatchTaskHandler.submit()` → `TaskPollingMonitor`, aborting the session.

The job it complains about keeps running and billing while the run is torn down. A reporter on the issue confirmed this with Cloud Logging: a `502:Bad Gateway`, then `ALREADY_EXISTS` on the same job name, and `gcloud batch describe` showing that job eventually `SUCCEEDED`.

`process.errorStrategy` does not help, since a gax `ApiException` is not a `ProcessException` and so never reaches `checkErrorStrategy()`.

This was flagged as a residual gap while triaging the sibling issue #6878; the `DeadlineExceededException` branch added in 944f48f9b adds another path into it but did not create it — `UNAVAILABLE` already reached it on 24.04.x.

## Change

Handle `AlreadyExistsException` in `submitJob()` by fetching the job the previous attempt created. The job id is fixed per task handler (`nf-<task hash>-<currentTimeMillis>`, `GoogleBatchTaskHandler:135`), so `ALREADY_EXISTS` on that name can only mean an earlier attempt of the same submission succeeded.

The lookup sits **inside** the retry policy deliberately: if it comes back `NOT_FOUND` — `ALREADY_EXISTS` was reported but the job is not actually there — `NotFoundException` is already retryable, so failsafe re-runs the supplier and re-attempts the create. Wrapping `apply()` from the outside would retry only the lookup and then abort the task.

The recovery is scoped to `submitJob`; `apply()` stays generic, so `ALREADY_EXISTS` from `getJob`/`listTasks`/`deleteJob` still surfaces as before.

## Tests

New `BatchClientSubmitJobTest`. `BatchServiceClient.createJob` and `getJob` are `final` and cannot be mocked, and `BatchServiceGrpc` is not on the classpath (`google-cloud-batch` builds its method descriptors by hand; only `proto-google-cloud-batch-v1` is pulled in), so there is no generated service base to subclass either. The test instead injects a fake `ManagedChannel` that answers RPCs from a scripted queue and builds a **real** `BatchServiceClient` over it via `FixedTransportChannelProvider` — exercising the actual API client, the gax call plumbing and the failsafe policy, with no new dependency.

Six cases: plain submit; recovery after `UNAVAILABLE`; recovery after `DEADLINE_EXCEEDED`; `NOT_FOUND` on the lookup falling back to a fresh create; the bounded give-up path; and `ALREADY_EXISTS` still surfacing from a generic call.

Verified red/green — with the fix reverted, the four recovery cases fail with `com.google.api.gax.rpc.AlreadyExistsException` (the reported error) while the two control cases still pass. With it applied all six pass, and the full `:plugins:nf-google:test` suite is green.

## Notes for review

- With a custom `jobName` closure a user can produce colliding names across concurrent runs, and this makes Nextflow adopt the pre-existing job rather than failing. The previous behaviour aborted the whole session in that case, so it was not a useful guard either — but if a louder signal is wanted, `log.warn` when the job's `createTime` predates this submit would cover it.
- Separate and not addressed here: `createBatchService()` builds `BatchServiceSettings` without any `RetrySettings`, so every call is pinned to gax's 60s `totalTimeout` and `google.batch.requestTimeout` (which several users set) is not a real config option.