### PR TITLE
Clean local task dirs in hybrid runs

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -1242,14 +1242,26 @@ class Session implements ISession {
         }
 
         log.trace "Cleaning-up workdir"
+        int skipped = 0
         try (CacheDB db = CacheFactory.create(uniqueId, runName).openForRead()) {
             db.eachRecord { HashCode hash, TraceRecord record ->
+                final taskDir = record.workDir as String
+                final scheme = FileHelper.getUrlProtocol(taskDir)
+                if( scheme && scheme != 'file' ) {
+                    // a hybrid run can offload tasks to a remote work dir (e.g. `-bucket-dir`)
+                    // which cleanup does not support -- skip it and keep the local ones
+                    log.trace "Skipping cleanup of remote task dir: $taskDir"
+                    skipped++
+                    return
+                }
                 def deleted = db.removeTaskEntry(hash)
                 if( deleted ) {
                     // delete folder
-                    FileHelper.deletePath(FileHelper.asPath(record.workDir))
+                    FileHelper.deletePath(FileHelper.asPath(taskDir))
                 }
             }
+            if( skipped )
+                log.warn "The `cleanup` option is not supported for remote work directories -- $skipped task director${skipped==1 ? 'y was' : 'ies were'} not deleted"
             log.trace "Clean workdir complete"
         }
         catch( Exception e ) {

--- a/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/SessionTest.groovy
@@ -23,19 +23,29 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
+import nextflow.cache.CacheDB
+import nextflow.cache.DefaultCacheStore
 import nextflow.config.Manifest
 import nextflow.container.ContainerConfig
 import nextflow.container.DockerConfig
 import nextflow.container.PodmanConfig
 import nextflow.container.SarusConfig
 import nextflow.exception.AbortOperationException
+import nextflow.executor.CachedTaskHandler
 import nextflow.file.FileHelper
+import nextflow.processor.TaskId
+import nextflow.processor.TaskProcessor
+import nextflow.processor.TaskRun
+import nextflow.script.BodyDef
+import nextflow.script.ProcessConfig
 import nextflow.script.ScriptFile
 import nextflow.script.WorkflowMetadata
 import nextflow.trace.TraceFileObserver
 import nextflow.trace.TraceHelper
+import nextflow.trace.TraceRecord
 import nextflow.trace.TraceObserverV2
 import nextflow.trace.WorkflowStatsObserver
+import nextflow.util.CacheHelper
 import nextflow.util.Duration
 import nextflow.util.VersionNumber
 import spock.lang.Specification
@@ -493,5 +503,50 @@ class SessionTest extends Specification {
 
         then:
         1 * observer.onFlowComplete()
+    }
+
+    private void writeCacheEntry(CacheDB cache, String key, String workDir) {
+        final hash = CacheHelper.hasher(key).hash()
+        final proc = Mock(TaskProcessor)
+        proc.getTaskBody() >> new BodyDef(null,'source')
+        proc.getConfig() >> new ProcessConfig([:])
+        proc.isCacheable() >> true
+        final task = Mock(TaskRun)
+        task.getProcessor() >> proc
+        task.getHash() >> hash
+        task.getId() >> TaskId.of(1)
+        final trace = new TraceRecord([task_id: 1, process: 'foo', exit: 0, workdir: workDir])
+        final handler = new CachedTaskHandler(task, trace)
+        cache.writeTaskEntry0(handler, trace)
+        cache.writeTaskIndex0(handler, false)
+    }
+
+    def 'should cleanup local task dirs and skip the remote ones' () {
+        given: 'a local work dir holding one task dir'
+        def cacheHome = Files.createTempDirectory('cache')
+        def work = Files.createTempDirectory('work')
+        def localTask = Files.createDirectories(work.resolve('aa/bbbbbb'))
+        Files.createFile(localTask.resolve('.command.sh'))
+        SysEnv.push(NXF_CACHE_DIR: cacheHome.toString())
+
+        and:
+        def session = new Session([cleanup: true, workDir: work.toString(), runName: 'test_1'])
+
+        and: 'a cache holding one remote task and one local task'
+        def cache = new CacheDB(new DefaultCacheStore(session.uniqueId, 'test_1', cacheHome)).open()
+        writeCacheEntry(cache, 'remote', 's3://some-bucket/48/299e411a526eb1453a5a2acfa0f721')
+        writeCacheEntry(cache, 'local', localTask.toString())
+        cache.close()
+
+        when:
+        session.cleanup()
+
+        then: 'the remote task does not prevent the local one from being deleted'
+        !Files.exists(localTask)
+
+        cleanup:
+        SysEnv.pop()
+        work?.deleteDir()
+        cacheHome?.deleteDir()
     }
 }


### PR DESCRIPTION
Closes #7334

## Problem

In a hybrid run, where most processes use a local work dir and some are offloaded to AWS Batch with `-bucket-dir s3://...`, `cleanup = true` deletes nothing at all:

```
WARN  nextflow.Session - Failed to cleanup work dir: /projectA/temp/.../work
java.lang.IllegalStateException: Missing plugin 'nf-amazon' required to read file: s3://private-bucket/48/299e411a526eb1453a5a2acfa0f721
	at nextflow.file.FileHelper.asPath(FileHelper.groovy:409)
	at nextflow.Session$_cleanup_closure41.doCall(Session.groovy:1165)
	at nextflow.cache.CacheDB.eachRecord(CacheDB.groovy:212)
	at nextflow.Session.cleanup(Session.groovy:1161)
```

Cleanup for a remote work dir is unsupported by design, but the local one should still be cleaned.

## Cause

`Session.cleanup()` assumes every task dir in the cache is a local path and calls `FileHelper.asPath()` on all of them, S3 ones included. That throws, because `ScriptRunner.shutdown()` calls `Plugins.stop()` before `session.cleanup()`, so `nf-amazon` is already gone. `FileHelper.autoStartMissingPlugin()` can't recover it either, since `SCHEME_CHECKED['s3']` was set during the run.

The `try/catch` wraps the whole `eachRecord` loop rather than a single record, so one remote task aborts cleanup for every remaining task. Record order decides how much gets cleaned, which in practice means nothing.

Reordering the shutdown would only trade one bug for another, since cleanup would then try to delete the bucket contents.

## Change

Skip cache records whose work dir has a non-`file` URL scheme, which is the same check `cleanup()` already applies to the session work dir, now applied per task. Skipped tasks keep their cache entry, since the directory still exists. A single warning at the end reports how many task dirs were left behind, so leftover remote data isn't a silent surprise.

## Test

`SessionTest > should cleanup local task dirs and skip the remote ones` builds a cache with one local and one `s3://` task record and asserts the local dir is deleted. It fails on master with the exact exception above and passes with this change.