### PR TITLE
Fix Google Batch storing symlinked task outputs as gcsfuse placeholders

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/executor/SimpleFileCopyStrategy.groovy
@@ -167,7 +167,7 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
      * to the shared working directory
      */
     @Override
-    String getUnstageOutputFilesScript(List<String> outputFiles, Path targetDir) {
+    String getUnstageOutputFilesScript(List<String> outputFiles, Path unstageDir) {
         final patterns = normalizeGlobStarPaths(outputFiles)
         // create a bash script that will copy the out file to the working directory
         log.trace "Unstaging file path: $patterns"
@@ -179,11 +179,17 @@ class SimpleFileCopyStrategy implements ScriptFileCopyStrategy {
         for( String it : patterns )
             escape.add( Escape.path(it) )
 
-        final mode = stageoutMode ?: ( workDir==targetDir ? 'copy' : 'move' )
+        // NOTE: the mode is determined by comparing the *task* work and target dirs, not
+        // the `unstageDir` argument: an executor may remap the latter to a container mount
+        // path (e.g. Google Batch), which would never match the work dir and therefore
+        // always select 'move'. Moving relocates a symlink verbatim instead of resolving
+        // it, which corrupts outputs that are links to staged inputs.
+        // See https://github.com/nextflow-io/nextflow/issues/4819
+        final mode = stageoutMode ?: ( this.targetDir==null || this.workDir==this.targetDir ? 'copy' : 'move' )
         return """\
             IFS=\$'\\n'
             for name in \$(eval "ls -1d ${escape.join(' ')}" | sort | uniq); do
-                ${stageOutCommand('$name', targetDir, mode)}
+                ${stageOutCommand('$name', unstageDir, mode)}
             done
             unset IFS""".stripIndent(true)
     }

--- a/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
+++ b/modules/nextflow/src/test/groovy/nextflow/executor/SimpleFileCopyStrategyTest.groovy
@@ -262,7 +262,7 @@ class SimpleFileCopyStrategyTest extends Specification {
         given:
         def outputs =  [ 'simple.txt', 'my/path/file.bam' ]
         def target = Paths.get('/target/work dir')
-        def task = new TaskBean(workDir: target)
+        def task = new TaskBean(workDir: target, targetDir: target)
 
         when:
         def strategy = new SimpleFileCopyStrategy(task)
@@ -279,13 +279,31 @@ class SimpleFileCopyStrategyTest extends Specification {
 
     }
 
+    def 'should return cp script to unstage output files when the unstage dir is a container mount' () {
+
+        given:
+        // the Google Batch launcher remaps the task dirs onto a gcsfuse container mount,
+        // which must not be mistaken for a storeDir -- see issue #4819
+        def outputs = [ 'out/*' ]
+        def workDir = Paths.get('/work/da/2fe756')
+        def mount = Paths.get('/mnt/disks/my-bucket/work/da/2fe756')
+        def task = new TaskBean(workDir: workDir, targetDir: workDir)
+
+        when:
+        def strategy = new SimpleFileCopyStrategy(task)
+        def script = strategy.getUnstageOutputFilesScript(outputs, mount)
+        then:
+        script.contains('nxf_fs_copy "$name" /mnt/disks/my-bucket/work/da/2fe756')
+
+    }
+
     def 'should return mv script to unstage output files when storeDir used' () {
 
         given:
         def outputs =  [ 'simple.txt', 'my/path/file.bam' ]
         def workDir = Paths.get('/target/work')
         def storeDir = Paths.get('/target/store')
-        def task = new TaskBean(workDir: workDir)
+        def task = new TaskBean(workDir: workDir, targetDir: storeDir)
 
         when:
         def strategy = new SimpleFileCopyStrategy(task)


### PR DESCRIPTION
Fixes #4819
Fixes #4845

## Problem

On the `google-batch` executor, a task output that is a symlink gets written into the GCS
work directory as a symlink rather than as the file it points at. The work directory is a
gcsfuse mount, so gcsfuse persists the link as a placeholder object. The object content is
the link target path, with `gcsfuse_symlink_target` and `goog-reserved-file-is-symlink`
metadata. It is not the file data.

Two symptoms follow, and both are reported:

- The link points into the task scratch dir (`/tmp/nxf.XXXX/...`), which is gone once the
  VM is torn down. The downstream task stages a dangling link and fails with
  "No such file or directory" (#4819), or reports the input file as missing (#4845).
- The link points at another gcsfuse path, so a downstream task can still follow it
  through the mount and appears to work. The object still holds only the path string, so
  `publishDir`, downloads and copies to another filesystem get the placeholder. That is
  where the empty published files in #4819 come from.

The same pipelines work on the local executor.

## Cause

`SimpleFileCopyStrategy.getUnstageOutputFilesScript` picks the unstage mode with:

```groovy
final mode = stageoutMode ?: ( workDir==targetDir ? 'copy' : 'move' )
```

The method parameter is also named `targetDir`, so it shadows the field. The comparison is
not "work dir vs target dir" but "work dir field vs whatever the caller passed".

For most executors those coincide and the bug stays invisible. `GoogleBatchScriptLauncher`
is the exception. Its constructor calls `super(bean)` first, which builds the copy strategy
and captures the original `gs://` work and target dirs, and only then remaps the bean dirs
onto the gcsfuse container mount. A `gs://` path never equals a `/mnt/disks/...` path, so
Google Batch always selects `move`.

`nxf_fs_move` is `mv -f`, which relocates a symlink verbatim. The `copy` branch is
`nxf_fs_copy`, that is `cp -fRL`, whose `-L` resolves the link. The one mode that would
have worked is the one Google Batch can never choose.

The heuristic is trying to tell two situations apart: unstaging from a scratch dir into the
work dir, which must copy, and unstaging into a `storeDir`, which moves.
`TaskRun.getTargetDir()` returns `storeDir ?: workDir`, so the bean's own two fields
already encode that distinction. Only the shadowed parameter broke it.

## Fix

Rename the parameter to `unstageDir` so it cannot shadow the field, and pick the mode from
the strategy's own work and target dirs. A null `targetDir` counts as "same as work dir",
since a `TaskBean` built outside `TaskBean(TaskRun)` may leave it unset.

| case | before | after |
|---|---|---|
| local or grid with scratch (`workDir == targetDir`) | copy | copy |
| `storeDir` set | move | move |
| explicit `stageOutMode` | as configured | as configured |
| Google Batch | move | **copy** |

No performance cost on Google Batch. The scratch dir is local and the destination is the
gcsfuse mount, so `mv` was already a cross device copy then unlink, and the scratch dir is
removed on exit either way.

## Testing

Ran against live Google Batch in `europe-west2`, before and after, using a build of this
branch.

**#4819 shape**, a task output that links to a staged input. Before, `CHECK (B-symlink)`
fails with `cat: data.txt: No such file or directory`, and the output object in the bucket
is 28 bytes carrying `gcsfuse_symlink_target=/tmp/nxf.9vGiwqyxuj/data.txt`. After, every
task passes and the object holds the file content.

The `includeInputs` variant passed even before the patch, but the object held the path
string rather than the data:

```
$ gcs cat work/0d/4d22f2.../data.txt
/mnt/disks/rnaseq-nf/work-gh4819/cc/e3e5ea.../data.txt     # before
hello-world                                                # after
```

**#4845 shape**, a seed file hosted on GCS passed as pipeline input, in four
configurations:

| case | shape | before | after |
|---|---|---|---|
| seed in a different bucket than the work dir | staged straight into the task | pass | pass |
| seed at the bucket root | staged straight into the task | pass | pass |
| seed in the work dir bucket | staged straight into the task | pass | pass |
| seed re-emitted by a task, then consumed | passthrough | **fail** | pass |

Before: `[FAILED] completed=6 failed=1`. After: `[SUCCESS] completed=8 failed=0`.

Unit tests: `:nextflow:test --tests 'nextflow.executor.*'` and `:plugins:nf-google:test`
both pass.

Added `should return cp script to unstage output files when the unstage dir is a container
mount`, which pins the Google Batch shape. Reverting the predicate to compare against the
parameter makes it fail, so the test is not vacuous.

Two existing specs built a `TaskBean` with no `targetDir` and leaned on the parameter to
decide the mode. They now set `targetDir` the way `TaskBean(TaskRun)` does, `workDir` for
the cp case and `storeDir` for the mv case.

## Note on #4845

That issue's title and diagnosis are wrong, and I would not close it on the terms it
states. Staging a GCS hosted input by symlink works fine. All three direct cases above pass
even without this patch, in any bucket. Moving the executor to hardlinks, as the title
proposes, would not have fixed this. The break is on the unstage side.

One detail explains why #4845 fails loudly where the `includeInputs` case fails quietly.
The placeholder there points into `/mnt/disks/nf-data/...`, but a task only mounts the
buckets its own inputs live in, and that bucket is not one of them, so the link dangles
outright.

The `stageInMode = 'copy'` workaround in both threads works because it leaves no symlink
for the unstage step to mishandle.
