### PR TITLE
fix(plugins): resolve non-core plugin dependencies from the registry

### DIFF
--- a/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/PluginUpdater.groovy
@@ -524,7 +524,7 @@ class PluginUpdater extends UpdateManager {
 
             // 2. find latest satisfying req
             // -- if it's a core nextflow plugin use the version expected by it
-            def depVersion = defaultPlugins.getPlugin(it.pluginId)?.version
+            def depVersion = defaultPlugins.hasPlugin(it.pluginId) ? defaultPlugins.getPlugin(it.pluginId).version : null
             // -- otherwise try to find the newest matching release
             if( !depVersion )
                 depVersion = findNewestMatchingRelease(it.pluginId, it.pluginVersionSupport)?.version

--- a/modules/nf-commons/src/test/nextflow/plugin/PluginUpdaterTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/plugin/PluginUpdaterTest.groovy
@@ -90,6 +90,43 @@ class PluginUpdaterTest extends Specification {
         folder?.deleteDir()
     }
 
+    def 'should install a plugin depending on a non-core plugin' () {
+        given:
+        def folder = Files.createTempDirectory('test')
+        def repo = Files.createDirectory(folder.resolve('repo'))
+        and:
+        // the dependency is a registry plugin, NOT one of the nextflow core plugins
+        def dep = createPlugin(repo, '0.7.1', 'dep-plugin')
+        dep.zip = zipDir(dep.path)
+        and:
+        def main = createPlugin(repo, '1.0.0', PLUGIN_ID, 'dep-plugin@0.7.1')
+        main.zip = zipDir(main.path)
+        and:
+        def index = repo.resolve('plugins.json')
+        index.text = """
+            [{ "id": "dep-plugin", "description": "Test dependency", "releases": [
+                 {"version": "0.7.1", "date": "Jun 25, 2020 9:58:35 PM", "url": "file:${dep.zip}"} ]},
+             { "id": "$PLUGIN_ID", "description": "Test plugin", "releases": [
+                 {"version": "1.0.0", "date": "Jun 25, 2020 9:58:35 PM", "url": "file:${main.zip}"} ]}]
+            """
+        and:
+        def local = Files.createDirectory(folder.resolve('plugins'))
+        def manager = new LocalPluginManager(local)
+        def updater = new PluginUpdater(manager, local, index.toUri().toURL(), false)
+
+        when:
+        updater.installPlugin(PLUGIN_ID, '1.0.0')
+
+        then:
+        noExceptionThrown()
+        and:
+        manager.getPlugin('dep-plugin').descriptor.version == '0.7.1'
+        manager.getPlugin(PLUGIN_ID).descriptor.version == '1.0.0'
+
+        cleanup:
+        folder?.deleteDir()
+    }
+
     def 'should detect already-installed pinned plugin from the on-disk store' () {
         given:
         def folder = Files.createTempDirectory('test')
@@ -670,8 +707,7 @@ class PluginUpdaterTest extends Specification {
         return plugin
     }
 
-    static private MockPlugin createPlugin(Path baseDir, String ver) {
-        def id = "my-plugin"
+    static private MockPlugin createPlugin(Path baseDir, String ver, String id=PLUGIN_ID, String dependencies=null) {
         def clazz = FooPlugin.class
         def fqn = "$id-$ver".toString()
         def pluginDir = baseDir.resolve(fqn)
@@ -684,7 +720,7 @@ class PluginUpdaterTest extends Specification {
                 Plugin-Class: ${clazz.getName()}
                 Plugin-Id: $id
                 Plugin-Version: $ver
-                """.stripIndent()
+                """.stripIndent() + (dependencies ? "Plugin-Dependencies: $dependencies\n" : '')
 
         return new MockPlugin(version: ver, path: pluginDir)
     }


### PR DESCRIPTION
Closes #7455

## Problem

A plugin whose manifest declares `Plugin-Dependencies` on a plugin that is not one of the bundled core plugins fails to load:

```
ERROR ~ Unknown Nextflow plugin 'nf-sqldb'

java.lang.IllegalArgumentException: Unknown Nextflow plugin 'nf-sqldb'
    at nextflow.plugin.DefaultPlugins.getPlugin(DefaultPlugins.groovy:55)
    at nextflow.plugin.PluginUpdater.load0(PluginUpdater.groovy:419)
    at nextflow.plugin.PluginUpdater.installPlugin(PluginUpdater.groovy:249)
```

The issue was reported for a local `nf-trino` build depending on `nf-sqldb@0.7.1`, but the defect has nothing to do with either plugin, or with the depending plugin being local. It applies to every non-core dependency, published or not, so no registry-hosted plugin can be used as a declared dependency.

## Cause

`PluginUpdater.load0()` reads the pinned version of a core plugin using safe navigation:

```groovy
def depVersion = defaultPlugins.getPlugin(it.pluginId)?.version
```

The `?.` shows the intent. Get null for a non-core plugin, then let the next line resolve it from the registry via `findNewestMatchingRelease()`. But `DefaultPlugins.getPlugin()` throws for an unknown id rather than returning null, and `?.` only guards a null receiver, never a throwing call. Resolution aborts one line before the registry lookup that would have handled it.

`DefaultPlugins` exposes `hasPlugin()` for exactly this. Every other call site in the codebase pairs the two (`PluginRef`, `PluginsFacade`) or only ever passes a known core id. This was the single unguarded caller.

Preinstalling the dependency with `nextflow plugin install` does not help either, because the earlier `checkInstalled()` check only sees plugins loaded into the manager for the current run, not ones sitting in the on-disk store.

## Change

One line, guarding the lookup with `hasPlugin()`. Core plugins still resolve to their pinned version. Everything else falls through to the registry as intended.

An already-installed dependency causes no extra download: `load0()` checks `FilesEx.exists(pluginPath)` before calling `safeDownload()` and reuses what is in the store.

## Test

Added `'should install a plugin depending on a non-core plugin'` to `PluginUpdaterTest`. It builds a local repository with `dep-plugin@0.7.1` standing in for a registry plugin that is not a core plugin, and `my-plugin@1.0.0` declaring it in `Plugin-Dependencies`.

The existing `createPlugin()` helper now takes a plugin id and an optional dependency string, so the new test reuses the file, zip, and index scaffolding already there rather than copying it.

The test fails without the fix with `Unknown Nextflow plugin 'dep-plugin'` and passes with it. Full `:nf-commons` suite is green: 986 tests, 0 failures.

## Note for reviewers

`checkInstalled()` still ignores the on-disk plugin store. That is harmless now that the registry lookup covers the case, but it does mean resolving a dependency needs registry metadata even when the plugin is already downloaded, which will hurt in offline mode. It felt out of scope here and probably deserves its own issue.
