### PR TITLE
fix(cache): honour cloudcache.enabled when the plugin is explicitly declared

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/Session.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/Session.groovy
@@ -491,7 +491,7 @@ class Session implements ISession {
         binding.setParams( (Map)config.params )
         binding.setArgs( new ScriptRunner.ArgsList(args) )
 
-        cache = CacheFactory.create(uniqueId,runName).open()
+        cache = CacheFactory.create(this, uniqueId, runName).open()
 
         return this
     }
@@ -1242,7 +1242,7 @@ class Session implements ISession {
         }
 
         log.trace "Cleaning-up workdir"
-        try (CacheDB db = CacheFactory.create(uniqueId, runName).openForRead()) {
+        try (CacheDB db = CacheFactory.create(this, uniqueId, runName).openForRead()) {
             db.eachRecord { HashCode hash, TraceRecord record ->
                 def deleted = db.removeTaskEntry(hash)
                 if( deleted ) {

--- a/modules/nextflow/src/main/groovy/nextflow/cache/CacheFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/CacheFactory.groovy
@@ -20,6 +20,7 @@ import java.nio.file.Path
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.Session
 import nextflow.plugin.Plugins
 import org.pf4j.ExtensionPoint
 
@@ -32,15 +33,23 @@ import org.pf4j.ExtensionPoint
 @CompileStatic
 abstract class CacheFactory implements ExtensionPoint {
 
-    protected abstract CacheDB newInstance(UUID uniqueId, String runName, Path home=null)
+    protected abstract CacheDB newInstance(Session session, UUID uniqueId, String runName, Path home=null)
 
-    static CacheDB create(UUID uniqueId, String runName, Path home=null) {
+    /**
+     * Whether this factory applies to the given session.
+     *
+     * @param session The current {@link Session}, or null when running outside of a workflow
+     *        execution e.g. the `log` and `clean` commands
+     */
+    protected boolean enabled(Session session) { true }
+
+    static CacheDB create(Session session, UUID uniqueId, String runName, Path home=null) {
         final all = Plugins.getPriorityExtensions(CacheFactory)
-        if( !all )
+        final factory = all.find(it -> it.enabled(session))
+        if( !factory )
             throw new IllegalStateException("Unable to find Nextflow cache factory")
-        final factory = all.first()
         log.debug "Using Nextflow cache factory: ${factory.getClass().getName()}"
-        return factory.newInstance(uniqueId, runName, home)
+        return factory.newInstance(session, uniqueId, runName, home)
     }
 
 }

--- a/modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheFactory.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cache/DefaultCacheFactory.groovy
@@ -19,6 +19,7 @@ package nextflow.cache
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
+import nextflow.Session
 import nextflow.exception.AbortOperationException
 import nextflow.plugin.Priority
 
@@ -34,7 +35,7 @@ import nextflow.plugin.Priority
 class DefaultCacheFactory extends CacheFactory {
 
     @Override
-    protected CacheDB newInstance(UUID uniqueId, String runName, Path home) {
+    protected CacheDB newInstance(Session session, UUID uniqueId, String runName, Path home) {
         if( !uniqueId ) throw new AbortOperationException("Missing cache `uuid`")
         if( !runName ) throw new AbortOperationException("Missing cache `runName`")
         final store = new DefaultCacheStore(uniqueId, runName, home)

--- a/modules/nf-cli-v1/src/main/groovy/nextflow/cli/CacheBase.groovy
+++ b/modules/nf-cli-v1/src/main/groovy/nextflow/cli/CacheBase.groovy
@@ -67,7 +67,8 @@ trait CacheBase {
     }
 
     CacheDB cacheFor(HistoryFile.Record entry) {
-        CacheFactory.create(entry.sessionId, entry.runName, basePath)
+        // no session is available outside of a workflow execution
+        CacheFactory.create(null, entry.sessionId, entry.runName, basePath)
     }
 
     List<HistoryFile.Record> listIds() {

--- a/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheFactory.groovy
+++ b/plugins/nf-cloudcache/src/main/nextflow/cache/CloudCacheFactory.groovy
@@ -19,7 +19,6 @@ package nextflow.cache
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
-import nextflow.Global
 import nextflow.Session
 import nextflow.exception.AbortOperationException
 import nextflow.plugin.Priority
@@ -35,10 +34,15 @@ import nextflow.plugin.Priority
 class CloudCacheFactory extends CacheFactory {
 
     @Override
-    protected CacheDB newInstance(UUID uniqueId, String runName, Path home) {
+    protected boolean enabled(Session session) {
+        return session?.cloudCachePath != null
+    }
+
+    @Override
+    protected CacheDB newInstance(Session session, UUID uniqueId, String runName, Path home) {
         if( !uniqueId ) throw new AbortOperationException("Missing cache `uuid`")
         if( !runName ) throw new AbortOperationException("Missing cache `runName`")
-        final path = (Global.session as Session).cloudCachePath
+        final path = session?.cloudCachePath
         if( !path )
             throw new IllegalArgumentException("Cloud-cache path not defined - use either -with-cloudcache run option or NXF_CLOUDCACHE_PATH environment variable")
         final store = new CloudCacheStore(uniqueId, runName, path)

--- a/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveDebugCmd.groovy
+++ b/plugins/nf-wave/src/main/io/seqera/wave/plugin/cli/WaveDebugCmd.groovy
@@ -88,7 +88,7 @@ class WaveDebugCmd {
         if( !history.exists() || history.empty() || !(runRecord=history.findByIdOrName('last')[0]) )
             throw new AbortOperationException("It looks no pipeline was executed in this folder (or execution history is empty)")
 
-        this.cacheDb = CacheFactory.create(runRecord.sessionId, runRecord.runName)
+        this.cacheDb = CacheFactory.create(session, runRecord.sessionId, runRecord.runName)
         cacheDb.openForRead()
         try {
             final trace = getOrFindTrace(criteria)


### PR DESCRIPTION
Closes #7456.

## Problem

Declaring `nf-cloudcache` in the `plugins` scope to pin its version, while keeping the cache off, aborts the run:

```groovy
plugins {
    id 'nf-cloudcache@0.6.0'
}

cloudcache.enabled = false
```

```
ERROR ~ Cloud-cache path not defined - use either -with-cloudcache run option or NXF_CLOUDCACHE_PATH environment variable
```

`CacheFactory.create()` picks a cache implementation by `@Priority` alone, with no check of whether the winning factory applies. `CloudCacheFactory` is `@Priority(-10)` against `DefaultCacheFactory`'s `@Priority(0)`, so once the plugin is loaded its factory wins regardless of the flag.

Normally that is harmless because `PluginsFacade` only auto-loads `nf-cloudcache` when `cloudcache.enabled == true`. Declaring the plugin explicitly bypasses that gate: the plugin is loaded, its factory outranks the default one, and `newInstance()` then throws on the `null` path that `Session.cloudCachePath()` correctly returns for a disabled cloud cache. There is currently no way to pin the plugin version while keeping it switched off.

## Change

Add an `enabled()` hook to `CacheFactory`, defaulting to `true`, and select the highest-priority factory that actually applies:

```groovy
final factory = all.find(it -> it.enabled(session))
```

`CloudCacheFactory` overrides it to decline when the session resolved no cloud cache path. This fixes selection rather than the single call site the issue names, so any future cache plugin can opt out the same way.

The current `Session` is passed to the factory explicitly, following the `TraceObserverFactory.create(Session)` pattern, instead of being read from `Global.session`. Call sites:

- `Session` passes `this` (two sites).
- `WaveDebugCmd` passes its own `session` field. This removes a latent coupling — the command builds a `Session` of its own via `PluginAbstractExec` (which reads `NXF_CLOUDCACHE_PATH`), but the factory then read whichever session happened to be installed in `Global`.
- `CacheBase` (`nextflow log` / `nextflow clean`) passes `null`; there is genuinely no session there.

## Testing

Built with `make compile` and ran the reproducer from the issue:

- **`cloudcache.enabled = false`** — runs to completion; log shows `Using Nextflow cache factory: nextflow.cache.DefaultCacheFactory`.
- **`cloudcache.enabled = true`** with a `cloudcache.path` — unchanged; log shows `Using Nextflow cache factory: nextflow.cache.CloudCacheFactory`.
- **`nextflow log`** — still lists run history, exercising the `null`-session path.

`./gradlew :nextflow:test --tests 'nextflow.cache.*' --tests 'nextflow.Session*' :plugins:nf-cloudcache:test :plugins:nf-wave:test :nf-cli-v1:test` passes.

## Notes for review

Draft, because three points need a decision:

1. **Plugin version bump.** The change spans core and `nf-cloudcache`, so the plugin needs a release — both the `enabled()` override and the new `newInstance()` signature ship in it. An older `nf-cloudcache` against the new core would fail to resolve `newInstance`, so the plugin's `nextflowVersion` minimum should probably move to the release carrying this change.
2. **`create()` signature.** It gained a leading `Session` parameter, which is source-breaking for out-of-tree plugins that call it. A deprecated three-arg overload would avoid that, but it would have to fall back to `Global.session` — the coupling this PR removes. Left out deliberately.
3. **No unit test** for the new selection behaviour. A spec asserting `create()` skips a disabled factory would be a reasonable addition if wanted.
