### PR TITLE
Make NXF_AGENT_MODE an explicit override of agent mode auto-detection

### DIFF
--- a/modules/nf-commons/src/main/nextflow/SysEnv.groovy
+++ b/modules/nf-commons/src/main/nextflow/SysEnv.groovy
@@ -64,19 +64,14 @@ class SysEnv {
     }
 
     /**
-     * Check if agent output mode is enabled via environment variables.
+     * Check if agent output mode is enabled via a truthy {@code NXF_AGENT_MODE}.
      * When enabled, Nextflow replaces interactive ANSI logging with minimal,
      * structured output optimized for AI agents.
-     *
-     * Supported variables (any truthy value activates the mode):
-     * {@code NXF_AGENT_MODE}, {@code AGENT}, {@code CLAUDECODE}.
      *
      * @return {@code true} if agent mode is enabled
      */
     static boolean isAgentMode() {
-        return getBool('NXF_AGENT_MODE', false) ||
-               getBool('AGENT', false) ||
-               getBool('CLAUDECODE', false)
+        return getBool('NXF_AGENT_MODE', false)
     }
 
     static void push(Map<String,String> env) {

--- a/modules/nf-commons/src/test/nextflow/SysEnvTest.groovy
+++ b/modules/nf-commons/src/test/nextflow/SysEnvTest.groovy
@@ -136,13 +136,10 @@ class SysEnvTest extends Specification {
         [:]                         | false
         [NXF_AGENT_MODE:'true']          | true
         [NXF_AGENT_MODE:'false']         | false
-        [AGENT:'true']              | true
-        [CLAUDECODE:'true']         | true
-        // Multiple can be set, any true triggers agent mode
-        [NXF_AGENT_MODE:'true', AGENT:'false']  | true
         // Support '1' as truthy value (common Unix convention)
         [NXF_AGENT_MODE:'1']             | true
-        [AGENT:'1']                 | true
-        [CLAUDECODE:'1']            | true
+        [NXF_AGENT_MODE:'0']             | false
+        // The environment of an agent no longer enables the mode by itself
+        [AGENT:'1', CLAUDECODE:'1']      | false
     }
 }


### PR DESCRIPTION
Closes #7478.

Agent output mode is auto-enabled by the presence of `AGENT` or `CLAUDECODE` in the environment. That detection is undocumented and, once it fires, cannot be switched off:

- `SysEnv.isAgentMode()` ORs the three variables, so `NXF_AGENT_MODE=false` is indistinguishable from unset — the variable can only ever turn the mode *on*.
- `CmdRun` discards an explicit `-ansi-log true` / `NXF_ANSI_LOG=true` whenever agent mode is on, without a warning.

The only escape is `env -u CLAUDECODE`.

These variables are set because an agent launched the run, but an agent-launched process is not always an agent-*watched* one. `tmux`, `screen`, `nohup`, CI runners and `sudo -E` all propagate them past the lifetime of the agent that set them. In the reported case an agent launched a multi-day pipeline into a detached tmux session and a human attached to that pane days later, to 341 static `[PROCESS]` lines and no progress view.

This PR keeps the auto-detection and makes `NXF_AGENT_MODE` a three-state override instead. When it is set, its boolean value decides and the other variables are ignored; `AGENT` and `CLAUDECODE` are consulted only when it is unset.

```groovy
static boolean isAgentMode() {
    if( get('NXF_AGENT_MODE') != null )
        return getBool('NXF_AGENT_MODE', false)
    return getBool('AGENT', false) ||
           getBool('CLAUDECODE', false)
}
```

| `NXF_AGENT_MODE` | `AGENT` / `CLAUDECODE` | Result |
|---|---|---|
| `true` / `1` | any | agent mode (explicit on) |
| `false` / `0` | any | ANSI table (explicit off — **the fix**) |
| unset | truthy | agent mode (auto-detected) |
| unset | unset | ANSI table |

Zero-config detection is unchanged for everyone else; #7478 is solved by `NXF_AGENT_MODE=false` in the detached session. The leaky proxy simply becomes overridable by whoever owns the terminal.

`docs/reference/env-vars.mdx` now documents the `AGENT`/`CLAUDECODE` detection and the override. Neither was documented before, which is why the reporter had nothing pointing at the cause.

### Verification

`./gradlew :nf-commons:test --tests '*SysEnvTest*'` passes, with cases covering each row above. Running the issue's reproducer from a local build:

| `CLAUDECODE` | `NXF_AGENT_MODE` | Before | After |
|---|---|---|---|
| `1` | unset | agent output | agent output |
| `1` | `false` | agent output | **ANSI progress table** |
| unset | `true` | agent output | agent output |
| unset | unset | ANSI table | ANSI table |

Only the second row changes, which is the bug.

### Not addressed

`CmdRun` still silently discards an explicit `-ansi-log true` when agent mode is on (`runner.session.ansiLog = launcher.options.ansiLog && !SysEnv.isAgentMode()`). `NXF_AGENT_MODE=false` now gives a working way out, so this is no longer blocking, but a dropped CLI flag arguably deserves a warning. Happy to fold that in here or leave it as a follow-up.

### Review history

The first commit removed `AGENT`/`CLAUDECODE` outright; the second restores them and implements the override per review. Kept as two commits so the delta is reviewable — squash on merge.